### PR TITLE
Stage 0.2.6 release: changelog, docs, CI optimization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect whether code paths changed — skip tests for docs-only PRs
+  detect-changes:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for code changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+          else
+            BASE=${{ github.event.before }}
+          fi
+          # List changed files between base and head
+          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "FORCE_RUN")
+
+          # If git diff failed (e.g. force push with unknown base), run everything
+          if echo "$CHANGED" | grep -q "FORCE_RUN"; then
+            echo "code=true" >> $GITHUB_OUTPUT
+            echo "Could not determine base — running all jobs"
+            exit 0
+          fi
+
+          # Check if any changed file is outside docs-only paths
+          CODE_CHANGED="false"
+          while IFS= read -r file; do
+            case "$file" in
+              site/*|docs/*|plan/*|skills/*|*.md|LICENSE|.context/*) ;;
+              *) CODE_CHANGED="true"; break ;;
+            esac
+          done <<< "$CHANGED"
+
+          echo "code=$CODE_CHANGED" >> $GITHUB_OUTPUT
+          if [ "$CODE_CHANGED" = "false" ]; then
+            echo "Docs-only change — skipping test jobs"
+          else
+            echo "Code changed — running test jobs"
+          fi
+
   # Fast check: unit tests only for quick PR feedback
   fast-check:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -51,9 +97,9 @@ jobs:
 
   # Baseurl spot-checks + Coverage (single-process)
   full-suite:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    needs: fast-check
+    if: ${{ !cancelled() && needs.fast-check.result == 'success' }}
     runs-on: ubuntu-latest
-    needs: fast-check  # Only run if fast-check passes
     strategy:
       matrix:
         python-version: ["3.14t"]
@@ -102,9 +148,9 @@ jobs:
 
   # E2E tests (build + validate + check links)
   e2e:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    runs-on: ubuntu-latest
     needs: full-suite
+    if: ${{ !cancelled() && needs.full-suite.result == 'success' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
@@ -143,9 +189,9 @@ jobs:
 
   # Integration tests split into 4 shards to avoid timeout
   integration:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    runs-on: ubuntu-latest
     needs: full-suite
+    if: ${{ !cancelled() && needs.full-suite.result == 'success' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -202,9 +248,9 @@ jobs:
 
   # Render output regression sentinels (autodoc + fallback path)
   render-output-regression:
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
-    runs-on: ubuntu-latest
     needs: full-suite
+    if: ${{ !cancelled() && needs.full-suite.result == 'success' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
@@ -344,3 +390,27 @@ jobs:
     - name: Upload coverage
       if: matrix.baseurl == ''
       uses: codecov/codecov-action@v4
+
+  # Gate job for branch protection — succeeds when tests pass OR were skipped (docs-only)
+  ci-ok:
+    if: always()
+    needs: [detect-changes, fast-check, full-suite, e2e, integration, render-output-regression]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide status
+        run: |
+          # If detect-changes decided no code changed, all test jobs are skipped — that's OK
+          if [ "${{ needs.detect-changes.outputs.code }}" = "false" ]; then
+            echo "Docs-only change — all tests skipped, CI passes"
+            exit 0
+          fi
+          # Otherwise, check that no test job failed
+          if [ "${{ needs.fast-check.result }}" = "failure" ] || \
+             [ "${{ needs.full-suite.result }}" = "failure" ] || \
+             [ "${{ needs.e2e.result }}" = "failure" ] || \
+             [ "${{ needs.integration.result }}" = "failure" ] || \
+             [ "${{ needs.render-output-regression.result }}" = "failure" ]; then
+            echo "One or more test jobs failed"
+            exit 1
+          fi
+          echo "All test jobs passed"

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -11,7 +11,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for code changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=${{ github.event.pull_request.base.sha }}
+          else
+            BASE=${{ github.event.before }}
+          fi
+          CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "FORCE_RUN")
+
+          if echo "$CHANGED" | grep -q "FORCE_RUN"; then
+            echo "code=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CODE_CHANGED="false"
+          while IFS= read -r file; do
+            case "$file" in
+              site/*|docs/*|plan/*|skills/*|*.md|LICENSE|.context/*) ;;
+              *) CODE_CHANGED="true"; break ;;
+            esac
+          done <<< "$CHANGED"
+
+          echo "code=$CODE_CHANGED" >> $GITHUB_OUTPUT
+
   lint-and-type:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,3 +76,21 @@ jobs:
 
       - name: Run ty type checker
         run: uv run ty check bengal/
+
+  # Gate job for branch protection — succeeds when lint passes OR was skipped (docs-only)
+  lint-ok:
+    if: always()
+    needs: [detect-changes, lint-and-type]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide status
+        run: |
+          if [ "${{ needs.detect-changes.outputs.code }}" = "false" ]; then
+            echo "Docs-only change — lint skipped, CI passes"
+            exit 0
+          fi
+          if [ "${{ needs.lint-and-type.result }}" = "failure" ]; then
+            echo "Lint/type check failed"
+            exit 1
+          fi
+          echo "Lint/type check passed"

--- a/README.md
+++ b/README.md
@@ -322,17 +322,13 @@ Bengal ships with a modern, accessible default theme:
 Bengal follows a "bring your own" pattern — swap engines without changing your content.
 
 <details>
-<summary><strong>Template Engines</strong></summary>
+<summary><strong>Template Engine</strong></summary>
 
 | Engine | Description | Install |
 |--------|-------------|---------|
-| **Kida** (default) | Bengal's native engine. AST-native, free-threading safe, Jinja2-compatible syntax | Built-in |
-| **Jinja2** | Industry-standard with extensive ecosystem | Built-in |
+| **Kida** | Bengal's native engine. AST-native, free-threading safe, Jinja2-compatible syntax | Built-in |
 
-```yaml
-# config/_default/site.yaml
-template_engine: kida  # or jinja2
-```
+Kida is the built-in template engine. It uses Jinja2-compatible syntax, so existing Jinja2 templates generally work without changes. See the [Kida migration guide](https://lbliii.github.io/bengal/docs/theming/templating/kida/migration/from-jinja/) if migrating from Jinja2.
 
 </details>
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,53 @@
 ## [Unreleased]
 
+## 0.2.6 - 2026-03-17
+
+### Double-Buffered Dev Server
+- **server**: add BufferManager for double-buffered output — eliminates FOUC during rapid rebuilds
+- **server**: ASGI app accepts callable output_dir for per-request directory consistency
+- **server**: zero-disk reactive path for content-only edits
+- **server**: in-process builds for clean Ctrl+C shutdown (no zombie subprocesses)
+- **server**: remove stopgap FOUC mitigations now redundant with double-buffer
+
+### i18n Gettext Workflow
+- **cli**: add `bengal i18n extract`, `bengal i18n compile`, `bengal i18n status` commands (Phase 1A)
+- **i18n**: add PO/MO catalog management and coverage computation
+- **cli**: narrow exception handling in i18n commands and catalog
+
+### Jinja2 Engine Removed
+- **rendering**: remove Jinja2 engine and adapter — Kida is now the only template engine
+- **BREAKING**: `template_engine: jinja2` config no longer valid; use `kida`
+
+### Performance
+- **navigation**: O(n²)→O(1) page navigation via lazy dict index with auto-invalidation
+- **validation**: precompute newline positions + bisect for O(N + M log N) cross-ref validation
+- **cache**: add excerpt index for PageProxy without full page load
+
+### Orchestration
+- **orchestration**: wire block cache into WaveScheduler for per-page rendering optimization
+- **orchestration**: propagate asset manifest context explicitly through pipeline
+- **orchestration**: aggregated fallback diagnostics (sampled, summarized at phase end)
+- **orchestration**: add parsed/rendered cache hit metrics to build summary
+
+### New Output Generators
+- **postprocess**: add agent manifest generator
+- **postprocess**: add changelog generator
+- **postprocess**: add llms.txt generator
+- **postprocess**: add robots.txt generator
+
+### Other
+- **core**: add `visibility.ai_train` and `visibility.ai_input` page properties for Content Signals
+- **core**: normalize tags in `Frontmatter.from_dict()` for malformed input
+- **core**: rename menu `url` → `href`; remove `active`/`active_trail` from MenuItem.to_dict()
+- **directives**: fix list-table options mapping, re-enable skipped tests
+- **cli**: use CLIOutput for stale process and port-in-use messaging
+- **rendering**: add `direction()` template function for RTL language support
+- **rendering**: add template context validation (`--templates-context` flag)
+- **rendering**: add template profiler for render performance analysis
+- **cli**: scan all subdirectories for Bengal site markers (not hardcoded names)
+- **code**: remove three unused methods from PageOperationsMixin
+- **deps**: kida-templates ≥0.2.8, patitas ≥0.3.5, bengal-pounce ≥0.3.0
+
 ## 0.2.5 - 2026-03-03
 
 ### Kida 0.2.3

--- a/site/content/docs/reference/architecture/tooling/server.md
+++ b/site/content/docs/reference/architecture/tooling/server.md
@@ -20,7 +20,8 @@ Provide a local development environment with automatic rebuilds.
 
 ### Features
 
-- Built-in HTTP server (ThreadingTCPServer)
+- ASGI server via [Pounce](https://github.com/lbliii/pounce)
+- Double-buffered output (eliminates FOUC during rebuilds)
 - File system watching with watchfiles
 - Automatic rebuild on changes
 - Live reload via SSE (Server-Sent Events)
@@ -28,6 +29,7 @@ Provide a local development environment with automatic rebuilds.
 - Automatic browser opening
 - Stale process detection and cleanup
 - Automatic port fallback if port is in use
+- In-process builds for clean Ctrl+C shutdown
 
 ### Architecture
 
@@ -79,7 +81,7 @@ bengal serve --verbose
 The server watches for changes in:
 
 - Content files (`content/**/*.md`)
-- Templates (`templates/**/*.html`, `templates/**/*.jinja2`)
+- Templates (`templates/**/*.html`)
 - Assets (`assets/**/*`)
 - Data files (`data/**/*`)
 - Static files (`static/**/*`) if enabled
@@ -131,13 +133,21 @@ source.onmessage = (event) => {
 </script>
 ```
 
+### Double-Buffered Output
+
+The dev server uses a double-buffered output strategy to prevent flash-of-unstyled-content (FOUC) during rebuilds. Instead of writing directly to the directory being served, builds write to an alternate buffer and atomically swap it in when complete.
+
+- **BufferManager** manages two output directories and provides an atomic swap
+- The ASGI app resolves the active directory per-request, so in-flight requests always see a consistent snapshot
+- Content-only edits can use a zero-disk reactive path that skips the full write cycle
+
 ### Performance Considerations
 
 - **Incremental builds**: Only rebuild changed files (5-10x faster than full builds)
 - **Debouncing**: Groups rapid changes (300ms delay) to avoid multiple rebuilds
 - **Efficient watching**: Uses watchfiles with native file system events
 - **Selective injection**: Reload script only in HTML, not assets
-- **Process isolation**: Builds run in subprocess for crash resilience
+- **In-process builds**: Builds run in the server process for clean Ctrl+C shutdown
 
 ### Configuration
 

--- a/site/content/docs/reference/directives/formatting.md
+++ b/site/content/docs/reference/directives/formatting.md
@@ -40,7 +40,7 @@ Create styled badges for labels, tags, or status indicators.
 **Aliases**: `bdg`
 
 :::{note}
-Bengal also supports **inline badge syntax**: `{bdg-primary}`text`` for embedding badges within paragraphs. See [Inline Elements](/docs/reference/inline/) for details.
+Bengal also supports **inline badge syntax**: `{bdg-primary}`text`` for embedding badges within paragraphs.
 :::
 
 **Syntax**:

--- a/site/content/releases/0.2.6.md
+++ b/site/content/releases/0.2.6.md
@@ -1,48 +1,104 @@
 ---
 title: Bengal 0.2.6
-description: Build performance improvements — O(n²)→O(n) page navigation, faster cross-ref validation, and dead code removal
+description: Double-buffered dev server, i18n gettext workflow, Jinja2 removal, navigation and validation performance, new output generators
 type: changelog
 date: 2026-03-17
 draft: false
 lang: en
-tags: [release, changelog, performance, navigation, validation]
-keywords: [release, 0.2.6, performance, navigation, cross-ref, optimization]
+tags: [release, changelog, server, i18n, performance, navigation, orchestration]
+keywords: [release, 0.2.6, double-buffer, i18n, gettext, jinja2, navigation, wave-scheduler, output-formats]
 category: changelog
 ---
 
 # Bengal 0.2.6
 
-**Key additions:** Build performance improvements targeting page navigation, health validation, and internal code hygiene. Sites with large numbers of pages (particularly those using taxonomy, archive, or track pages) will see the most benefit.
+**Key additions:** Double-buffered dev server that eliminates flash-of-unstyled-content during rebuilds, a gettext PO/MO workflow for i18n, Jinja2 engine removal (Kida is now the only template engine), O(n²)→O(1) page navigation, new output format generators, and orchestration improvements for build metrics and diagnostics.
 
 ---
 
 ## Highlights
 
-### Faster Page Navigation
+### Double-Buffered Dev Server
 
-Previous/next page lookups previously used `list.index()`, which scans the full page list linearly for each navigation call. On a site with N pages, this produced O(n²) total work across the build.
+The dev server now uses a double-buffered output strategy to eliminate FOUC (flash of unstyled content) during rapid rebuilds. Instead of writing directly to the output directory while the server is serving it, the build writes to an alternate buffer directory and atomically swaps it in when complete.
 
-Navigation now uses lazily-built dicts keyed by page identity. The index is constructed once on first access and invalidated automatically when the page list grows (e.g., as taxonomy and archive pages are appended). Each lookup is O(1).
+- **BufferManager**: New component manages two output directories and provides atomic swap
+- **ASGI integration**: The ASGI app accepts a callable that returns the current active directory, so each request sees a consistent snapshot
+- **Zero-disk reactive path**: Content-only edits can skip full disk writes entirely
+- **In-process builds**: Dev server builds now run in-process for cleaner Ctrl+C shutdown (no zombie subprocesses)
 
-This improvement applies to all four navigation helpers: `page.next`, `page.prev`, `page.next_in_section`, and `page.prev_in_section`.
+### i18n Gettext Workflow (Phase 1A)
+
+New `bengal i18n` command group for gettext PO/MO translation workflows:
+
+- **`bengal i18n extract`** — Scan templates for `t()` calls and generate `.pot` template files
+- **`bengal i18n compile`** — Compile `.po` files to `.mo` binary format
+- **`bengal i18n status`** — Show translation coverage per locale with color-coded percentages
+
+The underlying `i18n/catalog.py` provides PO/MO catalog management and coverage computation. Exception handling in i18n commands uses narrow, specific catches.
+
+### Jinja2 Engine Removed
+
+Jinja2 is no longer a built-in template engine. Kida is now the canonical (and only) engine.
+
+- Removed `jinja.py` engine and adapter
+- Removed Jinja2 from `detect_adapter_type()` logic
+- If you were using `template_engine: jinja2` in your config, switch to `template_engine: kida`. Kida uses Jinja2-compatible syntax, so most templates work without changes. See the [Kida migration guide](/docs/theming/templating/kida/migration/from-jinja/) for details.
+
+### O(n²)→O(1) Page Navigation
+
+Previous/next page lookups used `list.index()`, scanning the full page list for every call. On a site with N pages this was O(n²) total work.
+
+Navigation now uses lazily-built dicts keyed by page identity. The index is constructed once on first access and invalidated when the page list grows (e.g., as taxonomy pages are appended). Each lookup is O(1).
+
+Applies to: `page.next`, `page.prev`, `page.next_in_section`, `page.prev_in_section`.
 
 ### Faster Cross-Reference Validation
 
-The health validator that checks code references and anchor links previously recomputed line numbers by slicing the full content string on every match (`content[:pos].count("\n")`). For a page with M matches and content of length N, this was O(M×N) per page.
+The health validator previously recomputed line numbers by slicing the content string on every match. Newline positions are now precomputed once and binary-searched with `bisect_left`, reducing validation from O(M×N) to O(N + M log N) per page.
 
-Newline positions are now precomputed once per method and binary-searched using `bisect_left`, reducing validation to O(N + M log N) per page.
+---
+
+## New Output Generators
+
+The postprocess pipeline gains several new output format generators:
+
+- **`agent_manifest_generator`** — Machine-readable manifest for AI agent consumption
+- **`changelog_generator`** — Generates changelog pages from structured release data
+- **`llms_txt_generator`** — Produces [llms.txt](https://llmstxt.org/) output for LLM discovery
+- **`robots.txt` generator** — Configurable robots.txt with sitemap references
+
+---
+
+## Orchestration Improvements
+
+- **Block cache in WaveScheduler**: Per-page rendering now leverages the block cache for faster incremental builds
+- **Explicit manifest context**: Asset manifest context is propagated explicitly through the orchestration pipeline (before falling back to ContextVar)
+- **Aggregated fallback diagnostics**: Instead of per-asset warnings, asset manifest fallbacks are sampled and summarized at phase end — reduces log noise on large sites
+- **Build metrics**: Parsed/rendered cache hit rates now appear in the build summary
 
 ---
 
 ## Other Changes
 
-- Removed three unused methods from `PageOperationsMixin` (`render`, `validate_links`, `apply_template`). These were dead code — no callers existed in the codebase or templates. The mixin now only provides `extract_links`, which the rendering pipeline actively uses.
+- **Content Signals**: New `visibility.ai_train` and `visibility.ai_input` page properties for controlling AI training and RAG/grounding signals, with site-level defaults via `content_signals` config
+- **Tag normalization**: `Frontmatter.from_dict()` and `Page.__post_init__()` normalize malformed tag input (e.g., nested lists, None values)
+- **Menu field rename**: `url` → `href` in `MenuItem.to_dict()`; `active`/`active_trail` removed (templates compute active state via URL comparison for cache stability)
+- **Excerpt index**: New `get_excerpt_for_path()` in the cache layer provides lightweight excerpt lookups for PageProxy without triggering a full page load
+- **list-table directive**: Fixed options mapping; previously skipped tests re-enabled
+- **CLI output**: Stale process and port-in-use messages now use `CLIOutput` for consistent formatting
+- **RTL support**: New `direction()` template function for right-to-left language detection
+- **Template validation**: New `--templates-context` flag for Kida context validation to catch missing variables before render
+- **Subdirectory detection**: `bengal serve` and `bengal build` now scan all subdirectories for Bengal site markers instead of hardcoding directory names
+- **Dead code removal**: Three unused methods removed from `PageOperationsMixin`
+- **Dependency bumps**: kida-templates ≥0.2.8, patitas ≥0.3.5, bengal-pounce ≥0.3.0
 
 ---
 
 ## Breaking Changes
 
-None. Fully backward-compatible release.
+- **Jinja2 removed**: If your config specifies `template_engine: jinja2`, change it to `kida`. See the [Kida migration guide](/docs/theming/templating/kida/migration/from-jinja/).
+- **Menu dict shape**: `url` renamed to `href`; `active` and `active_trail` fields removed. Templates that read `item.url` should use `item.href`. Templates that relied on `item.active` should compare `item.href` against the current page URL instead.
 
 ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'github'", specifier = ">=3.9.0" },
     { name = "aiohttp", marker = "extra == 'notion'", specifier = ">=3.9.0" },
     { name = "aiohttp", marker = "extra == 'rest'", specifier = ">=3.9.0" },
-    { name = "bengal-pounce", specifier = ">=0.2.2" },
+    { name = "bengal-pounce", specifier = ">=0.3.0" },
     { name = "cachetools", marker = "extra == 'all-sources'", specifier = ">=5.0.0" },
     { name = "cachetools", marker = "extra == 'notion'", specifier = ">=5.0.0" },
     { name = "click", specifier = ">=8.1.7" },


### PR DESCRIPTION
## Summary

Comprehensive staging for Bengal 0.2.6 release. Complete release notes covering all major changes since v0.2.5, updated documentation to reflect breaking changes (Jinja2 removal) and new features (double-buffered dev server, i18n gettext workflow), plus CI optimization to skip expensive test runs on docs-only changes.

**Release 0.2.6 includes:**
- Double-buffered dev server eliminating FOUC during rebuilds
- i18n gettext PO/MO workflow for translations
- Jinja2 engine removal (Kida is now canonical)
- O(n²)→O(1) page navigation performance
- New output generators (agent manifest, changelog, llms.txt, robots.txt)
- Orchestration improvements (block cache in WaveScheduler, manifest context, aggregated diagnostics)

**CI improvements:**
- Detect-changes job skips expensive test/lint runs for docs-only PRs
- Gate jobs (ci-ok, lint-ok) provide clean branch protection integration
- Pattern-based file filtering recognizes docs, plans, and release notes changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)