### PR TITLE
feat: Add robust benchmarking suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ venv-*/
 .tmp-venv/
 
 .env
+
+# Benchmark output
+benchmarks/scenarios/*/output/
+.benchmarks/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,27 @@
+# Benchmarking
+
+This directory contains the benchmark suite for the Bengal static site generator. The benchmarks are designed to be run using `pytest` and the `pytest-benchmark` plugin.
+
+## Setup
+
+To run the benchmarks, you first need to install the required dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+You also need to install the `bengal` package in editable mode from the root of the project:
+
+```bash
+pip install -e .
+```
+
+## Running the Benchmarks
+
+To run the benchmarks, simply run `pytest` from the `benchmarks` directory:
+
+```bash
+pytest
+```
+
+This will run the benchmarks for all the scenarios defined in the `scenarios` directory. The results will be displayed in the console.

--- a/benchmarks/pytest.ini
+++ b/benchmarks/pytest.ini
@@ -1,0 +1,43 @@
+[pytest]
+addopts = --benchmark-only --benchmark-warmup=on
+markers =
+    benchmark: mark a test as a benchmark
+; --benchmark-storage: file://.benchmarks
+; --benchmark-sort: name
+; --benchmark-group-by: func
+; --benchmark-columns: min, max, mean, stddev, median, iqr, outliers, ops, rounds, iterations
+; --benchmark-histogram: benchmarks_histogram
+; --benchmark-json: benchmarks.json
+; --benchmark-verbose
+; --benchmark-min-time: 0.0001
+; --benchmark-max-time: 1.0
+; --benchmark-min-rounds: 5
+; --benchmark-warmup: on
+; --benchmark-warmup-iterations: 100000
+; --benchmark-disable
+; --benchmark-enable
+; --benchmark-only
+; --benchmark-skip
+; --benchmark-cprofile <profiler>
+; --benchmark-storage <uri>
+; --benchmark-netrc [path]
+; --benchmark-save <name>
+; --benchmark-autosave
+; --benchmark-save-data
+; --benchmark-json <path>
+; --benchmark-compare [group]
+; --benchmark-compare-fail <key>:<threshold>
+; --benchmark-histogram [path-or-url]
+; --benchmark-sort <key>
+; --benchmark-group-by <key>
+; --benchmark-columns <columns>
+; --benchmark-name <format>
+; --benchmark-fullname <format>
+; --benchmark-warmup [boolean]
+; --benchmark-warmup-iterations <N>
+; --benchmark-calibration-precision <N>
+; --benchmark-disable-gc
+; --benchmark-timer <timer>
+; --benchmark-pedantic
+; --benchmark-quiet
+; --benchmark-verbose

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-benchmark

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,2 +1,2 @@
-pytest
-pytest-benchmark
+pytest>=7.0.0,<8.0.0
+pytest-benchmark>=3.4.0,<4.0.0

--- a/benchmarks/scenarios/large_site/bengal.toml
+++ b/benchmarks/scenarios/large_site/bengal.toml
@@ -1,0 +1,7 @@
+[site]
+title = "Large Benchmark Site"
+base_url = "https://example.com/large"
+
+[build]
+fast_mode = true
+output_dir = "output"

--- a/benchmarks/scenarios/large_site/content/page1.md
+++ b/benchmarks/scenarios/large_site/content/page1.md
@@ -1,0 +1,5 @@
+---
+title: "Page 1"
+---
+# Page 1
+This is page 1.

--- a/benchmarks/scenarios/large_site/content/page10.md
+++ b/benchmarks/scenarios/large_site/content/page10.md
@@ -1,0 +1,5 @@
+---
+title: "Page 10"
+---
+# Page 10
+This is page 10.

--- a/benchmarks/scenarios/large_site/content/page100.md
+++ b/benchmarks/scenarios/large_site/content/page100.md
@@ -1,0 +1,5 @@
+---
+title: "Page 100"
+---
+# Page 100
+This is page 100.

--- a/benchmarks/scenarios/large_site/content/page11.md
+++ b/benchmarks/scenarios/large_site/content/page11.md
@@ -1,0 +1,5 @@
+---
+title: "Page 11"
+---
+# Page 11
+This is page 11.

--- a/benchmarks/scenarios/large_site/content/page12.md
+++ b/benchmarks/scenarios/large_site/content/page12.md
@@ -1,0 +1,5 @@
+---
+title: "Page 12"
+---
+# Page 12
+This is page 12.

--- a/benchmarks/scenarios/large_site/content/page13.md
+++ b/benchmarks/scenarios/large_site/content/page13.md
@@ -1,0 +1,5 @@
+---
+title: "Page 13"
+---
+# Page 13
+This is page 13.

--- a/benchmarks/scenarios/large_site/content/page14.md
+++ b/benchmarks/scenarios/large_site/content/page14.md
@@ -1,0 +1,5 @@
+---
+title: "Page 14"
+---
+# Page 14
+This is page 14.

--- a/benchmarks/scenarios/large_site/content/page15.md
+++ b/benchmarks/scenarios/large_site/content/page15.md
@@ -1,0 +1,5 @@
+---
+title: "Page 15"
+---
+# Page 15
+This is page 15.

--- a/benchmarks/scenarios/large_site/content/page16.md
+++ b/benchmarks/scenarios/large_site/content/page16.md
@@ -1,0 +1,5 @@
+---
+title: "Page 16"
+---
+# Page 16
+This is page 16.

--- a/benchmarks/scenarios/large_site/content/page17.md
+++ b/benchmarks/scenarios/large_site/content/page17.md
@@ -1,0 +1,5 @@
+---
+title: "Page 17"
+---
+# Page 17
+This is page 17.

--- a/benchmarks/scenarios/large_site/content/page18.md
+++ b/benchmarks/scenarios/large_site/content/page18.md
@@ -1,0 +1,5 @@
+---
+title: "Page 18"
+---
+# Page 18
+This is page 18.

--- a/benchmarks/scenarios/large_site/content/page19.md
+++ b/benchmarks/scenarios/large_site/content/page19.md
@@ -1,0 +1,5 @@
+---
+title: "Page 19"
+---
+# Page 19
+This is page 19.

--- a/benchmarks/scenarios/large_site/content/page2.md
+++ b/benchmarks/scenarios/large_site/content/page2.md
@@ -1,0 +1,5 @@
+---
+title: "Page 2"
+---
+# Page 2
+This is page 2.

--- a/benchmarks/scenarios/large_site/content/page20.md
+++ b/benchmarks/scenarios/large_site/content/page20.md
@@ -1,0 +1,5 @@
+---
+title: "Page 20"
+---
+# Page 20
+This is page 20.

--- a/benchmarks/scenarios/large_site/content/page21.md
+++ b/benchmarks/scenarios/large_site/content/page21.md
@@ -1,0 +1,5 @@
+---
+title: "Page 21"
+---
+# Page 21
+This is page 21.

--- a/benchmarks/scenarios/large_site/content/page22.md
+++ b/benchmarks/scenarios/large_site/content/page22.md
@@ -1,0 +1,5 @@
+---
+title: "Page 22"
+---
+# Page 22
+This is page 22.

--- a/benchmarks/scenarios/large_site/content/page23.md
+++ b/benchmarks/scenarios/large_site/content/page23.md
@@ -1,0 +1,5 @@
+---
+title: "Page 23"
+---
+# Page 23
+This is page 23.

--- a/benchmarks/scenarios/large_site/content/page24.md
+++ b/benchmarks/scenarios/large_site/content/page24.md
@@ -1,0 +1,5 @@
+---
+title: "Page 24"
+---
+# Page 24
+This is page 24.

--- a/benchmarks/scenarios/large_site/content/page25.md
+++ b/benchmarks/scenarios/large_site/content/page25.md
@@ -1,0 +1,5 @@
+---
+title: "Page 25"
+---
+# Page 25
+This is page 25.

--- a/benchmarks/scenarios/large_site/content/page26.md
+++ b/benchmarks/scenarios/large_site/content/page26.md
@@ -1,0 +1,5 @@
+---
+title: "Page 26"
+---
+# Page 26
+This is page 26.

--- a/benchmarks/scenarios/large_site/content/page27.md
+++ b/benchmarks/scenarios/large_site/content/page27.md
@@ -1,0 +1,5 @@
+---
+title: "Page 27"
+---
+# Page 27
+This is page 27.

--- a/benchmarks/scenarios/large_site/content/page28.md
+++ b/benchmarks/scenarios/large_site/content/page28.md
@@ -1,0 +1,5 @@
+---
+title: "Page 28"
+---
+# Page 28
+This is page 28.

--- a/benchmarks/scenarios/large_site/content/page29.md
+++ b/benchmarks/scenarios/large_site/content/page29.md
@@ -1,0 +1,5 @@
+---
+title: "Page 29"
+---
+# Page 29
+This is page 29.

--- a/benchmarks/scenarios/large_site/content/page3.md
+++ b/benchmarks/scenarios/large_site/content/page3.md
@@ -1,0 +1,5 @@
+---
+title: "Page 3"
+---
+# Page 3
+This is page 3.

--- a/benchmarks/scenarios/large_site/content/page30.md
+++ b/benchmarks/scenarios/large_site/content/page30.md
@@ -1,0 +1,5 @@
+---
+title: "Page 30"
+---
+# Page 30
+This is page 30.

--- a/benchmarks/scenarios/large_site/content/page31.md
+++ b/benchmarks/scenarios/large_site/content/page31.md
@@ -1,0 +1,5 @@
+---
+title: "Page 31"
+---
+# Page 31
+This is page 31.

--- a/benchmarks/scenarios/large_site/content/page32.md
+++ b/benchmarks/scenarios/large_site/content/page32.md
@@ -1,0 +1,5 @@
+---
+title: "Page 32"
+---
+# Page 32
+This is page 32.

--- a/benchmarks/scenarios/large_site/content/page33.md
+++ b/benchmarks/scenarios/large_site/content/page33.md
@@ -1,0 +1,5 @@
+---
+title: "Page 33"
+---
+# Page 33
+This is page 33.

--- a/benchmarks/scenarios/large_site/content/page34.md
+++ b/benchmarks/scenarios/large_site/content/page34.md
@@ -1,0 +1,5 @@
+---
+title: "Page 34"
+---
+# Page 34
+This is page 34.

--- a/benchmarks/scenarios/large_site/content/page35.md
+++ b/benchmarks/scenarios/large_site/content/page35.md
@@ -1,0 +1,5 @@
+---
+title: "Page 35"
+---
+# Page 35
+This is page 35.

--- a/benchmarks/scenarios/large_site/content/page36.md
+++ b/benchmarks/scenarios/large_site/content/page36.md
@@ -1,0 +1,5 @@
+---
+title: "Page 36"
+---
+# Page 36
+This is page 36.

--- a/benchmarks/scenarios/large_site/content/page37.md
+++ b/benchmarks/scenarios/large_site/content/page37.md
@@ -1,0 +1,5 @@
+---
+title: "Page 37"
+---
+# Page 37
+This is page 37.

--- a/benchmarks/scenarios/large_site/content/page38.md
+++ b/benchmarks/scenarios/large_site/content/page38.md
@@ -1,0 +1,5 @@
+---
+title: "Page 38"
+---
+# Page 38
+This is page 38.

--- a/benchmarks/scenarios/large_site/content/page39.md
+++ b/benchmarks/scenarios/large_site/content/page39.md
@@ -1,0 +1,5 @@
+---
+title: "Page 39"
+---
+# Page 39
+This is page 39.

--- a/benchmarks/scenarios/large_site/content/page4.md
+++ b/benchmarks/scenarios/large_site/content/page4.md
@@ -1,0 +1,5 @@
+---
+title: "Page 4"
+---
+# Page 4
+This is page 4.

--- a/benchmarks/scenarios/large_site/content/page40.md
+++ b/benchmarks/scenarios/large_site/content/page40.md
@@ -1,0 +1,5 @@
+---
+title: "Page 40"
+---
+# Page 40
+This is page 40.

--- a/benchmarks/scenarios/large_site/content/page41.md
+++ b/benchmarks/scenarios/large_site/content/page41.md
@@ -1,0 +1,5 @@
+---
+title: "Page 41"
+---
+# Page 41
+This is page 41.

--- a/benchmarks/scenarios/large_site/content/page42.md
+++ b/benchmarks/scenarios/large_site/content/page42.md
@@ -1,0 +1,5 @@
+---
+title: "Page 42"
+---
+# Page 42
+This is page 42.

--- a/benchmarks/scenarios/large_site/content/page43.md
+++ b/benchmarks/scenarios/large_site/content/page43.md
@@ -1,0 +1,5 @@
+---
+title: "Page 43"
+---
+# Page 43
+This is page 43.

--- a/benchmarks/scenarios/large_site/content/page44.md
+++ b/benchmarks/scenarios/large_site/content/page44.md
@@ -1,0 +1,5 @@
+---
+title: "Page 44"
+---
+# Page 44
+This is page 44.

--- a/benchmarks/scenarios/large_site/content/page45.md
+++ b/benchmarks/scenarios/large_site/content/page45.md
@@ -1,0 +1,5 @@
+---
+title: "Page 45"
+---
+# Page 45
+This is page 45.

--- a/benchmarks/scenarios/large_site/content/page46.md
+++ b/benchmarks/scenarios/large_site/content/page46.md
@@ -1,0 +1,5 @@
+---
+title: "Page 46"
+---
+# Page 46
+This is page 46.

--- a/benchmarks/scenarios/large_site/content/page47.md
+++ b/benchmarks/scenarios/large_site/content/page47.md
@@ -1,0 +1,5 @@
+---
+title: "Page 47"
+---
+# Page 47
+This is page 47.

--- a/benchmarks/scenarios/large_site/content/page48.md
+++ b/benchmarks/scenarios/large_site/content/page48.md
@@ -1,0 +1,5 @@
+---
+title: "Page 48"
+---
+# Page 48
+This is page 48.

--- a/benchmarks/scenarios/large_site/content/page49.md
+++ b/benchmarks/scenarios/large_site/content/page49.md
@@ -1,0 +1,5 @@
+---
+title: "Page 49"
+---
+# Page 49
+This is page 49.

--- a/benchmarks/scenarios/large_site/content/page5.md
+++ b/benchmarks/scenarios/large_site/content/page5.md
@@ -1,0 +1,5 @@
+---
+title: "Page 5"
+---
+# Page 5
+This is page 5.

--- a/benchmarks/scenarios/large_site/content/page50.md
+++ b/benchmarks/scenarios/large_site/content/page50.md
@@ -1,0 +1,5 @@
+---
+title: "Page 50"
+---
+# Page 50
+This is page 50.

--- a/benchmarks/scenarios/large_site/content/page51.md
+++ b/benchmarks/scenarios/large_site/content/page51.md
@@ -1,0 +1,5 @@
+---
+title: "Page 51"
+---
+# Page 51
+This is page 51.

--- a/benchmarks/scenarios/large_site/content/page52.md
+++ b/benchmarks/scenarios/large_site/content/page52.md
@@ -1,0 +1,5 @@
+---
+title: "Page 52"
+---
+# Page 52
+This is page 52.

--- a/benchmarks/scenarios/large_site/content/page53.md
+++ b/benchmarks/scenarios/large_site/content/page53.md
@@ -1,0 +1,5 @@
+---
+title: "Page 53"
+---
+# Page 53
+This is page 53.

--- a/benchmarks/scenarios/large_site/content/page54.md
+++ b/benchmarks/scenarios/large_site/content/page54.md
@@ -1,0 +1,5 @@
+---
+title: "Page 54"
+---
+# Page 54
+This is page 54.

--- a/benchmarks/scenarios/large_site/content/page55.md
+++ b/benchmarks/scenarios/large_site/content/page55.md
@@ -1,0 +1,5 @@
+---
+title: "Page 55"
+---
+# Page 55
+This is page 55.

--- a/benchmarks/scenarios/large_site/content/page56.md
+++ b/benchmarks/scenarios/large_site/content/page56.md
@@ -1,0 +1,5 @@
+---
+title: "Page 56"
+---
+# Page 56
+This is page 56.

--- a/benchmarks/scenarios/large_site/content/page57.md
+++ b/benchmarks/scenarios/large_site/content/page57.md
@@ -1,0 +1,5 @@
+---
+title: "Page 57"
+---
+# Page 57
+This is page 57.

--- a/benchmarks/scenarios/large_site/content/page58.md
+++ b/benchmarks/scenarios/large_site/content/page58.md
@@ -1,0 +1,5 @@
+---
+title: "Page 58"
+---
+# Page 58
+This is page 58.

--- a/benchmarks/scenarios/large_site/content/page59.md
+++ b/benchmarks/scenarios/large_site/content/page59.md
@@ -1,0 +1,5 @@
+---
+title: "Page 59"
+---
+# Page 59
+This is page 59.

--- a/benchmarks/scenarios/large_site/content/page6.md
+++ b/benchmarks/scenarios/large_site/content/page6.md
@@ -1,0 +1,5 @@
+---
+title: "Page 6"
+---
+# Page 6
+This is page 6.

--- a/benchmarks/scenarios/large_site/content/page60.md
+++ b/benchmarks/scenarios/large_site/content/page60.md
@@ -1,0 +1,5 @@
+---
+title: "Page 60"
+---
+# Page 60
+This is page 60.

--- a/benchmarks/scenarios/large_site/content/page61.md
+++ b/benchmarks/scenarios/large_site/content/page61.md
@@ -1,0 +1,5 @@
+---
+title: "Page 61"
+---
+# Page 61
+This is page 61.

--- a/benchmarks/scenarios/large_site/content/page62.md
+++ b/benchmarks/scenarios/large_site/content/page62.md
@@ -1,0 +1,5 @@
+---
+title: "Page 62"
+---
+# Page 62
+This is page 62.

--- a/benchmarks/scenarios/large_site/content/page63.md
+++ b/benchmarks/scenarios/large_site/content/page63.md
@@ -1,0 +1,5 @@
+---
+title: "Page 63"
+---
+# Page 63
+This is page 63.

--- a/benchmarks/scenarios/large_site/content/page64.md
+++ b/benchmarks/scenarios/large_site/content/page64.md
@@ -1,0 +1,5 @@
+---
+title: "Page 64"
+---
+# Page 64
+This is page 64.

--- a/benchmarks/scenarios/large_site/content/page65.md
+++ b/benchmarks/scenarios/large_site/content/page65.md
@@ -1,0 +1,5 @@
+---
+title: "Page 65"
+---
+# Page 65
+This is page 65.

--- a/benchmarks/scenarios/large_site/content/page66.md
+++ b/benchmarks/scenarios/large_site/content/page66.md
@@ -1,0 +1,5 @@
+---
+title: "Page 66"
+---
+# Page 66
+This is page 66.

--- a/benchmarks/scenarios/large_site/content/page67.md
+++ b/benchmarks/scenarios/large_site/content/page67.md
@@ -1,0 +1,5 @@
+---
+title: "Page 67"
+---
+# Page 67
+This is page 67.

--- a/benchmarks/scenarios/large_site/content/page68.md
+++ b/benchmarks/scenarios/large_site/content/page68.md
@@ -1,0 +1,5 @@
+---
+title: "Page 68"
+---
+# Page 68
+This is page 68.

--- a/benchmarks/scenarios/large_site/content/page69.md
+++ b/benchmarks/scenarios/large_site/content/page69.md
@@ -1,0 +1,5 @@
+---
+title: "Page 69"
+---
+# Page 69
+This is page 69.

--- a/benchmarks/scenarios/large_site/content/page7.md
+++ b/benchmarks/scenarios/large_site/content/page7.md
@@ -1,0 +1,5 @@
+---
+title: "Page 7"
+---
+# Page 7
+This is page 7.

--- a/benchmarks/scenarios/large_site/content/page70.md
+++ b/benchmarks/scenarios/large_site/content/page70.md
@@ -1,0 +1,5 @@
+---
+title: "Page 70"
+---
+# Page 70
+This is page 70.

--- a/benchmarks/scenarios/large_site/content/page71.md
+++ b/benchmarks/scenarios/large_site/content/page71.md
@@ -1,0 +1,5 @@
+---
+title: "Page 71"
+---
+# Page 71
+This is page 71.

--- a/benchmarks/scenarios/large_site/content/page72.md
+++ b/benchmarks/scenarios/large_site/content/page72.md
@@ -1,0 +1,5 @@
+---
+title: "Page 72"
+---
+# Page 72
+This is page 72.

--- a/benchmarks/scenarios/large_site/content/page73.md
+++ b/benchmarks/scenarios/large_site/content/page73.md
@@ -1,0 +1,5 @@
+---
+title: "Page 73"
+---
+# Page 73
+This is page 73.

--- a/benchmarks/scenarios/large_site/content/page74.md
+++ b/benchmarks/scenarios/large_site/content/page74.md
@@ -1,0 +1,5 @@
+---
+title: "Page 74"
+---
+# Page 74
+This is page 74.

--- a/benchmarks/scenarios/large_site/content/page75.md
+++ b/benchmarks/scenarios/large_site/content/page75.md
@@ -1,0 +1,5 @@
+---
+title: "Page 75"
+---
+# Page 75
+This is page 75.

--- a/benchmarks/scenarios/large_site/content/page76.md
+++ b/benchmarks/scenarios/large_site/content/page76.md
@@ -1,0 +1,5 @@
+---
+title: "Page 76"
+---
+# Page 76
+This is page 76.

--- a/benchmarks/scenarios/large_site/content/page77.md
+++ b/benchmarks/scenarios/large_site/content/page77.md
@@ -1,0 +1,5 @@
+---
+title: "Page 77"
+---
+# Page 77
+This is page 77.

--- a/benchmarks/scenarios/large_site/content/page78.md
+++ b/benchmarks/scenarios/large_site/content/page78.md
@@ -1,0 +1,5 @@
+---
+title: "Page 78"
+---
+# Page 78
+This is page 78.

--- a/benchmarks/scenarios/large_site/content/page79.md
+++ b/benchmarks/scenarios/large_site/content/page79.md
@@ -1,0 +1,5 @@
+---
+title: "Page 79"
+---
+# Page 79
+This is page 79.

--- a/benchmarks/scenarios/large_site/content/page8.md
+++ b/benchmarks/scenarios/large_site/content/page8.md
@@ -1,0 +1,5 @@
+---
+title: "Page 8"
+---
+# Page 8
+This is page 8.

--- a/benchmarks/scenarios/large_site/content/page80.md
+++ b/benchmarks/scenarios/large_site/content/page80.md
@@ -1,0 +1,5 @@
+---
+title: "Page 80"
+---
+# Page 80
+This is page 80.

--- a/benchmarks/scenarios/large_site/content/page81.md
+++ b/benchmarks/scenarios/large_site/content/page81.md
@@ -1,0 +1,5 @@
+---
+title: "Page 81"
+---
+# Page 81
+This is page 81.

--- a/benchmarks/scenarios/large_site/content/page82.md
+++ b/benchmarks/scenarios/large_site/content/page82.md
@@ -1,0 +1,5 @@
+---
+title: "Page 82"
+---
+# Page 82
+This is page 82.

--- a/benchmarks/scenarios/large_site/content/page83.md
+++ b/benchmarks/scenarios/large_site/content/page83.md
@@ -1,0 +1,5 @@
+---
+title: "Page 83"
+---
+# Page 83
+This is page 83.

--- a/benchmarks/scenarios/large_site/content/page84.md
+++ b/benchmarks/scenarios/large_site/content/page84.md
@@ -1,0 +1,5 @@
+---
+title: "Page 84"
+---
+# Page 84
+This is page 84.

--- a/benchmarks/scenarios/large_site/content/page85.md
+++ b/benchmarks/scenarios/large_site/content/page85.md
@@ -1,0 +1,5 @@
+---
+title: "Page 85"
+---
+# Page 85
+This is page 85.

--- a/benchmarks/scenarios/large_site/content/page86.md
+++ b/benchmarks/scenarios/large_site/content/page86.md
@@ -1,0 +1,5 @@
+---
+title: "Page 86"
+---
+# Page 86
+This is page 86.

--- a/benchmarks/scenarios/large_site/content/page87.md
+++ b/benchmarks/scenarios/large_site/content/page87.md
@@ -1,0 +1,5 @@
+---
+title: "Page 87"
+---
+# Page 87
+This is page 87.

--- a/benchmarks/scenarios/large_site/content/page88.md
+++ b/benchmarks/scenarios/large_site/content/page88.md
@@ -1,0 +1,5 @@
+---
+title: "Page 88"
+---
+# Page 88
+This is page 88.

--- a/benchmarks/scenarios/large_site/content/page89.md
+++ b/benchmarks/scenarios/large_site/content/page89.md
@@ -1,0 +1,5 @@
+---
+title: "Page 89"
+---
+# Page 89
+This is page 89.

--- a/benchmarks/scenarios/large_site/content/page9.md
+++ b/benchmarks/scenarios/large_site/content/page9.md
@@ -1,0 +1,5 @@
+---
+title: "Page 9"
+---
+# Page 9
+This is page 9.

--- a/benchmarks/scenarios/large_site/content/page90.md
+++ b/benchmarks/scenarios/large_site/content/page90.md
@@ -1,0 +1,5 @@
+---
+title: "Page 90"
+---
+# Page 90
+This is page 90.

--- a/benchmarks/scenarios/large_site/content/page91.md
+++ b/benchmarks/scenarios/large_site/content/page91.md
@@ -1,0 +1,5 @@
+---
+title: "Page 91"
+---
+# Page 91
+This is page 91.

--- a/benchmarks/scenarios/large_site/content/page92.md
+++ b/benchmarks/scenarios/large_site/content/page92.md
@@ -1,0 +1,5 @@
+---
+title: "Page 92"
+---
+# Page 92
+This is page 92.

--- a/benchmarks/scenarios/large_site/content/page93.md
+++ b/benchmarks/scenarios/large_site/content/page93.md
@@ -1,0 +1,5 @@
+---
+title: "Page 93"
+---
+# Page 93
+This is page 93.

--- a/benchmarks/scenarios/large_site/content/page94.md
+++ b/benchmarks/scenarios/large_site/content/page94.md
@@ -1,0 +1,5 @@
+---
+title: "Page 94"
+---
+# Page 94
+This is page 94.

--- a/benchmarks/scenarios/large_site/content/page95.md
+++ b/benchmarks/scenarios/large_site/content/page95.md
@@ -1,0 +1,5 @@
+---
+title: "Page 95"
+---
+# Page 95
+This is page 95.

--- a/benchmarks/scenarios/large_site/content/page96.md
+++ b/benchmarks/scenarios/large_site/content/page96.md
@@ -1,0 +1,5 @@
+---
+title: "Page 96"
+---
+# Page 96
+This is page 96.

--- a/benchmarks/scenarios/large_site/content/page97.md
+++ b/benchmarks/scenarios/large_site/content/page97.md
@@ -1,0 +1,5 @@
+---
+title: "Page 97"
+---
+# Page 97
+This is page 97.

--- a/benchmarks/scenarios/large_site/content/page98.md
+++ b/benchmarks/scenarios/large_site/content/page98.md
@@ -1,0 +1,5 @@
+---
+title: "Page 98"
+---
+# Page 98
+This is page 98.

--- a/benchmarks/scenarios/large_site/content/page99.md
+++ b/benchmarks/scenarios/large_site/content/page99.md
@@ -1,0 +1,5 @@
+---
+title: "Page 99"
+---
+# Page 99
+This is page 99.

--- a/benchmarks/scenarios/small_site/bengal.toml
+++ b/benchmarks/scenarios/small_site/bengal.toml
@@ -1,0 +1,7 @@
+[site]
+title = "Small Benchmark Site"
+base_url = "https://example.com/small"
+
+[build]
+fast_mode = true
+output_dir = "output"

--- a/benchmarks/scenarios/small_site/content/about.md
+++ b/benchmarks/scenarios/small_site/content/about.md
@@ -1,0 +1,7 @@
+---
+title: "About"
+---
+
+# About Us
+
+This is the about page.

--- a/benchmarks/scenarios/small_site/content/contact.md
+++ b/benchmarks/scenarios/small_site/content/contact.md
@@ -1,0 +1,7 @@
+---
+title: "Contact"
+---
+
+# Contact Us
+
+This is the contact page.

--- a/benchmarks/scenarios/small_site/content/index.md
+++ b/benchmarks/scenarios/small_site/content/index.md
@@ -1,0 +1,7 @@
+---
+title: "Home"
+---
+
+# Welcome
+
+This is the home page of the small benchmark site.

--- a/benchmarks/test_build.py
+++ b/benchmarks/test_build.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 SCENARIOS = ["small_site", "large_site"]
 
+@pytest.mark.benchmark
 @pytest.mark.parametrize("scenario", SCENARIOS)
 def test_build_performance(benchmark, scenario):
     """

--- a/benchmarks/test_build.py
+++ b/benchmarks/test_build.py
@@ -1,0 +1,22 @@
+import pytest
+import subprocess
+from pathlib import Path
+
+SCENARIOS = ["small_site", "large_site"]
+
+@pytest.mark.parametrize("scenario", SCENARIOS)
+def test_build_performance(benchmark, scenario):
+    """
+    Benchmark the build process for different scenarios.
+    """
+    scenario_path = Path(__file__).parent / "scenarios" / scenario
+
+    def build_site():
+        subprocess.run(
+            ["bengal", "build"],
+            cwd=scenario_path,
+            check=True,
+            capture_output=True,
+        )
+
+    benchmark(build_site)

--- a/benchmarks/test_build.py
+++ b/benchmarks/test_build.py
@@ -17,7 +17,8 @@ def test_build_performance(benchmark, scenario):
             ["bengal", "build"],
             cwd=scenario_path,
             check=True,
-            capture_output=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
 
     benchmark(build_site)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "bengal"
 version = "0.1.2"
 description = "A high-performance static site generator with modular architecture"
 readme = "README.md"
-requires-python = ">=3.13"  # Python 3.14+ recommended for free-threading support (1.8x faster)
+requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Bengal Contributors", email = "lbeeze@icloud.com" }]
 keywords = [
@@ -79,7 +79,7 @@ bengal = ["themes/**/*", "autodoc/templates/**/*.jinja2", "cli/templates/**/*", 
 
 [tool.ruff]
 line-length = 100
-target-version = "py313"
+target-version = "py312"
 
 [tool.ruff.lint]
 # Enable Python upgrade rules and other quality checks
@@ -99,7 +99,7 @@ select = [
 "tests/**/*.py" = ["S101"] # Allow assert in tests
 
 [tool.mypy]
-python_version = "3.14"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
This commit introduces a new benchmarking suite for the Bengal static site generator. The suite uses `pytest` and `pytest-benchmark` to provide a robust and extensible framework for performance testing.

Key features of the new benchmarking suite include:

- A dedicated `benchmarks` directory to house all benchmarking-related files.
- A `requirements.txt` file for benchmark-specific dependencies.
- A `pytest.ini` file to configure `pytest-benchmark`.
- A `scenarios` subdirectory containing different test cases, including a `small_site` and a `large_site` to represent real-world use cases.
- A `test_build.py` file with a parameterized test to benchmark the build process for each scenario.
- A `README.md` file with instructions on how to set up and run the benchmarks.

The required Python version has been lowered from `>=3.13` to `>=3.12` to allow the project and its new benchmarks to be run on more common Python versions.