### PR TITLE
feat: add excerpt-break directive for author-controlled excerpts

### DIFF
--- a/bengal/parsing/backends/patitas/directives/builtins/__init__.py
+++ b/bengal/parsing/backends/patitas/directives/builtins/__init__.py
@@ -53,6 +53,9 @@ from bengal.parsing.backends.patitas.directives.builtins.embed import (
     SpotifyDirective,
     StackBlitzDirective,
 )
+from bengal.parsing.backends.patitas.directives.builtins.excerpt_break import (
+    ExcerptBreakDirective,
+)
 from bengal.parsing.backends.patitas.directives.builtins.glossary import (
     GlossaryDirective,
 )
@@ -143,6 +146,8 @@ __all__ = [
     # Dropdown
     "DropdownDirective",
     "ExampleLabelDirective",
+    # Excerpt
+    "ExcerptBreakDirective",
     "FigureDirective",
     "GalleryDirective",
     "GistDirective",

--- a/bengal/parsing/backends/patitas/directives/builtins/excerpt_break.py
+++ b/bengal/parsing/backends/patitas/directives/builtins/excerpt_break.py
@@ -1,0 +1,80 @@
+"""Excerpt break directive for author-controlled excerpt boundaries.
+
+Provides a leaf directive that marks where the excerpt should end.
+When present, the excerpt extractor uses content above the break
+instead of the default position-based truncation.
+
+Syntax:
+    :::{excerpt-break}
+    :::
+
+The directive renders to nothing in HTML output — it is purely
+a signal to the excerpt extraction pipeline.
+
+Thread Safety:
+    Stateless handler. Safe for concurrent use across threads.
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from patitas.directives.options import DirectiveOptions
+from patitas.nodes import Directive
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from patitas.nodes import Block, SourceLocation
+    from patitas.rendering import StringBuilder
+
+
+class ExcerptBreakDirective:
+    """Mark the excerpt boundary in a document.
+
+    Everything above this directive becomes the excerpt. When absent,
+    the default position-based extraction (max_chars) applies.
+
+    Syntax:
+        :::{excerpt-break}
+        :::
+
+    Output:
+        (nothing — invisible to rendered HTML)
+
+    Thread Safety:
+        Stateless handler. Safe for concurrent use.
+
+    """
+
+    names: ClassVar[tuple[str, ...]] = ("excerpt-break",)
+    token_type: ClassVar[str] = "excerpt_break"
+    contract: ClassVar[None] = None
+    options_class: ClassVar[type[DirectiveOptions]] = DirectiveOptions
+
+    def parse(
+        self,
+        name: str,
+        title: str | None,
+        options: DirectiveOptions,
+        content: str,
+        children: Sequence[Block],
+        location: SourceLocation,
+    ) -> Directive:
+        """Build excerpt-break AST node."""
+        return Directive(
+            location=location,
+            name=name,
+            title=title,
+            options=options,
+            children=(),
+        )
+
+    def render(
+        self,
+        node: Directive[DirectiveOptions],
+        rendered_children: str,
+        sb: StringBuilder,
+    ) -> None:
+        """Render nothing — excerpt-break is invisible in output."""

--- a/bengal/parsing/backends/patitas/directives/builtins/excerpt_break.py
+++ b/bengal/parsing/backends/patitas/directives/builtins/excerpt_break.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from patitas.nodes import Block, SourceLocation
-    from patitas.rendering import StringBuilder
+    from patitas.stringbuilder import StringBuilder
 
 
 class ExcerptBreakDirective:

--- a/bengal/parsing/backends/patitas/directives/registry.py
+++ b/bengal/parsing/backends/patitas/directives/registry.py
@@ -238,6 +238,8 @@ def create_default_registry() -> DirectiveRegistry:
         DropdownDirective,
         # Misc
         ExampleLabelDirective,
+        # Excerpt
+        ExcerptBreakDirective,
         FigureDirective,
         GalleryDirective,
         # Developer embeds
@@ -340,6 +342,9 @@ def create_default_registry() -> DirectiveRegistry:
     # File I/O
     builder.register(IncludeDirective())
     builder.register(LiteralIncludeDirective())
+
+    # Excerpt
+    builder.register(ExcerptBreakDirective())
 
     # Misc
     builder.register(ExampleLabelDirective())

--- a/bengal/parsing/backends/patitas/wrapper.py
+++ b/bengal/parsing/backends/patitas/wrapper.py
@@ -29,6 +29,22 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _slice_blocks_at_excerpt_break(
+    blocks: tuple[Block, ...] | Document,
+) -> tuple[Block, ...] | None:
+    """Find an excerpt-break directive and return blocks before it.
+
+    Returns None if no excerpt-break is found (caller falls through to default).
+    """
+    from patitas.nodes import Directive, Document
+
+    children = blocks.children if isinstance(blocks, Document) else blocks
+    for i, block in enumerate(children):
+        if isinstance(block, Directive) and block.name == "excerpt-break":
+            return children[:i]
+    return None
+
+
 class PatitasParser(BaseMarkdownParser):
     """Parser using Patitas library (modern Markdown parser).
 
@@ -171,8 +187,17 @@ class PatitasParser(BaseMarkdownParser):
         try:
             from patitas import extract_excerpt, extract_meta_description
 
-            max_chars = metadata.get("_excerpt_length", get_default("content", "excerpt_length"))
-            excerpt = extract_excerpt(ast, content, excerpt_as_html=True, max_chars=max_chars)
+            # If author placed :::{excerpt-break}, use only blocks above it
+            excerpt_blocks = _slice_blocks_at_excerpt_break(ast)
+            if excerpt_blocks is not None:
+                excerpt = extract_excerpt(
+                    excerpt_blocks, content, excerpt_as_html=True, max_chars=999_999
+                )
+            else:
+                max_chars = metadata.get(
+                    "_excerpt_length", get_default("content", "excerpt_length")
+                )
+                excerpt = extract_excerpt(ast, content, excerpt_as_html=True, max_chars=max_chars)
             meta_desc = (
                 extract_meta_description(ast, content)
                 if not metadata.get("description")
@@ -304,13 +329,22 @@ class PatitasParser(BaseMarkdownParser):
             try:
                 from patitas import extract_excerpt, extract_meta_description
 
-                # Per-article override: pipeline sets metadata._excerpt_length
-                content_cfg = context.get("config", {}).get("content", {}) or {}
-                max_chars = metadata.get(
-                    "_excerpt_length",
-                    content_cfg.get("excerpt_length", get_default("content", "excerpt_length")),
-                )
-                excerpt = extract_excerpt(ast, content, excerpt_as_html=True, max_chars=max_chars)
+                # If author placed :::{excerpt-break}, use only blocks above it
+                excerpt_blocks = _slice_blocks_at_excerpt_break(ast)
+                if excerpt_blocks is not None:
+                    excerpt = extract_excerpt(
+                        excerpt_blocks, content, excerpt_as_html=True, max_chars=999_999
+                    )
+                else:
+                    # Per-article override: pipeline sets metadata._excerpt_length
+                    content_cfg = context.get("config", {}).get("content", {}) or {}
+                    max_chars = metadata.get(
+                        "_excerpt_length",
+                        content_cfg.get("excerpt_length", get_default("content", "excerpt_length")),
+                    )
+                    excerpt = extract_excerpt(
+                        ast, content, excerpt_as_html=True, max_chars=max_chars
+                    )
                 meta_desc = (
                     extract_meta_description(ast, content)
                     if not metadata.get("description")

--- a/bengal/parsing/backends/patitas/wrapper.py
+++ b/bengal/parsing/backends/patitas/wrapper.py
@@ -16,6 +16,7 @@ parser/renderer instances with no shared state.
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from bengal.config.defaults import get_default
@@ -191,7 +192,7 @@ class PatitasParser(BaseMarkdownParser):
             excerpt_blocks = _slice_blocks_at_excerpt_break(ast)
             if excerpt_blocks is not None:
                 excerpt = extract_excerpt(
-                    excerpt_blocks, content, excerpt_as_html=True, max_chars=999_999
+                    excerpt_blocks, content, excerpt_as_html=True, max_chars=sys.maxsize
                 )
             else:
                 max_chars = metadata.get(
@@ -333,7 +334,7 @@ class PatitasParser(BaseMarkdownParser):
                 excerpt_blocks = _slice_blocks_at_excerpt_break(ast)
                 if excerpt_blocks is not None:
                     excerpt = extract_excerpt(
-                        excerpt_blocks, content, excerpt_as_html=True, max_chars=999_999
+                        excerpt_blocks, content, excerpt_as_html=True, max_chars=sys.maxsize
                     )
                 else:
                     # Per-article override: pipeline sets metadata._excerpt_length

--- a/tests/rendering/parsers/test_patitas/test_excerpt_break.py
+++ b/tests/rendering/parsers/test_patitas/test_excerpt_break.py
@@ -1,0 +1,85 @@
+"""Tests for the excerpt-break directive.
+
+Verifies that :::{excerpt-break} controls excerpt extraction boundaries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bengal.parsing.backends.patitas.wrapper import PatitasParser
+
+
+@pytest.fixture
+def parser() -> PatitasParser:
+    return PatitasParser()
+
+
+class TestExcerptBreak:
+    """Excerpt-break directive scopes excerpt extraction."""
+
+    def test_excerpt_contains_only_content_above_break(self, parser: PatitasParser) -> None:
+        """Content below excerpt-break is excluded from excerpt."""
+        content = (
+            "This is the summary.\n\n"
+            ":::{excerpt-break}\n"
+            ":::\n\n"
+            "This is the rest of the post that should not appear in the excerpt."
+        )
+        _html, _toc, excerpt, _meta = parser.parse_with_toc(content, {})
+        assert "summary" in excerpt
+        assert "rest of the post" not in excerpt
+
+    def test_no_break_uses_default_extraction(self, parser: PatitasParser) -> None:
+        """Without excerpt-break, position-based extraction applies."""
+        content = "First paragraph.\n\nSecond paragraph."
+        _html, _toc, excerpt, _meta = parser.parse_with_toc(content, {})
+        assert "First paragraph" in excerpt
+        assert "Second paragraph" in excerpt
+
+    def test_break_renders_nothing_in_html(self, parser: PatitasParser) -> None:
+        """Excerpt-break produces no visible HTML output."""
+        content = "Before.\n\n:::{excerpt-break}\n:::\n\nAfter."
+        html, _toc, _excerpt, _meta = parser.parse_with_toc(content, {})
+        assert "excerpt-break" not in html
+        assert "Before" in html
+        assert "After" in html
+
+    def test_break_at_beginning_yields_empty_excerpt(self, parser: PatitasParser) -> None:
+        """Excerpt-break at the top produces an empty excerpt."""
+        content = ":::{excerpt-break}\n:::\n\nAll content is below the break."
+        _html, _toc, excerpt, _meta = parser.parse_with_toc(content, {})
+        assert excerpt == ""
+
+    def test_break_with_multiple_paragraphs_above(self, parser: PatitasParser) -> None:
+        """Multiple paragraphs above the break are all included."""
+        content = (
+            "First paragraph.\n\nSecond paragraph.\n\n:::{excerpt-break}\n:::\n\nThird paragraph."
+        )
+        _html, _toc, excerpt, _meta = parser.parse_with_toc(content, {})
+        assert "First paragraph" in excerpt
+        assert "Second paragraph" in excerpt
+        assert "Third paragraph" not in excerpt
+
+    def test_break_with_context_parsing(self, parser: PatitasParser) -> None:
+        """Excerpt-break works through parse_with_toc_and_context path."""
+        content = "Summary line.\n\n:::{excerpt-break}\n:::\n\nExtended content."
+        context = {"config": {"content": {}}}
+        _html, _toc, excerpt, _meta = parser.parse_with_toc_and_context(content, {}, context)
+        assert "Summary" in excerpt
+        assert "Extended" not in excerpt
+
+    def test_break_ignores_max_chars(self, parser: PatitasParser) -> None:
+        """When excerpt-break is present, excerpt_length config is ignored."""
+        # Set a very short excerpt_length that would normally truncate
+        content = (
+            "This is a longer summary that exceeds ten characters easily.\n\n"
+            ":::{excerpt-break}\n"
+            ":::\n\n"
+            "Below the fold."
+        )
+        metadata = {"_excerpt_length": 10}
+        _html, _toc, excerpt, _meta = parser.parse_with_toc(content, metadata)
+        # The full content above the break is included despite small excerpt_length
+        assert "exceeds ten characters" in excerpt
+        assert "Below the fold" not in excerpt


### PR DESCRIPTION
## Summary

- Adds `:::{excerpt-break}` leaf directive that lets authors mark exactly where the excerpt should end on a per-file basis
- When present, all content above the directive becomes the excerpt (ignoring `excerpt_length` config); when absent, the existing position-based extraction applies unchanged
- The directive renders to nothing in HTML — it's purely a signal to the extraction pipeline
- Wired into both `parse_with_toc` and `parse_with_toc_and_context` code paths via a `_slice_blocks_at_excerpt_break` helper that scans top-level AST blocks

## Test plan

- [x] 7 new tests covering: content above/below break, no-break fallback, invisible HTML output, empty excerpt at top, multi-paragraph, context parsing path, and max_chars override
- [x] All 1075 existing patitas tests still pass
- [x] Pre-commit hooks (ruff, ty, cycle check) pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)