### PR TITLE
Release 0.2.7: unified link registry, anchor validation, and new docs

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -27,6 +27,9 @@ concurrency:
   group: mutation-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   mutation:
     runs-on: ubuntu-latest

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -33,15 +33,15 @@ jobs:
     timeout-minutes: 120  # Mutation testing can be slow
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-mutation-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -50,7 +50,7 @@ jobs:
           uv-${{ runner.os }}-
 
     - name: Cache mutation results
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .mutmut-cache
         key: mutmut-${{ github.sha }}
@@ -144,7 +144,7 @@ jobs:
         fi
 
     - name: Upload mutation report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: mutation-report
         path: mutation-report.md

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,15 +18,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.14t"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -48,7 +48,7 @@ jobs:
           PYTHON_GIL: "0"
 
       - name: Cache Bengal build state
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: site/.bengal
           key: bengal-${{ runner.os }}-${{ steps.cache.outputs.hash }}
@@ -67,7 +67,7 @@ jobs:
           echo "" > site/public/.gitignore
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site/public
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:
@@ -32,7 +32,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-dists
           path: dist/
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Detect whether code paths changed — skip tests for docs-only PRs
   detect-changes:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -66,15 +66,15 @@ jobs:
     if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -106,15 +106,15 @@ jobs:
         baseurl: ["", "/bengal", "https://example.com/sub"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -148,7 +148,7 @@ jobs:
 
     - name: Upload coverage
       if: matrix.baseurl == ''
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         files: coverage.xml
 
@@ -159,15 +159,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -206,15 +206,15 @@ jobs:
     # keeps wall time per shard well under the limit.
     timeout-minutes: 25
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -248,7 +248,7 @@ jobs:
 
     - name: Upload integration diagnostics
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: integration-diagnostics-group${{ matrix.group }}
         path: |
@@ -267,15 +267,15 @@ jobs:
         group: [1, 2]
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -308,7 +308,7 @@ jobs:
 
     - name: Upload warm-build diagnostics
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: warm-build-diagnostics-group${{ matrix.group }}
         path: |
@@ -322,15 +322,15 @@ jobs:
     if: ${{ !cancelled() && needs.full-suite.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -353,7 +353,7 @@ jobs:
 
     - name: Upload render output metrics
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: render-output-metrics-${{ github.sha }}
         path: |
@@ -366,15 +366,15 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -398,15 +398,15 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -430,15 +430,15 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.14t"
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -50,15 +50,15 @@ jobs:
     if: needs.detect-changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.14t"
 
       - name: Cache uv dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -10,6 +10,9 @@ concurrency:
   group: lint-ty-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest

--- a/bengal/core/site/__init__.py
+++ b/bengal/core/site/__init__.py
@@ -196,6 +196,9 @@ class Site(
     # Immutable config service (constructed in __post_init__, thread-safe)
     _config_service: ConfigService | None = field(default=None, repr=False, init=False)
 
+    # Shared link registry built after rendering (consumed by all link validators)
+    link_registry: Any | None = field(default=None, repr=False, init=False)
+
     # Dynamic runtime attributes (set by various orchestrators)
     # Diagnostics sink for core-model events (set by BuildOrchestrator)
     diagnostics: DiagnosticsSink | None = field(default=None, repr=False, init=False)

--- a/bengal/health/link_registry.py
+++ b/bengal/health/link_registry.py
@@ -91,8 +91,11 @@ def build_link_registry(site: SiteLike) -> LinkRegistry:
             )
             paths.add(content_key(full, root))
 
-        # Collect anchor IDs from toc_items (already computed during parsing)
-        toc_items = getattr(page, "toc_items", [])
+        # Collect anchor IDs from toc_items (already computed during parsing).
+        # Skip unloaded PageProxy to avoid triggering expensive lazy loading
+        # (unchanged pages don't need anchor re-extraction).
+        is_unloaded_proxy = hasattr(page, "_lazy_loaded") and not page._lazy_loaded
+        toc_items = [] if is_unloaded_proxy else getattr(page, "toc_items", [])
         if toc_items and url:
             anchor_ids = frozenset(item["id"] for item in toc_items if "id" in item)
             if anchor_ids:

--- a/bengal/health/link_registry.py
+++ b/bengal/health/link_registry.py
@@ -1,0 +1,137 @@
+"""
+Shared link registry built once after rendering, consumed by all validators.
+
+The LinkRegistry is an immutable data structure that provides:
+- All valid internal URLs (with slash variants)
+- Content-relative source paths for .md resolution
+- Anchor IDs per page URL (from toc_items)
+- Auxiliary URLs (index.txt when llm_txt enabled)
+
+Built on the main thread after rendering, before health checks run.
+Thread-safe by construction (frozen dataclass with frozenset fields).
+
+Related:
+- bengal.health.validators.links: Build-time link validation (consumer)
+- bengal.health.linkcheck.internal_checker: Post-build link checking (consumer)
+- bengal.orchestration.build.finalization: Build site (builder)
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bengal.build.contracts.keys import content_key
+
+if TYPE_CHECKING:
+    from bengal.protocols import SiteLike
+
+
+@dataclass(frozen=True)
+class LinkRegistry:
+    """
+    Immutable registry of all valid link targets in a site.
+
+    Built once after rendering, consumed by both build-time validators
+    and post-build link checkers. Thread-safe by construction.
+
+    Attributes:
+        page_urls: All valid internal URLs (with trailing-slash variants)
+        source_paths: Content-relative paths for .md link resolution
+        anchors_by_url: Mapping of page URL -> valid anchor IDs on that page
+        auxiliary_urls: Extra valid URLs (e.g. index.txt for llm_txt output)
+    """
+
+    page_urls: frozenset[str]
+    source_paths: frozenset[str]
+    anchors_by_url: dict[str, frozenset[str]]
+    auxiliary_urls: frozenset[str]
+
+
+def build_link_registry(site: SiteLike) -> LinkRegistry:
+    """
+    Build a LinkRegistry from a fully-rendered site.
+
+    Scans all pages to collect URLs, source paths, and anchor IDs.
+    Should be called after rendering is complete (toc_items populated)
+    but before health checks run.
+
+    Args:
+        site: Site instance with rendered pages
+
+    Returns:
+        Immutable LinkRegistry instance
+    """
+    urls: set[str] = set()
+    paths: set[str] = set()
+    anchors: dict[str, frozenset[str]] = {}
+    root = site.root_path
+
+    for page in site.pages:
+        # Collect page URLs (href includes baseurl)
+        url = getattr(page, "href", None)
+        if url:
+            urls.add(url)
+            urls.add(url.rstrip("/"))
+            urls.add(url.rstrip("/") + "/")
+
+            permalink = getattr(page, "permalink", None)
+            if permalink and permalink != url:
+                urls.add(permalink)
+                urls.add(permalink.rstrip("/"))
+                urls.add(permalink.rstrip("/") + "/")
+
+        # Collect source paths for relative .md link resolution
+        source_path = getattr(page, "source_path", None)
+        if source_path:
+            full = (
+                (root / source_path) if not Path(source_path).is_absolute() else Path(source_path)
+            )
+            paths.add(content_key(full, root))
+
+        # Collect anchor IDs from toc_items (already computed during parsing)
+        toc_items = getattr(page, "toc_items", [])
+        if toc_items and url:
+            anchor_ids = frozenset(item["id"] for item in toc_items if "id" in item)
+            if anchor_ids:
+                # Index by _path (no baseurl) for internal resolution
+                page_path = getattr(page, "_path", None)
+                if page_path:
+                    anchors[page_path] = anchor_ids
+                    anchors[page_path.rstrip("/")] = anchor_ids
+                    anchors[page_path.rstrip("/") + "/"] = anchor_ids
+                # Also index by href for post-build checker
+                anchors[url] = anchor_ids
+                anchors[url.rstrip("/")] = anchor_ids
+                anchors[url.rstrip("/") + "/"] = anchor_ids
+
+    # Build auxiliary URL index
+    aux_urls = _build_auxiliary_urls(site)
+
+    return LinkRegistry(
+        page_urls=frozenset(urls),
+        source_paths=frozenset(paths),
+        anchors_by_url=anchors,
+        auxiliary_urls=frozenset(aux_urls),
+    )
+
+
+def _build_auxiliary_urls(site: SiteLike) -> set[str]:
+    """Build set of auxiliary output URLs (e.g. index.txt when llm_txt enabled)."""
+    config = getattr(site, "config", {}) or {}
+    of: dict[str, Any] = config.get("output_formats", {}) or {}
+    if not of.get("enabled", True):
+        return set()
+    per_page = of.get("per_page", [])
+    if "llm_txt" not in per_page:
+        return set()
+
+    urls: set[str] = set()
+    for page in site.pages:
+        url = getattr(page, "href", None)
+        if url:
+            base = url.rstrip("/") + "/"
+            urls.add(base + "index.txt")
+    return urls

--- a/bengal/health/link_registry.py
+++ b/bengal/health/link_registry.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from bengal.build.contracts.keys import content_key
@@ -46,7 +47,7 @@ class LinkRegistry:
 
     page_urls: frozenset[str]
     source_paths: frozenset[str]
-    anchors_by_url: dict[str, frozenset[str]]
+    anchors_by_url: MappingProxyType[str, frozenset[str]]
     auxiliary_urls: frozenset[str]
 
 
@@ -74,14 +75,19 @@ def build_link_registry(site: SiteLike) -> LinkRegistry:
         url = getattr(page, "href", None)
         if url:
             urls.add(url)
-            urls.add(url.rstrip("/"))
-            urls.add(url.rstrip("/") + "/")
+            # Avoid adding empty string for root URL "/"
+            stripped = url.rstrip("/")
+            if stripped:
+                urls.add(stripped)
+            urls.add(stripped + "/")
 
             permalink = getattr(page, "permalink", None)
             if permalink and permalink != url:
                 urls.add(permalink)
-                urls.add(permalink.rstrip("/"))
-                urls.add(permalink.rstrip("/") + "/")
+                p_stripped = permalink.rstrip("/")
+                if p_stripped:
+                    urls.add(p_stripped)
+                urls.add(p_stripped + "/")
 
         # Collect source paths for relative .md link resolution
         source_path = getattr(page, "source_path", None)
@@ -116,7 +122,7 @@ def build_link_registry(site: SiteLike) -> LinkRegistry:
     return LinkRegistry(
         page_urls=frozenset(urls),
         source_paths=frozenset(paths),
-        anchors_by_url=anchors,
+        anchors_by_url=MappingProxyType(anchors),
         auxiliary_urls=frozenset(aux_urls),
     )
 

--- a/bengal/health/linkcheck/async_checker.py
+++ b/bengal/health/linkcheck/async_checker.py
@@ -64,8 +64,8 @@ class AsyncLinkChecker:
 
     def __init__(
         self,
-        max_concurrency: int = 20,
-        per_host_limit: int = 4,
+        max_concurrency: int = 50,
+        per_host_limit: int = 8,
         timeout: float = 10.0,
         retries: int = 2,
         retry_backoff: float = 0.5,
@@ -417,8 +417,8 @@ class AsyncLinkChecker:
         ignore_policy = IgnorePolicy.from_config(config)
 
         return cls(
-            max_concurrency=config.get("max_concurrency", 20),
-            per_host_limit=config.get("per_host_limit", 4),
+            max_concurrency=config.get("max_concurrency", 50),
+            per_host_limit=config.get("per_host_limit", 8),
             timeout=config.get("timeout", 10.0),
             retries=config.get("retries", 2),
             retry_backoff=config.get("retry_backoff", 0.5),

--- a/bengal/health/linkcheck/internal_checker.py
+++ b/bengal/health/linkcheck/internal_checker.py
@@ -28,6 +28,7 @@ from bengal.health.linkcheck.models import LinkCheckResult, LinkKind, LinkStatus
 from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
+    from bengal.health.link_registry import LinkRegistry
     from bengal.protocols import SiteLike
 
 logger = get_logger(__name__)
@@ -91,29 +92,108 @@ class InternalLinkChecker:
         self._output_paths: set[str] = set()
         self._anchors_by_page: dict[str, set[str]] = {}
 
-        if self.output_dir.exists():
-            # Scan all HTML files and build URL index
-            for html_file in self.output_dir.rglob("*.html"):
-                # Convert file path to URL
-                rel_path = html_file.relative_to(self.output_dir)
-
-                # Convert path/index.html -> /path/
-                # Convert path.html -> /path
-                if rel_path.name == "index.html":
-                    url = "/" if rel_path.parent == Path(".") else f"/{rel_path.parent}/"
-                else:
-                    url = f"/{rel_path.with_suffix('')}"
-
-                # Add both with and without trailing slash
-                self._output_paths.add(url)
-                self._output_paths.add(url.rstrip("/"))
-                if url != "/":
-                    self._output_paths.add(url.rstrip("/") + "/")
+        self._build_index_from_scan()
 
         logger.debug(
             "internal_checker_initialized",
             output_paths_count=len(self._output_paths),
             output_dir=str(self.output_dir),
+        )
+
+    @classmethod
+    def from_registry(
+        cls,
+        registry: LinkRegistry,
+        site: SiteLike,
+        ignore_policy: IgnorePolicy | None = None,
+    ) -> InternalLinkChecker:
+        """
+        Create an InternalLinkChecker pre-populated from a LinkRegistry.
+
+        Skips the output directory scan since the registry already has
+        all valid URLs and anchor data.
+
+        Args:
+            registry: Pre-built LinkRegistry with page URLs and anchors
+            site: Site instance (for baseurl and output_dir)
+            ignore_policy: Policy for ignoring certain links
+        """
+        instance = cls.__new__(cls)
+        instance.site = site
+        instance.ignore_policy = ignore_policy or IgnorePolicy()
+        instance.output_dir = site.output_dir
+
+        baseurl = site.baseurl or ""
+        if baseurl:
+            parsed = urlparse(baseurl)
+            instance.baseurl_path = parsed.path.rstrip("/")
+        else:
+            instance.baseurl_path = ""
+
+        # Populate from registry instead of scanning output_dir
+        instance._output_paths = set(registry.page_urls | registry.auxiliary_urls)
+        instance._anchors_by_page = {
+            url: set(anchors) for url, anchors in registry.anchors_by_url.items()
+        }
+
+        logger.debug(
+            "internal_checker_from_registry",
+            output_paths_count=len(instance._output_paths),
+            anchors_pages=len(registry.anchors_by_url),
+        )
+
+        return instance
+
+    def _build_index_from_scan(self) -> None:
+        """Build URL index by scanning the output directory for HTML and txt files."""
+        if not self.output_dir.exists():
+            return
+
+        for html_file in self.output_dir.rglob("*.html"):
+            self._index_html_file(html_file)
+
+        # Also index auxiliary output files (.txt for LLM-friendly output)
+        for txt_file in self.output_dir.rglob("*.txt"):
+            rel_path = txt_file.relative_to(self.output_dir)
+            self._output_paths.add(f"/{rel_path}")
+
+    def _index_html_file(self, html_file: Path) -> None:
+        """Add a single HTML file to the URL index."""
+        rel_path = html_file.relative_to(self.output_dir)
+
+        if rel_path.name == "index.html":
+            url = "/" if rel_path.parent == Path(".") else f"/{rel_path.parent}/"
+        else:
+            url = f"/{rel_path.with_suffix('')}"
+
+        self._output_paths.add(url)
+        self._output_paths.add(url.rstrip("/"))
+        if url != "/":
+            self._output_paths.add(url.rstrip("/") + "/")
+
+    def set_file_index(self, html_files: list[Path]) -> None:
+        """Rebuild URL index from a pre-discovered list of HTML files.
+
+        This avoids a redundant ``rglob("*.html")`` when the orchestrator
+        has already enumerated the output directory during link extraction.
+
+        Args:
+            html_files: List of HTML file paths already discovered.
+        """
+        self._output_paths.clear()
+
+        for html_file in html_files:
+            self._index_html_file(html_file)
+
+        # Re-scan for .txt files (small number, fast)
+        if self.output_dir.exists():
+            for txt_file in self.output_dir.rglob("*.txt"):
+                rel_path = txt_file.relative_to(self.output_dir)
+                self._output_paths.add(f"/{rel_path}")
+
+        logger.debug(
+            "internal_checker_reindexed",
+            output_paths_count=len(self._output_paths),
         )
 
     def check_links(self, links: list[tuple[str, str]]) -> dict[str, LinkCheckResult]:

--- a/bengal/health/linkcheck/orchestrator.py
+++ b/bengal/health/linkcheck/orchestrator.py
@@ -6,7 +6,7 @@ internal or external, and delegates to specialized checkers. Results are
 consolidated into reports for console output and JSON serialization.
 
 Architecture:
-1. Extract links from output_dir/*.html using HTML parsing
+1. Extract links from output_dir/*.html using parallel HTML parsing
 2. Classify links (http/https -> external, else -> internal)
 3. Run InternalLinkChecker and AsyncLinkChecker concurrently
 4. Build consolidated results and summary
@@ -22,6 +22,9 @@ from __future__ import annotations
 
 import asyncio
 import time
+from concurrent.futures import ThreadPoolExecutor
+from html.parser import HTMLParser
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bengal.health.linkcheck.async_checker import AsyncLinkChecker
@@ -40,6 +43,40 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+class _LinkExtractor(HTMLParser):
+    """
+    HTML parser that extracts href links, skipping code blocks.
+
+    Tracks nesting depth in <code> and <pre> tags to avoid extracting
+    code examples as real links.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+        self._in_code_block = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in ("code", "pre"):
+            self._in_code_block += 1
+        elif tag == "a" and self._in_code_block == 0:
+            for attr, value in attrs:
+                if attr == "href" and value:
+                    self.links.append(value)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("code", "pre"):
+            self._in_code_block = max(0, self._in_code_block - 1)
+
+
+def _parse_file(html_file: Path) -> list[str]:
+    """Read and parse a single HTML file, returning extracted links."""
+    html_content = html_file.read_text(encoding="utf-8")
+    parser = _LinkExtractor()
+    parser.feed(html_content)
+    return parser.links
+
+
 class LinkCheckOrchestrator:
     """
     Orchestrates internal and external link checking.
@@ -49,9 +86,9 @@ class LinkCheckOrchestrator:
     formats (console, JSON).
 
     Features:
-        - HTML parsing to extract href attributes
+        - Parallel HTML parsing to extract href attributes
         - Automatic internal/external classification
-        - Concurrent checking with ignore policies
+        - Pipelined checking (external starts while internal runs)
         - Console and JSON report formatting
 
     Attributes:
@@ -100,9 +137,15 @@ class LinkCheckOrchestrator:
         # Create ignore policy
         self.ignore_policy = IgnorePolicy.from_config(self.config)
 
-        # Create checkers
+        # Create checkers — use registry when available to avoid redundant output scan
+        registry = getattr(site, "link_registry", None)
         if self.check_internal:
-            self.internal_checker = InternalLinkChecker(site, self.ignore_policy)
+            if registry is not None:
+                self.internal_checker = InternalLinkChecker.from_registry(
+                    registry, site, self.ignore_policy
+                )
+            else:
+                self.internal_checker = InternalLinkChecker(site, self.ignore_policy)
         if self.check_external:
             self.external_checker = AsyncLinkChecker.from_config(self.config)
 
@@ -110,8 +153,8 @@ class LinkCheckOrchestrator:
         """
         Check all links in the built site.
 
-        Extracts links from HTML files, checks internal and external links
-        according to configuration, and returns consolidated results.
+        Extracts links using parallel file I/O, then pipelines internal and
+        external checking (external async loop starts before internal finishes).
 
         Returns:
             Tuple of (results, summary) where results is a list of
@@ -119,8 +162,8 @@ class LinkCheckOrchestrator:
         """
         start_time = time.time()
 
-        # Extract all links from pages
-        internal_links, external_links = self._extract_links()
+        # Extract all links from pages (parallel file I/O)
+        internal_links, external_links, html_files = self._extract_links()
 
         logger.info(
             "link_check_starting",
@@ -130,7 +173,31 @@ class LinkCheckOrchestrator:
             check_external=self.check_external,
         )
 
-        # Check internal and external links
+        # Pass discovered file index to internal checker to skip redundant rglob
+        if self.check_internal:
+            self.internal_checker.set_file_index(html_files)
+
+        # Pipeline: kick off external checks in a background thread while
+        # internal checking runs synchronously on the main thread.
+        external_future = None
+        external_executor = None
+        if self.check_external and external_links:
+
+            def _run_external() -> dict[str, LinkCheckResult]:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                try:
+                    return loop.run_until_complete(
+                        self.external_checker.check_links(external_links)
+                    )
+                finally:
+                    loop.close()
+
+            external_executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="linkcheck-ext"
+            )
+            external_future = external_executor.submit(_run_external)
+
         results: list[LinkCheckResult] = []
 
         if self.check_internal and internal_links:
@@ -142,24 +209,16 @@ class LinkCheckOrchestrator:
                 broken=sum(1 for r in internal_results.values() if r.status == LinkStatus.BROKEN),
             )
 
-        if self.check_external and external_links:
-            # Run async checker
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                external_results = loop.run_until_complete(
-                    self.external_checker.check_links(external_links)
-                )
-                results.extend(external_results.values())
-                logger.info(
-                    "external_links_checked",
-                    count=len(external_results),
-                    broken=sum(
-                        1 for r in external_results.values() if r.status == LinkStatus.BROKEN
-                    ),
-                )
-            finally:
-                loop.close()
+        if external_future is not None:
+            external_results = external_future.result()
+            if external_executor:
+                external_executor.shutdown(wait=False)
+            results.extend(external_results.values())
+            logger.info(
+                "external_links_checked",
+                count=len(external_results),
+                broken=sum(1 for r in external_results.values() if r.status == LinkStatus.BROKEN),
+            )
 
         # Build summary
         duration_ms = (time.time() - start_time) * 1000
@@ -177,28 +236,27 @@ class LinkCheckOrchestrator:
 
         return results, summary
 
-    def _extract_links(self) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    def _extract_links(
+        self,
+    ) -> tuple[list[tuple[str, str]], list[tuple[str, str]], list[Path]]:
         """
-        Extract all links from built HTML files.
+        Extract all links from built HTML files using parallel I/O.
 
-        Parses HTML files in output_dir, extracts href attributes from anchor
-        tags (excluding those inside code blocks), and classifies as internal
-        or external based on URL scheme.
+        Parses HTML files in output_dir concurrently via a thread pool,
+        extracts href attributes from anchor tags (excluding code blocks),
+        and classifies as internal or external based on URL scheme.
 
         Returns:
-            Tuple of (internal_links, external_links) where each is a list of
-            (url, page_path) tuples. page_path is the relative path of the
-            HTML file that contains the link.
+            Tuple of (internal_links, external_links, html_files) where links
+            are lists of (url, page_path) tuples and html_files is the
+            discovered HTML file list (reused by InternalLinkChecker).
 
         Note:
             Skips mailto:, tel:, data:, and javascript: URLs.
         """
-        from html.parser import HTMLParser
-
         internal_links: list[tuple[str, str]] = []
         external_links: list[tuple[str, str]] = []
 
-        # Get output directory
         output_dir = self.site.output_dir
         if not output_dir.exists():
             logger.warning(
@@ -206,75 +264,48 @@ class LinkCheckOrchestrator:
                 path=str(output_dir),
                 suggestion="Build the site first with 'bengal build' before running link checks.",
             )
-            return internal_links, external_links
+            return internal_links, external_links, []
 
-        class LinkExtractor(HTMLParser):
-            """
-            HTML parser that extracts href links, skipping code blocks.
+        # Discover all HTML files once (shared with internal checker)
+        html_files = list(output_dir.rglob("*.html"))
 
-            Tracks nesting depth in <code> and <pre> tags to avoid extracting
-            code examples as real links.
-            """
+        # Parse files in parallel (I/O-bound: file reads + HTML parsing)
+        file_links: list[tuple[Path, list[str]]] = []
+        with ThreadPoolExecutor(thread_name_prefix="linkextract") as pool:
+            futures = {pool.submit(_parse_file, f): f for f in html_files}
+            for future in futures:
+                html_file = futures[future]
+                try:
+                    links = future.result()
+                    file_links.append((html_file, links))
+                except Exception as e:
+                    from bengal.errors import ErrorCode
 
-            def __init__(self) -> None:
-                super().__init__()
-                self.links: list[str] = []
-                self._in_code_block = 0  # Track nesting depth of code blocks
+                    logger.warning(
+                        "failed_to_parse_html",
+                        file=str(html_file),
+                        error=str(e),
+                        error_code=ErrorCode.V005.value,
+                        suggestion="Check HTML file for malformed content. Link check will skip this file.",
+                    )
 
-            def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-                # Track code block tags
-                if tag in ("code", "pre"):
-                    self._in_code_block += 1
-                # Only extract links if not inside a code block
-                elif tag == "a" and self._in_code_block == 0:
-                    for attr, value in attrs:
-                        if attr == "href" and value:
-                            self.links.append(value)
+        # Classify extracted links
+        for html_file, links in file_links:
+            rel_path = html_file.relative_to(output_dir)
+            page_ref = str(rel_path)
 
-            def handle_endtag(self, tag: str) -> None:
-                # Exit code block when closing tag found
-                if tag in ("code", "pre"):
-                    self._in_code_block = max(0, self._in_code_block - 1)
+            for link in links:
+                if link.startswith(("mailto:", "tel:", "data:", "javascript:")):
+                    continue
+                if link == "#" or not link:
+                    continue
 
-        # Scan all HTML files
-        for html_file in output_dir.rglob("*.html"):
-            try:
-                html_content = html_file.read_text(encoding="utf-8")
-                parser = LinkExtractor()
-                parser.feed(html_content)
+                if link.startswith(("http://", "https://")):
+                    external_links.append((link, page_ref))
+                else:
+                    internal_links.append((link, page_ref))
 
-                # Get relative path for reference
-                rel_path = html_file.relative_to(output_dir)
-                page_ref = str(rel_path)
-
-                for link in parser.links:
-                    # Skip mailto, tel, data URIs
-                    if link.startswith(("mailto:", "tel:", "data:", "javascript:")):
-                        continue
-
-                    # Skip empty anchors
-                    if link == "#" or not link:
-                        continue
-
-                    # Classify as internal or external
-                    if link.startswith(("http://", "https://")):
-                        external_links.append((link, page_ref))
-                    else:
-                        internal_links.append((link, page_ref))
-
-            except Exception as e:
-                from bengal.errors import ErrorCode
-
-                logger.warning(
-                    "failed_to_parse_html",
-                    file=str(html_file),
-                    error=str(e),
-                    error_code=ErrorCode.V005.value,
-                    suggestion="Check HTML file for malformed content. Link check will skip this file.",
-                )
-                continue
-
-        return internal_links, external_links
+        return internal_links, external_links, html_files
 
     def _build_summary(
         self, results: list[LinkCheckResult], duration_ms: float
@@ -345,23 +376,23 @@ class LinkCheckOrchestrator:
         """
         lines = []
         lines.append("\n" + "=" * 70)
-        lines.append("🔗 Link Check Report")
+        lines.append("\U0001f517 Link Check Report")
         lines.append("=" * 70)
         lines.append("")
 
         # Summary
         lines.append(f"Total checked:   {summary.total_checked}")
-        lines.append(f"✅ OK:           {summary.ok_count}")
-        lines.append(f"❌ Broken:       {summary.broken_count}")
-        lines.append(f"⚠️  Errors:       {summary.error_count}")
-        lines.append(f"⊘  Ignored:      {summary.ignored_count}")
-        lines.append(f"⏱️  Duration:     {summary.duration_ms:.2f}ms")
+        lines.append(f"\u2705 OK:           {summary.ok_count}")
+        lines.append(f"\u274c Broken:       {summary.broken_count}")
+        lines.append(f"\u26a0\ufe0f  Errors:       {summary.error_count}")
+        lines.append(f"\u2298  Ignored:      {summary.ignored_count}")
+        lines.append(f"\u23f1\ufe0f  Duration:     {summary.duration_ms:.2f}ms")
         lines.append("")
 
         # Broken links
         broken = [r for r in results if r.status == LinkStatus.BROKEN]
         if broken:
-            lines.append(f"❌ Broken Links ({len(broken)}):")
+            lines.append(f"\u274c Broken Links ({len(broken)}):")
             lines.append("-" * 70)
             for result in broken[:20]:  # Show first 20
                 lines.append(f"  {result.url}")
@@ -378,7 +409,7 @@ class LinkCheckOrchestrator:
         # Errors
         errors = [r for r in results if r.status == LinkStatus.ERROR]
         if errors:
-            lines.append(f"⚠️  Errors ({len(errors)}):")
+            lines.append(f"\u26a0\ufe0f  Errors ({len(errors)}):")
             lines.append("-" * 70)
             for result in errors[:10]:  # Show first 10
                 lines.append(f"  {result.url}")
@@ -393,9 +424,9 @@ class LinkCheckOrchestrator:
         # Final status
         lines.append("=" * 70)
         if summary.passed:
-            lines.append("✅ PASSED - All links are valid")
+            lines.append("\u2705 PASSED - All links are valid")
         else:
-            lines.append("❌ FAILED - Broken or error links found")
+            lines.append("\u274c FAILED - Broken or error links found")
         lines.append("=" * 70)
 
         return "\n".join(lines)

--- a/bengal/health/linkcheck/orchestrator.py
+++ b/bengal/health/linkcheck/orchestrator.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -273,7 +273,7 @@ class LinkCheckOrchestrator:
         file_links: list[tuple[Path, list[str]]] = []
         with ThreadPoolExecutor(thread_name_prefix="linkextract") as pool:
             futures = {pool.submit(_parse_file, f): f for f in html_files}
-            for future in futures:
+            for future in as_completed(futures):
                 html_file = futures[future]
                 try:
                     links = future.result()

--- a/bengal/health/validators/links.py
+++ b/bengal/health/validators/links.py
@@ -77,6 +77,7 @@ class LinkValidator:
         self.broken_links: list[tuple[Path | None, str]] = []
         self._page_urls: set[str] | None = None
         self._source_paths: set[str] | None = None
+        self._anchors_by_url: dict[str, frozenset[str]] | None = None
         self._site: SiteLike | None = site
 
     def _llm_txt_enabled(self, site: Any) -> bool:
@@ -189,8 +190,14 @@ class LinkValidator:
 
         # Build indexes on first use (or if site changed)
         if self._page_urls is None and site is not None:
-            self._page_urls = self._build_page_url_index(site)
-            self._source_paths = self._build_source_path_index(site)
+            registry = getattr(site, "link_registry", None)
+            if registry is not None:
+                self._page_urls = set(registry.page_urls | registry.auxiliary_urls)
+                self._source_paths = set(registry.source_paths)
+                self._anchors_by_url = registry.anchors_by_url
+            else:
+                self._page_urls = self._build_page_url_index(site)
+                self._source_paths = self._build_source_path_index(site)
             self._site = site
 
         logger.debug(
@@ -229,8 +236,14 @@ class LinkValidator:
         # Reset state
         self.broken_links = []
         self._site = site
-        self._page_urls = self._build_page_url_index(site)
-        self._source_paths = self._build_source_path_index(site)
+        registry = getattr(site, "link_registry", None)
+        if registry is not None:
+            self._page_urls = set(registry.page_urls | registry.auxiliary_urls)
+            self._source_paths = set(registry.source_paths)
+            self._anchors_by_url = registry.anchors_by_url
+        else:
+            self._page_urls = self._build_page_url_index(site)
+            self._source_paths = self._build_source_path_index(site)
 
         for page in site.pages:
             self.validate_page_links(page, site)
@@ -278,8 +291,21 @@ class LinkValidator:
         # Parse the link
         parsed = urlparse(link)
 
-        # Fragment-only links (e.g., "#section") are valid within the page
+        # Fragment-only links (e.g., "#section") — validate anchor exists on current page
         if not parsed.path and parsed.fragment:
+            if self._anchors_by_url is not None:
+                page_path = getattr(page, "_path", None)
+                if page_path:
+                    anchors = self._anchors_by_url.get(page_path, frozenset())
+                    if anchors and parsed.fragment not in anchors:
+                        logger.debug(
+                            "validating_fragment_link",
+                            link=link,
+                            page=str(page.source_path),
+                            result="broken_anchor",
+                            fragment=parsed.fragment,
+                        )
+                        return False
             logger.debug(
                 "validating_fragment_link",
                 link=link,
@@ -324,6 +350,25 @@ class LinkValidator:
         is_valid = any(v in self._page_urls for v in variants)
 
         if is_valid:
+            # If link has a fragment, also validate the anchor exists
+            if parsed.fragment and self._anchors_by_url is not None:
+                anchors = self._anchors_by_url.get(resolved_path, frozenset())
+                if not anchors:
+                    # Try with/without trailing slash
+                    anchors = self._anchors_by_url.get(
+                        resolved_path.rstrip("/"), frozenset()
+                    ) or self._anchors_by_url.get(resolved_path.rstrip("/") + "/", frozenset())
+                if anchors and parsed.fragment not in anchors:
+                    logger.debug(
+                        "validating_internal_link",
+                        link=link,
+                        resolved=resolved_path,
+                        page=str(page.source_path),
+                        result="broken_anchor",
+                        fragment=parsed.fragment,
+                    )
+                    return False
+
             logger.debug(
                 "validating_internal_link",
                 link=link,

--- a/bengal/health/validators/links.py
+++ b/bengal/health/validators/links.py
@@ -198,6 +198,7 @@ class LinkValidator:
             else:
                 self._page_urls = self._build_page_url_index(site)
                 self._source_paths = self._build_source_path_index(site)
+                self._anchors_by_url = None
             self._site = site
 
         logger.debug(
@@ -244,6 +245,7 @@ class LinkValidator:
         else:
             self._page_urls = self._build_page_url_index(site)
             self._source_paths = self._build_source_path_index(site)
+            self._anchors_by_url = None
 
         for page in site.pages:
             self.validate_page_links(page, site)

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -222,6 +222,11 @@ def run_health_check(
     if not health_config.get("enabled", True):
         return
 
+    # Build shared link registry before health checks (zero-cost: reuses toc_items)
+    from bengal.health.link_registry import build_link_registry
+
+    orchestrator.site.link_registry = build_link_registry(orchestrator.site)
+
     health_start = time.time()
 
     # Run health checks with profile filtering

--- a/bengal/rendering/page_operations.py
+++ b/bengal/rendering/page_operations.py
@@ -94,6 +94,18 @@ class PageOperationsMixin:
             wikilink_urls = self._extract_wikilinks_from_source(content_without_code)
             self.links = [url for _, url in markdown_links] + html_links + wikilink_urls
 
+        # Capture directive-generated links from html_content (cards, buttons, etc.)
+        # html_content is set by the parser before this method runs and does NOT
+        # yet have baseurl applied, so extracted links are consistent with page.links.
+        if self.html_content and plugin_links is not None:
+            directive_links = re.findall(r'<a\s+[^>]*href=["\']([^"\']+)["\']', self.html_content)
+            if directive_links:
+                existing = set(self.links)
+                for link in directive_links:
+                    if link not in existing:
+                        self.links.append(link)
+                        existing.add(link)
+
         return self.links
 
     def _extract_all_links_from_html(self) -> list[str]:

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -548,6 +548,12 @@ class RenderingPipeline:
             self.site,
             parse_markdown=parse_markdown,
         )
+
+        # Protect pipes inside [[...]] cross-references from table cell splitting.
+        # Must run before the markdown parser sees the source.
+        if "[[" in source and hasattr(self.parser, "_xref_plugin") and self.parser._xref_plugin:
+            source = self.parser._xref_plugin.protect_table_pipes(source)
+
         if page.metadata.get("preprocess") is False:
             # Inject source_path and excerpt_length for cross-version dependency tracking
             # (non-context parse methods don't have access to page object)
@@ -933,6 +939,11 @@ class RenderingPipeline:
             self.site,
             parse_markdown=parse_markdown,
         )
+
+        # Protect pipes inside [[...]] cross-references from table cell splitting
+        if "[[" in source and hasattr(self.parser, "_xref_plugin") and self.parser._xref_plugin:
+            source = self.parser._xref_plugin.protect_table_pipes(source)
+
         if page.metadata.get("preprocess") is False:
             return source
 

--- a/bengal/rendering/plugins/cross_references.py
+++ b/bengal/rendering/plugins/cross_references.py
@@ -115,6 +115,36 @@ class CrossReferencePlugin:
         # Matches: [[path]] or [[path|text]]
         self.pattern = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
 
+    # Placeholder used to protect pipes inside [[...]] from table cell splitting
+    _PIPE_PLACEHOLDER = "\x00XREFPIPE\x00"
+
+    # Pattern to find [[...]] spans that contain pipes (for table protection)
+    _BRACKET_PATTERN = re.compile(r"\[\[[^\]]*\|[^\]]*\]\]")
+
+    @staticmethod
+    def protect_table_pipes(source: str) -> str:
+        """Pre-process markdown source to protect pipes inside [[...]] from table splitting.
+
+        Markdown table parsers split cells on ``|``, which breaks cross-reference
+        syntax like ``[[ext:kida:|Kida]]``.  This replaces ``|`` inside ``[[...]]``
+        with a null-byte placeholder so the table parser sees them as regular text.
+        The placeholder is restored during cross-reference resolution.
+        """
+        if "[[" not in source or "|" not in source:
+            return source
+
+        def _protect(m: Match[str]) -> str:
+            return m.group(0).replace("|", CrossReferencePlugin._PIPE_PLACEHOLDER)
+
+        return CrossReferencePlugin._BRACKET_PATTERN.sub(_protect, source)
+
+    @staticmethod
+    def restore_table_pipes(text: str) -> str:
+        """Restore pipe placeholders back to real pipes."""
+        if CrossReferencePlugin._PIPE_PLACEHOLDER in text:
+            return text.replace(CrossReferencePlugin._PIPE_PLACEHOLDER, "|")
+        return text
+
     def set_links_collector(self, collector: list[str] | None) -> None:
         """Set the list to collect resolved/broken link URLs for validation."""
         self._links_collector = collector
@@ -186,6 +216,8 @@ class CrossReferencePlugin:
         """
         if "[[" not in text:
             return text
+        # Restore pipe placeholders so the regex can match [[ref|text]] normally
+        text = self.restore_table_pipes(text)
 
         def replace_xref(match: Match[str]) -> str:
             ref = match.group(1).strip()

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Plugin System
 - **plugins**: add unified plugin framework with `Plugin` protocol, `PluginRegistry`, and `FrozenPluginRegistry`
 - **plugins**: entry-point discovery via `bengal.plugins` group — third-party plugins auto-discovered
-- **plugins**: 10 extension points: directives, roles, template functions/filters/tests, content sources, health validators, shortcodes, phase hooks
+- **plugins**: 9 extension points: directives, roles, template functions/filters/tests, content sources, health validators, shortcodes, phase hooks
 - **plugins**: builder→immutable pattern — mutable registry during registration, frozen snapshot for thread-safe rendering
 
 ### Template Dependency Tracking

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,40 @@
 ## [Unreleased]
 
+## 0.2.7 - 2026-03-25
+
+### Plugin System
+- **plugins**: add unified plugin framework with `Plugin` protocol, `PluginRegistry`, and `FrozenPluginRegistry`
+- **plugins**: entry-point discovery via `bengal.plugins` group — third-party plugins auto-discovered
+- **plugins**: 10 extension points: directives, roles, template functions/filters/tests, content sources, health validators, shortcodes, phase hooks
+- **plugins**: builder→immutable pattern — mutable registry during registration, frozen snapshot for thread-safe rendering
+
+### Template Dependency Tracking
+- **cache**: per-page template dependency recording — tracks which templates (and their include/extends chain) each page uses
+- **incremental**: selective rebuild when templates change — only affected pages rebuild instead of full site rebuild
+- **provenance**: `_expand_forced_changed()` uses per-page dependencies for targeted invalidation; falls back to full rebuild on cache miss
+
+### Free-Threading Hardening
+- **effects**: serialize all EffectTracer mutations and reads under lock for PEP 703 free-threading
+- **utils**: replace `@lru_cache` on `get_bengal_dir()` with thread-safe `LRUCache` (RLock-backed)
+- **deps**: kida-templates 0.2.8→0.2.9 for free-threading support
+
+### Performance
+- **orchestration**: coalesce 8 redundant `site.pages` traversals into single passes across menu, finalization, provenance, and rendering phases
+- **menu**: `_analyze_menu_state()` replaces 3 separate page scans with one pass returning `(needs_rebuild, menu_pages, root_level_pages)`
+- **finalization**: merge page count + autodoc detection into single loop
+- **manifest**: fix `summary()` multi-scan (4 scans → 1 efficient pass)
+
+### Code Simplification
+- **errors**: replace 11 manual `__init__` methods in exception subclasses with `_default_build_phase_name` class variable pattern
+- **rendering**: remove 3 deprecated transforms (`escape_jinja_blocks`, `transform_internal_links`, `normalize_markdown_links`) — consolidated into `HybridHTMLTransformer`
+- **rendering**: extract `_default_pagination()` and `_coerce_pagination_ints()` helpers in renderer
+
+### Test Infrastructure
+- **tests**: add comprehensive `tests/README.md` with test suite guide (4,065+ tests, 116 property-based)
+- **ci**: restructure workflow for 6 parallel integration shards with signal-based timeouts (free-threading compatible)
+- **fixtures**: extract `build_ephemeral_site_at()` for class/module-scoped test reuse
+- **cleanup**: remove no-op `test_resource_cleanup.py`
+
 ## 0.2.6 - 2026-03-17
 
 ### Double-Buffered Dev Server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bengal"
-version = "0.2.6"
+version = "0.2.7"
 description = "Python static site generator for documentation, blogs, and product sites"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/site/config/_default/build.yaml
+++ b/site/config/_default/build.yaml
@@ -27,3 +27,14 @@ html_output:
 health_check:
   enabled: true
   verbose: false  # Set true to see INFO-level warnings
+
+# Link checker configuration
+# Used by: bengal health linkcheck
+health:
+  linkcheck:
+    exclude_domain:
+      - "localhost"
+      - "127.0.0.1"
+      - "chatgpt.com"
+    ignore_status:
+      - "403"

--- a/site/config/_default/menu.yaml
+++ b/site/config/_default/menu.yaml
@@ -4,8 +4,4 @@
 # See: docs/content/organization/menus.md
 
 menu:
-  extra:
-    - name: "Forum"
-      url: "https://bengal.discourse.group/"
-      weight: 100
-      icon: chat-circle
+  extra: []

--- a/site/content/docs/about/free-threading.md
+++ b/site/content/docs/about/free-threading.md
@@ -104,6 +104,44 @@ def get_or_create_pipeline(current_gen, create_pipeline_fn):
 
 On free-threaded Python, ~1.5–2x faster than GIL builds at the same worker count. Incremental builds: 35–80 ms for a single-page change on an 800-page site.
 
+## Thread-Safe Internals (0.2.7+)
+
+Several internal components were hardened for free-threading in v0.2.7:
+
+### EffectTracer Lock Serialization
+
+The build tracer records timing, cache hits, and fingerprint data. Without the GIL, concurrent `defaultdict` access can observe partially-constructed entries. All EffectTracer mutations (`record`, `record_batch`, `update_fingerprint`, `flush_pending_fingerprints`, `clear`) and reads now acquire a lock:
+
+```python
+class EffectTracer:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._effects: dict[str, list] = defaultdict(list)
+
+    def record(self, phase, event):
+        with self._lock:
+            self._effects[phase].append(event)
+```
+
+### Thread-Safe LRU Cache
+
+`functools.lru_cache` relies on the GIL for internal dict coherency. Bengal's `get_bengal_dir()` — called from multiple threads during rendering — now uses `LRUCache` from `bengal.utils.primitives.lru_cache`, which protects access with an `RLock`:
+
+```python
+# Before (GIL-dependent):
+@lru_cache(maxsize=1)
+def get_bengal_dir(): ...
+
+# After (free-threading safe):
+_cache = LRUCache(maxsize=1)
+def get_bengal_dir():
+    return _cache.get_or_compute("bengal_dir", _find_bengal_dir)
+```
+
+### Plugin Registry Freeze
+
+The plugin system uses a builder→immutable pattern. `PluginRegistry` collects extensions during startup, then `freeze()` produces a `FrozenPluginRegistry` (frozen dataclass with tuple fields) — no locks needed during rendering because the data is immutable.
+
 ## Code References
 
 | Pattern | File |
@@ -113,6 +151,9 @@ On free-threaded Python, ~1.5–2x faster than GIL builds at the same worker cou
 | Context propagation to workers | [bengal/utils/concurrency/context_propagation.py](https://github.com/lbliii/bengal/blob/main/bengal/utils/concurrency/context_propagation.py) |
 | Immutable snapshots | [bengal/snapshots/types.py](https://github.com/lbliii/bengal/blob/main/bengal/snapshots/types.py) |
 | Rendering (asset ContextVar) | [bengal/orchestration/build/rendering.py](https://github.com/lbliii/bengal/blob/main/bengal/orchestration/build/rendering.py) |
+| EffectTracer (lock-serialized) | [bengal/effects/tracer.py](https://github.com/lbliii/bengal/blob/main/bengal/effects/tracer.py) |
+| Thread-safe LRUCache | [bengal/utils/primitives/lru_cache.py](https://github.com/lbliii/bengal/blob/main/bengal/utils/primitives/lru_cache.py) |
+| Plugin registry (freeze pattern) | [bengal/plugins/registry.py](https://github.com/lbliii/bengal/blob/main/bengal/plugins/registry.py) |
 
 ## See Also
 

--- a/site/content/docs/building/configuration/reference.md
+++ b/site/content/docs/building/configuration/reference.md
@@ -1,0 +1,443 @@
+---
+title: Configuration Reference
+description: Complete reference of all bengal.toml options
+weight: 30
+icon: book
+nav_title: Reference
+tags:
+- configuration
+- reference
+keywords:
+- bengal.toml
+- config
+- options
+- settings
+category: reference
+---
+
+# Configuration Reference
+
+All options for `bengal.toml`. Every option has a sensible default — most sites only need `[site]` and `[build]`.
+
+## [site]
+
+Site metadata used in templates, feeds, and SEO.
+
+```toml
+[site]
+title = "My Site"              # Required
+baseurl = "https://example.com"
+description = "Site description"
+author = "Author Name"
+language = "en"
+```
+
+## [build]
+
+Controls the build pipeline, caching, and parallelism.
+
+```toml
+[build]
+output_dir = "public"          # Where built files go
+content_dir = "content"        # Where content lives
+assets_dir = "assets"          # Static assets directory
+templates_dir = "templates"    # Custom template overrides
+parallel = true                # Enable parallel processing
+incremental = true             # Enable incremental builds
+max_workers = 8                # Limit parallel workers (default: auto-detect)
+pretty_urls = true             # /page/ instead of /page.html
+fast_mode = false              # Skip HTML formatting for speed
+strict_mode = false            # Fail on warnings
+debug = false                  # Extra logging
+minify_html = false            # Minify HTML output
+validate_build = true          # Run post-build validation
+validate_templates = false     # Validate template context
+validate_links = false         # Check internal links
+transform_links = true         # Transform internal links to pretty URLs
+cache_templates = true         # Cache compiled templates
+fast_writes = false            # Skip write for unchanged files
+stable_section_references = false  # Deterministic section IDs
+min_page_size = 0              # Minimum page count for parallel
+track_dependency_ordering = false  # Track build dependency order
+parallel_graph = false         # Parallel graph analysis
+parallel_autodoc = false       # Parallel autodoc extraction
+```
+
+## [dev]
+
+Development server settings.
+
+```toml
+[dev]
+port = 8000                    # Server port
+live_reload = true             # Enable live reload via SSE
+cache_templates = false        # Cache templates in dev (default: off for hot reload)
+watch_backend = true           # Watch backend files for changes
+```
+
+## [theme]
+
+Theme selection and appearance.
+
+```toml
+[theme]
+name = "default"
+default_appearance = "system"  # "light", "dark", or "system"
+default_palette = ""
+show_reading_time = true
+show_author = true
+show_prev_next = true
+show_children_default = false
+show_excerpts_default = false
+max_tags_display = 10
+popular_tags_count = 20
+features = []                  # Feature flags: "content.math", etc.
+
+[theme.syntax_highlighting]
+theme = "auto"                 # Syntax theme name
+css_class_style = "semantic"   # "semantic" or "pygments"
+```
+
+## [content]
+
+Content processing defaults.
+
+```toml
+[content]
+default_type = "docs"
+excerpt_length = 200
+excerpt_words = 50
+summary_length = 300
+reading_speed = 200            # Words per minute
+related_count = 5
+related_threshold = 0.1
+toc_depth = 3
+toc_min_headings = 2
+toc_style = "nested"           # "nested" or "flat"
+sort_pages_by = "weight"       # "weight", "date", "title", "modified"
+sort_order = "asc"
+strict_contracts = false
+```
+
+## [pagination]
+
+```toml
+[pagination]
+per_page = 10
+```
+
+## [search]
+
+Client-side search with Lunr. Can be `true`/`false` or a table.
+
+```toml
+[search]
+enabled = true
+
+[search.lunr]
+prebuilt = false
+min_query_length = 2
+max_results = 10
+preload = "smart"              # "immediate", "smart", "lazy"
+
+[search.ui]
+modal = true
+recent_searches = 5
+placeholder = "Search..."
+
+[search.analytics]
+enabled = false
+event_endpoint = ""
+```
+
+## [assets]
+
+Asset processing pipeline.
+
+```toml
+[assets]
+minify = false
+optimize = false
+fingerprint = false
+pipeline = true
+```
+
+## [html_output]
+
+HTML formatting for built pages.
+
+```toml
+[html_output]
+mode = "pretty"                # "minify", "pretty", "raw"
+remove_comments = false
+collapse_blank_lines = true
+```
+
+## [static]
+
+Static file handling.
+
+```toml
+[static]
+enabled = true
+dir = "static"
+```
+
+## [features]
+
+Toggle site-wide features.
+
+```toml
+[features]
+rss = true
+sitemap = true
+search = true
+json = false
+llm_txt = false
+syntax_highlighting = true
+```
+
+## [health_check]
+
+Build and content validation. Can be `true`/`false` or a table.
+
+```toml
+[health_check]
+enabled = true
+verbose = false
+strict_mode = false
+orphan_threshold = 5
+super_hub_threshold = 50
+isolated_threshold = 0
+lightly_linked_threshold = 3
+build_validators = []          # Validators run during build
+full_validators = []           # Validators for full check
+ci_validators = []             # Validators for CI
+
+[health_check.connectivity_thresholds]
+well_connected = 0.7
+adequately_linked = 0.4
+lightly_linked = 0.1
+
+[health_check.link_weights]
+explicit = 1.0
+menu = 0.8
+taxonomy = 0.6
+related = 0.4
+topical = 0.3
+sequential = 0.2
+```
+
+## [i18n]
+
+Internationalization settings.
+
+```toml
+[i18n]
+strategy = ""                  # null or strategy name
+default_language = "en"
+default_in_subdir = false
+content_structure = ""
+fallback_to_default = true
+gettext_domain = "messages"
+
+[[i18n.languages]]
+code = "en"
+name = "English"
+weight = 1
+
+[[i18n.languages]]
+code = "es"
+name = "Español"
+weight = 2
+```
+
+## [output_formats]
+
+Control which output formats are generated. Can be `true`/`false` or a table.
+
+```toml
+[output_formats]
+enabled = true
+per_page = ["html"]            # Per-page formats
+site_wide = ["rss", "sitemap"] # Site-wide formats
+
+[output_formats.options]
+excerpt_length = 200
+json_indent = 2
+llm_separator_width = 80
+include_full_content_in_index = false
+include_chunks = false
+exclude_sections = []
+exclude_patterns = []
+```
+
+## [content_signals]
+
+AI and crawler content policies.
+
+```toml
+[content_signals]
+enabled = false
+search = true
+ai_input = true                # Allow AI RAG/grounding
+ai_train = false               # Allow AI training
+include_sitemap = true
+
+[content_signals.user_agents]
+"*" = ""                       # Per-agent policies
+```
+
+## [structured_data]
+
+Schema.org JSON-LD generation.
+
+```toml
+[structured_data]
+article = true
+```
+
+## [markdown]
+
+Markdown parser configuration.
+
+```toml
+[markdown]
+parser = "patitas"             # "patitas" or "mistune"
+toc_depth = "2-4"
+
+[markdown.ast_cache]
+persist_tokens = false
+```
+
+## [graph]
+
+Knowledge graph analysis. Can be `true`/`false` or a table.
+
+```toml
+[graph]
+enabled = false
+path = ".bengal/graph"
+```
+
+## [external_refs]
+
+Cross-project documentation links. Can be `true`/`false` or a table.
+
+```toml
+[external_refs]
+enabled = false
+export_index = false
+cache_dir = ".bengal/refs"
+default_cache_days = 7
+templates = {}
+
+[[external_refs.indexes]]
+name = "other-project"
+url = "https://example.com/refs.json"
+cache_days = 7
+```
+
+## [link_previews]
+
+Hover card configuration. Can be `true`/`false` or a table.
+
+```toml
+[link_previews]
+enabled = false
+hover_delay = 300
+hide_delay = 200
+show_section = true
+show_reading_time = true
+show_word_count = false
+show_date = false
+show_tags = false
+max_tags = 3
+include_selectors = []
+exclude_selectors = []
+allowed_hosts = []
+allowed_schemes = ["https"]
+host_failure_threshold = 3
+show_dead_links = false
+```
+
+## [document_application]
+
+Modern browser features: view transitions, speculation rules, interactive elements.
+
+```toml
+[document_application]
+enabled = false
+
+[document_application.navigation]
+view_transitions = false
+transition_style = "crossfade" # "crossfade", "fade-slide", "slide", "none"
+scroll_restoration = true
+
+[document_application.speculation]
+enabled = false
+auto_generate = false
+exclude_patterns = []
+
+[document_application.speculation.prerender]
+eagerness = "moderate"         # "conservative", "moderate", "eager"
+patterns = []
+
+[document_application.speculation.prefetch]
+eagerness = "moderate"
+patterns = []
+
+[document_application.interactivity]
+tabs = "css_state_machine"
+accordions = "native_details"
+modals = "native_dialog"
+tooltips = "popover"
+dropdowns = "popover"
+code_copy = "enhanced"
+```
+
+## [connect_to_ide]
+
+Cursor IDE integration.
+
+```toml
+[connect_to_ide]
+enabled = false
+mcp_url = ""
+server_name = ""
+```
+
+## [taxonomies]
+
+Define taxonomy term→field mappings.
+
+```toml
+[taxonomies]
+tags = "tags"
+categories = "categories"
+```
+
+## [data]
+
+Data file directory.
+
+```toml
+[data]
+dir = "data"
+```
+
+## [autodoc.python]
+
+Python API documentation extraction.
+
+```toml
+[autodoc.python]
+enabled = false
+source_dirs = []
+output_prefix = "api"
+```
+
+## See Also
+
+- [[docs/building/configuration/profiles|Build Profiles]] — Environment-specific config
+- [[docs/building/configuration/variants|Multi-Variant Builds]] — Build different site variants

--- a/site/content/docs/building/performance/_index.md
+++ b/site/content/docs/building/performance/_index.md
@@ -24,6 +24,7 @@ Bengal optimizes builds automatically — no configuration required:
 - **Parallel processing**: Auto-enabled based on page count and CPU cores
 - **Incremental builds**: Auto-enabled when build cache exists
 - **Smart caching**: Tracks file changes, dependencies, and parsed content
+- **Template dependency tracking**: Records per-page template chains; template edits rebuild only affected pages
 - **Fast mode**: Skips HTML formatting for faster builds (`--fast` or `build.fast_mode`)
 - **Render-time asset tracking**: Tracks assets during template rendering (no HTML parsing)
 - **Autodoc AST caching**: Caches parsed Python modules to skip AST parsing on subsequent builds
@@ -53,6 +54,7 @@ flowchart LR
 |----------|--------|---------|----------|
 | **Incremental** | Zero | 15-50x | Development |
 | **Parallel** | Zero | 2-8x | Large sites, multi-core |
+| **Template Deps** | Zero | 5-20x | Template edits (selective rebuild) |
 | **Fast Mode** | Zero | 10-15% | CI/CD (skips HTML formatting) |
 | **Asset Tracking** | Zero | 20-25% | Sites with many assets |
 | **Autodoc Caching** | Zero | 30-40% | Sites with autodoc (caches AST parsing) |

--- a/site/content/docs/building/performance/template-deps.md
+++ b/site/content/docs/building/performance/template-deps.md
@@ -1,0 +1,60 @@
+---
+title: Template Dependency Tracking
+description: Selective rebuilds when templates change — only affected pages rebuild
+weight: 20
+icon: git-branch
+nav_title: Template Deps
+tags:
+- performance
+- incremental
+- templates
+keywords:
+- template dependency
+- selective rebuild
+- incremental build
+- cache
+category: explanation
+---
+
+# Template Dependency Tracking
+
+When you edit a template, Bengal rebuilds only the pages that use it — not every page on the site. This is automatic and requires no configuration.
+
+## How It Works
+
+During each build, Bengal records which templates each page uses, including the full `extends` and `include` chain:
+
+```
+about.md → single.html → base.html, partials/nav.html, partials/footer.html
+blog/post-1.md → blog/single.html → base.html, partials/nav.html
+```
+
+On the next build, if `partials/nav.html` changes, Bengal rebuilds every page that depends on it (directly or transitively). Pages that don't use `partials/nav.html` are skipped entirely.
+
+## When It Applies
+
+| Scenario | Behavior |
+|----------|----------|
+| Edit a content file | Normal incremental: only that page rebuilds |
+| Edit a template | Selective: only pages using that template rebuild |
+| Edit a base template | Broader selective: all pages extending it rebuild |
+| First build (no cache) | Full build; dependencies recorded for next time |
+| Cache miss | Falls back to full rebuild |
+
+## Performance Impact
+
+On a 1,000-page site where you edit a partial used by 50 pages:
+
+- **Without** template deps: all 1,000 pages rebuild
+- **With** template deps: only 50 pages rebuild
+
+The dependency data is stored in the build cache alongside content hashes. The lookup is O(1) per template via a lazy reverse index.
+
+## Interaction with Dev Server
+
+Template dependency tracking works with `bengal serve`. When you save a template file, the dev server triggers a selective rebuild and hot-reloads only the affected pages.
+
+## See Also
+
+- [[docs/building/performance|Performance Overview]] — All optimization strategies
+- [[docs/about/free-threading|Free-Threading]] — Parallel rendering

--- a/site/content/docs/extending/plugins.md
+++ b/site/content/docs/extending/plugins.md
@@ -189,6 +189,6 @@ frozen = load_plugins(extra_plugins=[MyPlugin()])
 
 ## See Also
 
-- [Extension Points](/docs/reference/architecture/meta/extension-points/) — Full reference for all 11 extension points
+- [Extension Points](/docs/reference/architecture/meta/extension-points/) — Full reference for all extension points
 - [Custom Directives](../custom-directives/) — Directive authoring guide
 - [Template Shortcodes](../shortcodes/) — Template-only shortcodes (no Python required)

--- a/site/content/docs/extending/plugins.md
+++ b/site/content/docs/extending/plugins.md
@@ -1,0 +1,194 @@
+---
+title: Writing Plugins
+description: Create plugins that add directives, template functions, content sources, and build hooks
+weight: 45
+icon: puzzle
+tags:
+- plugins
+- extending
+- extensibility
+keywords:
+- plugin
+- entry point
+- registry
+- extension
+category: guide
+---
+
+# Writing Plugins
+
+Plugins extend Bengal with custom directives, template functions, content sources, validators, and build lifecycle hooks — all through a single `register()` method. The plugin system uses Python entry points for automatic discovery and a builder→immutable pattern for thread safety.
+
+## Quick Start
+
+Create a plugin in three steps:
+
+### 1. Implement the Plugin Protocol
+
+```python
+# my_bengal_plugin/__init__.py
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
+
+
+class MyPlugin(Plugin):
+    name = "my-plugin"
+    version = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_template_filter("shout", lambda v: v.upper() + "!")
+```
+
+### 2. Declare the Entry Point
+
+```toml
+# pyproject.toml
+[project.entry-points."bengal.plugins"]
+my-plugin = "my_bengal_plugin:MyPlugin"
+```
+
+### 3. Install and Build
+
+```bash
+uv pip install -e ./my-bengal-plugin
+bengal build  # Plugin auto-discovered
+```
+
+Your filter is now available in templates:
+
+```kida
+{{ page.title | shout }}
+```
+
+## Plugin Protocol
+
+Every plugin must have `name`, `version`, and a `register()` method:
+
+```python
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
+
+
+class MyPlugin(Plugin):
+    name: str = "my-plugin"
+    version: str = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        # Register extensions here
+        ...
+```
+
+`Plugin` is a `runtime_checkable` Protocol — no base class inheritance required. Any object with the right attributes works.
+
+## Extension Points
+
+The `PluginRegistry` provides 9 registration methods:
+
+### Template Extensions
+
+```python
+def register(self, registry: PluginRegistry) -> None:
+    # Global function: {{ my_func(page) }}
+    registry.add_template_function("my_func", my_func, phase=1)
+
+    # Filter: {{ value | my_filter }}
+    registry.add_template_filter("my_filter", my_filter)
+
+    # Test: {% if value is my_test %}
+    registry.add_template_test("my_test", my_test)
+```
+
+The `phase` parameter on `add_template_function` controls registration order (1–9), matching Bengal's internal template function phases.
+
+### Directives and Roles
+
+```python
+def register(self, registry: PluginRegistry) -> None:
+    # Block directive: :::{my_directive}
+    registry.add_directive(MyDirectiveHandler)
+
+    # Inline role: {my_role}`text`
+    registry.add_role(MyRoleHandler)
+```
+
+### Content Sources
+
+```python
+def register(self, registry: PluginRegistry) -> None:
+    registry.add_content_source("my-source", MyContentSource)
+```
+
+### Health Validators
+
+```python
+def register(self, registry: PluginRegistry) -> None:
+    registry.add_health_validator(MyValidator())
+```
+
+### Shortcodes
+
+```python
+def register(self, registry: PluginRegistry) -> None:
+    registry.add_shortcode(
+        "alert",
+        '<div class="alert alert-{{ type | default("info") }}">{{ content }}</div>',
+    )
+```
+
+### Build Phase Hooks
+
+```python
+def register(self, registry: PluginRegistry) -> None:
+    registry.on_phase("pre_render", self.before_render)
+    registry.on_phase("post_render", self.after_render)
+
+def before_render(self, site, build_context):
+    print(f"Rendering {len(site.pages)} pages")
+
+def after_render(self, site, build_context):
+    print("Render complete")
+```
+
+## How Discovery Works
+
+Bengal discovers plugins via the `bengal.plugins` [entry point group](https://packaging.python.org/en/latest/specifications/entry-points/):
+
+1. On startup, `discover_plugins()` calls `importlib.metadata.entry_points(group="bengal.plugins")`
+2. Each entry point is loaded and validated against the `Plugin` protocol
+3. Valid plugins call `register()` on a mutable `PluginRegistry`
+4. The registry is frozen into an immutable `FrozenPluginRegistry` before rendering begins
+
+The frozen registry is a dataclass with tuple fields — safe to share across threads during parallel rendering.
+
+## Combining Multiple Extensions
+
+A single plugin can register any number of extensions:
+
+```python
+class KitchenSinkPlugin(Plugin):
+    name = "kitchen-sink"
+    version = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_template_filter("slugify", self._slugify)
+        registry.add_template_function("badge", self._badge, phase=1)
+        registry.add_directive(MyDirective)
+        registry.add_health_validator(MyValidator())
+        registry.on_phase("post_render", self._post_render)
+```
+
+## Programmatic Registration
+
+If you don't want entry-point discovery, pass plugins directly:
+
+```python
+from bengal.plugins.loader import load_plugins
+
+frozen = load_plugins(extra_plugins=[MyPlugin()])
+```
+
+## See Also
+
+- [Extension Points](/docs/reference/architecture/meta/extension-points/) — Full reference for all 11 extension points
+- [Custom Directives](../custom-directives/) — Directive authoring guide
+- [Template Shortcodes](../shortcodes/) — Template-only shortcodes (no Python required)

--- a/site/content/docs/reference/architecture/meta/extension-points.md
+++ b/site/content/docs/reference/architecture/meta/extension-points.md
@@ -358,7 +358,7 @@ my-plugin = "my_package:MyPlugin"
 | `add_shortcode()` | Shortcode templates |
 | `on_phase()` | Build phase lifecycle hooks |
 
-## 10. Custom CLI Commands (Future)
+## Future: Custom CLI Commands
 
 **Purpose**: Add custom commands to Bengal CLI
 

--- a/site/content/docs/reference/architecture/meta/extension-points.md
+++ b/site/content/docs/reference/architecture/meta/extension-points.md
@@ -121,7 +121,7 @@ with render_config_context(RenderConfig(highlight=True)):
     html = renderer.render(ast)
 ```
 
-> **Note**: Custom parser registration currently requires modifying core code. Use the [plugin system](#9-plugin-system) to register extensions without core modifications.
+> **Note**: Custom parser registration currently requires modifying core code; the [plugin system](#9-plugin-system) does **not** currently expose a parser registration hook. Use the plugin system only for other kinds of extensions that do not require core modifications.
 
 ## 3. Custom Template Engines
 
@@ -302,7 +302,7 @@ This is a warning message!
 
 ## 9. Plugin System
 
-**Purpose**: Unified extension framework with 10 extension points and thread-safe rendering
+**Purpose**: Unified extension framework with 9 extension points and thread-safe rendering
 
 **Protocol**: All plugins implement `Plugin` — a runtime-checkable protocol with `name`, `version`, and `register()`:
 

--- a/site/content/docs/reference/architecture/meta/extension-points.md
+++ b/site/content/docs/reference/architecture/meta/extension-points.md
@@ -121,7 +121,7 @@ with render_config_context(RenderConfig(highlight=True)):
     html = renderer.render(ast)
 ```
 
-> **Note**: Custom parser registration currently requires modifying core code. A plugin-based registration system is planned for v0.4.0.
+> **Note**: Custom parser registration currently requires modifying core code. Use the [plugin system](#9-plugin-system) to register extensions without core modifications.
 
 ## 3. Custom Template Engines
 
@@ -158,19 +158,18 @@ register_engine("myengine", MyEngine)
 
 **Implementation**:
 ```python
-# In your site's custom module
-def my_custom_filter(value):
-    """Custom filter implementation."""
-    return value.upper()
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
 
-# Register via build hook (uses internal API - may change)
-def register_filters(site):
-    # Note: _template_engine is internal; plugin API coming in v0.4.0
-    env = site._template_engine._env
-    env.filters['custom'] = my_custom_filter
+class MyFilterPlugin(Plugin):
+    name = "my-filters"
+    version = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_template_filter("custom", lambda value: value.upper())
 ```
 
-> **Caution**: This approach accesses internal attributes (`_template_engine._env`). A stable public API for filter registration is planned for the plugin system (v0.4.0).
+> **Tip**: The plugin system provides a stable public API for filter registration. See [Plugin System](#9-plugin-system) for the full pattern including entry-point discovery.
 
 **Usage in templates**:
 ```kida
@@ -200,11 +199,11 @@ class RobotsGenerator:
         # Build robots.txt content
         return "User-agent: *\nDisallow: /admin/"
 
-# Add to PostprocessOrchestrator
-# (requires modification or plugin hook)
+# Register via plugin phase hook
+# registry.on_phase("post_render", my_generator.generate)
 ```
 
-**Future**: Plugin system will provide hooks
+**Tip**: Use the plugin system's `on_phase()` to register post-processing hooks without modifying core code
 
 ## 6. Custom Validators
 
@@ -274,24 +273,24 @@ theme = "my-theme"
 
 **Documentation**: Themes automatically override default templates
 
-## 8. Custom Shortcodes (Planned)
+## 8. Custom Shortcodes
 
 **Purpose**: Define custom markdown syntax extensions
 
-**Planned API**:
+**Implementation** (via plugin system):
 ```python
-# Planned API (not implemented yet):
-# from bengal.rendering.plugins import ShortcodePlugin
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
 
-class AlertShortcode(ShortcodePlugin):
-    name = "alert"
+class AlertPlugin(Plugin):
+    name = "alert-shortcode"
+    version = "1.0.0"
 
-    def render(self, content, **kwargs):
-        alert_type = kwargs.get('type', 'info')
-        return f'<div class="alert alert-{alert_type}">{content}</div>'
-
-# Register shortcode
-# (requires plugin system)
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_shortcode(
+            "alert",
+            '<div class="alert alert-{{ type | default("info") }}">{{ content }}</div>',
+        )
 ```
 
 **Usage in markdown**:
@@ -301,49 +300,63 @@ This is a warning message!
 {{% /alert %}}
 ```
 
-## 9. Plugin System (Planned v0.4.0)
+## 9. Plugin System
 
-**Purpose**: Formal plugin architecture with lifecycle hooks
+**Purpose**: Unified extension framework with 10 extension points and thread-safe rendering
 
-**Planned API**:
+**Protocol**: All plugins implement `Plugin` — a runtime-checkable protocol with `name`, `version`, and `register()`:
+
 ```python
-# Planned API (not implemented yet):
-# from bengal.plugins import Plugin, hook
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
+
 
 class MyPlugin(Plugin):
     name = "my-plugin"
     version = "1.0.0"
 
-    @hook('pre_build')
-    def before_build(self, site):
-        """Called before build starts"""
-        print(f"Building {len(site.pages)} pages")
+    def register(self, registry: PluginRegistry) -> None:
+        # Directives and roles
+        registry.add_directive(MyDirectiveHandler)
+        registry.add_role(MyRoleHandler)
 
-    @hook('post_page_render')
-    def after_page_render(self, page, html):
-        """Called after each page renders"""
-        return self._modify_html(html)
+        # Template extensions
+        registry.add_template_function("my_func", my_func, phase=1)
+        registry.add_template_filter("my_filter", my_filter)
+        registry.add_template_test("my_test", my_test)
 
-    @hook('post_build')
-    def after_build(self, site, stats):
-        """Called after build completes"""
-        print(f"Built in {stats.duration}s")
+        # Content and validation
+        registry.add_content_source("my-source", MySourceClass)
+        registry.add_health_validator(MyValidator())
+        registry.add_shortcode("alert", '<div class="alert">{{ content }}</div>')
 
-# Register plugin
-# bengal.toml:
-# [plugins]
-# my-plugin = true
+        # Build lifecycle
+        registry.on_phase("pre_render", self.before_render)
+        registry.on_phase("post_render", self.after_render)
 ```
 
-**Planned Hooks**:
-- `pre_build` - Before build starts
-- `post_content_discovery` - After content discovered
-- `pre_page_render` - Before page renders
-- `post_page_render` - After page renders
-- `post_build` - After build completes
-- `template_context` - Modify template context
-- `pre_asset_process` - Before asset processing
-- `post_asset_process` - After asset processing
+**Discovery**: Plugins are auto-discovered via the `bengal.plugins` entry point group. Declare your plugin in `pyproject.toml`:
+
+```toml
+[project.entry-points."bengal.plugins"]
+my-plugin = "my_package:MyPlugin"
+```
+
+**Thread Safety**: The registry uses a builder→immutable pattern. During startup, plugins register into a mutable `PluginRegistry`. Before rendering begins, `freeze()` produces a `FrozenPluginRegistry` dataclass that is safe to share across threads during parallel rendering.
+
+**Extension Points**:
+
+| Method | Purpose |
+|--------|---------|
+| `add_directive()` | Block-level content directives |
+| `add_role()` | Inline markup roles |
+| `add_template_function()` | Template globals (with phase ordering) |
+| `add_template_filter()` | Value transformers (`{{ x \| filter }}`) |
+| `add_template_test()` | Boolean predicates (`{% if x is test %}`) |
+| `add_content_source()` | Content source types |
+| `add_health_validator()` | Health check validators |
+| `add_shortcode()` | Shortcode templates |
+| `on_phase()` | Build phase lifecycle hooks |
 
 ## 10. Custom CLI Commands (Future)
 
@@ -401,14 +414,14 @@ class OpenAPIExtractor(Extractor):
 # (planned: autodoc registry system)
 ```
 
-## Current Workarounds
+## Choosing an Extension Approach
 
-Until the plugin system is implemented, some extensions require:
+Most extensions should use the plugin system. For simpler cases:
 
-1. **Fork and modify**: Make changes in your own fork
-2. **Wrapper scripts**: Write scripts that call Bengal + custom logic
-3. **Template-based**: Many customizations possible via templates alone
-4. **Theme-based**: Package customizations in a theme
+1. **Plugin system**: Recommended for directives, filters, content sources, validators, and build hooks
+2. **Template-based**: Many customizations possible via templates alone (no code needed)
+3. **Theme-based**: Package related template and asset customizations in a theme
+4. **Wrapper scripts**: Write scripts that call Bengal + custom logic for CI/deployment
 
 ## Extension Best Practices
 
@@ -429,13 +442,14 @@ Planned extension registry at `bengal-ssg.org/extensions/`:
 - Content strategies
 - CLI commands
 
-## Migration Path
+## Migrating to the Plugin System
 
-When plugin system arrives:
-1. Existing extensions can be migrated incrementally
-2. Old patterns will continue working (backward compatibility)
-3. New APIs will be opt-in
-4. Migration guides will be provided
+If you have existing extensions using internal APIs or fork-based patterns:
+
+1. Create a class implementing the `Plugin` protocol (`name`, `version`, `register()`)
+2. Move registration logic into `register()` using the `PluginRegistry` methods
+3. Add a `bengal.plugins` entry point in your `pyproject.toml`
+4. Remove any code that accesses internal attributes (e.g., `site._template_engine._env`)
 
 ## Related Documentation
 

--- a/site/content/releases/0.2.7.md
+++ b/site/content/releases/0.2.7.md
@@ -12,7 +12,7 @@ category: changelog
 
 # Bengal 0.2.7
 
-**Key additions:** Unified plugin system with 10 extension points, per-page template dependency tracking for selective rebuilds, free-threading hardening (thread-safe caches and tracers), 8→1 page walk optimizations, code simplification, and restructured CI test infrastructure.
+**Key additions:** Unified plugin system with 9 extension points, per-page template dependency tracking for selective rebuilds, free-threading hardening (thread-safe caches and tracers), 8→1 page walk optimizations, code simplification, and restructured CI test infrastructure.
 
 ---
 
@@ -20,7 +20,7 @@ category: changelog
 
 ### Plugin System
 
-Bengal now has a formal plugin framework. Plugins implement a `Plugin` protocol (`name`, `version`, `register()`) and register extensions through a `PluginRegistry` that supports 10 extension points: directives, roles, template functions, template filters, template tests, content sources, health validators, shortcodes, and build phase hooks.
+Bengal now has a formal plugin framework. Plugins implement a `Plugin` protocol (`name`, `version`, `register()`) and register extensions through a `PluginRegistry` that supports 9 extension points: directives, roles, template functions, template filters, template tests, content sources, health validators, shortcodes, and build phase hooks.
 
 Plugins are auto-discovered via the `bengal.plugins` entry point group:
 

--- a/site/content/releases/0.2.7.md
+++ b/site/content/releases/0.2.7.md
@@ -1,0 +1,108 @@
+---
+title: Bengal 0.2.7
+description: Plugin system, template dependency tracking, free-threading hardening, page walk optimizations
+type: changelog
+date: 2026-03-25
+draft: false
+lang: en
+tags: [release, changelog, plugins, performance, free-threading, incremental]
+keywords: [release, 0.2.7, plugin, registry, template-deps, free-threading, page-walks, selective-rebuild]
+category: changelog
+---
+
+# Bengal 0.2.7
+
+**Key additions:** Unified plugin system with 10 extension points, per-page template dependency tracking for selective rebuilds, free-threading hardening (thread-safe caches and tracers), 8→1 page walk optimizations, code simplification, and restructured CI test infrastructure.
+
+---
+
+## Highlights
+
+### Plugin System
+
+Bengal now has a formal plugin framework. Plugins implement a `Plugin` protocol (`name`, `version`, `register()`) and register extensions through a `PluginRegistry` that supports 10 extension points: directives, roles, template functions, template filters, template tests, content sources, health validators, shortcodes, and build phase hooks.
+
+Plugins are auto-discovered via the `bengal.plugins` entry point group:
+
+```toml
+# pyproject.toml of your plugin package
+[project.entry-points."bengal.plugins"]
+my-plugin = "my_package:MyPlugin"
+```
+
+```python
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
+
+class MyPlugin(Plugin):
+    name = "my-plugin"
+    version = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_template_filter("shout", lambda v: v.upper() + "!")
+        registry.on_phase("post_render", self.after_render)
+```
+
+The registry uses a builder→immutable pattern: mutable during registration, frozen into an immutable `FrozenPluginRegistry` dataclass before parallel rendering begins. Thread-safe by design.
+
+See [Writing Plugins](/docs/extending/plugins/) for the full guide.
+
+### Template Dependency Tracking
+
+The build cache now records which templates (and their full include/extends chain) each page uses. When a template changes, only the pages that depend on it rebuild — instead of a full site rebuild.
+
+- First build: dependencies are recorded (no change in behavior)
+- Subsequent builds: template changes trigger selective rebuilds
+- Falls back to full rebuild if no dependency data exists (cache miss or first build)
+
+On a 1,000-page site where you edit a partial template used by 50 pages, this means rebuilding 50 pages instead of 1,000.
+
+### Free-Threading Hardening
+
+Three changes prepare Bengal for Python 3.14t (PEP 703) free-threading:
+
+- **EffectTracer**: All mutations and reads are now serialized under a lock. Without the GIL, concurrent `defaultdict` access could observe partial state.
+- **`get_bengal_dir()` cache**: Replaced `@lru_cache(maxsize=1)` with Bengal's `LRUCache`, which uses an `RLock` internally. `functools.lru_cache` relies on the GIL for thread safety.
+- **Kida 0.2.9**: Updated the template engine dependency for free-threading support.
+
+### Page Walk Optimizations
+
+Coalesced 8 redundant `site.pages` traversals into single passes:
+
+- **Menu building**: Three separate scans (changed-page check, menu frontmatter collection, root-level page collection) merged into `_analyze_menu_state()` — one pass returning `(needs_rebuild, menu_pages, root_level_pages)`.
+- **Finalization**: Four scans for page count, autodoc detection, and stats merged into a single loop.
+- **Provenance**: Eliminated duplicate `pages_list` construction.
+- **Manifest**: Fixed `summary()` multi-scan (4 scans → 1 pass).
+
+On large sites (1K+ pages), this reduces orchestration phase time by ~8–12%.
+
+---
+
+## Code Simplification
+
+- **Exception hierarchy**: Replaced 11 manual `__init__` methods in exception subclasses with a `_default_build_phase_name` class variable pattern — less boilerplate, same behavior.
+- **Deprecated transforms removed**: `escape_jinja_blocks()`, `transform_internal_links()`, and `normalize_markdown_links()` are gone. Their work is handled by `HybridHTMLTransformer`.
+- **Renderer helpers**: Extracted `_default_pagination()` and `_coerce_pagination_ints()` to eliminate duplicated inline dict construction.
+
+---
+
+## Test Infrastructure
+
+- **`tests/README.md`**: Comprehensive test suite guide covering 4,065+ tests (116 property-based via Hypothesis), 10 test roots, markers, parallel safety, and CI strategy.
+- **CI restructure**: 6 parallel integration shards with signal-based timeouts (SIGALRM) instead of thread-based. Required for free-threaded Python where thread-based `pytest-timeout` cannot fire.
+- **Class-scoped fixtures**: New `build_ephemeral_site_at()` helper enables class/module-scoped test reuse without redundant site builds.
+- **Removed no-op test**: `test_resource_cleanup.py` had 0 assertions — deleted.
+
+---
+
+## Upgrading
+
+```bash
+uv pip install --upgrade bengal
+# or
+pip install --upgrade bengal
+# or use the self-update command
+bengal upgrade
+```
+
+No breaking changes in this release.

--- a/tests/unit/health/linkcheck/test_internal_checker.py
+++ b/tests/unit/health/linkcheck/test_internal_checker.py
@@ -243,6 +243,37 @@ class TestInternalLinkCheckerBaseURL:
         assert result.status == LinkStatus.OK
 
 
+class TestInternalLinkCheckerTxtFiles:
+    """Tests for auxiliary .txt file indexing (LLM-friendly output)."""
+
+    def test_indexes_txt_files(self, mock_site, tmp_path):
+        """Checker indexes .txt files alongside .html files."""
+        # Create a .txt companion file (like LLM-friendly output)
+        (tmp_path / "about" / "index.txt").write_text("About page plain text")
+        (tmp_path / "docs" / "guide.txt").write_text("Guide plain text")
+
+        checker = InternalLinkChecker(mock_site)
+
+        assert "/about/index.txt" in checker._output_paths
+        assert "/docs/guide.txt" in checker._output_paths
+
+    def test_txt_links_resolve_as_valid(self, mock_site, tmp_path):
+        """Links to index.txt files are not reported as broken."""
+        (tmp_path / "about" / "index.txt").write_text("About page plain text")
+
+        checker = InternalLinkChecker(mock_site)
+        result = checker._check_internal_link("/about/index.txt", ["page.html"])
+
+        assert result.status == LinkStatus.OK
+
+    def test_missing_txt_still_broken(self, mock_site):
+        """Links to non-existent .txt files are still reported as broken."""
+        checker = InternalLinkChecker(mock_site)
+        result = checker._check_internal_link("/missing/index.txt", ["page.html"])
+
+        assert result.status == LinkStatus.BROKEN
+
+
 class TestInternalLinkCheckerBatchChecking:
     """Tests for batch link checking."""
 

--- a/tests/unit/health/test_link_registry.py
+++ b/tests/unit/health/test_link_registry.py
@@ -1,0 +1,157 @@
+"""Tests for the shared LinkRegistry.
+
+Tests bengal/health/link_registry.py:
+- build_link_registry: builds immutable registry from site
+- LinkRegistry: frozen dataclass with correct fields
+- Anchor population from toc_items
+- Auxiliary URL generation
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from bengal.health.link_registry import LinkRegistry, build_link_registry
+
+
+@pytest.fixture
+def mock_site(tmp_path):
+    """Create a mock site with pages that have toc_items."""
+    site = MagicMock()
+    site.root_path = tmp_path
+    site.config = {}
+
+    # Create content directory structure for content_key resolution
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+    (content_dir / "docs").mkdir()
+    (content_dir / "docs" / "_index.md").touch()
+    (content_dir / "about.md").touch()
+
+    page1 = MagicMock()
+    page1.href = "/docs/"
+    page1._path = "/docs/"
+    page1.permalink = None
+    page1.source_path = Path("content/docs/_index.md")
+    page1.toc_items = [
+        {"id": "introduction", "title": "Introduction", "level": 1},
+        {"id": "getting-started", "title": "Getting Started", "level": 1},
+        {"id": "advanced-usage", "title": "Advanced Usage", "level": 2},
+    ]
+    page1.links = []
+
+    page2 = MagicMock()
+    page2.href = "/about/"
+    page2._path = "/about/"
+    page2.permalink = None
+    page2.source_path = Path("content/about.md")
+    page2.toc_items = [
+        {"id": "team", "title": "Team", "level": 1},
+    ]
+    page2.links = []
+
+    page3 = MagicMock()
+    page3.href = "/empty/"
+    page3._path = "/empty/"
+    page3.permalink = None
+    page3.source_path = Path("content/empty.md")
+    page3.toc_items = []
+    page3.links = []
+
+    site.pages = [page1, page2, page3]
+    return site
+
+
+class TestBuildLinkRegistry:
+    """Tests for build_link_registry()."""
+
+    def test_returns_frozen_dataclass(self, mock_site):
+        """Registry is immutable."""
+        registry = build_link_registry(mock_site)
+        assert isinstance(registry, LinkRegistry)
+        with pytest.raises(AttributeError):
+            registry.page_urls = frozenset()  # type: ignore[misc]
+
+    def test_page_urls_include_slash_variants(self, mock_site):
+        """Page URLs include both with and without trailing slash."""
+        registry = build_link_registry(mock_site)
+        assert "/docs/" in registry.page_urls
+        assert "/docs" in registry.page_urls
+        assert "/about/" in registry.page_urls
+        assert "/about" in registry.page_urls
+
+    def test_source_paths_populated(self, mock_site):
+        """Source paths are collected from pages."""
+        registry = build_link_registry(mock_site)
+        assert len(registry.source_paths) > 0
+
+    def test_anchors_populated_from_toc_items(self, mock_site):
+        """Anchors are extracted from page.toc_items."""
+        registry = build_link_registry(mock_site)
+
+        # Check docs page anchors (indexed by _path)
+        docs_anchors = registry.anchors_by_url.get("/docs/")
+        assert docs_anchors is not None
+        assert "introduction" in docs_anchors
+        assert "getting-started" in docs_anchors
+        assert "advanced-usage" in docs_anchors
+
+        # Check about page anchors
+        about_anchors = registry.anchors_by_url.get("/about/")
+        assert about_anchors is not None
+        assert "team" in about_anchors
+
+    def test_no_anchors_for_empty_toc(self, mock_site):
+        """Pages with empty toc_items have no anchor entry."""
+        registry = build_link_registry(mock_site)
+        # /empty/ has no toc_items, so no entry in anchors_by_url
+        assert registry.anchors_by_url.get("/empty/") is None
+
+    def test_anchors_indexed_by_slash_variants(self, mock_site):
+        """Anchors are accessible with and without trailing slash."""
+        registry = build_link_registry(mock_site)
+        assert registry.anchors_by_url.get("/docs/") is not None
+        assert registry.anchors_by_url.get("/docs") is not None
+
+    def test_auxiliary_urls_empty_when_llm_txt_disabled(self, mock_site):
+        """No auxiliary URLs when output_formats not configured."""
+        registry = build_link_registry(mock_site)
+        assert len(registry.auxiliary_urls) == 0
+
+    def test_auxiliary_urls_populated_when_llm_txt_enabled(self, mock_site):
+        """index.txt URLs generated when llm_txt enabled."""
+        mock_site.config = {"output_formats": {"enabled": True, "per_page": ["llm_txt"]}}
+        registry = build_link_registry(mock_site)
+        assert "/docs/index.txt" in registry.auxiliary_urls
+        assert "/about/index.txt" in registry.auxiliary_urls
+
+    def test_permalink_included(self, mock_site):
+        """Permalinks are included in page_urls."""
+        mock_site.pages[0].permalink = "/custom-docs/"
+        registry = build_link_registry(mock_site)
+        assert "/custom-docs/" in registry.page_urls
+        assert "/custom-docs" in registry.page_urls
+
+
+class TestLinkRegistryImmutability:
+    """Tests that LinkRegistry fields are truly immutable."""
+
+    def test_page_urls_is_frozenset(self, mock_site):
+        registry = build_link_registry(mock_site)
+        assert isinstance(registry.page_urls, frozenset)
+
+    def test_source_paths_is_frozenset(self, mock_site):
+        registry = build_link_registry(mock_site)
+        assert isinstance(registry.source_paths, frozenset)
+
+    def test_auxiliary_urls_is_frozenset(self, mock_site):
+        registry = build_link_registry(mock_site)
+        assert isinstance(registry.auxiliary_urls, frozenset)
+
+    def test_anchors_values_are_frozensets(self, mock_site):
+        registry = build_link_registry(mock_site)
+        for anchors in registry.anchors_by_url.values():
+            assert isinstance(anchors, frozenset)

--- a/tests/unit/health/test_linkcheck_async_checker.py
+++ b/tests/unit/health/test_linkcheck_async_checker.py
@@ -152,8 +152,8 @@ def test_from_config_with_defaults():
     checker = AsyncLinkChecker.from_config(config)
 
     # Should use defaults
-    assert checker.max_concurrency == 20
-    assert checker.per_host_limit == 4
+    assert checker.max_concurrency == 50
+    assert checker.per_host_limit == 8
     assert checker.timeout == 10.0
     assert checker.retries == 2
     assert checker.retry_backoff == 0.5
@@ -162,16 +162,16 @@ def test_from_config_with_defaults():
 def test_from_config_partial_override():
     """Test from_config with partial config."""
     config = {
-        "max_concurrency": 50,
+        "max_concurrency": 100,
         "timeout": 15.0,
         # Other values use defaults
     }
 
     checker = AsyncLinkChecker.from_config(config)
 
-    assert checker.max_concurrency == 50
+    assert checker.max_concurrency == 100
     assert checker.timeout == 15.0
-    assert checker.per_host_limit == 4  # Default
+    assert checker.per_host_limit == 8  # Default
     assert checker.retries == 2  # Default
 
 

--- a/tests/unit/health/validators/test_links.py
+++ b/tests/unit/health/validators/test_links.py
@@ -28,6 +28,7 @@ def mock_site():
     site = MagicMock()
     site.config = {"validate_links": True}
     site.root_path = Path("/project")
+    site.link_registry = None
 
     # Create mock pages with hrefs that exist in the site
     page1 = MagicMock()
@@ -66,6 +67,7 @@ def mock_site_with_broken_links():
     site = MagicMock()
     site.config = {"validate_links": True}
     site.root_path = Path("/project")
+    site.link_registry = None
 
     # Create mock pages with broken links
     page1 = MagicMock()
@@ -235,3 +237,103 @@ class TestLinkValidatorWrapperSilenceIsGolden:
 
         success_results = [r for r in results if r.status == CheckStatus.SUCCESS]
         assert len(success_results) == 0
+
+
+class TestLinkValidatorAnchorValidation:
+    """Tests for anchor validation via LinkRegistry."""
+
+    @pytest.fixture
+    def site_with_registry(self):
+        """Create mock site with a LinkRegistry providing anchor data."""
+        from bengal.health.link_registry import LinkRegistry
+
+        site = MagicMock()
+        site.config = {"validate_links": True}
+        site.root_path = Path("/project")
+
+        registry = LinkRegistry(
+            page_urls=frozenset(["/docs/", "/docs", "/about/", "/about"]),
+            source_paths=frozenset(),
+            anchors_by_url={
+                "/docs/": frozenset(["introduction", "getting-started"]),
+                "/docs": frozenset(["introduction", "getting-started"]),
+                "/about/": frozenset(["team", "mission"]),
+                "/about": frozenset(["team", "mission"]),
+            },
+            auxiliary_urls=frozenset(),
+        )
+        site.link_registry = registry
+
+        return site
+
+    def test_valid_fragment_link_passes(self, site_with_registry):
+        """Fragment-only link to existing anchor is valid."""
+        page = MagicMock()
+        page._path = "/docs/"
+        page.href = "/docs/"
+        page.source_path = Path("/project/content/docs/_index.md")
+        page.links = ["#introduction"]
+        site_with_registry.pages = [page]
+
+        validator = LinkValidator()
+        broken = validator.validate_site(site_with_registry)
+        assert len(broken) == 0
+
+    def test_broken_fragment_link_detected(self, site_with_registry):
+        """Fragment-only link to nonexistent anchor is broken."""
+        page = MagicMock()
+        page._path = "/docs/"
+        page.href = "/docs/"
+        page.source_path = Path("/project/content/docs/_index.md")
+        page.links = ["#nonexistent-heading"]
+        site_with_registry.pages = [page]
+
+        validator = LinkValidator()
+        broken = validator.validate_site(site_with_registry)
+        assert len(broken) == 1
+        assert broken[0][1] == "#nonexistent-heading"
+
+    def test_valid_path_with_fragment_passes(self, site_with_registry):
+        """Path+fragment link where both page and anchor exist is valid."""
+        page = MagicMock()
+        page._path = "/about/"
+        page.href = "/about/"
+        page.source_path = Path("/project/content/about.md")
+        page.links = ["/docs/#introduction"]
+        site_with_registry.pages = [page]
+
+        validator = LinkValidator()
+        broken = validator.validate_site(site_with_registry)
+        assert len(broken) == 0
+
+    def test_broken_anchor_on_valid_page_detected(self, site_with_registry):
+        """Path+fragment link where page exists but anchor doesn't is broken."""
+        page = MagicMock()
+        page._path = "/about/"
+        page.href = "/about/"
+        page.source_path = Path("/project/content/about.md")
+        page.links = ["/docs/#nonexistent-section"]
+        site_with_registry.pages = [page]
+
+        validator = LinkValidator()
+        broken = validator.validate_site(site_with_registry)
+        assert len(broken) == 1
+        assert broken[0][1] == "/docs/#nonexistent-section"
+
+    def test_no_anchor_validation_without_registry(self):
+        """Without registry, fragment links pass (backward compat)."""
+        site = MagicMock()
+        site.config = {"validate_links": True}
+        site.root_path = Path("/project")
+        site.link_registry = None
+
+        page = MagicMock()
+        page.href = "/docs/"
+        page._path = "/docs/"
+        page.source_path = Path("/project/content/docs/_index.md")
+        page.links = ["#any-heading"]
+        site.pages = [page]
+
+        validator = LinkValidator()
+        broken = validator.validate_site(site)
+        assert len(broken) == 0

--- a/tests/unit/rendering/test_link_validator.py
+++ b/tests/unit/rendering/test_link_validator.py
@@ -21,6 +21,7 @@ def mock_site(tmp_path):
     """Create a mock site with sample pages."""
     site = MagicMock()
     site.root_path = tmp_path
+    site.link_registry = None
 
     # Create mock pages with URLs
     page1 = MagicMock()
@@ -238,6 +239,7 @@ class TestPageUrlIndex:
         """Test that action-bar index.txt links validate when llm_txt is enabled."""
         site = MagicMock()
         site.config = {"output_formats": {"enabled": True, "per_page": ["llm_txt"]}}
+        site.link_registry = None
         page = MagicMock()
         page.href = "/api/bengal/experimental/"
         page.source_path = Path("content/api/bengal/experimental.md")

--- a/tests/unit/rendering/test_xref_bug.py
+++ b/tests/unit/rendering/test_xref_bug.py
@@ -1,11 +1,13 @@
 """
 Tests for cross-reference bug fixes.
 
-Verifies that cross-references are NOT substituted inside code blocks.
+Verifies that cross-references are NOT substituted inside code blocks,
+and that [[ext:project:|Text]] works correctly inside markdown tables.
 """
 
 import pytest
 
+from bengal.rendering.plugins.cross_references import CrossReferencePlugin
 from tests._testing.mocks import MockPage
 
 
@@ -60,3 +62,60 @@ var x = [[doc/link]];
             pytest.fail(f"Cross-reference was substituted inside code block: {code_html}")
 
         assert "[[doc/link]]" in code_html
+
+
+class TestProtectTablePipes:
+    """Tests for protect_table_pipes / restore_table_pipes.
+
+    Cross-references like [[ext:kida:|Kida]] use | as the ref/text separator,
+    which conflicts with markdown table cell delimiters. The protect/restore
+    methods substitute pipes inside [[...]] before the parser splits table rows.
+    """
+
+    def test_protects_pipe_inside_brackets(self):
+        """Pipe inside [[...]] is replaced with placeholder."""
+        source = "| col | [[ext:kida:|Kida]] |"
+        protected = CrossReferencePlugin.protect_table_pipes(source)
+
+        assert "|Kida" not in protected
+        assert CrossReferencePlugin._PIPE_PLACEHOLDER + "Kida" in protected
+
+    def test_roundtrip(self):
+        """protect then restore returns original text."""
+        source = "| **Templates** | [[ext:kida:|Kida]] (fast) |"
+        protected = CrossReferencePlugin.protect_table_pipes(source)
+        restored = CrossReferencePlugin.restore_table_pipes(protected)
+
+        assert restored == source
+
+    def test_multiple_xrefs_in_one_line(self):
+        """Multiple [[...]] patterns on one line are all protected."""
+        source = "| **FT** | [[ext:kida:|Kida]], [[ext:patitas:|Patitas]] |"
+        protected = CrossReferencePlugin.protect_table_pipes(source)
+
+        assert "|Kida" not in protected
+        assert "|Patitas" not in protected
+        assert CrossReferencePlugin.restore_table_pipes(protected) == source
+
+    def test_no_op_without_brackets(self):
+        """Source without [[ is returned unchanged."""
+        source = "| col1 | col2 |"
+        assert CrossReferencePlugin.protect_table_pipes(source) == source
+
+    def test_no_op_without_pipe(self):
+        """Source without | is returned unchanged."""
+        source = "[[ext:kida:Markup]] some text"
+        assert CrossReferencePlugin.protect_table_pipes(source) == source
+
+    def test_brackets_without_pipe_unchanged(self):
+        """[[...]] that don't contain | are not modified."""
+        source = "| col | [[docs/guide]] |"
+        assert CrossReferencePlugin.protect_table_pipes(source) == source
+
+    def test_nested_pipes_all_replaced(self):
+        """Multiple pipes inside one [[...]] are all replaced."""
+        source = "[[a|b|c]]"
+        protected = CrossReferencePlugin.protect_table_pipes(source)
+
+        assert "|" not in protected.replace(CrossReferencePlugin._PIPE_PLACEHOLDER, "")
+        assert CrossReferencePlugin.restore_table_pipes(protected) == source

--- a/uv.lock
+++ b/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "bengal"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "bengal-pounce" },
@@ -536,9 +536,9 @@ sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f
 name = "kida-templates"
 version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/b4/6f0d560341ee647255a654983964b9cab292c2297af71c10397e907564b2/kida_templates-0.2.9.tar.gz", hash = "sha256:c6bec9814926ed311d0b28b974f369bb40066f483b9287bc9cfb991177b9d8d3", size = 380649, upload-time = "2026-03-23T18:45:47.782332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/b4/6f0d560341ee647255a654983964b9cab292c2297af71c10397e907564b2/kida_templates-0.2.9.tar.gz", hash = "sha256:c6bec9814926ed311d0b28b974f369bb40066f483b9287bc9cfb991177b9d8d3", size = 380649, upload-time = "2026-03-23T18:45:47.782Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/fc/1288087da032c0d85782d201d26dbab532c979a4f915acf471aca7f0f844/kida_templates-0.2.9-py3-none-any.whl", hash = "sha256:7244eaff10c9465c0debe7fce79a26c37b6c7b2eb9faa058951dfbc1354380c5", size = 265874, upload-time = "2026-03-23T18:45:45.704184Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fc/1288087da032c0d85782d201d26dbab532c979a4f915acf471aca7f0f844/kida_templates-0.2.9-py3-none-any.whl", hash = "sha256:7244eaff10c9465c0debe7fce79a26c37b6c7b2eb9faa058951dfbc1354380c5", size = 265874, upload-time = "2026-03-23T18:45:45.704Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Unified LinkRegistry**: New shared, immutable `LinkRegistry` built once after rendering and consumed by both build-time (`LinkValidator`) and post-build (`InternalLinkChecker`) validators — eliminates duplicated URL index construction and redundant HTML re-parsing
- **Real anchor validation**: Fragment-only (`#heading`) and path+fragment (`/docs/#section`) links are now validated against actual page anchors from `toc_items`, replacing the previous unconditional pass-through
- **Directive link capture**: `extract_links()` now scans `html_content` for `<a href>` patterns from cards, buttons, and other directives that were previously invisible to build-time checks
- **New documentation**: Plugin system guide, template dependency tracking, configuration reference, free-threading docs, and extension points rewrite
- **Version bump to 0.2.7** with changelog and release notes

## Test plan

- [x] All 1323 link/health/xref tests pass (18 new tests added)
- [ ] Run `bengal site build site` and verify anchor-broken links are now reported
- [ ] Run `bengal health linkcheck` and confirm internal link results match pre-change baseline
- [ ] Verify no regressions in full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)