### PR TITLE
feat: WorkScope structured concurrency — migrate all executor sites

### DIFF
--- a/bengal/analysis/graph/builder.py
+++ b/bengal/analysis/graph/builder.py
@@ -278,13 +278,15 @@ class GraphBuilder:
             }
 
         # Parallel execution
+        from bengal.utils.concurrency.executor import managed_executor
+
         results: list[dict[str, Any]] = []
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        with managed_executor(max_workers, thread_name_prefix="graphbuild") as executor:
             future_to_page = {executor.submit(analyze_page, page): page for page in analysis_pages}
             for future in concurrent.futures.as_completed(future_to_page):
                 page = future_to_page[future]
                 try:
-                    result = future.result()
+                    result = future.result(timeout=90)
                     results.append(result)
                 except Exception as e:
                     # Track error for session aggregation and debugging

--- a/bengal/analysis/graph/builder.py
+++ b/bengal/analysis/graph/builder.py
@@ -280,7 +280,11 @@ class GraphBuilder:
         from bengal.utils.concurrency.work_scope import WorkScope
 
         def _analyze_with_page(page):
-            return page, analyze_page(page)
+            try:
+                return page, analyze_page(page)
+            except Exception as e:
+                e.__page_source_path__ = str(page.source_path)  # type: ignore[attr-defined]
+                raise
 
         results: list[dict[str, Any]] = []
         with WorkScope("graphbuild", max_workers=max_workers) as scope:
@@ -288,8 +292,10 @@ class GraphBuilder:
             for r in work_results:
                 if r.error:
                     # Track error for session aggregation and debugging
+                    page_path = getattr(r.error, "__page_source_path__", None)
                     logger.warning(
                         "graph_page_analysis_failed",
+                        page=page_path,
                         error=str(r.error),
                         code="G005",
                     )

--- a/bengal/analysis/graph/builder.py
+++ b/bengal/analysis/graph/builder.py
@@ -17,7 +17,6 @@ GraphBuilder: Builds the knowledge graph from site data.
 
 """
 
-import concurrent.futures
 import os
 import threading
 from collections import defaultdict
@@ -278,33 +277,25 @@ class GraphBuilder:
             }
 
         # Parallel execution
-        from bengal.utils.concurrency.executor import managed_executor
+        from bengal.utils.concurrency.work_scope import WorkScope
+
+        def _analyze_with_page(page):
+            return page, analyze_page(page)
 
         results: list[dict[str, Any]] = []
-        with managed_executor(max_workers, thread_name_prefix="graphbuild") as executor:
-            future_to_page = {executor.submit(analyze_page, page): page for page in analysis_pages}
-            for future in concurrent.futures.as_completed(future_to_page):
-                page = future_to_page[future]
-                try:
-                    result = future.result(timeout=90)
-                    results.append(result)
-                except Exception as e:
+        with WorkScope("graphbuild", max_workers=max_workers) as scope:
+            work_results = scope.map(_analyze_with_page, analysis_pages)
+            for r in work_results:
+                if r.error:
                     # Track error for session aggregation and debugging
-                    page_path = getattr(page, "source_path", None)
-                    error = BengalGraphError(
-                        f"Page analysis failed: {page_path}",
-                        code=ErrorCode.G005,
-                        file_path=page_path,
-                        original_error=e,
-                        suggestion="Check page content and link structure",
-                    )
-                    record_error(error, file_path=str(page_path) if page_path else None)
                     logger.warning(
                         "graph_page_analysis_failed",
-                        page=str(getattr(page, "source_path", page)),
-                        error=str(e),
+                        error=str(r.error),
                         code="G005",
                     )
+                elif r.value is not None:
+                    page, result = r.value
+                    results.append(result)
 
         # Merge phase: combine all thread-local results
         # This runs single-threaded after all workers complete

--- a/bengal/autodoc/extractors/python/extractor.py
+++ b/bengal/autodoc/extractors/python/extractor.py
@@ -17,7 +17,6 @@ significant speedup (3-4x on multi-core machines).
 from __future__ import annotations
 
 import ast
-import concurrent.futures
 import multiprocessing
 import os
 import time
@@ -431,15 +430,14 @@ class PythonExtractor(Extractor):
                 )
                 return []
 
-        from bengal.utils.concurrency.executor import managed_executor
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-        with managed_executor(max_workers, thread_name_prefix="autodoc") as executor:
-            future_to_file = {
-                executor.submit(extract_single_file, py_file): py_file for py_file in py_files
-            }
-            for future in concurrent.futures.as_completed(future_to_file):
-                file_elements = future.result(timeout=90)
-                elements.extend(file_elements)
+        with WorkScope("autodoc", max_workers=max_workers) as scope:
+            results = scope.map(extract_single_file, py_files)
+            for r in results:
+                if r.error:
+                    raise r.error
+                elements.extend(r.value)
 
         elapsed = time.perf_counter() - start_time
         files_per_second = len(py_files) / elapsed if elapsed > 0 else 0

--- a/bengal/autodoc/extractors/python/extractor.py
+++ b/bengal/autodoc/extractors/python/extractor.py
@@ -431,12 +431,14 @@ class PythonExtractor(Extractor):
                 )
                 return []
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        from bengal.utils.concurrency.executor import managed_executor
+
+        with managed_executor(max_workers, thread_name_prefix="autodoc") as executor:
             future_to_file = {
                 executor.submit(extract_single_file, py_file): py_file for py_file in py_files
             }
             for future in concurrent.futures.as_completed(future_to_file):
-                file_elements = future.result()
+                file_elements = future.result(timeout=90)
                 elements.extend(file_elements)
 
         elapsed = time.perf_counter() - start_time

--- a/bengal/build/provenance/filter.py
+++ b/bengal/build/provenance/filter.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import contextlib
 import os
 import threading
-from concurrent.futures import as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -207,16 +206,19 @@ class ProvenanceFilter:
         # Phase 2: Verify cache validity - parallel when many pages
         parallel_threshold = 100
         if len(pages_to_verify) >= parallel_threshold:
-            from bengal.utils.concurrency.executor import managed_executor
+            from bengal.utils.concurrency.work_scope import WorkScope
 
             max_workers = min(32, (os.cpu_count() or 1) + 4)
-            with managed_executor(max_workers, thread_name_prefix="provenance") as executor:
-                futures = [
-                    executor.submit(self._verify_page_provenance, page, stored_hash)
-                    for page, stored_hash in pages_to_verify
-                ]
-                for future in as_completed(futures):
-                    build, skip, tags, sections, paths = future.result(timeout=90)
+            with WorkScope("provenance-verify", max_workers=max_workers) as scope:
+                results = scope.map(
+                    lambda item: self._verify_page_provenance(item[0], item[1]),
+                    pages_to_verify,
+                )
+                for r in results:
+                    if r.error:
+                        raise r.error
+                    assert r.value is not None  # guarded by r.error check above
+                    build, skip, tags, sections, paths = r.value
                     if build is not None:
                         pages_to_build.append(build)
                         affected_tags.update(tags)

--- a/bengal/build/provenance/filter.py
+++ b/bengal/build/provenance/filter.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import contextlib
 import os
 import threading
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -207,14 +207,16 @@ class ProvenanceFilter:
         # Phase 2: Verify cache validity - parallel when many pages
         parallel_threshold = 100
         if len(pages_to_verify) >= parallel_threshold:
+            from bengal.utils.concurrency.executor import managed_executor
+
             max_workers = min(32, (os.cpu_count() or 1) + 4)
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            with managed_executor(max_workers, thread_name_prefix="provenance") as executor:
                 futures = [
                     executor.submit(self._verify_page_provenance, page, stored_hash)
                     for page, stored_hash in pages_to_verify
                 ]
                 for future in as_completed(futures):
-                    build, skip, tags, sections, paths = future.result()
+                    build, skip, tags, sections, paths = future.result(timeout=90)
                     if build is not None:
                         pages_to_build.append(build)
                         affected_tags.update(tags)

--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -211,6 +211,7 @@ class ContentDiscovery:
         )
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
 
+        clean_exit = False
         try:
             # Walk top-level items
             for item in sorted(self.content_dir.iterdir()):
@@ -229,9 +230,14 @@ class ContentDiscovery:
                     else None
                 )
                 self._process_top_level_item_surgical(item, cache, current_lang=current_lang)
+            clean_exit = True
         finally:
             if self._executor:
-                self._executor.shutdown(wait=True)
+                if clean_exit:
+                    self._executor.shutdown(wait=True)
+                else:
+                    # On error, don't block on hung threads
+                    self._executor.shutdown(wait=False, cancel_futures=True)
                 self._executor = None
 
         # Sort sections
@@ -619,7 +625,7 @@ class ContentDiscovery:
         for fut in futures:
 
             def get_page_result(f: Any = fut) -> Page:
-                return cast(Page, f.result())
+                return cast(Page, f.result(timeout=90))
 
             page = with_error_recovery(
                 get_page_result,

--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -37,8 +37,8 @@ Related:
 from __future__ import annotations
 
 import contextlib
+import contextvars
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -47,6 +47,7 @@ from bengal.content.discovery.directory_walker import DirectoryWalker
 from bengal.content.discovery.section_builder import SectionBuilder
 from bengal.core.page import Page, PageProxy
 from bengal.core.section import Section
+from bengal.utils.concurrency.executor import managed_executor
 from bengal.utils.concurrency.workers import WorkloadType, get_optimal_workers
 from bengal.utils.observability.logger import get_logger
 
@@ -137,7 +138,7 @@ class ContentDiscovery:
         self._section_builder = SectionBuilder(site)
 
         # Thread pool for parallel processing (initialized during discovery)
-        self._executor: ThreadPoolExecutor | None = None
+        self._executor: Any = None  # ThreadPoolExecutor from managed_executor
 
     @property
     def _validation_errors(self) -> list[tuple[Path, str, list[Any]]]:
@@ -209,35 +210,29 @@ class ContentDiscovery:
             if self.site and self.site.config
             else None,
         )
-        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        with managed_executor(max_workers, thread_name_prefix="Bengal-Discovery") as executor:
+            self._executor = executor
+            try:
+                # Walk top-level items
+                for item in sorted(self.content_dir.iterdir()):
+                    if self._walker.should_skip_item(item):
+                        continue
 
-        clean_exit = False
-        try:
-            # Walk top-level items
-            for item in sorted(self.content_dir.iterdir()):
-                if self._walker.should_skip_item(item):
-                    continue
+                    # Detect language-root directories for i18n
+                    if self._is_language_root(item, i18n_config):
+                        for sub in sorted(item.iterdir()):
+                            self._process_top_level_item_surgical(
+                                sub, cache, current_lang=item.name
+                            )
+                        continue
 
-                # Detect language-root directories for i18n
-                if self._is_language_root(item, i18n_config):
-                    for sub in sorted(item.iterdir()):
-                        self._process_top_level_item_surgical(sub, cache, current_lang=item.name)
-                    continue
-
-                current_lang = (
-                    i18n_config.get("default_lang")
-                    if i18n_config.get("strategy") == "prefix"
-                    else None
-                )
-                self._process_top_level_item_surgical(item, cache, current_lang=current_lang)
-            clean_exit = True
-        finally:
-            if self._executor:
-                if clean_exit:
-                    self._executor.shutdown(wait=True)
-                else:
-                    # On error, don't block on hung threads
-                    self._executor.shutdown(wait=False, cancel_futures=True)
+                    current_lang = (
+                        i18n_config.get("default_lang")
+                        if i18n_config.get("strategy") == "prefix"
+                        else None
+                    )
+                    self._process_top_level_item_surgical(item, cache, current_lang=current_lang)
+            finally:
                 self._executor = None
 
         # Sort sections
@@ -272,7 +267,10 @@ class ContentDiscovery:
                 self._section_builder.pages.append(page)
             elif self._executor:
                 # Cache miss: submit to executor
-                future = self._executor.submit(self._create_page, item_path, current_lang, None)
+                ctx = contextvars.copy_context()
+                future = self._executor.submit(
+                    ctx.run, self._create_page, item_path, current_lang, None
+                )
                 # Resolve immediately for top-level pages (no section)
                 self._resolve_page_futures([future])
             else:
@@ -317,8 +315,11 @@ class ContentDiscovery:
                     self._section_builder.pages.append(page)
                 elif self._executor:
                     # Cache miss: None returned, submit to executor for parsing
+                    ctx = contextvars.copy_context()
                     file_futures.append(
-                        self._executor.submit(self._create_page, item, current_lang, parent_section)
+                        self._executor.submit(
+                            ctx.run, self._create_page, item, current_lang, parent_section
+                        )
                     )
                 else:
                     # No executor available, parse synchronously
@@ -449,29 +450,27 @@ class ContentDiscovery:
             if self.site and self.site.config
             else None,
         )
-        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        with managed_executor(max_workers, thread_name_prefix="Bengal-Discovery") as executor:
+            self._executor = executor
+            try:
+                # Walk top-level items
+                for item in sorted(self.content_dir.iterdir()):
+                    if self._walker.should_skip_item(item):
+                        continue
 
-        try:
-            # Walk top-level items
-            for item in sorted(self.content_dir.iterdir()):
-                if self._walker.should_skip_item(item):
-                    continue
+                    # Detect language-root directories for i18n
+                    if self._is_language_root(item, i18n_config):
+                        for sub in sorted(item.iterdir()):
+                            self._process_top_level_item(sub, current_lang=item.name)
+                        continue
 
-                # Detect language-root directories for i18n
-                if self._is_language_root(item, i18n_config):
-                    for sub in sorted(item.iterdir()):
-                        self._process_top_level_item(sub, current_lang=item.name)
-                    continue
-
-                current_lang = (
-                    i18n_config.get("default_lang")
-                    if i18n_config.get("strategy") == "prefix"
-                    else None
-                )
-                self._process_top_level_item(item, current_lang=current_lang)
-        finally:
-            if self._executor:
-                self._executor.shutdown(wait=True)
+                    current_lang = (
+                        i18n_config.get("default_lang")
+                        if i18n_config.get("strategy") == "prefix"
+                        else None
+                    )
+                    self._process_top_level_item(item, current_lang=current_lang)
+            finally:
                 self._executor = None
 
         # Sort sections
@@ -555,8 +554,9 @@ class ContentDiscovery:
 
         if item_path.is_file() and self._walker.is_content_file(item_path):
             if self._executor:
+                ctx = contextvars.copy_context()
                 pending_pages.append(
-                    self._executor.submit(self._create_page, item_path, current_lang, None)
+                    self._executor.submit(ctx.run, self._create_page, item_path, current_lang, None)
                 )
             else:
                 page = self._create_page(item_path, current_lang=current_lang, section=None)
@@ -595,8 +595,11 @@ class ContentDiscovery:
 
             if item.is_file() and self._walker.is_content_file(item):
                 if self._executor:
+                    ctx = contextvars.copy_context()
                     file_futures.append(
-                        self._executor.submit(self._create_page, item, current_lang, parent_section)
+                        self._executor.submit(
+                            ctx.run, self._create_page, item, current_lang, parent_section
+                        )
                     )
                 else:
                     page = self._create_page(

--- a/bengal/content/sources/__init__.py
+++ b/bengal/content/sources/__init__.py
@@ -57,6 +57,8 @@ Related:
 
 from __future__ import annotations
 
+import threading
+
 from bengal.content.sources.entry import ContentEntry
 
 # Loader factory functions (lazy import actual sources)
@@ -72,14 +74,16 @@ from bengal.content.sources.source import ContentSource
 # Source registry - maps type names to source classes
 # Remote sources use lazy loading to avoid importing heavy dependencies
 SOURCE_REGISTRY: dict[str, type[ContentSource]] = {}
+_registry_lock = threading.Lock()
 
 
 def _register_local_source() -> None:
     """Register the local source (always available)."""
     from bengal.content.sources.local import LocalSource
 
-    SOURCE_REGISTRY["local"] = LocalSource
-    SOURCE_REGISTRY["filesystem"] = LocalSource  # Alias
+    with _registry_lock:
+        SOURCE_REGISTRY["local"] = LocalSource
+        SOURCE_REGISTRY["filesystem"] = LocalSource  # Alias
 
 
 def _register_github_source() -> None:
@@ -87,7 +91,8 @@ def _register_github_source() -> None:
     try:
         from bengal.content.sources.github import GitHubSource
 
-        SOURCE_REGISTRY["github"] = GitHubSource
+        with _registry_lock:
+            SOURCE_REGISTRY["github"] = GitHubSource
     except ImportError:
         pass  # aiohttp not installed
 
@@ -97,8 +102,9 @@ def _register_rest_source() -> None:
     try:
         from bengal.content.sources.rest import RESTSource
 
-        SOURCE_REGISTRY["rest"] = RESTSource
-        SOURCE_REGISTRY["api"] = RESTSource  # Alias
+        with _registry_lock:
+            SOURCE_REGISTRY["rest"] = RESTSource
+            SOURCE_REGISTRY["api"] = RESTSource  # Alias
     except ImportError:
         pass  # aiohttp not installed
 
@@ -108,7 +114,8 @@ def _register_notion_source() -> None:
     try:
         from bengal.content.sources.notion import NotionSource
 
-        SOURCE_REGISTRY["notion"] = NotionSource
+        with _registry_lock:
+            SOURCE_REGISTRY["notion"] = NotionSource
     except ImportError:
         pass  # aiohttp not installed
 

--- a/bengal/core/asset/asset_core.py
+++ b/bengal/core/asset/asset_core.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import hashlib
 import shutil
+import threading
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -49,6 +50,10 @@ from typing import Any
 from bengal.assets.manifest import AssetManifest
 from bengal.core.asset.css_transforms import transform_css_nesting
 from bengal.core.diagnostics import emit as emit_diagnostic
+
+# Pillow C extensions are not thread-safe under free-threading (3.14t);
+# serialise all PIL operations with this lock so worker threads don't race.
+_pil_lock = threading.Lock()
 
 
 @dataclass
@@ -499,15 +504,17 @@ class Asset:
             from PIL import Image
             from PIL.Image import Image as PILImage
 
-            img: PILImage = Image.open(self.source_path)
+            # Pillow C extensions are not thread-safe under free-threading (3.14t)
+            with _pil_lock:
+                img: PILImage = Image.open(self.source_path)
 
-            # Basic optimization - could be expanded
-            if img.mode in ("RGBA", "LA"):
-                # Keep alpha channel
-                pass
-            else:
-                # Convert to RGB if needed
-                img = img.convert("RGB")
+                # Basic optimization - could be expanded
+                if img.mode in ("RGBA", "LA"):
+                    # Keep alpha channel
+                    pass
+                else:
+                    # Convert to RGB if needed
+                    img = img.convert("RGB")
 
             # Store optimized image (would be saved during copy_to_output)
             self._optimized_image = img
@@ -588,7 +595,11 @@ class Asset:
                 elif ext in ("PNG", "GIF", "WEBP"):
                     img_format = ext
 
-                self._optimized_image.save(tmp_path, format=img_format, optimize=True, quality=85)
+                # Pillow C extensions are not thread-safe under free-threading (3.14t)
+                with _pil_lock:
+                    self._optimized_image.save(
+                        tmp_path, format=img_format, optimize=True, quality=85
+                    )
                 tmp_path.replace(output_path)
             except Exception as e:
                 emit_diagnostic(

--- a/bengal/core/page/__init__.py
+++ b/bengal/core/page/__init__.py
@@ -224,6 +224,8 @@ class Page(
 
     # Private cache for lazy frontmatter property
     _frontmatter: Frontmatter | None = field(default=None, init=False, repr=False)
+    # Lock for thread-safe lazy initialization of _frontmatter
+    _init_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     # Cache for CascadeView (invalidated when site/section changes)
     _metadata_view_cache: CascadeView | None = field(default=None, init=False, repr=False)
@@ -454,7 +456,9 @@ class Page(
             'My Post'
         """
         if self._frontmatter is None:
-            self._frontmatter = Frontmatter.from_dict(self.metadata)
+            with self._init_lock:
+                if self._frontmatter is None:
+                    self._frontmatter = Frontmatter.from_dict(self.metadata)
         return self._frontmatter
 
     @classmethod

--- a/bengal/core/page/proxy.py
+++ b/bengal/core/page/proxy.py
@@ -16,6 +16,7 @@ Architecture:
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable, Mapping
 from datetime import datetime
 from pathlib import Path
@@ -170,6 +171,7 @@ class PageProxy:
         self._loader = loader
         self._lazy_loaded = False
         self._full_page: Page | None = None
+        self._load_lock = threading.Lock()
         self._related_posts_cache: list[Page] | None = None
         self._site = None  # Site reference - set externally
 
@@ -313,32 +315,36 @@ class PageProxy:
         if self._lazy_loaded:
             return
 
-        try:
-            self._full_page = self._loader(self.source_path)
-            self._lazy_loaded = True
+        with self._load_lock:
+            if self._lazy_loaded:
+                return
 
-            # Transfer site and section references to loaded page
-            if self._full_page:
-                if hasattr(self, "_site"):
-                    self._full_page._site = self._site
-                # Transfer section path (not object) for stable references
-                if self._section_path is not None:
-                    self._full_page._section_path = self._section_path
+            try:
+                self._full_page = self._loader(self.source_path)
+                self._lazy_loaded = True
+            except Exception as e:
+                emit_diagnostic(
+                    self,
+                    "error",
+                    "page_proxy_load_failed",
+                    source_path=str(self.source_path),
+                    error=str(e),
+                )
+                raise
 
-            # Apply any pending attributes that were set before loading
-            if hasattr(self, "_pending_output_path") and self._full_page:
-                self._full_page.output_path = self._pending_output_path
+        # Transfer site and section references to loaded page (outside lock)
+        if self._full_page:
+            if hasattr(self, "_site"):
+                self._full_page._site = self._site
+            # Transfer section path (not object) for stable references
+            if self._section_path is not None:
+                self._full_page._section_path = self._section_path
 
-            emit_diagnostic(self, "debug", "page_proxy_loaded", source_path=str(self.source_path))
-        except Exception as e:
-            emit_diagnostic(
-                self,
-                "error",
-                "page_proxy_load_failed",
-                source_path=str(self.source_path),
-                error=str(e),
-            )
-            raise
+        # Apply any pending attributes that were set before loading
+        if hasattr(self, "_pending_output_path") and self._full_page:
+            self._full_page.output_path = self._pending_output_path
+
+        emit_diagnostic(self, "debug", "page_proxy_loaded", source_path=str(self.source_path))
 
     # ============================================================================
     # Lazy Properties - Load full page on first access

--- a/bengal/core/page_cache.py
+++ b/bengal/core/page_cache.py
@@ -10,6 +10,7 @@ via invalidate() or invalidate_regular().
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -33,6 +34,7 @@ class PageCacheManager:
     __slots__ = (
         "_generated",
         "_listable",
+        "_lock",
         "_pages_fn",
         "_path_map",
         "_path_map_version",
@@ -48,6 +50,7 @@ class PageCacheManager:
         self._path_map: dict[str, Page] | None = None
         self._path_map_version: int = -1
         self._source_path_map: dict[Path, Page] | None = None
+        self._lock = threading.Lock()
 
     @property
     def regular_pages(self) -> list[Page]:
@@ -82,15 +85,19 @@ class PageCacheManager:
         pages = self._pages_fn()
         current_version = len(pages)
         if self._path_map is None or self._path_map_version != current_version:
-            self._path_map = {str(p.source_path): p for p in pages}
-            self._path_map_version = current_version
+            with self._lock:
+                if self._path_map is None or self._path_map_version != current_version:
+                    self._path_map = {str(p.source_path): p for p in pages}
+                    self._path_map_version = current_version
         return self._path_map
 
     @property
     def page_by_source_path(self) -> dict[Path, Page]:
         """O(1) page lookup by source Path (shared across orchestrators)."""
         if self._source_path_map is None:
-            self._source_path_map = {p.source_path: p for p in self._pages_fn()}
+            with self._lock:
+                if self._source_path_map is None:
+                    self._source_path_map = {p.source_path: p for p in self._pages_fn()}
         return self._source_path_map
 
     def invalidate(self) -> None:

--- a/bengal/core/site/__init__.py
+++ b/bengal/core/site/__init__.py
@@ -236,6 +236,9 @@ class Site(
     # Lock for thread-safe fallback set access (initialized in __post_init__)
     _asset_manifest_fallbacks_lock: Lock | None = field(default=None, repr=False, init=False)
 
+    # Shared lock for lazy-property initialization (double-checked locking pattern)
+    _init_lock: Lock = field(default_factory=Lock, repr=False, init=False)
+
     # --- Legacy Template Environment Caches (primary: BuildState) ---
     _bengal_theme_chain_cache: dict[str, Any] | None = field(default=None, repr=False, init=False)
     _bengal_template_dirs_cache: dict[str, Any] | None = field(default=None, repr=False, init=False)
@@ -371,7 +374,9 @@ class Site(
         via a frozen dataclass that requires no locks during parallel rendering.
         """
         if self._config_service is None:
-            self._config_service = ConfigService.from_config(self.config, self.root_path)
+            with self._init_lock:
+                if self._config_service is None:
+                    self._config_service = ConfigService.from_config(self.config, self.root_path)
         return self._config_service
 
     def _compute_config_hash(self) -> None:
@@ -390,9 +395,13 @@ class Site(
     def indexes(self) -> QueryIndexRegistry:
         """Access to query indexes for O(1) page lookups."""
         if self._query_registry is None:
-            from bengal.cache.query_index_registry import QueryIndexRegistry
+            with self._init_lock:
+                if self._query_registry is None:
+                    from bengal.cache.query_index_registry import QueryIndexRegistry
 
-            self._query_registry = QueryIndexRegistry(cast(SiteLike, self), self.paths.indexes_dir)
+                    self._query_registry = QueryIndexRegistry(
+                        cast(SiteLike, self), self.paths.indexes_dir
+                    )
         return self._query_registry
 
     @property
@@ -411,9 +420,12 @@ class Site(
             section = site.registry.get_section_by_url("/api/")
         """
         if self._registry is None:
-            self._registry = ContentRegistry()
-            self._registry.set_root_path(self.root_path)
-            self._registry.url_ownership = self.url_registry
+            with self._init_lock:
+                if self._registry is None:
+                    _reg = ContentRegistry()
+                    _reg.set_root_path(self.root_path)
+                    _reg.url_ownership = self.url_registry
+                    self._registry = _reg
         return self._registry
 
     # =========================================================================

--- a/bengal/core/site_content.py
+++ b/bengal/core/site_content.py
@@ -41,6 +41,7 @@ plan/drafted/rfc-site-responsibility-separation.md
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -111,6 +112,8 @@ class SiteContent:
     _regular_pages_cache: list[Page] | None = field(default=None, repr=False)
     _generated_pages_cache: list[Page] | None = field(default=None, repr=False)
     _listable_pages_cache: list[Page] | None = field(default=None, repr=False)
+    # Lock for thread-safe lazy initialization of page caches
+    _cache_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def freeze(self) -> None:
         """
@@ -176,7 +179,11 @@ class SiteContent:
                 print(page.title)
         """
         if self._regular_pages_cache is None:
-            self._regular_pages_cache = [p for p in self.pages if not p.metadata.get("_generated")]
+            with self._cache_lock:
+                if self._regular_pages_cache is None:
+                    self._regular_pages_cache = [
+                        p for p in self.pages if not p.metadata.get("_generated")
+                    ]
         return self._regular_pages_cache
 
     @property
@@ -188,7 +195,11 @@ class SiteContent:
             List of pages with _generated flag (taxonomy, archive, etc.)
         """
         if self._generated_pages_cache is None:
-            self._generated_pages_cache = [p for p in self.pages if p.metadata.get("_generated")]
+            with self._cache_lock:
+                if self._generated_pages_cache is None:
+                    self._generated_pages_cache = [
+                        p for p in self.pages if p.metadata.get("_generated")
+                    ]
         return self._generated_pages_cache
 
     @property
@@ -205,7 +216,9 @@ class SiteContent:
             List of pages that should appear in public listings
         """
         if self._listable_pages_cache is None:
-            self._listable_pages_cache = [p for p in self.pages if p.in_listings]
+            with self._cache_lock:
+                if self._listable_pages_cache is None:
+                    self._listable_pages_cache = [p for p in self.pages if p.in_listings]
         return self._listable_pages_cache
 
     @property

--- a/bengal/health/health_check.py
+++ b/bengal/health/health_check.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 
 import os
 import time
-from concurrent.futures import as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -632,42 +631,37 @@ class HealthCheck:
         # Use provided worker count or auto-detect
         max_workers = worker_count or self._get_optimal_workers(len(validators))
 
-        from bengal.utils.concurrency.executor import managed_executor
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-        with managed_executor(max_workers, thread_name_prefix="healthcheck") as executor:
-            # Submit all validators for parallel execution
-            futures = {
-                executor.submit(
-                    self._run_single_validator, v, build_context, cache, files_to_validate
-                ): v
-                for v in validators
-            }
+        def _run_validator(v):
+            return v, self._run_single_validator(v, build_context, cache, files_to_validate)
 
-            # Process results as they complete
-            for future in as_completed(futures):
-                validator = futures[future]
-                try:
-                    validator_report = future.result(timeout=90)
-                    report.validator_reports.append(validator_report)
+        with WorkScope("healthcheck", max_workers=max_workers) as scope:
+            results = scope.map(_run_validator, validators)
 
-                    if verbose:
-                        status = "✅" if not validator_report.has_problems else "⚠️"
-                        print(
-                            f"  {status} {validator.name}: "
-                            f"{len(validator_report.results)} checks in "
-                            f"{validator_report.duration_ms:.1f}ms"
-                        )
-                except Exception as e:
-                    # Future itself failed (shouldn't happen with our error handling)
-                    validator_report = ValidatorReport(
-                        validator_name=validator.name,
-                        results=[CheckResult.error(f"Validator execution failed: {e}")],
-                        duration_ms=0,
+        for r in results:
+            if r.error:
+                # Future itself failed (shouldn't happen with our error handling)
+                validator_report = ValidatorReport(
+                    validator_name="unknown",
+                    results=[CheckResult.error(f"Validator execution failed: {r.error}")],
+                    duration_ms=0,
+                )
+                report.validator_reports.append(validator_report)
+
+                if verbose:
+                    print(f"  ❌ unknown: execution failed - {r.error}")
+            elif r.value is not None:
+                validator, validator_report = r.value
+                report.validator_reports.append(validator_report)
+
+                if verbose:
+                    status = "✅" if not validator_report.has_problems else "⚠️"
+                    print(
+                        f"  {status} {validator.name}: "
+                        f"{len(validator_report.results)} checks in "
+                        f"{validator_report.duration_ms:.1f}ms"
                     )
-                    report.validator_reports.append(validator_report)
-
-                    if verbose:
-                        print(f"  ❌ {validator.name}: execution failed - {e}")
 
     def run_and_print(
         self, build_stats: dict[str, Any] | None = None, verbose: bool = False

--- a/bengal/health/health_check.py
+++ b/bengal/health/health_check.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import os
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -632,7 +632,9 @@ class HealthCheck:
         # Use provided worker count or auto-detect
         max_workers = worker_count or self._get_optimal_workers(len(validators))
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        from bengal.utils.concurrency.executor import managed_executor
+
+        with managed_executor(max_workers, thread_name_prefix="healthcheck") as executor:
             # Submit all validators for parallel execution
             futures = {
                 executor.submit(
@@ -645,7 +647,7 @@ class HealthCheck:
             for future in as_completed(futures):
                 validator = futures[future]
                 try:
-                    validator_report = future.result()
+                    validator_report = future.result(timeout=90)
                     report.validator_reports.append(validator_report)
 
                     if verbose:

--- a/bengal/health/linkcheck/orchestrator.py
+++ b/bengal/health/linkcheck/orchestrator.py
@@ -189,15 +189,15 @@ class LinkCheckOrchestrator:
 
             def _run_external() -> None:
                 nonlocal external_results, external_exc
-                from bengal.utils.concurrency.work_scope import WorkScope
-
                 loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(loop)
                 try:
-                    with WorkScope("linkcheck-ext", max_workers=1, timeout=120.0):
-                        external_results = loop.run_until_complete(
-                            self.external_checker.check_links(external_links)
+                    external_results = loop.run_until_complete(
+                        asyncio.wait_for(
+                            self.external_checker.check_links(external_links),
+                            timeout=120.0,
                         )
+                    )
                 except BaseException as exc:
                     external_exc = exc
                 finally:
@@ -219,9 +219,14 @@ class LinkCheckOrchestrator:
 
         if external_thread is not None:
             external_thread.join(timeout=130.0)
-            if external_exc is not None:
+            if external_thread.is_alive():
+                logger.warning(
+                    "external_link_check_timeout",
+                    message="External link check timed out after 130s",
+                )
+            elif external_exc is not None:
                 raise external_exc
-            if external_results is not None:
+            elif external_results is not None:
                 results.extend(external_results.values())
                 logger.info(
                     "external_links_checked",

--- a/bengal/health/linkcheck/orchestrator.py
+++ b/bengal/health/linkcheck/orchestrator.py
@@ -196,7 +196,7 @@ class LinkCheckOrchestrator:
             external_executor = ThreadPoolExecutor(
                 max_workers=1, thread_name_prefix="linkcheck-ext"
             )
-            external_future = external_executor.submit(_run_external)
+            external_future = external_executor.submit(_run_external)  # noqa: timeout on .result() below
 
         results: list[LinkCheckResult] = []
 
@@ -210,7 +210,7 @@ class LinkCheckOrchestrator:
             )
 
         if external_future is not None:
-            external_results = external_future.result()
+            external_results = external_future.result(timeout=120)
             if external_executor:
                 external_executor.shutdown(wait=False)
             results.extend(external_results.values())
@@ -270,13 +270,17 @@ class LinkCheckOrchestrator:
         html_files = list(output_dir.rglob("*.html"))
 
         # Parse files in parallel (I/O-bound: file reads + HTML parsing)
+        from bengal.utils.concurrency.executor import managed_executor
+
         file_links: list[tuple[Path, list[str]]] = []
-        with ThreadPoolExecutor(thread_name_prefix="linkextract") as pool:
+        with managed_executor(
+            max_workers=min(8, len(html_files) or 1), thread_name_prefix="linkextract"
+        ) as pool:
             futures = {pool.submit(_parse_file, f): f for f in html_files}
             for future in as_completed(futures):
                 html_file = futures[future]
                 try:
-                    links = future.result()
+                    links = future.result(timeout=90)
                     file_links.append((html_file, links))
                 except Exception as e:
                     from bengal.errors import ErrorCode

--- a/bengal/health/linkcheck/orchestrator.py
+++ b/bengal/health/linkcheck/orchestrator.py
@@ -21,6 +21,7 @@ Related:
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from html.parser import HTMLParser
 from pathlib import Path
@@ -176,24 +177,34 @@ class LinkCheckOrchestrator:
         if self.check_internal:
             self.internal_checker.set_file_index(html_files)
 
-        # Pipeline: run internal and external checks concurrently via WorkScope.
-        external_work_results = None
+        # Pipeline: run internal and external checks concurrently.
+        # External checks run in a background thread so internal checks can
+        # proceed on the main thread at the same time, restoring the original
+        # parallel design that was lost during the WorkScope migration.
+        external_results: dict[str, LinkCheckResult] | None = None
+        external_exc: BaseException | None = None
+        external_thread: threading.Thread | None = None
+
         if self.check_external and external_links:
 
-            def _run_external() -> dict[str, LinkCheckResult]:
+            def _run_external() -> None:
+                nonlocal external_results, external_exc
+                from bengal.utils.concurrency.work_scope import WorkScope
+
                 loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(loop)
                 try:
-                    return loop.run_until_complete(
-                        self.external_checker.check_links(external_links)
-                    )
+                    with WorkScope("linkcheck-ext", max_workers=1, timeout=120.0):
+                        external_results = loop.run_until_complete(
+                            self.external_checker.check_links(external_links)
+                        )
+                except BaseException as exc:
+                    external_exc = exc
                 finally:
                     loop.close()
 
-            from bengal.utils.concurrency.work_scope import WorkScope
-
-            with WorkScope("linkcheck-ext", max_workers=1, timeout=120.0) as scope:
-                external_work_results = scope.map(lambda _: _run_external(), [None])
+            external_thread = threading.Thread(target=_run_external, daemon=True)
+            external_thread.start()
 
         results: list[LinkCheckResult] = []
 
@@ -206,17 +217,19 @@ class LinkCheckOrchestrator:
                 broken=sum(1 for r in internal_results.values() if r.status == LinkStatus.BROKEN),
             )
 
-        if external_work_results is not None:
-            ext_result = external_work_results[0]
-            if ext_result.error:
-                raise ext_result.error
-            external_results = ext_result.value
-            results.extend(external_results.values())
-            logger.info(
-                "external_links_checked",
-                count=len(external_results),
-                broken=sum(1 for r in external_results.values() if r.status == LinkStatus.BROKEN),
-            )
+        if external_thread is not None:
+            external_thread.join(timeout=130.0)
+            if external_exc is not None:
+                raise external_exc
+            if external_results is not None:
+                results.extend(external_results.values())
+                logger.info(
+                    "external_links_checked",
+                    count=len(external_results),
+                    broken=sum(
+                        1 for r in external_results.values() if r.status == LinkStatus.BROKEN
+                    ),
+                )
 
         # Build summary
         duration_ms = (time.time() - start_time) * 1000
@@ -271,7 +284,11 @@ class LinkCheckOrchestrator:
         from bengal.utils.concurrency.work_scope import WorkScope
 
         def _parse_with_path(html_file: Path) -> tuple[Path, list[str]]:
-            return html_file, _parse_file(html_file)
+            try:
+                return html_file, _parse_file(html_file)
+            except Exception as e:
+                e.__html_file__ = str(html_file)  # type: ignore[attr-defined]
+                raise
 
         file_links: list[tuple[Path, list[str]]] = []
         with WorkScope("linkextract", max_workers=min(8, len(html_files) or 1)) as scope:
@@ -280,8 +297,10 @@ class LinkCheckOrchestrator:
             if r.error:
                 from bengal.errors import ErrorCode
 
+                html_file = getattr(r.error, "__html_file__", None)
                 logger.warning(
                     "failed_to_parse_html",
+                    file=html_file,
                     error=str(r.error),
                     error_code=ErrorCode.V005.value,
                     suggestion="Check HTML file for malformed content. Link check will skip this file.",

--- a/bengal/health/linkcheck/orchestrator.py
+++ b/bengal/health/linkcheck/orchestrator.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -177,10 +176,8 @@ class LinkCheckOrchestrator:
         if self.check_internal:
             self.internal_checker.set_file_index(html_files)
 
-        # Pipeline: kick off external checks in a background thread while
-        # internal checking runs synchronously on the main thread.
-        external_future = None
-        external_executor = None
+        # Pipeline: run internal and external checks concurrently via WorkScope.
+        external_work_results = None
         if self.check_external and external_links:
 
             def _run_external() -> dict[str, LinkCheckResult]:
@@ -193,10 +190,10 @@ class LinkCheckOrchestrator:
                 finally:
                     loop.close()
 
-            external_executor = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="linkcheck-ext"
-            )
-            external_future = external_executor.submit(_run_external)  # noqa: timeout on .result() below
+            from bengal.utils.concurrency.work_scope import WorkScope
+
+            with WorkScope("linkcheck-ext", max_workers=1, timeout=120.0) as scope:
+                external_work_results = scope.map(lambda _: _run_external(), [None])
 
         results: list[LinkCheckResult] = []
 
@@ -209,10 +206,11 @@ class LinkCheckOrchestrator:
                 broken=sum(1 for r in internal_results.values() if r.status == LinkStatus.BROKEN),
             )
 
-        if external_future is not None:
-            external_results = external_future.result(timeout=120)
-            if external_executor:
-                external_executor.shutdown(wait=False)
+        if external_work_results is not None:
+            ext_result = external_work_results[0]
+            if ext_result.error:
+                raise ext_result.error
+            external_results = ext_result.value
             results.extend(external_results.values())
             logger.info(
                 "external_links_checked",
@@ -270,28 +268,26 @@ class LinkCheckOrchestrator:
         html_files = list(output_dir.rglob("*.html"))
 
         # Parse files in parallel (I/O-bound: file reads + HTML parsing)
-        from bengal.utils.concurrency.executor import managed_executor
+        from bengal.utils.concurrency.work_scope import WorkScope
+
+        def _parse_with_path(html_file: Path) -> tuple[Path, list[str]]:
+            return html_file, _parse_file(html_file)
 
         file_links: list[tuple[Path, list[str]]] = []
-        with managed_executor(
-            max_workers=min(8, len(html_files) or 1), thread_name_prefix="linkextract"
-        ) as pool:
-            futures = {pool.submit(_parse_file, f): f for f in html_files}
-            for future in as_completed(futures):
-                html_file = futures[future]
-                try:
-                    links = future.result(timeout=90)
-                    file_links.append((html_file, links))
-                except Exception as e:
-                    from bengal.errors import ErrorCode
+        with WorkScope("linkextract", max_workers=min(8, len(html_files) or 1)) as scope:
+            results = scope.map(_parse_with_path, html_files)
+        for r in results:
+            if r.error:
+                from bengal.errors import ErrorCode
 
-                    logger.warning(
-                        "failed_to_parse_html",
-                        file=str(html_file),
-                        error=str(e),
-                        error_code=ErrorCode.V005.value,
-                        suggestion="Check HTML file for malformed content. Link check will skip this file.",
-                    )
+                logger.warning(
+                    "failed_to_parse_html",
+                    error=str(r.error),
+                    error_code=ErrorCode.V005.value,
+                    suggestion="Check HTML file for malformed content. Link check will skip this file.",
+                )
+            else:
+                file_links.append(r.value)
 
         # Classify extracted links
         for html_file, links in file_links:

--- a/bengal/orchestration/asset.py
+++ b/bengal/orchestration/asset.py
@@ -400,10 +400,14 @@ class AssetOrchestrator:
 
         def _process_asset(item: tuple[Asset, bool]) -> tuple[Asset, bool]:
             asset, is_css = item
-            if is_css:
-                self._process_css_entry(asset, minify, optimize, fingerprint)
-            else:
-                self._process_single_asset(asset, assets_output, minify, optimize, fingerprint)
+            try:
+                if is_css:
+                    self._process_css_entry(asset, minify, optimize, fingerprint)
+                else:
+                    self._process_single_asset(asset, assets_output, minify, optimize, fingerprint)
+            except Exception as e:
+                e.__asset_path__ = asset.source_path  # type: ignore[attr-defined]
+                raise
             return asset, is_css
 
         from bengal.utils.concurrency.work_scope import WorkScope
@@ -432,8 +436,9 @@ class AssetOrchestrator:
 
                 from bengal.errors import BengalError, ErrorContext, enrich_error
 
+                asset_path = getattr(e, "__asset_path__", None)
                 context = ErrorContext(
-                    file_path=None,
+                    file_path=asset_path,
                     operation="processing asset",
                     suggestion="Check file permissions, encoding, and format",
                     original_error=e,

--- a/bengal/orchestration/asset.py
+++ b/bengal/orchestration/asset.py
@@ -24,7 +24,6 @@ See Also:
 
 from __future__ import annotations
 
-import concurrent.futures
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -394,65 +393,57 @@ class AssetOrchestrator:
         # Use BatchProgressUpdater for throttled progress updates
         progress_updater = BatchProgressUpdater(progress_manager, phase="assets")
 
-        from bengal.utils.concurrency.executor import managed_executor
+        # Build tagged union: (asset, is_css_entry)
+        all_items: list[tuple[Asset, bool]] = [(entry, True) for entry in css_entries] + [
+            (asset, False) for asset in other_assets
+        ]
 
-        with managed_executor(max_workers, thread_name_prefix="Bengal-Assets") as executor:
-            futures: list[tuple[concurrent.futures.Future[None], Asset, bool]] = []
+        def _process_asset(item: tuple[Asset, bool]) -> tuple[Asset, bool]:
+            asset, is_css = item
+            if is_css:
+                self._process_css_entry(asset, minify, optimize, fingerprint)
+            else:
+                self._process_single_asset(asset, assets_output, minify, optimize, fingerprint)
+            return asset, is_css
 
-            # Submit CSS entries
-            for entry in css_entries:
-                future = executor.submit(
-                    self._process_css_entry, entry, minify, optimize, fingerprint
+        from bengal.utils.concurrency.work_scope import WorkScope
+
+        with WorkScope("Assets", max_workers=max_workers) as scope:
+            results = scope.map(_process_asset, all_items)
+
+        for r in results:
+            if r.ok and r.value is not None:
+                asset, is_css_entry = r.value
+                item_name = (
+                    f"{asset.source_path.name} (bundled {css_modules_count} modules)"
+                    if is_css_entry
+                    else asset.source_path.name
                 )
-                futures.append((future, entry, True))  # True = is_css_entry
-
-            # Submit other assets
-            for asset in other_assets:
-                future = executor.submit(
-                    self._process_single_asset, asset, assets_output, minify, optimize, fingerprint
+                progress_updater.increment(
+                    item_name,
+                    minified=minify if is_css_entry else None,
+                    bundled_modules=css_modules_count if is_css_entry else None,
                 )
-                futures.append((future, asset, False))  # False = not css_entry
+            else:
+                e = r.error
+                if is_shutdown_error(e):
+                    logger.debug("asset_shutdown")
+                    continue
 
-            # Collect results as they complete
-            for future, asset, is_css_entry in futures:
-                try:
-                    future.result(timeout=90)
+                from bengal.errors import BengalError, ErrorContext, enrich_error
 
-                    # Progress update with batching
-                    item_name = (
-                        f"{asset.source_path.name} (bundled {css_modules_count} modules)"
-                        if is_css_entry
-                        else asset.source_path.name
-                    )
-                    progress_updater.increment(
-                        item_name,
-                        minified=minify if is_css_entry else None,
-                        bundled_modules=css_modules_count if is_css_entry else None,
-                    )
-
-                except Exception as e:
-                    # Handle shutdown errors gracefully
-                    if is_shutdown_error(e):
-                        logger.debug("asset_shutdown", asset=asset.source_path.name)
-                        continue
-
-                    from bengal.errors import BengalError, ErrorContext, enrich_error
-
-                    # Enrich error with context
-                    asset_path = asset.source_path if hasattr(asset, "source_path") else None
-                    context = ErrorContext(
-                        file_path=asset_path,
-                        operation="processing asset",
-                        suggestion="Check file permissions, encoding, and format",
-                        original_error=e,
-                    )
-                    enriched = enrich_error(e, context, BengalError)
-                    errors.append(str(enriched))
-                    # Collect error in build stats if available
-                    if hasattr(self, "site") and hasattr(self.site, "_last_build_stats"):
-                        stats = self.site._last_build_stats
-                        if stats:
-                            stats.add_error(enriched, category="assets")
+                context = ErrorContext(
+                    file_path=None,
+                    operation="processing asset",
+                    suggestion="Check file permissions, encoding, and format",
+                    original_error=e,
+                )
+                enriched = enrich_error(e, context, BengalError)
+                errors.append(str(enriched))
+                if hasattr(self, "site") and hasattr(self.site, "_last_build_stats"):
+                    stats = self.site._last_build_stats
+                    if stats:
+                        stats.add_error(enriched, category="assets")
 
         # Final progress update
         progress_updater.finalize(total_assets)

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -49,7 +49,6 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -755,16 +754,14 @@ class BuildOrchestrator:
                 generated_page_cache.save()
 
         # Run cache saves in parallel
-        from bengal.utils.concurrency.executor import managed_executor
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-        with managed_executor(2, thread_name_prefix="CacheSave") as executor:
-            futures = [
-                executor.submit(_save_main_cache),
-                executor.submit(_save_generated_cache),
-            ]
-            # Wait for all saves to complete (bounded)
-            for future in as_completed(futures):
-                future.result(timeout=60)
+        with WorkScope("CacheSave", max_workers=2, per_item_timeout=60.0) as scope:
+            results = scope.map(lambda fn: fn(), [_save_main_cache, _save_generated_cache])
+
+        for r in results:
+            if r.error:
+                raise r.error
 
         cache_duration_ms = (time.perf_counter() - cache_start) * 1000
         if cli is not None:

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -756,7 +756,7 @@ class BuildOrchestrator:
         # Run cache saves in parallel
         from bengal.utils.concurrency.work_scope import WorkScope
 
-        with WorkScope("CacheSave", max_workers=2, per_item_timeout=60.0) as scope:
+        with WorkScope("CacheSave", max_workers=2) as scope:
             results = scope.map(lambda fn: fn(), [_save_main_cache, _save_generated_cache])
 
         for r in results:

--- a/bengal/orchestration/build/parsing.py
+++ b/bengal/orchestration/build/parsing.py
@@ -104,21 +104,28 @@ def phase_parse_content(
             from bengal.utils.concurrency.work_scope import WorkScope
 
             def _parse_with_page(page):
-                parse_page(page)
+                try:
+                    parse_page(page)
+                except Exception as e:
+                    e.__page_source_path__ = page.source_path  # type: ignore[attr-defined]
+                    raise
                 return page
 
             with WorkScope("parse", max_workers=max_workers) as scope:
                 results = scope.map(_parse_with_page, pages_to_parse)
             for r in results:
                 if r.error:
+                    page_path = getattr(r.error, "__page_source_path__", None)
                     logger.error(
                         "parsing_failed",
+                        page=str(page_path) if page_path is not None else None,
                         error=str(r.error),
                         error_type=type(r.error).__name__,
                     )
                     if orchestrator.stats:
+                        page_label = str(page_path) if page_path is not None else "unknown"
                         orchestrator.stats.add_error(
-                            Exception(f"Parsing failed: {r.error}"),
+                            Exception(f"Parsing failed for {page_label}: {r.error}"),
                             category="parsing",
                         )
         else:

--- a/bengal/orchestration/build/parsing.py
+++ b/bengal/orchestration/build/parsing.py
@@ -10,7 +10,6 @@ RFC: rfc-bengal-snapshot-engine (Snapshot Persistence section)
 from __future__ import annotations
 
 import time
-from concurrent.futures import as_completed
 from typing import TYPE_CHECKING
 
 from bengal.utils.observability.logger import get_logger
@@ -102,27 +101,26 @@ def phase_parse_content(
         if parallel and len(pages_to_parse) > 1:
             # Parallel parsing
             max_workers = min(len(pages_to_parse), 8)  # Reasonable limit
-            from bengal.utils.concurrency.executor import managed_executor
+            from bengal.utils.concurrency.work_scope import WorkScope
 
-            with managed_executor(max_workers, thread_name_prefix="Bengal-Parse") as executor:
-                futures = {executor.submit(parse_page, page): page for page in pages_to_parse}
+            def _parse_with_page(page):
+                parse_page(page)
+                return page
 
-                for future in as_completed(futures):
-                    page = futures[future]
-                    try:
-                        future.result(timeout=90)
-                    except Exception as e:
-                        logger.error(
-                            "parsing_failed",
-                            page=str(page.source_path),
-                            error=str(e),
-                            error_type=type(e).__name__,
+            with WorkScope("parse", max_workers=max_workers) as scope:
+                results = scope.map(_parse_with_page, pages_to_parse)
+            for r in results:
+                if r.error:
+                    logger.error(
+                        "parsing_failed",
+                        error=str(r.error),
+                        error_type=type(r.error).__name__,
+                    )
+                    if orchestrator.stats:
+                        orchestrator.stats.add_error(
+                            Exception(f"Parsing failed: {r.error}"),
+                            category="parsing",
                         )
-                        if orchestrator.stats:
-                            orchestrator.stats.add_error(
-                                Exception(f"Parsing failed for {page.source_path}: {e}"),
-                                category="parsing",
-                            )
         else:
             # Sequential parsing
             for page in pages_to_parse:

--- a/bengal/orchestration/build/provenance_filter.py
+++ b/bengal/orchestration/build/provenance_filter.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import os
 import time
-from concurrent.futures import as_completed
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -946,12 +945,13 @@ def record_all_page_builds(
     use_parallel = parallel and len(pages) > 50
     if use_parallel:
         max_workers = min(32, (os.cpu_count() or 1) + 4)
-        from bengal.utils.concurrency.executor import managed_executor
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-        with managed_executor(max_workers, thread_name_prefix="Bengal-Provenance") as executor:
-            futures = {executor.submit(pf.record_build, page): page for page in pages}
-            for future in as_completed(futures):
-                future.result(timeout=90)  # Raise any exception
+        with WorkScope("provenance", max_workers=max_workers) as scope:
+            results = scope.map(pf.record_build, pages)
+            for r in results:
+                if r.error:
+                    raise r.error
     else:
         for page in pages:
             pf.record_build(page)

--- a/bengal/orchestration/build_context.py
+++ b/bengal/orchestration/build_context.py
@@ -254,6 +254,7 @@ class BuildContext:
     # These eliminate redundant expensive computations across build phases
     _knowledge_graph: Any = field(default=None, repr=False)
     _knowledge_graph_enabled: bool = field(default=True, repr=False)
+    _knowledge_graph_lock: Lock = field(default_factory=Lock, repr=False)
 
     # Content cache - populated during discovery, shared by validators
     # Eliminates redundant disk I/O during health checks (4s+ → <100ms)
@@ -301,7 +302,9 @@ class BuildContext:
             return None
 
         if self._knowledge_graph is None:
-            self._knowledge_graph = self._build_knowledge_graph()
+            with self._knowledge_graph_lock:
+                if self._knowledge_graph is None:
+                    self._knowledge_graph = self._build_knowledge_graph()
         return self._knowledge_graph
 
     def _build_knowledge_graph(self) -> KnowledgeGraph | None:

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -25,7 +25,6 @@ See Also:
 
 from __future__ import annotations
 
-import concurrent.futures
 from collections.abc import Callable
 from threading import Lock
 from typing import TYPE_CHECKING
@@ -301,71 +300,72 @@ class PostprocessOrchestrator:
         """
         errors = []
         completed_count = 0
-        lock = Lock()
 
-        try:
-            from bengal.utils.concurrency.executor import managed_executor
+        def _run_task(name_fn_tuple: tuple[str, Callable[[], None]]) -> str:
+            name, fn = name_fn_tuple
+            fn()
+            return name
 
-            with managed_executor(len(tasks), thread_name_prefix="Bengal-PostProcess") as executor:
-                futures = {executor.submit(task_fn): name for name, task_fn in tasks}
+        def _on_progress(completed: int, total: int) -> None:
+            nonlocal completed_count
+            if progress_manager:
+                completed_count = completed
+                progress_manager.update_phase(
+                    "postprocess", current=completed_count, current_item=""
+                )
 
-                for future in concurrent.futures.as_completed(futures):
-                    # Get task name outside try block (dictionary lookup is fast)
-                    task_name = futures[future]
-                    try:
-                        future.result(timeout=90)
-                        if progress_manager:
-                            # Minimize lock hold time - only update counter and progress
-                            with lock:
-                                completed_count += 1
-                                progress_manager.update_phase(
-                                    "postprocess", current=completed_count, current_item=task_name
-                                )
-                    except Exception as e:
-                        # Suppress interpreter shutdown errors - these are expected on Ctrl+C
-                        if is_shutdown_error(e):
-                            logger.debug("postprocess_shutdown", task=task_name)
-                            continue
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-                        # Error handling outside lock
-                        error_msg = str(e)
-                        errors.append((task_name, error_msg))
+        with WorkScope("PostProcess", max_workers=len(tasks), on_progress=_on_progress) as scope:
+            results = scope.map(_run_task, tasks)
 
-                        # Import error handling utilities
-                        from bengal.errors import (
-                            BengalError,
-                            ErrorCode,
-                            ErrorContext,
-                            enrich_error,
-                            record_error,
-                        )
+        for r in results:
+            if r.ok:
+                task_name = r.value
+                if progress_manager:
+                    progress_manager.update_phase(
+                        "postprocess", current=completed_count, current_item=task_name
+                    )
+            else:
+                e = r.error
+                if is_shutdown_error(e):
+                    logger.debug("postprocess_shutdown")
+                    continue
 
-                        # Enrich error with context
-                        context = ErrorContext(
-                            operation=f"post-processing task: {task_name}",
-                            suggestion=f"Check {task_name} configuration and file permissions",
-                            original_error=e,
-                        )
-                        enriched = enrich_error(e, context, BengalError)
+                # Extract task name from the error if possible
+                task_name = "unknown"
+                error_msg = str(e)
+                errors.append((task_name, error_msg))
 
-                        # Log with error code
-                        logger.error(
-                            "postprocess_task_failed",
-                            task=task_name,
-                            error=str(enriched),
-                            error_type=type(e).__name__,
-                            error_code=ErrorCode.B008.value,
-                            suggestion=f"Check {task_name} configuration and file permissions",
-                        )
+                # Import error handling utilities
+                from bengal.errors import (
+                    BengalError,
+                    ErrorCode,
+                    ErrorContext,
+                    enrich_error,
+                    record_error,
+                )
 
-                        # Record in error session
-                        record_error(enriched, file_path=f"postprocess:{task_name}")
-        except RuntimeError as e:
-            # Handle graceful shutdown at executor level
-            if is_shutdown_error(e):
-                logger.debug("postprocess_executor_shutdown")
-                return
-            raise
+                # Enrich error with context
+                context = ErrorContext(
+                    operation=f"post-processing task: {task_name}",
+                    suggestion=f"Check {task_name} configuration and file permissions",
+                    original_error=e,
+                )
+                enriched = enrich_error(e, context, BengalError)
+
+                # Log with error code
+                logger.error(
+                    "postprocess_task_failed",
+                    task=task_name,
+                    error=str(enriched),
+                    error_type=type(e).__name__,
+                    error_code=ErrorCode.B008.value,
+                    suggestion=f"Check {task_name} configuration and file permissions",
+                )
+
+                # Record in error session
+                record_error(enriched, file_path=f"postprocess:{task_name}")
 
         # Report errors
         if errors and not progress_manager:

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -303,26 +303,23 @@ class PostprocessOrchestrator:
 
         def _run_task(name_fn_tuple: tuple[str, Callable[[], None]]) -> str:
             name, fn = name_fn_tuple
-            fn()
+            try:
+                fn()
+            except Exception as e:
+                e.__task_name__ = name  # type: ignore[attr-defined]
+                raise
             return name
-
-        def _on_progress(completed: int, total: int) -> None:
-            nonlocal completed_count
-            if progress_manager:
-                completed_count = completed
-                progress_manager.update_phase(
-                    "postprocess", current=completed_count, current_item=""
-                )
 
         from bengal.utils.concurrency.work_scope import WorkScope
 
-        with WorkScope("PostProcess", max_workers=len(tasks), on_progress=_on_progress) as scope:
+        with WorkScope("PostProcess", max_workers=len(tasks)) as scope:
             results = scope.map(_run_task, tasks)
 
         for r in results:
             if r.ok:
                 task_name = r.value
                 if progress_manager:
+                    completed_count += 1
                     progress_manager.update_phase(
                         "postprocess", current=completed_count, current_item=task_name
                     )
@@ -333,7 +330,7 @@ class PostprocessOrchestrator:
                     continue
 
                 # Extract task name from the error if possible
-                task_name = "unknown"
+                task_name = getattr(e, "__task_name__", "unknown")
                 error_msg = str(e)
                 errors.append((task_name, error_msg))
 

--- a/bengal/orchestration/related_posts.py
+++ b/bengal/orchestration/related_posts.py
@@ -36,7 +36,6 @@ bengal.orchestration.taxonomy: Provides taxonomy index used for matching
 
 from __future__ import annotations
 
-import concurrent.futures
 from typing import TYPE_CHECKING, Any
 
 from bengal.utils.concurrency.workers import WorkloadType, get_optimal_workers
@@ -247,34 +246,27 @@ class RelatedPostsOrchestrator:
 
         pages_with_related = 0
 
-        # Use managed_executor for safe shutdown on timeout/error
-        from bengal.utils.concurrency.executor import managed_executor
+        # Use WorkScope for safe shutdown on timeout/error
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-        with managed_executor(max_workers, thread_name_prefix="Bengal-Related") as executor:
-            # Submit all tasks
-            future_to_page = {
-                executor.submit(
-                    self._find_related_posts, page, page_tags_map, tags_dict, limit
-                ): page
-                for page in pages
-            }
+        def _find_related_for_page(page):
+            related = self._find_related_posts(page, page_tags_map, tags_dict, limit)
+            return page, related
 
-            # Collect results as they complete
-            for future in concurrent.futures.as_completed(future_to_page):
-                page = future_to_page[future]
-                try:
-                    related_posts = future.result(timeout=90)
-                    page.related_posts = related_posts
-                    if related_posts:
-                        pages_with_related += 1
-                except Exception as e:
-                    # Log error but don't fail the build
-                    logger.error(
-                        "related_posts_computation_failed",
-                        page=str(page.source_path),
-                        error=str(e),
-                    )
-                    page.related_posts = []
+        with WorkScope("related-posts", max_workers=max_workers) as scope:
+            results = scope.map(_find_related_for_page, pages)
+
+        for r in results:
+            if r.error:
+                logger.error(
+                    "related_posts_computation_failed",
+                    error=str(r.error),
+                )
+            elif r.value is not None:
+                page, related_posts = r.value
+                page.related_posts = related_posts
+                if related_posts:
+                    pages_with_related += 1
 
         # Single finalization pass: clear generated pages' related_posts
         for page in self.site.pages:

--- a/bengal/orchestration/related_posts.py
+++ b/bengal/orchestration/related_posts.py
@@ -250,7 +250,11 @@ class RelatedPostsOrchestrator:
         from bengal.utils.concurrency.work_scope import WorkScope
 
         def _find_related_for_page(page):
-            related = self._find_related_posts(page, page_tags_map, tags_dict, limit)
+            try:
+                related = self._find_related_posts(page, page_tags_map, tags_dict, limit)
+            except Exception as e:
+                e.__page_source_path__ = page.source_path  # type: ignore[attr-defined]
+                raise
             return page, related
 
         with WorkScope("related-posts", max_workers=max_workers) as scope:
@@ -258,8 +262,10 @@ class RelatedPostsOrchestrator:
 
         for r in results:
             if r.error:
+                page_path = getattr(r.error, "__page_source_path__", None)
                 logger.error(
                     "related_posts_computation_failed",
+                    page=str(page_path) if page_path is not None else None,
                     error=str(r.error),
                 )
             elif r.value is not None:

--- a/bengal/orchestration/render/orchestrator.py
+++ b/bengal/orchestration/render/orchestrator.py
@@ -244,6 +244,10 @@ class RenderOrchestrator(
         # (avoids TOCTOU race in per-thread RenderingPipeline.__init__)
         if not hasattr(self.site, "_external_ref_resolvers"):
             self.site._external_ref_resolvers = []
+        if not hasattr(self.site, "_external_ref_resolvers_lock"):
+            import threading
+
+            self.site._external_ref_resolvers_lock = threading.Lock()
 
         # Warm block cache before parallel rendering (Kida only)
         self._warm_block_cache()

--- a/bengal/orchestration/stats/models.py
+++ b/bengal/orchestration/stats/models.py
@@ -4,6 +4,7 @@ Build statistics data models.
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
@@ -170,6 +171,15 @@ class BuildStats:
     # Enhanced error collection by category
     errors_by_category: dict[str, ErrorCategory] = field(default_factory=dict)
 
+    # Thread-safety lock — protects counter increments, list appends, and lazy init
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        # Ensure _lock is always a real Lock even when dataclass __init__ is bypassed
+        # (e.g. copy.copy, pickle, or test construction via object.__setattr__).
+        if not isinstance(self._lock, threading.Lock):
+            object.__setattr__(self, "_lock", threading.Lock())
+
     def get_error_deduplicator(self) -> ErrorDeduplicator:
         """
         Get the error deduplicator for this build.
@@ -179,15 +189,17 @@ class BuildStats:
         Returns:
             ErrorDeduplicator instance for this build
         """
-        if self._error_deduplicator is None:
-            from bengal.rendering.errors import ErrorDeduplicator
+        with self._lock:
+            if self._error_deduplicator is None:
+                from bengal.rendering.errors import ErrorDeduplicator
 
-            self._error_deduplicator = ErrorDeduplicator()
-        return self._error_deduplicator
+                self._error_deduplicator = ErrorDeduplicator()
+            return self._error_deduplicator
 
     def add_warning(self, file_path: str, message: str, warning_type: str = "other") -> None:
         """Add a warning to the build."""
-        self.warnings.append(BuildWarning(file_path, message, warning_type))
+        with self._lock:
+            self.warnings.append(BuildWarning(file_path, message, warning_type))
 
     def add_template_error(self, error: Any) -> None:
         """
@@ -196,9 +208,10 @@ class BuildStats:
         Args:
             error: TemplateRenderError instance (or compatible exception)
         """
-        self.template_errors.append(error)
-        # Also add to categorized errors
-        self.add_error(error, category="rendering")
+        with self._lock:
+            self.template_errors.append(error)
+            # Also add to categorized errors (inline to avoid re-acquiring lock)
+            self._add_error_unlocked(error, category="rendering")
 
     def add_error(self, error: Any, category: str = "general") -> None:
         """
@@ -208,6 +221,11 @@ class BuildStats:
             error: BengalError instance (or compatible exception)
             category: Error category name (e.g., "rendering", "discovery", "config")
         """
+        with self._lock:
+            self._add_error_unlocked(error, category=category)
+
+    def _add_error_unlocked(self, error: Any, category: str = "general") -> None:
+        """Add error to category without acquiring the lock (caller must hold it)."""
         if category not in self.errors_by_category:
             self.errors_by_category[category] = ErrorCategory(name=category)
         self.errors_by_category[category].errors.append(error)
@@ -240,8 +258,11 @@ class BuildStats:
 
     def add_directive(self, directive_type: str) -> None:
         """Track a directive usage."""
-        self.total_directives += 1
-        self.directives_by_type[directive_type] = self.directives_by_type.get(directive_type, 0) + 1
+        with self._lock:
+            self.total_directives += 1
+            self.directives_by_type[directive_type] = (
+                self.directives_by_type.get(directive_type, 0) + 1
+            )
 
     @property
     def pages_built(self) -> int:

--- a/bengal/orchestration/stats/models.py
+++ b/bengal/orchestration/stats/models.py
@@ -177,7 +177,7 @@ class BuildStats:
     def __post_init__(self) -> None:
         # Ensure _lock is always a real Lock even when dataclass __init__ is bypassed
         # (e.g. copy.copy, pickle, or test construction via object.__setattr__).
-        if not isinstance(self._lock, threading.Lock):
+        if self._lock is None:
             object.__setattr__(self, "_lock", threading.Lock())
 
     def get_error_deduplicator(self) -> ErrorDeduplicator:

--- a/bengal/orchestration/taxonomy.py
+++ b/bengal/orchestration/taxonomy.py
@@ -51,7 +51,6 @@ bengal.orchestration.build: Phase 7 (taxonomies) coordination
 
 from __future__ import annotations
 
-import concurrent.futures
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -708,52 +707,47 @@ class TaxonomyOrchestrator:
 
         all_generated_pages = []
 
-        # Use managed_executor for safe shutdown on timeout/error
-        from bengal.utils.concurrency.executor import managed_executor
+        # Use WorkScope for structured concurrency
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-        with managed_executor(max_workers, thread_name_prefix="Bengal-Taxonomy") as executor:
-            # Submit all tasks
-            future_to_tag = {
-                executor.submit(self._create_tag_pages_for_lang, tag_slug, tag_data, lang): tag_slug
-                for tag_slug, tag_data in locale_tags.items()
-            }
+        def _create_tag_pages(tag_item: tuple[str, dict]) -> tuple[str, list]:
+            tag_slug, tag_data = tag_item
+            return tag_slug, self._create_tag_pages_for_lang(tag_slug, tag_data, lang)
 
-            # Use ErrorAggregator for batch error handling
-            aggregator = ErrorAggregator(total_items=len(locale_tags))
-            threshold = 5
+        with WorkScope("Taxonomy", max_workers=max_workers) as scope:
+            results = scope.map(_create_tag_pages, locale_tags.items())
 
-            # Collect results as they complete
-            for future in concurrent.futures.as_completed(future_to_tag):
-                tag_slug = future_to_tag[future]
-                try:
-                    tag_pages = future.result(timeout=90)
-                    # Set language for all pages
-                    for page in tag_pages:
-                        page.lang = lang
-                    all_generated_pages.extend(tag_pages)
-                except Exception as e:
-                    # Handle shutdown errors gracefully
-                    if is_shutdown_error(e):
-                        logger.debug("taxonomy_shutdown", tag_slug=tag_slug)
-                        continue
+        # Use ErrorAggregator for batch error handling
+        aggregator = ErrorAggregator(total_items=len(locale_tags))
+        threshold = 5
 
-                    # Use ErrorAggregator for structured error handling
-                    context = {
-                        "tag_slug": tag_slug,
-                        "lang": lang,
-                        "error": str(e),
-                        "error_type": type(e).__name__,
-                        "error_code": ErrorCode.B006.value,
-                        "suggestion": "Check tag template 'tag.html' exists and is valid Jinja2",
-                    }
-                    if aggregator.should_log_individual(
-                        e, context, threshold=threshold, max_samples=3
-                    ):
-                        logger.error("taxonomy_page_generation_failed", **context)
-                    aggregator.add_error(e, context=context)
+        # Process results (completion order)
+        for r in results:
+            if r.ok and r.value is not None:
+                _tag_slug, tag_pages = r.value
+                for page in tag_pages:
+                    page.lang = lang
+                all_generated_pages.extend(tag_pages)
+            else:
+                e = r.error
+                if is_shutdown_error(e):
+                    logger.debug("taxonomy_shutdown")
+                    continue
 
-            # Log summary if errors occurred
-            aggregator.log_summary(logger, threshold=threshold, error_type="taxonomy")
+                context = {
+                    "tag_slug": "unknown",
+                    "lang": lang,
+                    "error": str(e),
+                    "error_type": type(e).__name__,
+                    "error_code": ErrorCode.B006.value,
+                    "suggestion": "Check tag template 'tag.html' exists and is valid Jinja2",
+                }
+                if aggregator.should_log_individual(e, context, threshold=threshold, max_samples=3):
+                    logger.error("taxonomy_page_generation_failed", **context)
+                aggregator.add_error(e, context=context)
+
+        # Log summary if errors occurred
+        aggregator.log_summary(logger, threshold=threshold, error_type="taxonomy")
 
         # Append all generated pages at once (thread-safe)
         self.site.pages.extend(all_generated_pages)

--- a/bengal/orchestration/taxonomy.py
+++ b/bengal/orchestration/taxonomy.py
@@ -712,7 +712,11 @@ class TaxonomyOrchestrator:
 
         def _create_tag_pages(tag_item: tuple[str, dict]) -> tuple[str, list]:
             tag_slug, tag_data = tag_item
-            return tag_slug, self._create_tag_pages_for_lang(tag_slug, tag_data, lang)
+            try:
+                return tag_slug, self._create_tag_pages_for_lang(tag_slug, tag_data, lang)
+            except Exception as e:
+                e.__tag_slug__ = tag_slug  # type: ignore[attr-defined]
+                raise
 
         with WorkScope("Taxonomy", max_workers=max_workers) as scope:
             results = scope.map(_create_tag_pages, locale_tags.items())
@@ -735,7 +739,7 @@ class TaxonomyOrchestrator:
                     continue
 
                 context = {
-                    "tag_slug": "unknown",
+                    "tag_slug": getattr(e, "__tag_slug__", "unknown"),
                     "lang": lang,
                     "error": str(e),
                     "error_type": type(e).__name__,

--- a/bengal/orchestration/utils/parallel.py
+++ b/bengal/orchestration/utils/parallel.py
@@ -253,28 +253,30 @@ class ParallelProcessor[T, R]:
         aggregator = ErrorAggregator(total_items=len(items))
         completed_count = 0
 
-        def _on_progress(completed: int, total: int) -> None:
-            nonlocal completed_count
-            completed_count = completed
-            if progress_callback:
-                # progress_callback expects (count, item) but we don't have item in completion order
-                pass
+        def _wrapped(item: T) -> tuple[T, R]:
+            try:
+                return (item, process_fn(item))
+            except Exception as e:
+                e.__item__ = item  # type: ignore[attr-defined]
+                raise
 
         from bengal.utils.concurrency.work_scope import WorkScope
 
         with WorkScope("Parallel", max_workers=max_workers) as scope:
-            work_results = scope.map(process_fn, items)
+            work_results = scope.map(_wrapped, items)
 
         for r in work_results:
             if r.ok:
-                result.results.append(r.value)
+                assert r.value is not None  # guaranteed by r.ok
+                item, processed_value = r.value
+                result.results.append(processed_value)
                 result.total_processed += 1
 
                 if progress_updater:
-                    progress_updater.increment("")
+                    progress_updater.increment(str(item))
                 elif progress_callback:
                     completed_count += 1
-                    progress_callback(completed_count, r.value)
+                    progress_callback(completed_count, item)
 
             else:
                 e = r.error
@@ -282,13 +284,14 @@ class ParallelProcessor[T, R]:
                     logger.debug(f"{self._error_type}_shutdown")
                     continue
 
-                result.errors.append((None, e))
+                item = getattr(e, "__item__", None)
+                result.errors.append((item, e))
                 result.total_errors += 1
 
                 if context_extractor:
-                    context = context_extractor(e, None)
+                    context = context_extractor(e, item)
                 else:
-                    context = extract_error_context(e, None)
+                    context = extract_error_context(e, item)
 
                 if aggregator.should_log_individual(
                     e,
@@ -349,7 +352,7 @@ class ParallelProcessor[T, R]:
         aggregator = ErrorAggregator(total_items=len(items))
         generation_attr = f"{thread_local_attr}_generation"
 
-        def process_with_local(item: T) -> R:
+        def process_with_local(item: T) -> tuple[T, R]:
             """Process item with thread-local instance."""
             # Check if instance exists and is current generation
             needs_new = not hasattr(thread_local, thread_local_attr) or (
@@ -361,7 +364,11 @@ class ParallelProcessor[T, R]:
                     setattr(thread_local, generation_attr, generation)
 
             instance = getattr(thread_local, thread_local_attr)
-            return process_fn(item, instance)
+            try:
+                return (item, process_fn(item, instance))
+            except Exception as e:
+                e.__item__ = item  # type: ignore[attr-defined]
+                raise
 
         from bengal.utils.concurrency.work_scope import WorkScope
 
@@ -370,11 +377,13 @@ class ParallelProcessor[T, R]:
 
         for r in work_results:
             if r.ok:
-                result.results.append(r.value)
+                assert r.value is not None  # guaranteed by r.ok
+                item, processed_value = r.value
+                result.results.append(processed_value)
                 result.total_processed += 1
 
                 if progress_updater:
-                    progress_updater.increment("")
+                    progress_updater.increment(str(item))
 
             else:
                 e = r.error
@@ -382,13 +391,14 @@ class ParallelProcessor[T, R]:
                     logger.debug(f"{self._error_type}_shutdown")
                     continue
 
-                result.errors.append((None, e))
+                item = getattr(e, "__item__", None)
+                result.errors.append((item, e))
                 result.total_errors += 1
 
                 if context_extractor:
-                    context = context_extractor(e, None)
+                    context = context_extractor(e, item)
                 else:
-                    context = extract_error_context(e, None)
+                    context = extract_error_context(e, item)
 
                 if aggregator.should_log_individual(
                     e,

--- a/bengal/orchestration/utils/parallel.py
+++ b/bengal/orchestration/utils/parallel.py
@@ -25,8 +25,6 @@ Example:
 
 from __future__ import annotations
 
-import concurrent.futures
-import contextvars
 import threading
 import time
 from collections.abc import Callable
@@ -254,85 +252,60 @@ class ParallelProcessor[T, R]:
         result = ProcessResult[R]()
         aggregator = ErrorAggregator(total_items=len(items))
         completed_count = 0
-        lock = threading.Lock()
 
-        def process_item(item: T) -> R:
-            """Process single item with context propagation."""
-            return process_fn(item)
+        def _on_progress(completed: int, total: int) -> None:
+            nonlocal completed_count
+            completed_count = completed
+            if progress_callback:
+                # progress_callback expects (count, item) but we don't have item in completion order
+                pass
 
-        try:
-            from bengal.utils.concurrency.executor import managed_executor
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-            with managed_executor(max_workers, thread_name_prefix="Bengal-Parallel") as executor:
-                # Submit tasks with optional context propagation
-                if self._propagate_context:
-                    future_to_item = {
-                        executor.submit(
-                            contextvars.copy_context().run,
-                            process_item,
-                            item,
-                        ): item
-                        for item in items
-                    }
-                else:
-                    future_to_item = {executor.submit(process_fn, item): item for item in items}
+        with WorkScope("Parallel", max_workers=max_workers) as scope:
+            work_results = scope.map(process_fn, items)
 
-                # Process results as they complete
-                for future in concurrent.futures.as_completed(future_to_item):
-                    item = future_to_item[future]
-                    try:
-                        item_result = future.result(timeout=90)
-                        result.results.append(item_result)
-                        result.total_processed += 1
+        for r in work_results:
+            if r.ok:
+                result.results.append(r.value)
+                result.total_processed += 1
 
-                        # Progress update
-                        if progress_updater:
-                            progress_updater.increment(str(item))
-                        elif progress_callback:
-                            with lock:
-                                completed_count += 1
-                                progress_callback(completed_count, item)
-
-                    except Exception as e:
-                        # Handle shutdown errors gracefully
-                        if is_shutdown_error(e):
-                            logger.debug(f"{self._error_type}_shutdown", item=str(item))
-                            continue
-
-                        result.errors.append((item, e))
-                        result.total_errors += 1
-
-                        # Extract context for logging
-                        if context_extractor:
-                            context = context_extractor(e, item)
-                        else:
-                            context = extract_error_context(e, item)
-
-                        # Log individual errors until threshold
-                        if aggregator.should_log_individual(
-                            e,
-                            context,
-                            threshold=self._error_threshold,
-                            max_samples=self._max_error_samples,
-                        ):
-                            logger.error(f"{self._error_type}_processing_failed", **context)
-
-                        aggregator.add_error(e, context=context)
-
-                # Final progress update
                 if progress_updater:
-                    progress_updater.finalize(len(items))
+                    progress_updater.increment("")
+                elif progress_callback:
+                    completed_count += 1
+                    progress_callback(completed_count, r.value)
 
-                # Log aggregated summary if threshold exceeded
-                aggregator.log_summary(
-                    logger, threshold=self._error_threshold, error_type=self._error_type
-                )
-
-        except RuntimeError as e:
-            if is_shutdown_error(e):
-                logger.debug(f"{self._error_type}_executor_shutdown")
             else:
-                raise
+                e = r.error
+                if is_shutdown_error(e):
+                    logger.debug(f"{self._error_type}_shutdown")
+                    continue
+
+                result.errors.append((None, e))
+                result.total_errors += 1
+
+                if context_extractor:
+                    context = context_extractor(e, None)
+                else:
+                    context = extract_error_context(e, None)
+
+                if aggregator.should_log_individual(
+                    e,
+                    context,
+                    threshold=self._error_threshold,
+                    max_samples=self._max_error_samples,
+                ):
+                    logger.error(f"{self._error_type}_processing_failed", **context)
+
+                aggregator.add_error(e, context=context)
+
+        # Final progress update
+        if progress_updater:
+            progress_updater.finalize(len(items))
+
+        # Log aggregated summary if threshold exceeded
+        aggregator.log_summary(logger, threshold=self._error_threshold, error_type=self._error_type)
 
         return result
 
@@ -390,68 +363,46 @@ class ParallelProcessor[T, R]:
             instance = getattr(thread_local, thread_local_attr)
             return process_fn(item, instance)
 
-        try:
-            from bengal.utils.concurrency.executor import managed_executor
+        from bengal.utils.concurrency.work_scope import WorkScope
 
-            with managed_executor(max_workers, thread_name_prefix="Bengal-Parallel") as executor:
-                if self._propagate_context:
-                    future_to_item = {
-                        executor.submit(
-                            contextvars.copy_context().run,
-                            process_with_local,
-                            item,
-                        ): item
-                        for item in items
-                    }
-                else:
-                    future_to_item = {
-                        executor.submit(process_with_local, item): item for item in items
-                    }
+        with WorkScope("Parallel", max_workers=max_workers) as scope:
+            work_results = scope.map(process_with_local, items)
 
-                for future in concurrent.futures.as_completed(future_to_item):
-                    item = future_to_item[future]
-                    try:
-                        item_result = future.result(timeout=90)
-                        result.results.append(item_result)
-                        result.total_processed += 1
-
-                        if progress_updater:
-                            progress_updater.increment(str(item))
-
-                    except Exception as e:
-                        if is_shutdown_error(e):
-                            logger.debug(f"{self._error_type}_shutdown", item=str(item))
-                            continue
-
-                        result.errors.append((item, e))
-                        result.total_errors += 1
-
-                        if context_extractor:
-                            context = context_extractor(e, item)
-                        else:
-                            context = extract_error_context(e, item)
-
-                        if aggregator.should_log_individual(
-                            e,
-                            context,
-                            threshold=self._error_threshold,
-                            max_samples=self._max_error_samples,
-                        ):
-                            logger.error(f"{self._error_type}_processing_failed", **context)
-
-                        aggregator.add_error(e, context=context)
+        for r in work_results:
+            if r.ok:
+                result.results.append(r.value)
+                result.total_processed += 1
 
                 if progress_updater:
-                    progress_updater.finalize(len(items))
+                    progress_updater.increment("")
 
-                aggregator.log_summary(
-                    logger, threshold=self._error_threshold, error_type=self._error_type
-                )
-
-        except RuntimeError as e:
-            if is_shutdown_error(e):
-                logger.debug(f"{self._error_type}_executor_shutdown")
             else:
-                raise
+                e = r.error
+                if is_shutdown_error(e):
+                    logger.debug(f"{self._error_type}_shutdown")
+                    continue
+
+                result.errors.append((None, e))
+                result.total_errors += 1
+
+                if context_extractor:
+                    context = context_extractor(e, None)
+                else:
+                    context = extract_error_context(e, None)
+
+                if aggregator.should_log_individual(
+                    e,
+                    context,
+                    threshold=self._error_threshold,
+                    max_samples=self._max_error_samples,
+                ):
+                    logger.error(f"{self._error_type}_processing_failed", **context)
+
+                aggregator.add_error(e, context=context)
+
+        if progress_updater:
+            progress_updater.finalize(len(items))
+
+        aggregator.log_summary(logger, threshold=self._error_threshold, error_type=self._error_type)
 
         return result

--- a/bengal/output/globals.py
+++ b/bengal/output/globals.py
@@ -22,12 +22,14 @@ Related:
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from bengal.output.core import CLIOutput
 
 _cli_output: CLIOutput | None = None
+_cli_output_lock = threading.Lock()
 
 
 def get_cli_output() -> CLIOutput:
@@ -47,9 +49,11 @@ def get_cli_output() -> CLIOutput:
     """
     global _cli_output
     if _cli_output is None:
-        from bengal.output.core import CLIOutput
+        with _cli_output_lock:
+            if _cli_output is None:
+                from bengal.output.core import CLIOutput
 
-        _cli_output = CLIOutput()
+                _cli_output = CLIOutput()
     return _cli_output
 
 

--- a/bengal/parsing/backends/patitas/__init__.py
+++ b/bengal/parsing/backends/patitas/__init__.py
@@ -296,10 +296,20 @@ def parse_many(
     def _parse_one(source: str) -> str:
         return parse(source, highlight=highlight, delegate=delegate)
 
-    from bengal.utils.concurrency.executor import managed_executor
+    from bengal.utils.concurrency.work_scope import WorkScope
 
-    with managed_executor(max_workers=max_workers) as executor:
-        return list(executor.map(_parse_one, sources))
+    def _parse_indexed(item: tuple[int, str]) -> tuple[int, str]:
+        idx, source = item
+        return idx, _parse_one(source)
+
+    with WorkScope("patitas-parse", max_workers=max_workers) as scope:
+        results = scope.map(_parse_indexed, list(enumerate(sources)))
+    for r in results:
+        if r.error:
+            raise r.error
+    # Sort by original index to preserve submission order
+    ordered = sorted((r.value for r in results if r.value is not None), key=lambda x: x[0])
+    return [val for _, val in ordered]
 
 
 def parse_to_ast(

--- a/bengal/parsing/backends/patitas/__init__.py
+++ b/bengal/parsing/backends/patitas/__init__.py
@@ -48,7 +48,6 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Literal
 
 # Core types from external patitas package (nodes, location, tokens, stringbuilder)
@@ -297,7 +296,9 @@ def parse_many(
     def _parse_one(source: str) -> str:
         return parse(source, highlight=highlight, delegate=delegate)
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    from bengal.utils.concurrency.executor import managed_executor
+
+    with managed_executor(max_workers=max_workers) as executor:
         return list(executor.map(_parse_one, sources))
 
 

--- a/bengal/postprocess/output_formats/utils.py
+++ b/bengal/postprocess/output_formats/utils.py
@@ -53,7 +53,6 @@ Related:
 
 from __future__ import annotations
 
-import concurrent.futures
 import hashlib
 import re
 from collections.abc import Callable
@@ -345,20 +344,12 @@ def parallel_write_files[T](
             )
             return False
 
-    count = 0
-    try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Consume iterator fully before exiting context manager
-            # This ensures all tasks complete and exceptions are raised properly
-            results = list(executor.map(safe_write, items))
-            count = sum(1 for r in results if r)
-    except RuntimeError as e:
-        # Handle graceful shutdown - "cannot schedule new futures after interpreter shutdown"
-        if "interpreter shutdown" in str(e):
-            logger.debug(f"{operation_name}_shutdown", reason="interpreter_shutting_down")
-            return count
-        raise
+    from bengal.utils.concurrency.work_scope import WorkScope
 
+    with WorkScope("FileWrite", max_workers=max_workers) as scope:
+        results = scope.map(safe_write, items)
+
+    count = sum(1 for r in results if r.ok and r.value)
     return count
 
 

--- a/bengal/rendering/api_doc_enhancer.py
+++ b/bengal/rendering/api_doc_enhancer.py
@@ -24,6 +24,7 @@ enhanced_html = enhancer.enhance(html, page_type='python-module')
 from __future__ import annotations
 
 import re
+import threading
 from contextvars import ContextVar
 from typing import ClassVar, Protocol
 
@@ -193,7 +194,8 @@ class APIDocEnhancer(APIDocEnhancerProtocol):
 
 
 # Singleton instance for reuse across pages
-_enhancer = None
+_enhancer: APIDocEnhancer | None = None
+_enhancer_lock = threading.Lock()
 
 
 def get_enhancer() -> APIDocEnhancer:
@@ -206,5 +208,7 @@ def get_enhancer() -> APIDocEnhancer:
     """
     global _enhancer
     if _enhancer is None:
-        _enhancer = APIDocEnhancer()
+        with _enhancer_lock:
+            if _enhancer is None:
+                _enhancer = APIDocEnhancer()
     return _enhancer

--- a/bengal/rendering/content_cache.py
+++ b/bengal/rendering/content_cache.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -228,13 +229,16 @@ class ContentCache:
 
 # Global content cache instance (singleton)
 _content_cache: ContentCache | None = None
+_content_cache_lock = threading.Lock()
 
 
 def get_content_cache() -> ContentCache:
     """Get or create the global content cache."""
     global _content_cache
     if _content_cache is None:
-        _content_cache = ContentCache()
+        with _content_cache_lock:
+            if _content_cache is None:
+                _content_cache = ContentCache()
     return _content_cache
 
 

--- a/bengal/rendering/context/site_wrappers.py
+++ b/bengal/rendering/context/site_wrappers.py
@@ -10,6 +10,7 @@ RFC: rfc-incremental-build-dependency-gaps (Phase 1)
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any
 
 from bengal.rendering.context.data_wrappers import ParamsContext, SmartDict
@@ -51,12 +52,13 @@ class SiteContext:
 
     """
 
-    __slots__ = ("_params_cache", "_site", "_tracked_data_cache")
+    __slots__ = ("_init_lock", "_params_cache", "_site", "_tracked_data_cache")
 
     def __init__(self, site: SiteLike):
         self._site = site
         self._params_cache: ParamsContext | None = None
         self._tracked_data_cache: Any = None
+        self._init_lock = threading.Lock()
 
     def __getattr__(self, name: str) -> Any:
         """Proxy to underlying site, with safe fallbacks."""
@@ -97,11 +99,13 @@ class SiteContext:
         # TrackedData looks up tracker from ContextVar at access time,
         # so caching is safe even across different page renders.
         if self._tracked_data_cache is None:
-            data_dir = self._site.root_path / "data"
-            self._tracked_data_cache = TrackedData(
-                self._site.data,
-                data_dir,
-            )
+            with self._init_lock:
+                if self._tracked_data_cache is None:
+                    data_dir = self._site.root_path / "data"
+                    self._tracked_data_cache = TrackedData(
+                        self._site.data,
+                        data_dir,
+                    )
 
         return self._tracked_data_cache
 
@@ -178,7 +182,9 @@ class SiteContext:
             {{ site.params.social.twitter }}
         """
         if self._params_cache is None:
-            self._params_cache = ParamsContext(self._site.config.get("params", {}))
+            with self._init_lock:
+                if self._params_cache is None:
+                    self._params_cache = ParamsContext(self._site.config.get("params", {}))
         return self._params_cache
 
     def __bool__(self) -> bool:
@@ -207,11 +213,12 @@ class ThemeContext:
 
     """
 
-    __slots__ = ("_config_cache", "_theme")
+    __slots__ = ("_config_cache", "_init_lock", "_theme")
 
     def __init__(self, theme: Theme | None):
         self._theme = theme
         self._config_cache: ParamsContext | None = None
+        self._init_lock = threading.Lock()
 
     @classmethod
     def _empty(cls) -> ThemeContext:
@@ -293,10 +300,12 @@ class ThemeContext:
     def config(self) -> ParamsContext:
         """Theme config as ParamsContext for safe nested access (cached)."""
         if self._config_cache is None:
-            if self._theme is None or self._theme.config is None:
-                self._config_cache = ParamsContext({})
-            else:
-                self._config_cache = ParamsContext(self._theme.config)
+            with self._init_lock:
+                if self._config_cache is None:
+                    if self._theme is None or self._theme.config is None:
+                        self._config_cache = ParamsContext({})
+                    else:
+                        self._config_cache = ParamsContext(self._theme.config)
         return self._config_cache
 
     def has(self, feature: str) -> bool:

--- a/bengal/rendering/errors/deduplication.py
+++ b/bengal/rendering/errors/deduplication.py
@@ -17,6 +17,7 @@ Usage:
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -56,6 +57,8 @@ class ErrorDeduplicator:
     seen_errors: dict[ErrorDedupKey, list[str]] = field(default_factory=dict)
     # Maximum errors to show per unique error signature
     max_display_per_error: int = 2
+    # Thread-safety lock — protects seen_errors dict read+write in should_display
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
 
     def _get_error_key(self, error: TemplateRenderError) -> ErrorDedupKey:
         """Generate a key for error deduplication."""
@@ -78,13 +81,14 @@ class ErrorDeduplicator:
         key = self._get_error_key(error)
         page_source = str(error.page_source) if error.page_source else "unknown"
 
-        if key not in self.seen_errors:
-            self.seen_errors[key] = []
+        with self._lock:
+            if key not in self.seen_errors:
+                self.seen_errors[key] = []
 
-        self.seen_errors[key].append(page_source)
+            self.seen_errors[key].append(page_source)
 
-        # Display if we haven't hit the limit yet
-        return len(self.seen_errors[key]) <= self.max_display_per_error
+            # Display if we haven't hit the limit yet
+            return len(self.seen_errors[key]) <= self.max_display_per_error
 
     def get_suppressed_count(self) -> int:
         """Get total count of suppressed (not displayed) errors."""

--- a/bengal/rendering/metadata.py
+++ b/bengal/rendering/metadata.py
@@ -240,10 +240,8 @@ def build_template_metadata(site: SiteLike) -> dict[str, Any]:
             if _bs is not None:
                 _bs.template_metadata_cache = cache_val
             else:
-                import threading as _threading
-
                 _init_lock = getattr(site, "_init_lock", None)
-                if isinstance(_init_lock, _threading.Lock):
+                if _init_lock is not None:
                     with _init_lock:
                         if getattr(site, "_bengal_template_metadata_cache", None) is None:
                             site._bengal_template_metadata_cache = cache_val

--- a/bengal/rendering/metadata.py
+++ b/bengal/rendering/metadata.py
@@ -240,6 +240,14 @@ def build_template_metadata(site: SiteLike) -> dict[str, Any]:
             if _bs is not None:
                 _bs.template_metadata_cache = cache_val
             else:
-                site._bengal_template_metadata_cache = cache_val
+                import threading as _threading
+
+                _init_lock = getattr(site, "_init_lock", None)
+                if isinstance(_init_lock, _threading.Lock):
+                    with _init_lock:
+                        if getattr(site, "_bengal_template_metadata_cache", None) is None:
+                            site._bengal_template_metadata_cache = cache_val
+                else:
+                    site._bengal_template_metadata_cache = cache_val
 
     return result

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -195,11 +195,12 @@ class RenderingPipeline:
                 # fallback here handles direct RenderingPipeline use (tests, CLI).
                 if not hasattr(site, "_external_ref_resolvers"):
                     site._external_ref_resolvers = []
-                if not hasattr(site, "_external_ref_resolvers_lock"):
-                    import threading
+                import threading
 
-                    site._external_ref_resolvers_lock = threading.Lock()
-                with site._external_ref_resolvers_lock:
+                lock = getattr(site, "_external_ref_resolvers_lock", None)
+                if not isinstance(lock, threading.Lock):
+                    site._external_ref_resolvers_lock = lock = threading.Lock()
+                with lock:
                     site._external_ref_resolvers.append(external_ref_resolver)
                 site.external_ref_resolver = external_ref_resolver
 

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -202,7 +202,7 @@ class RenderingPipeline:
                     site._external_ref_resolvers_lock = lock = threading.Lock()
                 with lock:
                     site._external_ref_resolvers.append(external_ref_resolver)
-                site.external_ref_resolver = external_ref_resolver
+                    site.external_ref_resolver = external_ref_resolver
 
             rich_parser = cast(RichMarkdownParser, self.parser)
             rich_parser.enable_cross_references(

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -195,7 +195,12 @@ class RenderingPipeline:
                 # fallback here handles direct RenderingPipeline use (tests, CLI).
                 if not hasattr(site, "_external_ref_resolvers"):
                     site._external_ref_resolvers = []
-                site._external_ref_resolvers.append(external_ref_resolver)
+                if not hasattr(site, "_external_ref_resolvers_lock"):
+                    import threading
+
+                    site._external_ref_resolvers_lock = threading.Lock()
+                with site._external_ref_resolvers_lock:
+                    site._external_ref_resolvers.append(external_ref_resolver)
                 site.external_ref_resolver = external_ref_resolver
 
             rich_parser = cast(RichMarkdownParser, self.parser)

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -195,10 +195,11 @@ class RenderingPipeline:
                 # fallback here handles direct RenderingPipeline use (tests, CLI).
                 if not hasattr(site, "_external_ref_resolvers"):
                     site._external_ref_resolvers = []
+                import _thread
                 import threading
 
                 lock = getattr(site, "_external_ref_resolvers_lock", None)
-                if not isinstance(lock, threading.Lock):
+                if not isinstance(lock, _thread.LockType):
                     site._external_ref_resolvers_lock = lock = threading.Lock()
                 with lock:
                     site._external_ref_resolvers.append(external_ref_resolver)

--- a/bengal/rendering/pipeline/json_accumulator.py
+++ b/bengal/rendering/pipeline/json_accumulator.py
@@ -11,6 +11,7 @@ JsonAccumulator: Accumulates page data during rendering.
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any
 
 from bengal.utils.observability.logger import get_logger
@@ -56,6 +57,7 @@ class JsonAccumulator:
         self.build_context = build_context
         self._page_json_generator: Any = None
         self._page_json_generator_opts: tuple[bool, bool] | None = None
+        self._generator_lock = threading.Lock()
 
     def accumulate_unified_page_data(self, page: PageLike) -> None:
         """
@@ -261,8 +263,10 @@ class JsonAccumulator:
         # Reuse per-pipeline generator instance for speed.
         opts = (include_html, include_text)
         if self._page_json_generator is None or self._page_json_generator_opts != opts:
-            self._page_json_generator = PageJSONGenerator(self.site, graph_data=None)
-            self._page_json_generator_opts = opts
+            with self._generator_lock:
+                if self._page_json_generator is None or self._page_json_generator_opts != opts:
+                    self._page_json_generator = PageJSONGenerator(self.site, graph_data=None)
+                    self._page_json_generator_opts = opts
 
         return self._page_json_generator.page_to_json(
             page, include_html=include_html, include_text=include_text

--- a/bengal/rendering/renderer.py
+++ b/bengal/rendering/renderer.py
@@ -30,6 +30,8 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from bengal.protocols import SiteLike
+from bengal.rendering.context import build_page_context
+from bengal.rendering.errors import TemplateRenderError
 from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
@@ -377,8 +379,6 @@ class Renderer:
         Returns:
             Fully rendered HTML page
         """
-        from bengal.rendering.context import build_page_context
-
         if content is None:
             content = page.html_content or ""
             # Debug: Check core/page specifically
@@ -486,8 +486,6 @@ class Renderer:
             return str(result) if result else ""
         except Exception as e:
             import os
-
-            from bengal.rendering.errors import TemplateRenderError
 
             rich_error = TemplateRenderError.from_jinja2_error(
                 e, template_name, page.source_path, self.template_engine

--- a/bengal/rendering/template_functions/get_page.py
+++ b/bengal/rendering/template_functions/get_page.py
@@ -103,6 +103,55 @@ def _normalize_cache_key(path: str) -> str:
     return normalized
 
 
+def _create_template_parser(site: SiteLike) -> Any:
+    """
+    Create and configure a markdown parser for on-demand page parsing.
+
+    Instantiates the parser selected by site config and enables cross-reference
+    support when applicable.  Must be called under site._init_lock (if available)
+    to guarantee at-most-once creation in free-threaded Python.
+
+    Args:
+        site: Site instance supplying config and xref_index.
+
+    Returns:
+        Configured parser instance.
+
+    """
+    from bengal.parsing import create_markdown_parser
+
+    # Get parser engine from config (same logic as RenderingPipeline)
+    markdown_engine = site.config.get("markdown_engine")
+    if not markdown_engine:
+        markdown_config = site.config.get("markdown", {})
+        markdown_engine = markdown_config.get("parser", "patitas")
+
+    parser = create_markdown_parser(markdown_engine)
+
+    # Enable cross-references if available
+    if hasattr(site, "xref_index") and hasattr(parser, "enable_cross_references"):
+        version_config = getattr(site, "version_config", None)
+
+        # Create external reference resolver for [[ext:project:target]] syntax
+        external_ref_resolver = None
+        external_refs_config = site.config.get("external_refs", {})
+        if (
+            external_refs_config
+            and isinstance(external_refs_config, dict)
+            and external_refs_config.get("enabled", True)
+        ):
+            from bengal.rendering.external_refs import ExternalRefResolver
+
+            config_dict = cast(dict[str, Any], site.config)
+            external_ref_resolver = ExternalRefResolver(config_dict)
+
+        enable_method = getattr(parser, "enable_cross_references", None)
+        if callable(enable_method):
+            enable_method(site.xref_index, version_config, None, external_ref_resolver)
+
+    return parser
+
+
 def _ensure_page_parsed(page: Page, site: SiteLike) -> None:
     """
     Ensure a page is parsed if it hasn't been parsed yet.
@@ -123,49 +172,22 @@ def _ensure_page_parsed(page: Page, site: SiteLike) -> None:
     if not hasattr(page, "content") or not page._source:
         return
 
-    # Lazy-create parser on site object for reuse
+    # Lazy-create parser on site object for reuse (double-checked locking)
     # Type narrowing: _template_parser may not be on SiteLike protocol
     template_parser = getattr(site, "_template_parser", None)
     if template_parser is None:
-        from bengal.parsing import create_markdown_parser
-
-        # Get parser engine from config (same logic as RenderingPipeline)
-        markdown_engine = site.config.get("markdown_engine")
-        if not markdown_engine:
-            markdown_config = site.config.get("markdown", {})
-            markdown_engine = markdown_config.get("parser", "patitas")
-
-        template_parser = create_markdown_parser(markdown_engine)
-        if hasattr(site, "_template_parser"):
-            site._template_parser = template_parser
-
-        # Enable cross-references if available
-        if hasattr(site, "xref_index") and hasattr(
-            template_parser,
-            "enable_cross_references",
-        ):
-            # Pass version_config for cross-version linking support [[v2:path]]
-            version_config = getattr(site, "version_config", None)
-
-            # Create external reference resolver for [[ext:project:target]] syntax
-            # See: plan/rfc-external-references.md
-            external_ref_resolver = None
-            external_refs_config = site.config.get("external_refs", {})
-            if (
-                external_refs_config
-                and isinstance(external_refs_config, dict)
-                and external_refs_config.get("enabled", True)
-            ):
-                from bengal.rendering.external_refs import ExternalRefResolver
-
-                # Cast SiteConfig to dict[str, Any] for compatibility
-                config_dict = cast(dict[str, Any], site.config)
-                external_ref_resolver = ExternalRefResolver(config_dict)
-
-            # Type narrowing: check if method is callable
-            enable_method = getattr(template_parser, "enable_cross_references", None)
-            if callable(enable_method):
-                enable_method(site.xref_index, version_config, None, external_ref_resolver)
+        init_lock = getattr(site, "_init_lock", None)
+        if init_lock is not None:
+            with init_lock:
+                template_parser = getattr(site, "_template_parser", None)
+                if template_parser is None:
+                    template_parser = _create_template_parser(site)
+                    if hasattr(site, "_template_parser"):
+                        site._template_parser = template_parser
+        else:
+            template_parser = _create_template_parser(site)
+            if hasattr(site, "_template_parser"):
+                site._template_parser = template_parser
 
     parser = template_parser
 
@@ -366,24 +388,43 @@ def _build_lookup_maps(site: SiteLike) -> None:
         Build-scoped caching ensures maps are built once per build,
         not once per page render. This saves ~200ms on large sites.
     """
-    # Check if already cached on site object
+    # Check if already cached on site object (fast path — no lock)
     page_lookup_maps = getattr(site, "_page_lookup_maps", None)
     if page_lookup_maps is not None:
         return
 
-    # Try build-scoped cache first (preferred - automatically cleared per build)
-    from bengal.rendering.template_functions.memo import get_build_context
+    init_lock = getattr(site, "_init_lock", None)
+    if init_lock is not None:
+        with init_lock:
+            # Re-check inside the lock (double-checked locking)
+            if getattr(site, "_page_lookup_maps", None) is not None:
+                return
 
-    build_ctx = get_build_context()
-    if build_ctx is not None:
-        maps = build_ctx.get_cached("page_lookup_maps", lambda: _build_lookup_maps_impl(site))
+            # Try build-scoped cache first (preferred - automatically cleared per build)
+            from bengal.rendering.template_functions.memo import get_build_context
+
+            build_ctx = get_build_context()
+            if build_ctx is not None:
+                maps = build_ctx.get_cached(
+                    "page_lookup_maps", lambda: _build_lookup_maps_impl(site)
+                )
+            else:
+                maps = _build_lookup_maps_impl(site)
+
+            if hasattr(site, "_page_lookup_maps"):
+                site._page_lookup_maps = maps
     else:
-        # Fallback to direct computation (no build context available)
-        maps = _build_lookup_maps_impl(site)
+        # No lock available (e.g. mock site in tests) — best-effort
+        from bengal.rendering.template_functions.memo import get_build_context
 
-    # Cache on site object for subsequent lookups within this render
-    if hasattr(site, "_page_lookup_maps"):
-        site._page_lookup_maps = maps
+        build_ctx = get_build_context()
+        if build_ctx is not None:
+            maps = build_ctx.get_cached("page_lookup_maps", lambda: _build_lookup_maps_impl(site))
+        else:
+            maps = _build_lookup_maps_impl(site)
+
+        if hasattr(site, "_page_lookup_maps"):
+            site._page_lookup_maps = maps
 
 
 def page_exists(path: str, site: SiteLike) -> bool:

--- a/bengal/rendering/template_profiler.py
+++ b/bengal/rendering/template_profiler.py
@@ -425,6 +425,7 @@ def format_profile_report(report: dict[str, Any], top_n: int = 20) -> str:
 
 # Global profiler instance (disabled by default)
 _global_profiler: TemplateProfiler | None = None
+_global_profiler_lock = threading.Lock()
 
 
 def get_profiler() -> TemplateProfiler | None:
@@ -442,7 +443,9 @@ def enable_profiling() -> TemplateProfiler:
     """
     global _global_profiler
     if _global_profiler is None:
-        _global_profiler = TemplateProfiler()
+        with _global_profiler_lock:
+            if _global_profiler is None:
+                _global_profiler = TemplateProfiler()
     _global_profiler.enable()
     return _global_profiler
 

--- a/bengal/server/build_executor.py
+++ b/bengal/server/build_executor.py
@@ -57,7 +57,15 @@ logger = get_logger(__name__)
 
 # Use spawn context to avoid fork issues with threads
 # spawn starts a fresh Python interpreter, avoiding shared state issues
-mp_context = multiprocessing.get_context("spawn")
+# Lazy getter avoids the import-time side effect of get_context("spawn")
+_mp_context = None
+
+
+def _get_mp_context() -> multiprocessing.context.BaseContext:
+    global _mp_context
+    if _mp_context is None:
+        _mp_context = multiprocessing.get_context("spawn")
+    return _mp_context
 
 
 @dataclass(frozen=True, slots=True)
@@ -295,7 +303,7 @@ class BuildExecutor:
             else:
                 self._executor = ProcessPoolExecutor(
                     max_workers=self.max_workers,
-                    mp_context=mp_context,
+                    mp_context=_get_mp_context(),
                 )
                 logger.info("build_executor_created", type="process", workers=self.max_workers)
 

--- a/bengal/snapshots/scheduler.py
+++ b/bengal/snapshots/scheduler.py
@@ -266,7 +266,7 @@ class WaveScheduler:
                         current_generation=None,
                     )
                 except Exception as e:
-                    e.__page_source_path__ = page.source_path
+                    e.__page_source_path__ = page.source_path  # type: ignore[attr-defined]
                     raise
                 return page
 
@@ -403,7 +403,7 @@ class WaveScheduler:
                         current_generation=None,
                     )
                 except Exception as e:
-                    e.__page_source_path__ = page.source_path
+                    e.__page_source_path__ = page.source_path  # type: ignore[attr-defined]
                     raise
                 return page
 

--- a/bengal/snapshots/scheduler.py
+++ b/bengal/snapshots/scheduler.py
@@ -12,7 +12,7 @@ All data access is from frozen snapshot (lock-free).
 from __future__ import annotations
 
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import as_completed
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -250,14 +250,12 @@ class WaveScheduler:
             )
 
             # Render by template batch
-            # Manage executor manually to avoid shutdown(wait=True) hanging
-            # when a render thread is stuck (e.g., pytest-timeout fires
-            # KeyboardInterrupt but ThreadPoolExecutor.__exit__ blocks).
-            executor = ThreadPoolExecutor(
+            from bengal.utils.concurrency.executor import managed_executor
+
+            with managed_executor(
                 max_workers=self.max_workers,
                 thread_name_prefix="Bengal-Render",
-            )
-            try:
+            ) as executor:
                 for template_idx, template_name in enumerate(sorted_templates):
                     batch_pages = template_to_pages[template_name]
                     if not batch_pages:
@@ -311,14 +309,6 @@ class WaveScheduler:
                     batch_time = (time.perf_counter() - batch_start) * 1000
                     stats.template_batches[template_name] = len(batch_pages)
                     stats.batch_times_ms[template_name] = batch_time
-            except BaseException:
-                # Force-cancel remaining futures and shut down without waiting.
-                # Catches KeyboardInterrupt (pytest-timeout) and SystemExit
-                # to prevent hangs from ThreadPoolExecutor.shutdown(wait=True).
-                executor.shutdown(wait=False, cancel_futures=True)
-                raise
-            else:
-                executor.shutdown(wait=True)
 
             # Final progress update to ensure 100%
             self._progress_tracker.finalize(total_pages)
@@ -399,7 +389,9 @@ class WaveScheduler:
                 max_wave = max(waves.keys()) if waves else -1
                 waves[max_wave + 1] = orphan_pages
 
-            with ThreadPoolExecutor(
+            from bengal.utils.concurrency.executor import managed_executor
+
+            with managed_executor(
                 max_workers=self.max_workers,
                 thread_name_prefix="Bengal-Render",
             ) as executor:

--- a/bengal/snapshots/scheduler.py
+++ b/bengal/snapshots/scheduler.py
@@ -12,7 +12,6 @@ All data access is from frozen snapshot (lock-free).
 from __future__ import annotations
 
 import time
-from concurrent.futures import as_completed
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,7 +25,6 @@ from bengal.snapshots.utils import (
     RenderProgressTracker,
     resolve_template_name,
 )
-from bengal.utils.concurrency import submit_with_context
 from bengal.utils.observability.logger import get_logger
 
 logger = get_logger(__name__)
@@ -250,12 +248,32 @@ class WaveScheduler:
             )
 
             # Render by template batch
-            from bengal.utils.concurrency.executor import managed_executor
+            from bengal.utils.concurrency.work_scope import WorkScope
 
-            with managed_executor(
+            def process_page(page: Page) -> Page:
+                try:
+                    run_page(
+                        page,
+                        site=self.site,
+                        quiet=self.quiet,
+                        stats=self.stats,
+                        build_context=self.build_context,
+                        changed_sources=None,
+                        block_cache=self._block_cache,
+                        highlight_cache=None,
+                        output_collector=self._output_collector,
+                        write_behind=self._write_behind,
+                        current_generation=None,
+                    )
+                except Exception as e:
+                    e.__page_source_path__ = page.source_path
+                    raise
+                return page
+
+            with WorkScope(
+                "Render",
                 max_workers=self.max_workers,
-                thread_name_prefix="Bengal-Render",
-            ) as executor:
+            ) as scope:
                 for template_idx, template_name in enumerate(sorted_templates):
                     batch_pages = template_to_pages[template_name]
                     if not batch_pages:
@@ -267,44 +285,22 @@ class WaveScheduler:
                     if scout:
                         scout._worker_wave = template_idx + 1
 
-                    def process_page(page: Page) -> Page:
-                        run_page(
-                            page,
-                            site=self.site,
-                            quiet=self.quiet,
-                            stats=self.stats,
-                            build_context=self.build_context,
-                            changed_sources=None,
-                            block_cache=self._block_cache,
-                            highlight_cache=None,
-                            output_collector=self._output_collector,
-                            write_behind=self._write_behind,
-                            current_generation=None,
-                        )
-                        return page
+                    # WorkScope propagates context automatically
+                    results = scope.map(process_page, batch_pages)
 
-                    # Submit all pages in this template batch (context propagation for asset_url)
-                    futures = {
-                        submit_with_context(executor, process_page, page): page
-                        for page in batch_pages
-                    }
-
-                    # Collect results and update progress
-                    token = self.build_context.cancellation_token if self.build_context else None
-                    for future in as_completed(futures):
-                        page = futures[future]
-                        try:
-                            if token:
-                                rendered_page = token.result(future, per_item_timeout=60.0)
-                            else:
-                                rendered_page = future.result(timeout=90)
+                    # Process results
+                    for r in results:
+                        if r.ok:
+                            rendered_page = r.value
                             stats.pages_rendered += 1
                             self._progress_tracker.increment(rendered_page)
-                        except Exception as e:
+                        else:
+                            e = r.error
                             if type(e).__name__ == "CancellationError":
                                 logger.warning("render_cancelled_wave")
                                 break
-                            stats.errors.append((page.source_path, e))
+                            source = getattr(e, "__page_source_path__", None)
+                            stats.errors.append((source, e))
 
                     batch_time = (time.perf_counter() - batch_start) * 1000
                     stats.template_batches[template_name] = len(batch_pages)
@@ -389,12 +385,32 @@ class WaveScheduler:
                 max_wave = max(waves.keys()) if waves else -1
                 waves[max_wave + 1] = orphan_pages
 
-            from bengal.utils.concurrency.executor import managed_executor
+            from bengal.utils.concurrency.work_scope import WorkScope
 
-            with managed_executor(
+            def process_page_with_pipeline(page: Page) -> Page:
+                try:
+                    run_page(
+                        page,
+                        site=self.site,
+                        quiet=self.quiet,
+                        stats=self.stats,
+                        build_context=self.build_context,
+                        changed_sources=None,
+                        block_cache=self._block_cache,
+                        highlight_cache=None,
+                        output_collector=self._output_collector,
+                        write_behind=self._write_behind,
+                        current_generation=None,
+                    )
+                except Exception as e:
+                    e.__page_source_path__ = page.source_path
+                    raise
+                return page
+
+            with WorkScope(
+                "Render",
                 max_workers=self.max_workers,
-                thread_name_prefix="Bengal-Render",
-            ) as executor:
+            ) as scope:
                 wave_num = 0
 
                 for wave_idx in sorted(waves.keys()):
@@ -406,42 +422,21 @@ class WaveScheduler:
                     if scout:
                         scout._worker_wave = wave_num
 
-                    def process_page_with_pipeline(page: Page) -> Page:
-                        run_page(
-                            page,
-                            site=self.site,
-                            quiet=self.quiet,
-                            stats=self.stats,
-                            build_context=self.build_context,
-                            changed_sources=None,
-                            block_cache=self._block_cache,
-                            highlight_cache=None,
-                            output_collector=self._output_collector,
-                            write_behind=self._write_behind,
-                            current_generation=None,
-                        )
-                        return page
+                    # WorkScope propagates context automatically
+                    results = scope.map(process_page_with_pipeline, wave_pages)
 
-                    futures = {
-                        submit_with_context(executor, process_page_with_pipeline, page): page
-                        for page in wave_pages
-                    }
-
-                    token = self.build_context.cancellation_token if self.build_context else None
-                    for future in as_completed(futures):
-                        page = futures[future]
-                        try:
-                            if token:
-                                rendered_page = token.result(future, per_item_timeout=60.0)
-                            else:
-                                rendered_page = future.result(timeout=90)
+                    for r in results:
+                        if r.ok:
+                            rendered_page = r.value
                             stats.pages_rendered += 1
                             self._progress_tracker.increment(rendered_page)
-                        except Exception as e:
+                        else:
+                            e = r.error
                             if type(e).__name__ == "CancellationError":
                                 logger.warning("render_cancelled_wave")
                                 break
-                            stats.errors.append((page.source_path, e))
+                            source = getattr(e, "__page_source_path__", None)
+                            stats.errors.append((source, e))
 
             # Final progress update to ensure 100%
             self._progress_tracker.finalize(total_pages)

--- a/bengal/utils/concurrency/__init__.py
+++ b/bengal/utils/concurrency/__init__.py
@@ -38,6 +38,7 @@ from bengal.utils.concurrency.retry import (
     retry_with_backoff,
 )
 from bengal.utils.concurrency.thread_local import ThreadLocalCache, ThreadSafeSet
+from bengal.utils.concurrency.work_scope import WorkResult, WorkScope
 from bengal.utils.concurrency.workers import (
     Environment,
     WorkloadProfile,
@@ -54,16 +55,14 @@ __all__ = [
     "CancellationError",
     "CancellationToken",
     "Environment",
-    # concurrent_locks
     "PerKeyLockManager",
-    # thread_local
     "ThreadLocalCache",
     "ThreadSafeSet",
+    "WorkResult",
+    "WorkScope",
     "WorkloadProfile",
-    # workers
     "WorkloadType",
     "async_retry_with_backoff",
-    # retry
     "calculate_backoff",
     "detect_environment",
     "estimate_page_weight",
@@ -73,13 +72,10 @@ __all__ = [
     "get_profile",
     "has_free_threading_support",
     "install_uvloop",
-    # gil
     "is_gil_disabled",
-    # executor
     "managed_executor",
     "order_by_complexity",
     "retry_with_backoff",
-    # async_compat
     "run_async",
     "should_parallelize",
     "submit_with_context",

--- a/bengal/utils/concurrency/work_scope.py
+++ b/bengal/utils/concurrency/work_scope.py
@@ -83,7 +83,6 @@ class WorkScope:
         max_workers: Maximum worker threads. None = auto-tune.
         workload_type: Workload characteristics for auto-tuning.
         timeout: Scope-level deadline in seconds (0 = no deadline).
-        per_item_timeout: Per-work-item timeout in seconds.
         on_progress: Optional callback(completed_count, total_count)
             fired after each item completes.
     """
@@ -94,7 +93,7 @@ class WorkScope:
         "_max_workers",
         "_name",
         "_on_progress",
-        "_per_item_timeout",
+        "_timed_out",
         "_timeout",
         "_workload_type",
     )
@@ -106,36 +105,35 @@ class WorkScope:
         max_workers: int | None = None,
         workload_type: WorkloadType | None = None,
         timeout: float = 300.0,
-        per_item_timeout: float = 90.0,
         on_progress: Callable[[int, int], None] | None = None,
     ) -> None:
         self._name = name
         self._max_workers = max_workers
         self._workload_type = workload_type
         self._timeout = timeout
-        self._per_item_timeout = per_item_timeout
         self._on_progress = on_progress
         self._executor: concurrent.futures.ThreadPoolExecutor | None = None
         self._deadline: float = 0.0
+        self._timed_out: bool = False
 
     def __enter__(self) -> WorkScope:
         if self._timeout > 0:
             self._deadline = time.monotonic() + self._timeout
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         if self._executor is not None:
-            if exc_type is not None:
-                # Any exception: cancel pending and don't wait
+            if exc_type is not None or self._timed_out:
+                # Any exception or internal timeout: cancel pending and don't wait
                 self._executor.shutdown(wait=False, cancel_futures=True)
             else:
                 self._executor.shutdown(wait=True)
             self._executor = None
-        return None
+        return False
 
     @property
     def remaining(self) -> float:
-        """Seconds remaining before scope deadline. 0 if no deadline."""
+        """Seconds remaining before scope deadline. float('inf') if no deadline."""
         if self._deadline <= 0:
             return float("inf")
         return max(0.0, self._deadline - time.monotonic())
@@ -171,13 +169,6 @@ class WorkScope:
             )
         return self._executor
 
-    def _item_timeout(self) -> float:
-        """Effective per-item timeout, capped by scope remaining time."""
-        remaining = self.remaining
-        if remaining == float("inf"):
-            return self._per_item_timeout
-        return min(self._per_item_timeout, remaining)
-
     def map(
         self,
         fn: Callable[[T], R],
@@ -186,9 +177,8 @@ class WorkScope:
         """Process items in parallel, returning results for all items.
 
         Context variables are automatically propagated to worker threads.
-        Each item's result is bounded by per_item_timeout and the scope
-        deadline. Errors are captured per-item (never raises for individual
-        item failures).
+        Each item's result is bounded by the scope deadline. Errors are
+        captured per-item (never raises for individual item failures).
 
         Args:
             fn: Function to apply to each item.
@@ -289,6 +279,7 @@ class WorkScope:
 
         except FuturesTimeoutError:
             # as_completed timed out — scope deadline expired
+            self._timed_out = True
             remaining_count = total - completed
             logger.warning(
                 "work_scope_deadline_expired",

--- a/bengal/utils/concurrency/work_scope.py
+++ b/bengal/utils/concurrency/work_scope.py
@@ -5,8 +5,10 @@ ThreadPoolExecutor with correct shutdown semantics, context propagation,
 cancellation, and timeout enforcement.
 
 Every thread spawned within a WorkScope is bounded by that scope's lifetime.
-When the scope exits (normally or via exception), all threads are cancelled
-and joined. No thread outlives its scope.
+On normal exit, all threads are joined (shutdown(wait=True)). On exception
+or timeout, pending futures are cancelled and the executor shuts down without
+waiting (shutdown(wait=False, cancel_futures=True)) — running threads may
+briefly outlive the scope but receive no new work.
 
 Example:
     >>> from bengal.utils.concurrency.work_scope import WorkScope
@@ -213,6 +215,14 @@ class WorkScope:
         results: list[WorkResult[R]] = []
         total = len(items)
         for i, item in enumerate(items):
+            # Enforce scope deadline even in sequential mode
+            if self._deadline > 0 and time.monotonic() >= self._deadline:
+                self._timed_out = True
+                timeout_err = TimeoutError(f"{self._name}: scope deadline exceeded")
+                results.extend(
+                    WorkResult(value=None, error=timeout_err, elapsed_ms=0.0) for _ in items[i:]
+                )
+                break
             start = time.perf_counter()
             try:
                 value = fn(item)
@@ -268,6 +278,8 @@ class WorkScope:
                 except RuntimeError as e:
                     if _is_shutdown_error(e):
                         logger.debug("work_scope_shutdown", scope=self._name)
+                        for f in future_to_item:
+                            f.cancel()
                         break
                     results.append(WorkResult(value=None, error=e, elapsed_ms=0.0))
                 except Exception as e:
@@ -302,5 +314,14 @@ class WorkScope:
                 self._executor.shutdown(wait=False, cancel_futures=True)
                 self._executor = None
             raise
+
+        # Ensure results list has entries for all items (shutdown may have
+        # broken out of the loop early, leaving some items unaccounted for).
+        if len(results) < total:
+            shutdown_error = RuntimeError(f"{self._name}: executor shut down")
+            results.extend(
+                WorkResult(value=None, error=shutdown_error, elapsed_ms=0.0)
+                for _ in range(total - len(results))
+            )
 
         return results

--- a/bengal/utils/concurrency/work_scope.py
+++ b/bengal/utils/concurrency/work_scope.py
@@ -1,0 +1,315 @@
+"""Structured concurrency for Bengal's build pipeline.
+
+WorkScope is the single way to do parallel work in Bengal. It wraps
+ThreadPoolExecutor with correct shutdown semantics, context propagation,
+cancellation, and timeout enforcement.
+
+Every thread spawned within a WorkScope is bounded by that scope's lifetime.
+When the scope exits (normally or via exception), all threads are cancelled
+and joined. No thread outlives its scope.
+
+Example:
+    >>> from bengal.utils.concurrency.work_scope import WorkScope
+    >>> with WorkScope("render", max_workers=8, timeout=300) as scope:
+    ...     results = scope.map(render_page, pages)
+    ...     for r in results:
+    ...         if r.error:
+    ...             handle_error(r.error)
+    ...         else:
+    ...             use(r.value)
+
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import contextvars
+import time
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from bengal.utils.observability.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from bengal.utils.concurrency.workers import WorkloadType
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+logger = get_logger(__name__)
+
+
+def _is_shutdown_error(e: Exception) -> bool:
+    """Check if exception is due to interpreter shutdown."""
+    return "interpreter shutdown" in str(e)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkResult(Generic[R]):  # noqa: UP046
+    """Immutable result from a parallel work item.
+
+    Attributes:
+        value: The return value if successful, None on error.
+        error: The exception if failed, None on success.
+        elapsed_ms: Wall-clock time for this item in milliseconds.
+    """
+
+    value: R | None
+    error: Exception | None
+    elapsed_ms: float
+
+    @property
+    def ok(self) -> bool:
+        """True if the work item completed without error."""
+        return self.error is None
+
+
+class WorkScope:
+    """Structured concurrency scope for parallel work.
+
+    All threads spawned via .map() are bounded by this scope's lifetime.
+    On normal exit, waits for completion. On any exception, cancels pending
+    futures and shuts down without waiting for hung threads.
+
+    Supports multiple .map() calls within a single scope (the executor
+    is reused across calls).
+
+    Args:
+        name: Human-readable name for logging and thread prefixes.
+        max_workers: Maximum worker threads. None = auto-tune.
+        workload_type: Workload characteristics for auto-tuning.
+        timeout: Scope-level deadline in seconds (0 = no deadline).
+        per_item_timeout: Per-work-item timeout in seconds.
+        on_progress: Optional callback(completed_count, total_count)
+            fired after each item completes.
+    """
+
+    __slots__ = (
+        "_deadline",
+        "_executor",
+        "_max_workers",
+        "_name",
+        "_on_progress",
+        "_per_item_timeout",
+        "_timeout",
+        "_workload_type",
+    )
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        max_workers: int | None = None,
+        workload_type: WorkloadType | None = None,
+        timeout: float = 300.0,
+        per_item_timeout: float = 90.0,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> None:
+        self._name = name
+        self._max_workers = max_workers
+        self._workload_type = workload_type
+        self._timeout = timeout
+        self._per_item_timeout = per_item_timeout
+        self._on_progress = on_progress
+        self._executor: concurrent.futures.ThreadPoolExecutor | None = None
+        self._deadline: float = 0.0
+
+    def __enter__(self) -> WorkScope:
+        if self._timeout > 0:
+            self._deadline = time.monotonic() + self._timeout
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._executor is not None:
+            if exc_type is not None:
+                # Any exception: cancel pending and don't wait
+                self._executor.shutdown(wait=False, cancel_futures=True)
+            else:
+                self._executor.shutdown(wait=True)
+            self._executor = None
+        return None
+
+    @property
+    def remaining(self) -> float:
+        """Seconds remaining before scope deadline. 0 if no deadline."""
+        if self._deadline <= 0:
+            return float("inf")
+        return max(0.0, self._deadline - time.monotonic())
+
+    def _resolve_workers(self, task_count: int) -> int:
+        """Determine worker count, auto-tuning if needed."""
+        if self._max_workers is not None:
+            return self._max_workers
+
+        from bengal.utils.concurrency.workers import WorkloadType, get_optimal_workers
+
+        wt = self._workload_type or WorkloadType.CPU_BOUND
+        return get_optimal_workers(task_count, workload_type=wt)
+
+    def _should_parallelize(self, task_count: int) -> bool:
+        """Check if parallelization is worthwhile."""
+        if self._max_workers is not None:
+            # Explicit worker count: trust the caller, but not for 0-1 items
+            return task_count > 1 and self._max_workers > 1
+
+        from bengal.utils.concurrency.workers import WorkloadType, should_parallelize
+
+        wt = self._workload_type or WorkloadType.CPU_BOUND
+        return should_parallelize(task_count, workload_type=wt)
+
+    def _ensure_executor(self, task_count: int) -> concurrent.futures.ThreadPoolExecutor:
+        """Lazily create executor on first .map() call, reuse thereafter."""
+        if self._executor is None:
+            workers = self._resolve_workers(task_count)
+            self._executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=workers,
+                thread_name_prefix=f"Bengal-{self._name}",
+            )
+        return self._executor
+
+    def _item_timeout(self) -> float:
+        """Effective per-item timeout, capped by scope remaining time."""
+        remaining = self.remaining
+        if remaining == float("inf"):
+            return self._per_item_timeout
+        return min(self._per_item_timeout, remaining)
+
+    def map(
+        self,
+        fn: Callable[[T], R],
+        items: Iterable[T],
+    ) -> list[WorkResult[R]]:
+        """Process items in parallel, returning results for all items.
+
+        Context variables are automatically propagated to worker threads.
+        Each item's result is bounded by per_item_timeout and the scope
+        deadline. Errors are captured per-item (never raises for individual
+        item failures).
+
+        Args:
+            fn: Function to apply to each item.
+            items: Items to process.
+
+        Returns:
+            List of WorkResult in completion order. Check .ok or .error
+            on each result.
+
+        Raises:
+            KeyboardInterrupt: Re-raised after executor cleanup.
+            SystemExit: Re-raised after executor cleanup.
+        """
+        items_list = list(items)
+        if not items_list:
+            return []
+
+        total = len(items_list)
+
+        # Sequential fast path for small workloads
+        if not self._should_parallelize(total):
+            return self._map_sequential(fn, items_list)
+
+        return self._map_parallel(fn, items_list, total)
+
+    def _map_sequential(
+        self,
+        fn: Callable[[T], R],
+        items: list[T],
+    ) -> list[WorkResult[R]]:
+        """Sequential fallback for small workloads."""
+        results: list[WorkResult[R]] = []
+        total = len(items)
+        for i, item in enumerate(items):
+            start = time.perf_counter()
+            try:
+                value = fn(item)
+                elapsed = (time.perf_counter() - start) * 1000
+                results.append(WorkResult(value=value, error=None, elapsed_ms=elapsed))
+            except Exception as e:
+                elapsed = (time.perf_counter() - start) * 1000
+                results.append(WorkResult(value=None, error=e, elapsed_ms=elapsed))
+            if self._on_progress:
+                self._on_progress(i + 1, total)
+        return results
+
+    def _map_parallel(
+        self,
+        fn: Callable[[T], R],
+        items: list[T],
+        total: int,
+    ) -> list[WorkResult[R]]:
+        """Parallel execution with context propagation and bounded waits."""
+        executor = self._ensure_executor(total)
+        results: list[WorkResult[R]] = []
+        completed = 0
+
+        def _timed_call(item: T) -> tuple[R, float]:
+            start = time.perf_counter()
+            result = fn(item)
+            elapsed = (time.perf_counter() - start) * 1000
+            return result, elapsed
+
+        # Submit all items with context propagation.
+        # Each submit gets a fresh copy_context() so workers have independent
+        # context snapshots (required for thread-safety).
+        future_to_item: dict[Future[tuple[R, float]], T] = {
+            executor.submit(contextvars.copy_context().run, _timed_call, item): item
+            for item in items
+        }
+
+        try:
+            # Use as_completed with a timeout to enforce the scope deadline.
+            # This is the only reliable way to bound total wall-clock time —
+            # future.result(timeout=N) only bounds the *wait*, not execution.
+            iter_timeout = self.remaining if self._deadline > 0 else None
+            done_iter = concurrent.futures.as_completed(future_to_item, timeout=iter_timeout)
+
+            for future in done_iter:
+                try:
+                    value, elapsed_ms = future.result()
+                    results.append(WorkResult(value=value, error=None, elapsed_ms=elapsed_ms))
+                except KeyboardInterrupt, SystemExit:
+                    for f in future_to_item:
+                        f.cancel()
+                    raise
+                except RuntimeError as e:
+                    if _is_shutdown_error(e):
+                        logger.debug("work_scope_shutdown", scope=self._name)
+                        break
+                    results.append(WorkResult(value=None, error=e, elapsed_ms=0.0))
+                except Exception as e:
+                    results.append(WorkResult(value=None, error=e, elapsed_ms=0.0))
+
+                completed += 1
+                if self._on_progress:
+                    self._on_progress(completed, total)
+
+        except FuturesTimeoutError:
+            # as_completed timed out — scope deadline expired
+            remaining_count = total - completed
+            logger.warning(
+                "work_scope_deadline_expired",
+                scope=self._name,
+                completed=completed,
+                remaining=remaining_count,
+            )
+            for f in future_to_item:
+                f.cancel()
+            # Record timeout errors for uncompleted items
+            timeout_error = TimeoutError(
+                f"Scope '{self._name}' deadline expired after {self._timeout:.0f}s"
+            )
+            results.extend(
+                WorkResult(value=None, error=timeout_error, elapsed_ms=0.0)
+                for _ in range(remaining_count)
+            )
+        except KeyboardInterrupt, SystemExit:
+            if self._executor is not None:
+                self._executor.shutdown(wait=False, cancel_futures=True)
+                self._executor = None
+            raise
+
+        return results

--- a/bengal/utils/observability/logger.py
+++ b/bengal/utils/observability/logger.py
@@ -609,20 +609,23 @@ class LazyLogger:
 
     """
 
-    __slots__ = ("_name", "_real_logger", "_version")
+    __slots__ = ("_init_lock", "_name", "_real_logger", "_version")
 
     def __init__(self, name: str):
         self._name = name
         self._real_logger: BengalLogger | None = None
         self._version: int = -1
+        self._init_lock = threading.Lock()
 
     @property
     def _logger(self) -> BengalLogger:
         """Fetch the real logger, refreshing if the registry was reset."""
         global _registry_version
         if self._real_logger is None or self._version != _registry_version:
-            self._real_logger = _get_actual_logger(self._name)
-            self._version = _registry_version
+            with self._init_lock:
+                if self._real_logger is None or self._version != _registry_version:
+                    self._real_logger = _get_actual_logger(self._name)
+                    self._version = _registry_version
         return self._real_logger
 
     def __getattr__(self, attr: str) -> Any:

--- a/bengal/utils/observability/performance_collector.py
+++ b/bengal/utils/observability/performance_collector.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import sys
+import threading
 import time
 import tracemalloc
 from datetime import UTC, datetime
@@ -35,15 +36,18 @@ if TYPE_CHECKING:
 
 # Lazy logger - only loaded when actually logging (error paths)
 _logger: BengalLogger | None = None
+_logger_lock = threading.Lock()
 
 
 def _get_logger():
     """Get logger lazily to avoid import overhead."""
     global _logger
     if _logger is None:
-        from bengal.utils.observability.logger import get_logger
+        with _logger_lock:
+            if _logger is None:
+                from bengal.utils.observability.logger import get_logger
 
-        _logger = get_logger(__name__)
+                _logger = get_logger(__name__)
     return _logger
 
 

--- a/bengal/utils/observability/rich_console.py
+++ b/bengal/utils/observability/rich_console.py
@@ -50,6 +50,7 @@ See Also:
 from __future__ import annotations
 
 import os
+import threading
 from pathlib import Path
 
 from rich.console import Console
@@ -95,6 +96,7 @@ bengal_theme = Theme(
 )
 
 _console: Console | None = None
+_console_lock = threading.Lock()
 
 
 def should_use_emoji() -> bool:
@@ -121,22 +123,24 @@ def get_console() -> Console:
     global _console
 
     if _console is None:
-        # Detect environment
-        force_terminal = None
-        no_color = os.getenv("NO_COLOR") is not None
-        ci_mode = os.getenv("CI") is not None
+        with _console_lock:
+            if _console is None:
+                # Detect environment
+                force_terminal = None
+                no_color = os.getenv("NO_COLOR") is not None
+                ci_mode = os.getenv("CI") is not None
 
-        if ci_mode:
-            # In CI, force simple output
-            force_terminal = False
+                if ci_mode:
+                    # In CI, force simple output
+                    force_terminal = False
 
-        _console = Console(
-            theme=bengal_theme,
-            force_terminal=force_terminal,
-            no_color=no_color,
-            highlight=True,
-            emoji=should_use_emoji(),  # ASCII-first; opt-in via BENGAL_EMOJI=1
-        )
+                _console = Console(
+                    theme=bengal_theme,
+                    force_terminal=force_terminal,
+                    no_color=no_color,
+                    highlight=True,
+                    emoji=should_use_emoji(),  # ASCII-first; opt-in via BENGAL_EMOJI=1
+                )
 
     return _console
 

--- a/prek.toml
+++ b/prek.toml
@@ -111,3 +111,12 @@ language = "system"
 files = "^tests/.*\\.py$"
 pass_filenames = true
 priority = 2
+
+[[repos.hooks]]
+id = "check-bare-threadpool"
+name = "Block bare ThreadPoolExecutor in bengal/"
+entry = "uv run python scripts/check_bare_threadpool.py"
+language = "system"
+files = "^bengal/.*\\.py$"
+pass_filenames = true
+priority = 2

--- a/scripts/check_bare_threadpool.py
+++ b/scripts/check_bare_threadpool.py
@@ -44,10 +44,18 @@ def check_file(filepath: Path) -> list[str]:
         if rel.endswith(allowed):
             return []
 
+    in_docstring = False
     for i, line in enumerate(content.splitlines(), 1):
-        # Skip comments and docstrings
         stripped = line.lstrip()
-        if stripped.startswith(("#", '"""', "'''")):
+        # Toggle docstring state on triple-quote boundaries
+        if '"""' in stripped or "'''" in stripped:
+            count = stripped.count('"""') + stripped.count("'''")
+            if count % 2 == 1:  # odd number of triple-quotes toggles state
+                in_docstring = not in_docstring
+            continue
+        if in_docstring:
+            continue
+        if stripped.startswith("#"):
             continue
         if PATTERN.search(line):
             errors.append(
@@ -65,7 +73,7 @@ def main() -> int:
     all_errors = []
     for filepath in sys.argv[1:]:
         path = Path(filepath)
-        if path.suffix == ".py" and "bengal/" in str(path):
+        if path.suffix == ".py" and "bengal" in path.parts:
             errors = check_file(path)
             all_errors.extend(errors)
 

--- a/scripts/check_bare_threadpool.py
+++ b/scripts/check_bare_threadpool.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to block bare ThreadPoolExecutor imports in bengal/.
+
+All parallel work must go through WorkScope (bengal.utils.concurrency.work_scope).
+Direct ThreadPoolExecutor usage bypasses shutdown safety, context propagation,
+and timeout enforcement — causing CI hangs in free-threaded Python 3.14t.
+
+Allowed files:
+- bengal/utils/concurrency/executor.py (managed_executor wrapper)
+- bengal/utils/concurrency/work_scope.py (WorkScope implementation)
+- bengal/server/build_executor.py (dev server lifecycle management)
+
+Usage:
+    python scripts/check_bare_threadpool.py [files...]
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ALLOWED = {
+    "bengal/utils/concurrency/executor.py",
+    "bengal/utils/concurrency/work_scope.py",
+    "bengal/server/build_executor.py",
+}
+
+PATTERN = re.compile(
+    r"(?:from\s+concurrent\.futures\s+import\s+.*ThreadPoolExecutor"
+    r"|concurrent\.futures\.ThreadPoolExecutor"
+    r"|=\s*ThreadPoolExecutor\()"
+)
+
+
+def check_file(filepath: Path) -> list[str]:
+    errors = []
+    try:
+        content = filepath.read_text(encoding="utf-8")
+    except Exception as e:
+        return [f"{filepath}: Could not read file: {e}"]
+
+    # Normalize path for comparison
+    rel = str(filepath).replace("\\", "/")
+    for allowed in ALLOWED:
+        if rel.endswith(allowed):
+            return []
+
+    for i, line in enumerate(content.splitlines(), 1):
+        # Skip comments and docstrings
+        stripped = line.lstrip()
+        if stripped.startswith(("#", '"""', "'''")):
+            continue
+        if PATTERN.search(line):
+            errors.append(
+                f"{filepath}:{i}: Bare ThreadPoolExecutor import. "
+                "Use WorkScope from bengal.utils.concurrency.work_scope instead."
+            )
+
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        return 0
+
+    all_errors = []
+    for filepath in sys.argv[1:]:
+        path = Path(filepath)
+        if path.suffix == ".py" and "bengal/" in str(path):
+            errors = check_file(path)
+            all_errors.extend(errors)
+
+    if all_errors:
+        print("\n".join(all_errors), file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,7 @@ tests in their main thread.
 
 from __future__ import annotations
 
+import faulthandler
 import os
 import signal
 import sys
@@ -26,12 +27,24 @@ def _hard_build_timeout():
         return
 
     def _alarm_handler(signum, frame):
+        # Dump all thread stacks before raising — this is the only diagnostic
+        # we get from hung CI tests. Without it, we know a test hung but not why.
+        print("\n" + "=" * 72, file=sys.stderr, flush=True)
+        print("SIGALRM: integration test exceeded 110s hard timeout", file=sys.stderr, flush=True)
+        print("Dumping all thread stacks for deadlock diagnosis:", file=sys.stderr, flush=True)
+        print("=" * 72, file=sys.stderr, flush=True)
+        faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+        print("=" * 72, file=sys.stderr, flush=True)
         raise TimeoutError("SIGALRM: integration test exceeded 110s hard timeout")
 
     old_handler = signal.signal(signal.SIGALRM, _alarm_handler)
+    # Also set faulthandler to dump stacks at 105s — fires even if SIGALRM
+    # is blocked or the handler itself deadlocks.
+    faulthandler.dump_traceback_later(105, repeat=False, file=sys.stderr)
     signal.alarm(110)  # 110s — fires before the 120s pytest-timeout
     try:
         yield
     finally:
         signal.alarm(0)
+        faulthandler.cancel_dump_traceback_later()
         signal.signal(signal.SIGALRM, old_handler)

--- a/tests/unit/utils/test_work_scope.py
+++ b/tests/unit/utils/test_work_scope.py
@@ -1,0 +1,216 @@
+"""Tests for WorkScope structured concurrency primitive."""
+
+from __future__ import annotations
+
+import contextvars
+import threading
+import time
+
+import pytest
+
+from bengal.utils.concurrency.work_scope import WorkResult, WorkScope
+from bengal.utils.concurrency.workers import WorkloadType
+
+
+class TestWorkResult:
+    def test_success_result(self):
+        r = WorkResult(value=42, error=None, elapsed_ms=1.0)
+        assert r.ok
+        assert r.value == 42
+        assert r.error is None
+
+    def test_error_result(self):
+        err = ValueError("boom")
+        r = WorkResult(value=None, error=err, elapsed_ms=1.0)
+        assert not r.ok
+        assert r.error is err
+
+    def test_frozen(self):
+        r = WorkResult(value=1, error=None, elapsed_ms=0.0)
+        with pytest.raises(AttributeError):
+            r.value = 2  # type: ignore[misc]
+
+
+class TestWorkScopeSequential:
+    """Tests that hit the sequential fast path."""
+
+    def test_empty_items(self):
+        with WorkScope("test") as scope:
+            results = scope.map(lambda x: x * 2, [])
+        assert results == []
+
+    def test_single_item(self):
+        with WorkScope("test") as scope:
+            results = scope.map(lambda x: x * 2, [5])
+        assert len(results) == 1
+        assert results[0].value == 10
+        assert results[0].ok
+
+    def test_small_list_runs_sequentially(self):
+        """Below parallel threshold, items run in the calling thread."""
+        thread_ids: list[int] = []
+
+        def capture_thread(x: int) -> int:
+            thread_ids.append(threading.current_thread().ident)
+            return x
+
+        with WorkScope("test") as scope:
+            scope.map(capture_thread, [1, 2])
+
+        main = threading.current_thread().ident
+        assert all(tid == main for tid in thread_ids)
+
+    def test_error_captured_not_raised(self):
+        def fail(x: int) -> int:
+            if x == 2:
+                raise ValueError("bad")
+            return x
+
+        with WorkScope("test") as scope:
+            results = scope.map(fail, [1, 2, 3])
+
+        values = [r.value for r in results if r.ok]
+        errors = [r for r in results if not r.ok]
+        assert 1 in values
+        assert 3 in values
+        assert len(errors) == 1
+        assert "bad" in str(errors[0].error)
+
+    def test_elapsed_ms_populated(self):
+        def slow(x: int) -> int:
+            time.sleep(0.01)
+            return x
+
+        with WorkScope("test") as scope:
+            results = scope.map(slow, [1])
+
+        assert results[0].elapsed_ms >= 5  # at least 5ms
+
+
+class TestWorkScopeParallel:
+    """Tests that exercise the parallel path."""
+
+    def test_parallel_execution(self):
+        """Force parallel with explicit max_workers."""
+        thread_ids: list[int] = []
+
+        def work(x: int) -> int:
+            thread_ids.append(threading.current_thread().ident)
+            time.sleep(0.01)  # Small sleep so threads overlap
+            return x
+
+        with WorkScope("test", max_workers=4) as scope:
+            results = scope.map(work, [1, 2, 3, 4, 5, 6, 7, 8])
+
+        assert all(r.ok for r in results)
+        # At least 2 distinct threads used
+        assert len(set(thread_ids)) >= 2
+
+    def test_context_propagation(self):
+        """ContextVars from the submitting thread are visible in workers."""
+        test_var: contextvars.ContextVar[str] = contextvars.ContextVar("test_var")
+        test_var.set("hello")
+
+        def read_var(x: int) -> str:
+            return test_var.get("missing")
+
+        with WorkScope("test", max_workers=2) as scope:
+            results = scope.map(read_var, [1, 2, 3])
+
+        assert all(r.ok for r in results)
+        assert all(r.value == "hello" for r in results)
+
+    def test_scope_timeout_cancels_slow_items(self):
+        """Scope deadline causes remaining slow items to be cancelled."""
+        stop = threading.Event()
+
+        def slow(x: int) -> int:
+            if x > 2:
+                stop.wait(timeout=5)  # Interruptible wait
+            return x
+
+        with WorkScope("test", max_workers=2, timeout=0.5) as scope:
+            results = scope.map(slow, [1, 2, 3, 4, 5])
+
+        stop.set()  # Release any waiting threads
+
+        errors = [r for r in results if not r.ok]
+        assert len(errors) >= 1
+
+    def test_scope_deadline_parallel(self):
+        """Scope-level timeout cancels remaining work in parallel mode."""
+
+        def slow(x: int) -> int:
+            time.sleep(0.3)
+            return x
+
+        with WorkScope("test", max_workers=2, timeout=0.5) as scope:
+            results = scope.map(slow, list(range(20)))
+
+        # Some should complete, some should timeout
+        assert len(results) > 0
+        errors = [r for r in results if not r.ok]
+        assert len(errors) >= 1
+
+    def test_mixed_success_and_failure(self):
+        def work(x: int) -> int:
+            if x % 2 == 0:
+                raise ValueError(f"even: {x}")
+            return x * 10
+
+        with WorkScope("test", max_workers=4) as scope:
+            results = scope.map(work, [1, 2, 3, 4, 5])
+
+        successes = [r for r in results if r.ok]
+        failures = [r for r in results if not r.ok]
+        assert len(successes) == 3
+        assert len(failures) == 2
+
+    def test_multiple_map_calls_reuse_executor(self):
+        """Multiple .map() calls within one scope reuse the same executor."""
+        with WorkScope("test", max_workers=2) as scope:
+            r1 = scope.map(lambda x: x + 1, [1, 2, 3])
+            r2 = scope.map(lambda x: x * 2, [4, 5, 6])
+
+        assert len(r1) == 3
+        assert len(r2) == 3
+        assert all(r.ok for r in r1 + r2)
+
+    def test_on_progress_callback(self):
+        calls: list[tuple[int, int]] = []
+
+        def on_progress(completed: int, total: int) -> None:
+            calls.append((completed, total))
+
+        with WorkScope("test", max_workers=2, on_progress=on_progress) as scope:
+            scope.map(lambda x: x, [1, 2, 3, 4])
+
+        assert len(calls) == 4
+        totals = [t for _, t in calls]
+        assert all(t == 4 for t in totals)
+        completed_counts = sorted(c for c, _ in calls)
+        assert completed_counts == [1, 2, 3, 4]
+
+
+class TestWorkScopeEdgeCases:
+    def test_no_timeout(self):
+        """timeout=0 means no scope deadline."""
+        with WorkScope("test", timeout=0, max_workers=2) as scope:
+            results = scope.map(lambda x: x, [1, 2])
+        assert all(r.ok for r in results)
+
+    def test_exception_in_fn_does_not_crash_scope(self):
+        def crash(x: int) -> int:
+            raise RuntimeError("crash")
+
+        with WorkScope("test", max_workers=2) as scope:
+            results = scope.map(crash, [1, 2, 3])
+
+        assert len(results) == 3
+        assert all(not r.ok for r in results)
+
+    def test_workload_type_auto_tune(self):
+        """WorkloadType is used for auto-tuning when max_workers is None."""
+        with WorkScope("test", workload_type=WorkloadType.IO_BOUND) as scope:
+            results = scope.map(lambda x: x, list(range(100)))
+        assert len(results) == 100


### PR DESCRIPTION
## Summary

- Adds `WorkScope`, a structured concurrency primitive that wraps `ThreadPoolExecutor` with correct shutdown semantics (`cancel_futures=True` on error), automatic `contextvars` propagation, scope-level deadlines via `as_completed(timeout=...)`, and per-item error capture via frozen `WorkResult` dataclass
- Migrates all 15+ bare `ThreadPoolExecutor`/`managed_executor` sites across the codebase to use `WorkScope`, eliminating the class of CI hangs caused by `shutdown(wait=True)` blocking forever on hung threads in free-threaded Python 3.14t
- Adds `scripts/check_bare_threadpool.py` pre-commit hook (registered in `prek.toml`) to prevent future bare `ThreadPoolExecutor` usage in `bengal/`

## Migrated sites

scheduler (2), patitas batch_parse, parallel utils (2), taxonomy, postprocess, asset, build (3), related_posts, graph builder, linkcheck orchestrator, health_check, autodoc extractor, output_formats, provenance filter

## Test plan

- [x] All 18 new WorkScope unit tests pass (sequential, parallel, timeout, context propagation, progress, edge cases)
- [x] Pre-commit hook correctly blocks bare `ThreadPoolExecutor` imports and allows exempted files
- [x] All pre-commit hooks pass (ruff, ty, cycles, deps, threadpool check)
- [ ] Unit test suite passes
- [ ] Integration test suite passes
- [ ] No CI hangs from `shutdown(wait=True)` in 3.14t test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)