### PR TITLE
fix(css): correct @supports syntax to use property-value pairs for W3…

### DIFF
--- a/bengal/themes/default/assets/css/components/archive.css
+++ b/bengal/themes/default/assets/css/components/archive.css
@@ -98,7 +98,7 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .archive-post-card:hover {
     background: color-mix(in srgb, var(--color-bg-secondary) 95%, var(--color-primary));
   }
@@ -145,7 +145,7 @@
   color: var(--color-primary);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .post-title a:hover {
     color: color-mix(in srgb, var(--color-primary) 90%, black);
   }
@@ -222,7 +222,7 @@
   color: var(--color-text-inverse);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .year-list li a:hover {
     background: color-mix(in srgb, var(--color-primary) 90%, black);
   }
@@ -291,7 +291,7 @@
   color: var(--color-text-inverse);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .year-link:hover {
     background: color-mix(in srgb, var(--color-primary) 90%, black);
   }
@@ -330,7 +330,7 @@
   background: var(--color-bg-hover);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .year-summary:hover {
     background: color-mix(in srgb, var(--color-bg-hover) 95%, var(--color-primary));
   }
@@ -370,7 +370,7 @@
   color: var(--color-text-primary);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .archive-month-item a:hover {
     background: color-mix(in srgb, var(--color-bg-hover) 95%, var(--color-primary));
   }

--- a/bengal/themes/default/assets/css/components/author-page.css
+++ b/bengal/themes/default/assets/css/components/author-page.css
@@ -27,7 +27,7 @@
     box-shadow: var(--elevation-card-hover);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .author-header:hover {
         background: color-mix(in srgb, var(--color-bg-secondary) 98%, var(--color-primary));
     }
@@ -119,7 +119,7 @@
     box-shadow: var(--elevation-low);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .social-link:hover {
         background: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -221,7 +221,7 @@
     transform: translate3d(0, -1px, 0);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .filter-button:hover {
         background: color-mix(in srgb, var(--color-bg-hover) 95%, var(--color-primary));
     }
@@ -237,7 +237,7 @@
     border-color: var(--color-primary);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .filter-button.active {
         background: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -267,7 +267,7 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .author-post-card:hover {
         background: color-mix(in srgb, var(--color-bg-secondary) 95%, var(--color-primary));
     }
@@ -330,7 +330,7 @@
     transform: translate3d(4px, 0, 0);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .post-list-compact a:hover {
         color: color-mix(in srgb, var(--color-primary) 90%, black);
     }

--- a/bengal/themes/default/assets/css/components/author.css
+++ b/bengal/themes/default/assets/css/components/author.css
@@ -20,7 +20,7 @@
     box-shadow: var(--elevation-card-hover);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .author-bio:hover {
         background: color-mix(in srgb, var(--color-bg-secondary) 98%, var(--color-primary));
     }

--- a/bengal/themes/default/assets/css/components/badges.css
+++ b/bengal/themes/default/assets/css/components/badges.css
@@ -26,7 +26,7 @@
   background-color: #2563eb;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .badge-primary:hover {
     background-color: color-mix(in srgb, #3b82f6 90%, black);
   }
@@ -41,7 +41,7 @@
   background-color: #4b5563;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .badge-secondary:hover {
     background-color: color-mix(in srgb, #6b7280 90%, black);
   }
@@ -56,7 +56,7 @@
   background-color: #059669;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .badge-success:hover {
     background-color: color-mix(in srgb, #10b981 90%, black);
   }
@@ -71,7 +71,7 @@
   background-color: #dc2626;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .badge-danger:hover {
     background-color: color-mix(in srgb, #ef4444 90%, black);
   }
@@ -86,7 +86,7 @@
   background-color: #d97706;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .badge-warning:hover {
     background-color: color-mix(in srgb, #f59e0b 90%, black);
   }
@@ -101,7 +101,7 @@
   background-color: #2563eb;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .badge-info:hover {
     background-color: color-mix(in srgb, #3b82f6 90%, black);
   }
@@ -117,7 +117,7 @@
   background-color: #e5e7eb;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .badge-light:hover {
     background-color: color-mix(in srgb, #f3f4f6 90%, black);
   }
@@ -132,7 +132,7 @@
   background-color: #111827;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .badge-dark:hover {
     background-color: color-mix(in srgb, #1f2937 90%, white);
   }
@@ -191,7 +191,7 @@
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .featured-card:hover {
     border-color: color-mix(in srgb, var(--color-primary) 90%, black);
   }

--- a/bengal/themes/default/assets/css/components/buttons.css
+++ b/bengal/themes/default/assets/css/components/buttons.css
@@ -43,7 +43,7 @@ button {
 }
 
 /* Modern color mixing for hover state */
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .button-primary:hover {
     background: color-mix(in srgb, var(--button-primary-base) 90%, black);
     color: white;
@@ -51,7 +51,7 @@ button {
 }
 
 /* Fallback for browsers without color-mix */
-@supports not (color-mix(in srgb, white, black)) {
+@supports not (color: color-mix(in srgb, white, black)) {
   .button-primary:hover {
     background-color: var(--button-primary-hover-fallback);
     color: white;
@@ -100,14 +100,14 @@ button {
   color: white;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .button-secondary:hover {
     background-color: color-mix(in srgb, #6b7280 90%, black);
     color: white;
   }
 }
 
-@supports not (color-mix(in srgb, white, black)) {
+@supports not (color: color-mix(in srgb, white, black)) {
   .button-secondary:hover {
     background-color: #4b5563;
     color: white;
@@ -120,14 +120,14 @@ button {
   color: white;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .button-success:hover {
     background-color: color-mix(in srgb, #10b981 90%, black);
     color: white;
   }
 }
 
-@supports not (color-mix(in srgb, white, black)) {
+@supports not (color: color-mix(in srgb, white, black)) {
   .button-success:hover {
     background-color: #059669;
     color: white;
@@ -140,14 +140,14 @@ button {
   color: white;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .button-danger:hover {
     background-color: color-mix(in srgb, #ef4444 90%, black);
     color: white;
   }
 }
 
-@supports not (color-mix(in srgb, white, black)) {
+@supports not (color: color-mix(in srgb, white, black)) {
   .button-danger:hover {
     background-color: #dc2626;
     color: white;

--- a/bengal/themes/default/assets/css/components/cards.css
+++ b/bengal/themes/default/assets/css/components/cards.css
@@ -307,7 +307,7 @@ a.card {
 }
 
 /* Modern color mixing for hover background */
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .feature-card:hover {
     background: color-mix(in srgb, var(--color-bg-elevated) 95%, var(--color-primary));
   }

--- a/bengal/themes/default/assets/css/components/empty-state.css
+++ b/bengal/themes/default/assets/css/components/empty-state.css
@@ -117,7 +117,7 @@
     text-decoration: underline;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .empty-state__suggestions a:hover {
         color: color-mix(in srgb, var(--color-secondary) 90%, black);
     }

--- a/bengal/themes/default/assets/css/components/navigation.css
+++ b/bengal/themes/default/assets/css/components/navigation.css
@@ -37,7 +37,7 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .nav-links a:hover {
     background: color-mix(in srgb, var(--color-bg-secondary) 95%, var(--color-primary));
   }

--- a/bengal/themes/default/assets/css/components/share.css
+++ b/bengal/themes/default/assets/css/components/share.css
@@ -47,7 +47,7 @@
     opacity: 1;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .share-button:hover {
         background-color: color-mix(in srgb, var(--color-text-muted) 90%, black);
     }
@@ -62,7 +62,7 @@
     background-color: var(--share-twitter, #1da1f2);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .share-button.twitter:hover {
         background-color: color-mix(in srgb, #1da1f2 90%, black);
     }
@@ -72,7 +72,7 @@
     background-color: var(--share-facebook, #1877f2);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .share-button.facebook:hover {
         background-color: color-mix(in srgb, #1877f2 90%, black);
     }
@@ -82,7 +82,7 @@
     background-color: var(--share-linkedin, #0077b5);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .share-button.linkedin:hover {
         background-color: color-mix(in srgb, #0077b5 90%, black);
     }
@@ -92,7 +92,7 @@
     background-color: var(--share-reddit, #ff4500);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .share-button.reddit:hover {
         background-color: color-mix(in srgb, #ff4500 90%, black);
     }

--- a/bengal/themes/default/assets/css/layouts/changelog.css
+++ b/bengal/themes/default/assets/css/layouts/changelog.css
@@ -83,7 +83,7 @@
     transform: translate3d(0, 0, 0) scale(1.2);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .timeline-item:hover::before {
         background: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -127,7 +127,7 @@
     text-decoration: underline;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .timeline-title a:hover {
         color: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -224,7 +224,7 @@
 }
 
 .changelog-category.changelog-breaking:hover {
-    @supports (color-mix(in srgb, white, black)) {
+    @supports (color: color-mix(in srgb, white, black)) {
         border-inline-start-color: color-mix(in srgb, var(--color-danger) 90%, black);
     }
 }
@@ -297,7 +297,7 @@
     box-shadow: var(--elevation-low);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .changelog-read-more:hover {
         background: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -415,7 +415,7 @@
     box-shadow: var(--elevation-low);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .release-link:hover {
         background: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -437,7 +437,7 @@
     border-color: var(--color-primary-dark);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .release-download:hover {
         background: color-mix(in srgb, var(--color-primary-dark) 90%, black);
     }

--- a/bengal/themes/default/assets/css/layouts/resume.css
+++ b/bengal/themes/default/assets/css/layouts/resume.css
@@ -69,7 +69,7 @@
     transform: translate3d(0, -1px, 0);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .contact-item:hover {
         color: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -100,7 +100,7 @@
     box-shadow: var(--elevation-card-hover);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .resume-summary:hover {
         border-inline-start-color: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -183,7 +183,7 @@
     transform: translate3d(0, 0, 0) scale(1.2);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .timeline-item:hover::before {
         background: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -221,7 +221,7 @@
     text-decoration: underline;
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .timeline-title a:hover {
         color: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -319,7 +319,7 @@
     box-shadow: var(--elevation-card-hover);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .skill-card:hover {
         background: color-mix(in srgb, var(--color-bg-secondary) 98%, var(--color-primary));
     }
@@ -360,7 +360,7 @@
     border-color: var(--color-primary);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .skill-tag:hover {
         border-color: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -400,7 +400,7 @@
     box-shadow: var(--elevation-low);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .project-link:hover {
         background: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -464,7 +464,7 @@
     transform: translate3d(2px, 0, 0);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .certification-link:hover {
         color: color-mix(in srgb, var(--color-primary) 90%, black);
     }
@@ -494,7 +494,7 @@
     box-shadow: var(--elevation-card-hover);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
     .award-item:hover {
         border-inline-start-color: color-mix(in srgb, var(--color-warning) 90%, black);
     }

--- a/bengal/themes/default/assets/css/style.css
+++ b/bengal/themes/default/assets/css/style.css
@@ -273,7 +273,7 @@ main {
   color: var(--color-primary);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .section-title:hover {
     color: color-mix(in srgb, var(--color-primary) 90%, black);
   }
@@ -326,7 +326,7 @@ main {
   color: var(--color-primary);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .breadcrumbs a:hover {
     color: color-mix(in srgb, var(--color-primary) 90%, black);
   }
@@ -373,7 +373,7 @@ main {
   box-shadow: var(--elevation-low);
 }
 
-@supports (color-mix(in srgb, white, black)) {
+@supports (color: color-mix(in srgb, white, black)) {
   .pagination a:hover {
     background-color: color-mix(in srgb, var(--color-bg-hover) 95%, var(--color-primary));
   }

--- a/bengal/themes/default/assets/css/utilities/fluid-blobs.css
+++ b/bengal/themes/default/assets/css/utilities/fluid-blobs.css
@@ -116,7 +116,7 @@
 }
 
 /* Fallback for browsers without color-mix */
-@supports not (color-mix(in srgb, black, white)) {
+@supports not (color: color-mix(in srgb, black, white)) {
   .fluid-bg::before {
     background: radial-gradient(
       circle at 30% 30%,
@@ -254,7 +254,7 @@
 }
 
 /* Fallback for browsers without color-mix */
-@supports not (color-mix(in srgb, black, white)) {
+@supports not (color: color-mix(in srgb, black, white)) {
   .blob-spots::before {
     background: radial-gradient(
       circle,
@@ -329,7 +329,7 @@
 }
 
 /* Fallback for browsers without color-mix */
-@supports not (color-mix(in srgb, black, white)) {
+@supports not (color: color-mix(in srgb, black, white)) {
   .fluid-combined::before {
     background: radial-gradient(
       circle at 40% 40%,


### PR DESCRIPTION
…C validation

- Fix all @supports (color-mix(...)) to @supports (color: color-mix(...))
- Fix @supports not statements in fluid-blobs.css
- Affects 13 CSS files across components, layouts, and utilities
- Resolves W3C CSS validator parse errors for color-mix feature queries