### PR TITLE
fix: include graph_visualizer.html template in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ include = ["bengal*"]
 bengal = [
     "themes/**/*",
     "autodoc/templates/**/*.jinja2",
+    "analysis/graph/templates/**/*",
     "scaffolds/**/*",
     "py.typed",
 ]


### PR DESCRIPTION
## Problem

When installing Bengal from PyPI (v0.1.8), the `graph_visualizer.html` template file is missing, causing an error during builds:

```
Error: graph_generation_failed  error=[Errno 2] No such file or directory: 
'.venv/lib/python3.14/site-packages/bengal/analysis/templates/graph_visualizer.html'
```

## Root Cause

The `analysis/graph/templates/` directory was not included in `[tool.setuptools.package-data]` in `pyproject.toml`.

## Fix

Added `analysis/graph/templates/**/*` to the package-data configuration so the template is included in the PyPI distribution.

## Testing

- Verified the template exists in source at `bengal/analysis/graph/templates/graph_visualizer.html`
- The fix follows the same pattern as other template directories (`themes/**/*`, `autodoc/templates/**/*.jinja2`, etc.)