### PR TITLE
refactor: Parallelize GitHub Actions test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    runs-on: ubuntu-latest  # Or macos-latest for darwin consistency
+  test-baseurl:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.14"]  # Lock to 3.14; add "3.13" if needed for matrix
+        python-version: ["3.14"]
         baseurl: ["", "/bengal", "https://example.com/sub"]
 
     steps:
@@ -36,11 +36,94 @@ jobs:
         echo "Running with BENGAL_BASEURL='${BENGAL_BASEURL}'"
         pytest -q tests/unit/config/test_config_loader_baseurl_env.py tests/unit/rendering/test_asset_url_baseurl.py tests/unit/rendering/test_template_links_baseurl.py tests/integration/test_baseurl_builds.py -q
 
-    - name: Run full test suite (single env only)
-      if: matrix.baseurl == ''
-      run: |
-        python -m pytest -v --tb=short --cov=bengal --cov-report=xml
+  test-unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.14"]
 
-    - name: Upload coverage
-      if: matrix.baseurl == ''
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Run unit tests
+      run: |
+        python -m pytest -v --tb=short --cov=bengal --cov-report=xml tests/unit/
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-unit
+        path: coverage.xml
+
+  test-integration-and-other:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Run integration and other tests
+      run: |
+        python -m pytest -v --tb=short --cov=bengal --cov-report=xml tests/integration/ tests/*.py
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-integration
+        path: coverage.xml
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: [test-unit, test-integration-and-other]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Download coverage reports
+      uses: actions/download-artifact@v3
+      with:
+        path: coverage-reports
+
+    - name: List downloaded files
+      run: ls -R coverage-reports
+
+    - name: Merge coverage reports
+      run: |
+        coverage combine coverage-reports/coverage-unit/coverage.xml coverage-reports/coverage-integration/coverage.xml
+
+    - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        fail_ci_if_error: true


### PR DESCRIPTION
This commit refactors the GitHub Actions workflow for running tests to improve performance and provide faster feedback. The single, monolithic `test` job has been split into three parallel jobs:

- `test-baseurl`: Runs tests related to `baseurl` portability.
- `test-unit`: Runs the unit test suite.
- `test-integration-and-other`: Runs the integration tests and any other tests at the top level of the `tests` directory.

A new `coverage` job has been added to collect the coverage reports from the parallel test jobs, merge them, and upload a consolidated report to Codecov. This ensures that code coverage metrics remain accurate while benefiting from the speed improvements of parallel execution.