### PR TITLE
feat: introduce ParsedPage frozen record for immutable rendering pipeline

### DIFF
--- a/bengal/core/records.py
+++ b/bengal/core/records.py
@@ -1,0 +1,39 @@
+"""Immutable pipeline records for Bengal SSG.
+
+Frozen dataclasses representing the output of each pipeline stage.
+These replace mutable Page field mutations with typed, immutable records
+that flow through the pipeline.
+
+Sprint 1: ParsedPage — captures all parse-phase output.
+
+See Also:
+    plan/epic-immutable-page-pipeline.md
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedPage:
+    """Immutable record of parsing-phase output for a single page.
+
+    Constructed after markdown parsing, API-doc enhancement, and link
+    extraction.  Consumed by the rendering phase and cache layer.
+
+    All container fields use immutable types (tuple, not list) so the
+    record is safe to share across threads without synchronization.
+    """
+
+    html_content: str
+    toc: str
+    toc_items: tuple[dict[str, Any], ...]
+    excerpt: str
+    meta_description: str
+    plain_text: str
+    word_count: int
+    reading_time: int
+    links: tuple[str, ...]
+    ast_cache: dict[str, Any] | list[Any] | None = None

--- a/bengal/rendering/context/__init__.py
+++ b/bengal/rendering/context/__init__.py
@@ -320,6 +320,7 @@ def build_page_context(
     snapshot: Any = None,  # SiteSnapshot (optional)
     lazy: bool = True,  # Enable lazy evaluation for expensive fields
     build_context: Any = None,  # BuildContext for O(1) section lookup
+    parsed_page: Any = None,  # ParsedPage for immutable pipeline (Sprint 1)
 ) -> dict[str, Any]:
     """
     Build complete template context for any page type.
@@ -435,21 +436,36 @@ def build_page_context(
     # Pre-computed content (marked safe)
     context["content"] = Markup(content) if content else Markup("")
     context["title"] = getattr(page, "title", "") or ""
-    context["toc"] = Markup(getattr(page, "toc", "") or "")
 
-    # toc_items - lazy if possible (parsing can be expensive)
-    if lazy:
-        context["toc_items"] = make_lazy(lambda: getattr(page, "toc_items", []) or [])
+    # When ParsedPage is available, read parse-phase fields from the
+    # immutable record instead of from the mutable Page object.
+    if parsed_page is not None:
+        context["toc"] = Markup(parsed_page.toc)
+        if lazy:
+            pp = parsed_page  # capture for closure
+            context["toc_items"] = make_lazy(lambda: list(pp.toc_items))
+        else:
+            context["toc_items"] = list(parsed_page.toc_items)
+        context["meta_desc"] = (
+            parsed_page.meta_description or getattr(page, "description", "") or ""
+        )
+        context["word_count"] = parsed_page.word_count
+        context["reading_time"] = parsed_page.reading_time
+        context["excerpt"] = parsed_page.excerpt
     else:
-        context["toc_items"] = getattr(page, "toc_items", []) or []
-
-    # Pre-computed metadata (cheap, always eager)
-    context["meta_desc"] = (
-        getattr(page, "meta_description", "") or getattr(page, "description", "") or ""
-    )
-    context["word_count"] = getattr(page, "word_count", 0) or 0
-    context["reading_time"] = getattr(page, "reading_time", 0) or 0
-    context["excerpt"] = getattr(page, "excerpt", "") or ""
+        context["toc"] = Markup(getattr(page, "toc", "") or "")
+        # toc_items - lazy if possible (parsing can be expensive)
+        if lazy:
+            context["toc_items"] = make_lazy(lambda: getattr(page, "toc_items", []) or [])
+        else:
+            context["toc_items"] = getattr(page, "toc_items", []) or []
+        # Pre-computed metadata (cheap, always eager)
+        context["meta_desc"] = (
+            getattr(page, "meta_description", "") or getattr(page, "description", "") or ""
+        )
+        context["word_count"] = getattr(page, "word_count", 0) or 0
+        context["reading_time"] = getattr(page, "reading_time", 0) or 0
+        context["excerpt"] = getattr(page, "excerpt", "") or ""
 
     # Versioning defaults
     context["current_version"] = None

--- a/bengal/rendering/pipeline/cache_checker.py
+++ b/bengal/rendering/pipeline/cache_checker.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+from bengal.core.records import ParsedPage
 from bengal.rendering.pipeline.output import format_html, write_output
 from bengal.rendering.pipeline.toc import extract_toc_structure
 from bengal.utils.observability.logger import get_logger
@@ -223,8 +224,25 @@ class CacheChecker:
                     error_type=type(e).__name__,
                 )
 
+        # Build immutable ParsedPage from cached data (Sprint 1: Immutable Pipeline)
+        toc_items_list = cached.get("toc_items", [])
+        if not toc_items_list:
+            toc_items_list = extract_toc_structure(toc)
+        parsed_page = ParsedPage(
+            html_content=html,
+            toc=toc,
+            toc_items=tuple(toc_items_list),
+            excerpt=cached.get("excerpt", "") or "",
+            meta_description=cached.get("meta_description", "") or "",
+            plain_text=page.plain_text,
+            word_count=getattr(page, "word_count", 0) or 0,
+            reading_time=getattr(page, "reading_time", 0) or 0,
+            links=tuple(getattr(page, "links", None) or ()),
+            ast_cache=cached.get("ast"),
+        )
+
         html_content = self.renderer.render_content(parsed_content)
-        page.rendered_html = self.renderer.render_page(page, html_content)
+        page.rendered_html = self.renderer.render_page(page, html_content, parsed_page=parsed_page)
         page.rendered_html = format_html(page.rendered_html, page, cast("SiteLike", self.site))
 
         # Validate rendered HTML is not empty
@@ -253,7 +271,13 @@ class CacheChecker:
 
         return True
 
-    def cache_parsed_content(self, page: PageLike, template: str, parser_version: str) -> None:
+    def cache_parsed_content(
+        self,
+        page: PageLike,
+        template: str,
+        parser_version: str,
+        parsed_page: ParsedPage | None = None,
+    ) -> None:
         """
         Store parsed content in cache for next build.
 
@@ -261,27 +285,42 @@ class CacheChecker:
             page: Page with parsed content
             template: Template name used
             parser_version: Parser version used
+            parsed_page: Optional ParsedPage record to read from instead of page
         """
         if not self.build_cache or page.metadata.get("_generated"):
             return
 
         cache = self.build_cache
 
-        toc_items = extract_toc_structure(page.toc or "")
         md_cfg = self.site.config.get("markdown", {}) or {}
         ast_cache_cfg = md_cfg.get("ast_cache", {}) or {}
         persist_tokens = bool(ast_cache_cfg.get("persist_tokens", False))
-        cached_ast = getattr(page, "_ast_cache", None) if persist_tokens else None
-        cached_links = getattr(page, "links", None)
 
-        excerpt = getattr(page, "_excerpt", None) or ""
-        meta_description = getattr(page, "_meta_description", None) or ""
+        # Read from ParsedPage when available; fall back to page fields
+        if parsed_page is not None:
+            html_content = parsed_page.html_content
+            toc = parsed_page.toc
+            toc_items = list(parsed_page.toc_items)
+            links = list(parsed_page.links) if parsed_page.links else None
+            excerpt = parsed_page.excerpt
+            meta_description = parsed_page.meta_description
+            cached_ast = parsed_page.ast_cache if persist_tokens else None
+        else:
+            html_content = page.html_content
+            toc = page.toc
+            toc_items = extract_toc_structure(page.toc or "")
+            cached_links = getattr(page, "links", None)
+            links = cached_links if isinstance(cached_links, list) else None
+            excerpt = getattr(page, "_excerpt", None) or ""
+            meta_description = getattr(page, "_meta_description", None) or ""
+            cached_ast = getattr(page, "_ast_cache", None) if persist_tokens else None
+
         cache.store_parsed_content(
             page.source_path,
-            page.html_content,
-            page.toc,
+            html_content,
+            toc,
             toc_items,
-            cached_links if isinstance(cached_links, list) else None,
+            links,
             page.metadata,
             template,
             parser_version,

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -710,8 +710,10 @@ class RenderingPipeline:
             html_content=page.html_content or "",
             toc=page.toc or "",
             toc_items=toc_items,
-            excerpt=getattr(page, "_excerpt", None) or "",
-            meta_description=getattr(page, "_meta_description", None) or "",
+            excerpt=getattr(page, "excerpt", "") or "",
+            meta_description=getattr(page, "meta_description", "")
+            or getattr(page, "description", "")
+            or "",
             plain_text=page.plain_text,
             word_count=getattr(page, "word_count", 0) or 0,
             reading_time=getattr(page, "reading_time", 0) or 0,

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -30,6 +30,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from bengal.core.records import ParsedPage
 from bengal.rendering.api_doc_enhancer import set_enhancer_for_render
 
 if TYPE_CHECKING:
@@ -449,13 +450,20 @@ class RenderingPipeline:
                     "link_extraction",
                 )
 
+        # Build immutable ParsedPage record (Epic: Immutable Page Pipeline, Sprint 1)
+        parsed_page = self._build_parsed_page(page)
+
         if _prof:
             with _prof.step("cache_parsed"):
-                self._cache_checker.cache_parsed_content(page, template, parser_version)
+                self._cache_checker.cache_parsed_content(
+                    page, template, parser_version, parsed_page=parsed_page
+                )
         else:
-            self._cache_checker.cache_parsed_content(page, template, parser_version)
+            self._cache_checker.cache_parsed_content(
+                page, template, parser_version, parsed_page=parsed_page
+            )
 
-        self._render_and_write(page, template, _prof=_prof)
+        self._render_and_write(page, template, _prof=_prof, parsed_page=parsed_page)
         if _prof:
             _prof.record_page()
 
@@ -686,8 +694,37 @@ class RenderingPipeline:
         if enhancer and enhancer.should_enhance(page_type):
             page.html_content = enhancer.enhance(page.html_content or "", page_type)
 
+    def _build_parsed_page(self, page: PageLike) -> ParsedPage:
+        """Construct a ParsedPage from current page state after parsing.
+
+        Called after _parse_content, _enhance_api_docs, and extract_links
+        have finished mutating the page.  The resulting frozen record
+        captures all parse-phase output for downstream rendering.
+        """
+        from bengal.rendering.pipeline.toc import extract_toc_structure
+
+        toc_items = tuple(extract_toc_structure(page.toc or ""))
+        links = tuple(getattr(page, "links", None) or ())
+
+        return ParsedPage(
+            html_content=page.html_content or "",
+            toc=page.toc or "",
+            toc_items=toc_items,
+            excerpt=getattr(page, "_excerpt", None) or "",
+            meta_description=getattr(page, "_meta_description", None) or "",
+            plain_text=page.plain_text,
+            word_count=getattr(page, "word_count", 0) or 0,
+            reading_time=getattr(page, "reading_time", 0) or 0,
+            links=links,
+            ast_cache=getattr(page, "_ast_cache", None),
+        )
+
     def _render_and_write(
-        self, page: PageLike, template: str, _prof: RenderProfiler | None = None
+        self,
+        page: PageLike,
+        template: str,
+        _prof: RenderProfiler | None = None,
+        parsed_page: ParsedPage | None = None,
     ) -> None:
         """Render template and write output.
 
@@ -702,6 +739,9 @@ class RenderingPipeline:
         # (they're driven by template logic and frontmatter, not content)
         if page.html_content is None:
             page.html_content = ""  # Ensure it's a string, not None
+
+        # Read source HTML from ParsedPage when available (Sprint 1: Immutable Pipeline)
+        source_html = parsed_page.html_content if parsed_page else (page.html_content or "")
 
         # RFC: rfc-build-performance-optimizations Phase 2
         # Track assets during rendering (render-time tracking)
@@ -719,32 +759,40 @@ class RenderingPipeline:
                 with effect_recorder:
                     if _prof:
                         with _prof.step("render_content"):
-                            html_content = self.renderer.render_content(page.html_content or "")
+                            html_content = self.renderer.render_content(source_html)
                         with _prof.step("render_template"):
-                            page.rendered_html = self.renderer.render_page(page, html_content)
+                            page.rendered_html = self.renderer.render_page(
+                                page, html_content, parsed_page=parsed_page
+                            )
                         with _prof.step("format_html"):
                             page.rendered_html = format_html(
                                 page.rendered_html, page, cast("SiteLike", self.site)
                             )
                     else:
-                        html_content = self.renderer.render_content(page.html_content or "")
-                        page.rendered_html = self.renderer.render_page(page, html_content)
+                        html_content = self.renderer.render_content(source_html)
+                        page.rendered_html = self.renderer.render_page(
+                            page, html_content, parsed_page=parsed_page
+                        )
                         page.rendered_html = format_html(
                             page.rendered_html, page, cast("SiteLike", self.site)
                         )
             else:
                 if _prof:
                     with _prof.step("render_content"):
-                        html_content = self.renderer.render_content(page.html_content or "")
+                        html_content = self.renderer.render_content(source_html)
                     with _prof.step("render_template"):
-                        page.rendered_html = self.renderer.render_page(page, html_content)
+                        page.rendered_html = self.renderer.render_page(
+                            page, html_content, parsed_page=parsed_page
+                        )
                     with _prof.step("format_html"):
                         page.rendered_html = format_html(
                             page.rendered_html, page, cast("SiteLike", self.site)
                         )
                 else:
-                    html_content = self.renderer.render_content(page.html_content or "")
-                    page.rendered_html = self.renderer.render_page(page, html_content)
+                    html_content = self.renderer.render_content(source_html)
+                    page.rendered_html = self.renderer.render_page(
+                        page, html_content, parsed_page=parsed_page
+                    )
                     page.rendered_html = format_html(
                         page.rendered_html, page, cast("SiteLike", self.site)
                     )

--- a/bengal/rendering/renderer.py
+++ b/bengal/rendering/renderer.py
@@ -357,7 +357,12 @@ class Renderer:
 
         return result
 
-    def render_page(self, page: PageLike, content: str | None = None) -> str:
+    def render_page(
+        self,
+        page: PageLike,
+        content: str | None = None,
+        parsed_page: Any = None,
+    ) -> str:
         """
         Render a complete page with template.
 
@@ -416,6 +421,7 @@ class Renderer:
             content=content,
             snapshot=snapshot,
             build_context=self.build_context,  # PERF: O(1) section lookup
+            parsed_page=parsed_page,
         )
 
         # Inject cached blocks for KIDA templates (RFC: kida-template-introspection)


### PR DESCRIPTION
## Summary

- Adds `ParsedPage`, a frozen+slots dataclass in `bengal/core/records.py` that captures all parse-phase output (html_content, toc, toc_items, excerpt, meta_description, plain_text, word_count, reading_time, links, ast_cache)
- Threads `ParsedPage` through the rendering pipeline: constructed after parsing in `_process_page_impl`, passed to `_render_and_write`, `Renderer.render_page`, and `build_page_context`
- Context builder reads toc/excerpt/meta_description/word_count/reading_time from the immutable record when available
- CacheChecker constructs `ParsedPage` from cached data on parse-cache hits, and reads from it when storing to cache
- Dual-write is active: Page fields are still mutated for template/external compatibility — removal is a later sprint

This is Sprint 1 of the [Immutable Page Pipeline epic](plan/epic-immutable-page-pipeline.md).

## Test plan

- [x] Import smoke test: `from bengal.core.records import ParsedPage`
- [x] Full test suite: 4726+ tests pass, 0 regressions
- [x] All rendering unit tests pass (1756 passed)
- [x] Warm build integration tests pass
- [x] Pre-commit hooks pass (ruff, ruff format, ty, circular import check, dependency layer check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)