### PR TITLE
feat: improve agent score — fix llms.txt, add .md output, reorder DOM

### DIFF
--- a/bengal/config/defaults.py
+++ b/bengal/config/defaults.py
@@ -339,7 +339,7 @@ DEFAULTS: dict[str, Any] = {
     # -------------------------------------------------------------------------
     "output_formats": {
         "enabled": True,
-        "per_page": ["json"],
+        "per_page": ["json", "llm_txt", "markdown"],
         "site_wide": ["index_json", "llms_txt", "changelog", "agent_manifest"],
         "options": {
             "excerpt_length": 200,

--- a/bengal/config/feature_mappings.py
+++ b/bengal/config/feature_mappings.py
@@ -70,6 +70,9 @@ FEATURE_MAPPINGS: dict[str, dict[str, Any]] = {
     "llm_txt": {
         "output_formats.per_page": ["llm_txt"],
     },
+    "markdown": {
+        "output_formats.per_page": ["markdown"],
+    },
     "validate_links": {
         "validate_links": True,
         "health.linkcheck.enabled": True,

--- a/bengal/config/feature_mappings.py
+++ b/bengal/config/feature_mappings.py
@@ -14,6 +14,7 @@ Supported Features:
 - ``search``: Site search functionality
 - ``json``: Per-page JSON output
 - ``llm_txt``: LLM-friendly text output
+- ``markdown``: Per-page Markdown output for AI agent URL support
 - ``validate_links``: Link validation during build
 - ``minify_assets``: Asset minification
 - ``minify_html``: HTML output minification

--- a/bengal/config/snapshot.py
+++ b/bengal/config/snapshot.py
@@ -199,7 +199,7 @@ class FeaturesSection:
     search: bool = True
     json: bool = True
     llm_txt: bool = True
-    markdown: bool = False
+    markdown: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -431,7 +431,7 @@ class ConfigSnapshot:
                 search=bool(features_data.get("search", True)),
                 json=bool(features_data.get("json", True)),
                 llm_txt=bool(features_data.get("llm_txt", True)),
-                markdown=bool(features_data.get("markdown", False)),
+                markdown=bool(features_data.get("markdown", True)),
             )
         else:
             features_section = FeaturesSection()

--- a/bengal/config/snapshot.py
+++ b/bengal/config/snapshot.py
@@ -199,6 +199,7 @@ class FeaturesSection:
     search: bool = True
     json: bool = True
     llm_txt: bool = True
+    markdown: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -430,6 +431,7 @@ class ConfigSnapshot:
                 search=bool(features_data.get("search", True)),
                 json=bool(features_data.get("json", True)),
                 llm_txt=bool(features_data.get("llm_txt", True)),
+                markdown=bool(features_data.get("markdown", False)),
             )
         else:
             features_section = FeaturesSection()

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -195,7 +195,7 @@ class OutputFormatsGenerator:
         """Return default configuration."""
         return {
             "enabled": True,
-            "per_page": ["json", "llm_txt"],  # JSON + LLM text by default
+            "per_page": ["json", "llm_txt", "markdown"],  # JSON + LLM text + Markdown by default
             "site_wide": [
                 "index_json",
                 "llm_full",

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -36,6 +36,7 @@ from bengal.postprocess.output_formats.json_generator import PageJSONGenerator
 from bengal.postprocess.output_formats.llm_generator import SiteLlmTxtGenerator
 from bengal.postprocess.output_formats.llms_txt_generator import SiteLlmsTxtGenerator
 from bengal.postprocess.output_formats.lunr_index_generator import LunrIndexGenerator
+from bengal.postprocess.output_formats.md_generator import PageMarkdownGenerator
 from bengal.postprocess.output_formats.txt_generator import PageTxtGenerator
 from bengal.postprocess.utils import get_section_name
 from bengal.utils.observability.logger import get_logger
@@ -51,6 +52,7 @@ __all__ = [
     "LunrIndexGenerator",
     "OutputFormatsGenerator",
     "PageJSONGenerator",
+    "PageMarkdownGenerator",
     "PageTxtGenerator",
     "SiteIndexGenerator",
     "SiteLlmTxtGenerator",
@@ -309,6 +311,12 @@ class OutputFormatsGenerator:
             count = txt_gen.generate(ai_input_pages)
             generated.append(f"LLM text ({count} files)")
             logger.debug("generated_page_txt", file_count=count)
+
+        if "markdown" in per_page:
+            md_gen = PageMarkdownGenerator(self.site)
+            count = md_gen.generate(ai_input_pages)
+            generated.append(f"Markdown ({count} files)")
+            logger.debug("generated_page_markdown", file_count=count)
 
         # Site-wide outputs
         if "index_json" in site_wide:

--- a/bengal/postprocess/output_formats/llm_generator.py
+++ b/bengal/postprocess/output_formats/llm_generator.py
@@ -68,7 +68,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from bengal.postprocess.output_formats.utils import (
-    get_page_relative_url,
+    get_page_url,
 )
 from bengal.postprocess.utils import get_section_name, tags_to_list
 from bengal.utils.io.atomic_write import AtomicFile
@@ -197,7 +197,7 @@ class SiteLlmTxtGenerator:
                 f.write(f"\n## Page {idx}/{len(pages)}: {page.title}\n\n")
 
                 # Page metadata
-                url = get_page_relative_url(page, self.site)
+                url = get_page_url(page, self.site)
                 f.write(f"URL: {url}\n")
 
                 section_name = get_section_name(page)

--- a/bengal/postprocess/output_formats/llms_txt_generator.py
+++ b/bengal/postprocess/output_formats/llms_txt_generator.py
@@ -15,21 +15,27 @@ Output Format (per llmstxt.org spec):
 
     ## Getting Started
 
-    - [Installation](/docs/getting-started/installation/): Install and set up your first project
-    - [Quick Start](/docs/getting-started/quickstart/): Build and serve a site in 5 minutes
+    - [Installation](/bengal/docs/getting-started/installation/): Install and set up your first project
+    - [Quick Start](/bengal/docs/getting-started/quickstart/): Build and serve a site in 5 minutes
 
     ## Reference
 
-    - [Configuration](/docs/building/configuration/): Site config and build profiles
+    - [Configuration](/bengal/docs/building/configuration/): Site config and build profiles
 
     ## Optional
 
-    - [llm-full.txt](/llm-full.txt): Full plain-text content of all pages
+    - [llm-full.txt](/bengal/llm-full.txt): Full plain-text content of all pages
     ```
 
 The generator walks the site's section hierarchy and uses page descriptions
 from frontmatter to build link annotations. Sections are ordered by weight
 (matching the site's navigation order).
+
+Filtering:
+Pages are filtered to keep the file under the 100K character threshold
+required by most AI agents. Virtual pages (taxonomy terms, tag listings)
+are excluded. A configurable max_pages cap limits the total entries, and
+a max_chars cap triggers graceful truncation with a pointer to llm-full.txt.
 
 Configuration:
 Controlled via [output_formats] in bengal.toml:
@@ -37,6 +43,10 @@ Controlled via [output_formats] in bengal.toml:
     ```toml
     [output_formats]
     site_wide = ["index_json", "llm_full", "llms_txt"]
+
+    [output_formats.options]
+    llms_txt_max_pages = 100
+    llms_txt_max_chars = 80000
     ```
 
 Related:
@@ -51,7 +61,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from bengal.postprocess.output_formats.utils import get_page_relative_url
+from bengal.postprocess.output_formats.utils import get_page_url
 from bengal.postprocess.utils import get_section_name
 from bengal.utils.io.atomic_write import AtomicFile
 from bengal.utils.observability.logger import get_logger
@@ -65,6 +75,10 @@ logger = get_logger(__name__)
 
 _LLMS_TXT_SPEC_URL = "https://llmstxt.org/"
 
+# Default limits to keep llms.txt under the 100K agent threshold
+_DEFAULT_MAX_PAGES = 100
+_DEFAULT_MAX_CHARS = 80000
+
 
 class SiteLlmsTxtGenerator:
     """Generate llms.txt — a curated site overview for AI agents.
@@ -75,11 +89,22 @@ class SiteLlmsTxtGenerator:
 
     Attributes:
         site: Site instance with pages, sections, and configuration.
+        max_pages: Maximum number of page entries to include.
+        max_chars: Maximum character count before truncation.
     """
 
     def __init__(self, site: SiteLike) -> None:
         self.site = site
         self._logger = get_logger(__name__)
+        options = site.config.get("output_formats", {}).get("options", {})
+        self.max_pages = options.get("llms_txt_max_pages", _DEFAULT_MAX_PAGES)
+        self.max_chars = options.get("llms_txt_max_chars", _DEFAULT_MAX_CHARS)
+        # Cache section name map for O(1) lookups
+        self._section_name_map: dict[str, str] = {
+            getattr(s, "name", ""): getattr(s, "title", "")
+            for s in getattr(site, "sections", [])
+            if getattr(s, "name", "")
+        }
 
     def generate(self, pages: list[PageLike]) -> Path:
         """Generate llms.txt at the site root.
@@ -91,15 +116,61 @@ class SiteLlmsTxtGenerator:
         Returns:
             Path to the generated llms.txt file.
         """
-        content = self._render(pages)
+        curated = self._curate_pages(pages)
+        content = self._render(curated)
         output_path = self.site.output_dir / "llms.txt"
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         with AtomicFile(output_path, "w", encoding="utf-8") as f:
             f.write(content)
 
-        self._logger.info("llms_txt_generated", path=str(output_path))
+        self._logger.info(
+            "llms_txt_generated",
+            path=str(output_path),
+            pages_included=len(curated),
+            pages_total=len(pages),
+            chars=len(content),
+        )
         return output_path
+
+    def _curate_pages(self, pages: list[PageLike]) -> list[PageLike]:
+        """Filter pages to include only high-value navigation entries.
+
+        Excludes:
+        - Virtual/generated pages (taxonomy terms, tag listings)
+        - Pages without output paths
+        - Pages beyond the max_pages cap (lowest-weight pages preferred)
+        """
+        curated: list[PageLike] = []
+
+        for page in pages:
+            if not page.output_path:
+                continue
+
+            # Skip virtual pages (taxonomy term pages, tag listings, etc.)
+            if getattr(page, "is_virtual", False) is True:
+                continue
+
+            curated.append(page)
+
+        excluded = len(pages) - len(curated)
+        if excluded:
+            self._logger.debug(
+                "llms_txt_curated",
+                included=len(curated),
+                excluded=excluded,
+            )
+
+        # Cap at max_pages — pages are already weight-ordered from the site
+        if len(curated) > self.max_pages:
+            self._logger.debug(
+                "llms_txt_capped",
+                before=len(curated),
+                max_pages=self.max_pages,
+            )
+            curated = curated[: self.max_pages]
+
+        return curated
 
     def _render(self, pages: list[PageLike]) -> str:
         lines: list[str] = []
@@ -114,18 +185,39 @@ class SiteLlmsTxtGenerator:
             lines.append("")
 
         sections = self._group_by_section(pages)
+        total_pages = sum(len(sp) for _, sp in sections)
+        pages_rendered = 0
+        truncated = False
 
         for section_name, section_pages in sections:
             display_name = self._format_section_name(section_name)
             lines.append(f"## {display_name}")
             lines.append("")
             for page in section_pages:
-                url = get_page_relative_url(page, self.site)
+                url = get_page_url(page, self.site)
                 desc = page.description
                 if desc:
                     lines.append(f"- [{page.title}]({url}): {desc}")
                 else:
                     lines.append(f"- [{page.title}]({url})")
+                pages_rendered += 1
+
+                # Check character budget after each section
+                if self.max_chars and len("\n".join(lines)) > self.max_chars:
+                    truncated = True
+                    break
+            lines.append("")
+
+            if truncated:
+                break
+
+        if truncated:
+            remaining = total_pages - pages_rendered
+            baseurl = (self.site.baseurl or "").rstrip("/")
+            lines.append(
+                f"*... and {remaining} more pages. "
+                f"See [llm-full.txt]({baseurl}/llm-full.txt) for complete content.*"
+            )
             lines.append("")
 
         self._append_optional_section(lines)
@@ -163,20 +255,14 @@ class SiteLlmsTxtGenerator:
     ) -> list[tuple[str, list[PageLike]]]:
         """Order sections to match the site's navigation structure.
 
-        Uses the site's top-level sections list (which is weight-ordered)
+        Uses the cached section name map (which is weight-ordered)
         as the canonical ordering. Sections not in the site hierarchy are
         appended alphabetically.
         """
-        known_order: list[str] = []
-        for section in getattr(self.site, "sections", []):
-            name = getattr(section, "name", "")
-            if name:
-                known_order.append(name)
-
         ordered: list[tuple[str, list[PageLike]]] = []
         seen: set[str] = set()
 
-        for name in known_order:
+        for name in self._section_name_map:
             if name in section_map:
                 ordered.append((name, section_map[name]))
                 seen.add(name)
@@ -190,14 +276,12 @@ class SiteLlmsTxtGenerator:
     def _format_section_name(self, name: str) -> str:
         """Convert section slug to display name.
 
-        Checks the site's section objects for a proper title first,
+        Uses the cached section name map for O(1) lookup,
         falling back to title-casing the slug.
         """
-        for section in getattr(self.site, "sections", []):
-            if getattr(section, "name", "") == name:
-                section_title = getattr(section, "title", "")
-                if section_title and section_title != name:
-                    return section_title
+        title = self._section_name_map.get(name, "")
+        if title and title != name:
+            return title
         return name.replace("-", " ").replace("_", " ").title()
 
     def _append_optional_section(self, lines: list[str]) -> None:

--- a/bengal/postprocess/output_formats/llms_txt_generator.py
+++ b/bengal/postprocess/output_formats/llms_txt_generator.py
@@ -188,25 +188,32 @@ class SiteLlmsTxtGenerator:
         total_pages = sum(len(sp) for _, sp in sections)
         pages_rendered = 0
         truncated = False
+        # Track running character count to avoid O(n²) join on every entry
+        # +1 per line accounts for the newline separator in the final join
+        char_count = sum(len(line) + 1 for line in lines)
 
         for section_name, section_pages in sections:
             display_name = self._format_section_name(section_name)
-            lines.append(f"## {display_name}")
+            header_line = f"## {display_name}"
+            lines.append(header_line)
             lines.append("")
+            char_count += len(header_line) + 1 + 1  # header + newline + empty line
             for page in section_pages:
                 url = get_page_url(page, self.site)
                 desc = page.description
-                if desc:
-                    lines.append(f"- [{page.title}]({url}): {desc}")
-                else:
-                    lines.append(f"- [{page.title}]({url})")
-                pages_rendered += 1
+                entry = f"- [{page.title}]({url}): {desc}" if desc else f"- [{page.title}]({url})"
+                entry_chars = len(entry) + 1  # +1 for newline
 
-                # Check character budget after each section
-                if self.max_chars and len("\n".join(lines)) > self.max_chars:
+                # Check character budget before appending
+                if self.max_chars and char_count + entry_chars > self.max_chars:
                     truncated = True
                     break
+
+                lines.append(entry)
+                char_count += entry_chars
+                pages_rendered += 1
             lines.append("")
+            char_count += 1  # empty line
 
             if truncated:
                 break

--- a/bengal/postprocess/output_formats/md_generator.py
+++ b/bengal/postprocess/output_formats/md_generator.py
@@ -150,11 +150,17 @@ class PageMarkdownGenerator:
         # Raw markdown content (preferred) or plain text fallback
         raw = getattr(page, "_raw_content", None) or ""
         if raw:
-            # Strip leading H1 if it duplicates the title we already wrote
             content = raw.strip()
+            # Only strip leading H1 if it duplicates the title we already wrote
             if content.startswith("# "):
                 first_line_end = content.find("\n")
-                content = content[first_line_end:].lstrip("\n") if first_line_end != -1 else ""
+                h1_text = (
+                    content[2:first_line_end].strip()
+                    if first_line_end != -1
+                    else content[2:].strip()
+                )
+                if h1_text == page.title:
+                    content = content[first_line_end:].lstrip("\n") if first_line_end != -1 else ""
         else:
             # Fallback to plain text
             content = getattr(page, "plain_text", "") or ""

--- a/bengal/postprocess/output_formats/md_generator.py
+++ b/bengal/postprocess/output_formats/md_generator.py
@@ -1,0 +1,165 @@
+"""
+Per-page Markdown generator for Bengal SSG.
+
+Generates .md files alongside each HTML page so that AI agents can
+request structured markdown content at .md URLs (e.g.,
+``/docs/getting-started/index.md``). This enables the "Markdown URL
+Support" check in agent-readiness scorecards.
+
+Output Format:
+Each page.html gets a corresponding page.md (or index.md for
+directory index pages) containing the page's source markdown with
+a minimal metadata header:
+
+    ```markdown
+    # Page Title
+
+    URL: /bengal/docs/getting-started/
+    Section: docs
+
+    ---
+
+    [Original markdown content]
+    ```
+
+Configuration:
+Controlled via [output_formats] in bengal.toml:
+
+    ```toml
+    [output_formats]
+    per_page = ["json", "llm_txt", "markdown"]
+    ```
+
+Or via the features shorthand:
+
+    ```yaml
+    features:
+      markdown: true
+    ```
+
+Related:
+- bengal.postprocess.output_formats: OutputFormatsGenerator facade
+- bengal.postprocess.output_formats.txt_generator: Per-page plain text
+- bengal.postprocess.output_formats.llms_txt_generator: Site-wide llms.txt
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bengal.postprocess.output_formats.utils import (
+    get_page_md_path,
+    get_page_url,
+    parallel_write_files,
+)
+from bengal.postprocess.utils import get_section_name
+from bengal.utils.io.atomic_write import AtomicFile
+from bengal.utils.observability.logger import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bengal.protocols import PageLike, SiteLike
+
+logger = get_logger(__name__)
+
+
+class PageMarkdownGenerator:
+    """Generate per-page .md files for agent markdown URL support.
+
+    Creates a .md file alongside each HTML page containing the page's
+    source markdown content with a minimal metadata header.
+
+    Attributes:
+        site: Site instance with pages and configuration.
+    """
+
+    def __init__(self, site: SiteLike) -> None:
+        self.site = site
+
+    def generate(self, pages: list[PageLike]) -> int:
+        """Generate .md files for all pages.
+
+        Args:
+            pages: List of pages to generate markdown files for.
+
+        Returns:
+            Number of .md files generated.
+        """
+        page_items: list[tuple[Path, str]] = []
+        for page in pages:
+            md_path = get_page_md_path(page)
+            if not md_path:
+                continue
+
+            content = self._page_to_markdown(page)
+            if content:
+                page_items.append((md_path, content))
+
+        if not page_items:
+            return 0
+
+        def write_md(path: Path, content: str) -> None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with AtomicFile(path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+        count = parallel_write_files(
+            page_items,
+            write_md,
+            max_workers=8,
+            operation_name="markdown_write",
+        )
+        logger.info("markdown_files_generated", count=count, total=len(page_items))
+        return count
+
+    def _page_to_markdown(self, page: PageLike) -> str:
+        """Convert a page to its markdown output format.
+
+        Uses the page's raw markdown source content. Falls back to
+        plain_text if raw source is unavailable.
+
+        Args:
+            page: Page to convert.
+
+        Returns:
+            Markdown string with metadata header.
+        """
+        lines: list[str] = []
+
+        # Header
+        lines.append(f"# {page.title}")
+        lines.append("")
+
+        # Minimal metadata
+        url = get_page_url(page, self.site)
+        lines.append(f"URL: {url}")
+
+        section_name = get_section_name(page)
+        if section_name:
+            lines.append(f"Section: {section_name}")
+
+        if page.description:
+            lines.append(f"Description: {page.description}")
+
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+        # Raw markdown content (preferred) or plain text fallback
+        raw = getattr(page, "_raw_content", None) or ""
+        if raw:
+            # Strip leading H1 if it duplicates the title we already wrote
+            content = raw.strip()
+            if content.startswith("# "):
+                first_line_end = content.find("\n")
+                content = content[first_line_end:].lstrip("\n") if first_line_end != -1 else ""
+        else:
+            # Fallback to plain text
+            content = getattr(page, "plain_text", "") or ""
+
+        lines.append(content)
+        lines.append("")
+
+        return "\n".join(lines)

--- a/bengal/postprocess/output_formats/txt_generator.py
+++ b/bengal/postprocess/output_formats/txt_generator.py
@@ -63,8 +63,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bengal.postprocess.output_formats.utils import (
-    get_page_relative_url,
     get_page_txt_path,
+    get_page_url,
     parallel_write_files,
 )
 from bengal.postprocess.utils import get_section_name, tags_to_list
@@ -181,7 +181,7 @@ class PageTxtGenerator:
         lines.append(f"# {page.title}\n")
 
         # Metadata
-        url = get_page_relative_url(page, self.site)
+        url = get_page_url(page, self.site)
         lines.append(f"URL: {url}")
 
         section_name = get_section_name(page)

--- a/bengal/postprocess/output_formats/utils.py
+++ b/bengal/postprocess/output_formats/utils.py
@@ -12,9 +12,8 @@ Text Processing:
     - generate_excerpt: Create truncated preview text
 
 URL Handling:
-    - get_page_relative_url: Get URL without baseurl (for objectID)
-    - get_page_public_url: Get full URL with baseurl
-    - get_page_url: Alias for get_page_public_url
+    - get_page_relative_url: Get URL without baseurl (for objectID/search index)
+    - get_page_url: Get full public URL with baseurl
     - normalize_url: Normalize URL for consistent comparison
 
 Path Resolution:
@@ -142,25 +141,9 @@ def get_page_relative_url(page: PageLike, site: SiteLike) -> str:
     return page._path
 
 
-def get_page_public_url(page: PageLike, site: SiteLike) -> str:
-    """
-    Get the page's public URL including baseurl.
-
-    Args:
-        page: Page to get URL for
-        site: Site instance
-
-    Returns:
-        Full public URL including baseurl
-
-    """
-    # page.href already includes baseurl
-    return page.href
-
-
 def get_page_url(page: PageLike, site: SiteLike) -> str:
     """
-    Get the public URL for a page.
+    Get the public URL for a page (includes baseurl).
 
     Args:
         page: Page to get URL for
@@ -172,60 +155,50 @@ def get_page_url(page: PageLike, site: SiteLike) -> str:
     """
     # page.href already includes baseurl
     return page.href
+
+
+def get_page_output_path(page: PageLike, ext: str) -> Path | None:
+    """
+    Get the output path for a page's companion file with the given extension.
+
+    For index.html pages, returns index.{ext} in the same directory.
+    For other pages (page.html), returns page.{ext} with suffix swapped.
+
+    Args:
+        page: Page to get output path for
+        ext: File extension without dot (e.g., "json", "txt", "md")
+
+    Returns:
+        Path for the companion file, or None if output_path not available
+
+    """
+    output_path = getattr(page, "output_path", None)
+    if not output_path:
+        return None
+
+    # Handle invalid output paths (e.g., Path('.'))
+    if str(output_path) in (".", "..") or output_path.name == "":
+        return None
+
+    if output_path.name == "index.html":
+        return output_path.parent / f"index.{ext}"
+
+    return output_path.with_suffix(f".{ext}")
 
 
 def get_page_json_path(page: PageLike) -> Path | None:
-    """
-    Get the output path for a page's JSON file.
-
-    Args:
-        page: Page to get JSON path for
-
-    Returns:
-        Path for the JSON file, or None if output_path not available
-
-    """
-    output_path = getattr(page, "output_path", None)
-    if not output_path:
-        return None
-
-    # Handle invalid output paths (e.g., Path('.'))
-    if str(output_path) in (".", "..") or output_path.name == "":
-        return None
-
-    # If output is index.html, put index.json next to it
-    if output_path.name == "index.html":
-        return output_path.parent / "index.json"
-
-    # If output is page.html, put page.json next to it
-    return output_path.with_suffix(".json")
+    """Get the output path for a page's JSON file."""
+    return get_page_output_path(page, "json")
 
 
 def get_page_txt_path(page: PageLike) -> Path | None:
-    """
-    Get the output path for a page's TXT file.
+    """Get the output path for a page's TXT file."""
+    return get_page_output_path(page, "txt")
 
-    Args:
-        page: Page to get TXT path for
 
-    Returns:
-        Path for the TXT file, or None if output_path not available
-
-    """
-    output_path = getattr(page, "output_path", None)
-    if not output_path:
-        return None
-
-    # Handle invalid output paths (e.g., Path('.'))
-    if str(output_path) in (".", "..") or output_path.name == "":
-        return None
-
-    # If output is index.html, put index.txt next to it
-    if output_path.name == "index.html":
-        return output_path.parent / "index.txt"
-
-    # If output is page.html, put page.txt next to it
-    return output_path.with_suffix(".txt")
+def get_page_md_path(page: PageLike) -> Path | None:
+    """Get the output path for a page's Markdown file."""
+    return get_page_output_path(page, "md")
 
 
 def normalize_url(url: str) -> str:

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -192,8 +192,9 @@ HELPER: Render a menu item (desktop/mobile)
     {% end %}
 
     {# Markdown alternate for AI agent content negotiation #}
-    {% if _per_page_md %}
-    {% let _md_url = page.href | replace('.html', '.md') if page.href.endswith('.html') else (page.href ~ 'index.md' if page.href.endswith('/') else page.href ~ '/index.md') %}
+    {% if _per_page_md and page.href is defined and page.href is string %}
+    {% let _href = page.href %}
+    {% let _md_url = _href | replace('.html', '.md') if _href.endswith('.html') else (_href ~ 'index.md' if _href.endswith('/') else _href ~ '/index.md') %}
     <link rel="alternate" type="text/markdown" href="{{ _md_url }}">
     {% end %}
 

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -24,6 +24,7 @@ _path, kind, tags are always defined - no defensive checks needed.
 {% let _doc_app = site.document_application %}
 {% let _link_previews = site.link_previews %}
 {% let _per_page_json = 'json' in (config.output_formats.per_page ?? []) %}
+{% let _per_page_md = 'markdown' in (config.output_formats.per_page ?? []) %}
 
 {# Derived values #}
 {% let _main_menu = get_menu_lang('main', _current_lang) %}
@@ -190,6 +191,12 @@ HELPER: Render a menu item (desktop/mobile)
     <link rel="alternate" hreflang="{{ alt.hreflang }}" href="{{ alt.href }}">
     {% end %}
 
+    {# Markdown alternate for AI agent content negotiation #}
+    {% if _per_page_md %}
+    {% let _md_url = page.href | replace('.html', '.md') if page.href.endswith('.html') else (page.href ~ 'index.md' if page.href.endswith('/') else page.href ~ '/index.md') %}
+    <link rel="alternate" type="text/markdown" href="{{ _md_url }}">
+    {% end %}
+
     {# Favicon, preconnect, fonts, stylesheets — site-stable, same for every page in a build #}
     {% cache 'base-head-assets-' ~ (bengal.build.timestamp ?? '') %}
     {# Favicon - use let for safer nil handling #}
@@ -331,7 +338,71 @@ HELPER: Render a menu item (desktop/mobile)
     <a href="#main-content" class="skip-link">Skip to main content</a>
     {% end %}
 
-    {# Search Modal Block #}
+    {# Header #}
+    {% let _header_sticky = theme.header_sticky ?? true %}
+    {% let _header_nav_position = theme.header_nav_position ?? 'left' %}
+    <header role="banner" class="header-appshell" data-sticky="{{ _header_sticky | lower }}">
+        <nav role="navigation" aria-label="Main navigation">
+            <div class="header-nav-content" data-nav-position="{{ _header_nav_position }}">
+                <a href="{{ '/' | absolute_url }}" class="logo">
+                    {% match site.logo, site.logo_text %}
+                    {% case logo, _ if logo %}<img src="{{ logo | absolute_url }}" alt="{{ _site_title }}"
+                        class="brand-image" />
+                    {% case _, text if text %}<span class="brand-text">{{ text }}</span>
+                    {% case _ %}<span class="brand-text">{{ _site_title }}</span>
+                    {% end %}
+                </a>
+
+                {% if _main_menu or _auto_nav %}
+                {% spaceless %}
+                <ul class="nav-main hidden-mobile">
+                    {% for item in _main_menu %}{{ render_menu_item(item) }}{% end %}
+                    {% if _auto_nav %}
+                    <li class="{{ ['active' if _page_url == '/'] | classes }}"><a href="{{ '/' | absolute_url }}">Home</a>
+                    </li>
+                    {% for item in _auto_nav %}
+                    <li
+                        class="{{ ['active' if (_page_url is string and item._path is string and _page_url.startswith(item._path) and item._path != '/')] | classes }}">
+                        <a href="{{ item.href | absolute_url }}">{{ item.name }}</a>
+                    </li>
+                    {% end %}
+                    {% end %}
+                    {% with site.params.repo_url as repo_url %}
+                    {% if repo_url and not (site._dev_menu_metadata?.github_bundled ?? false) %}
+                    <li><a href="{{ repo_url }}" target="_blank" rel="noopener" aria-label="GitHub">{{
+                            icon('github-logo', size=16) }} <span>GitHub</span></a></li>
+                    {% end %}
+                    {% end %}
+                    {% block nav_items %}{% end %}
+                </ul>
+                {% end %}
+                {% end %}
+
+                <div class="header-actions hidden-mobile">
+                    {% with config.search.ui as ui %}
+                    {% if ui.modal ?? false %}
+                    <button type="button" class="nav-search-trigger" id="nav-search-trigger" title="Search (⌘K)">{{
+                        icon('magnifying-glass', size=16) }} <span>Search</span> <kbd
+                            class="nav-search-shortcut">⌘K</kbd></button>
+                    {% else %}
+                    <a href="{{ '/search/' | absolute_url }}" class="nav-search-trigger" title="Search (⌘K)">{{
+                        icon('magnifying-glass', size=16) }} <span>Search</span></a>
+                    {% end %}
+                    {% end %}
+                    {% cache 'base-theme-ctrl-d-' ~ _current_lang ~ '-' ~ (bengal.build.timestamp ?? '') %}{% with theme_menu_id='theme-menu-desktop' %}{% include 'partials/theme-controls.html' %}{% end %}{% end %}{# /cache base-theme-ctrl-d #}
+                </div>
+
+                <button class="mobile-nav-toggle visible-mobile" aria-label="Open menu"
+                    onclick="document.getElementById('mobile-nav-dialog').showModal()">
+                    {{ icon('list', size=24) }}
+                </button>
+            </div>
+        </nav>
+    </header>
+
+    <main id="main-content" role="main">{% block content %}{% end %}</main>
+
+    {# Search Modal Block — placed after <main> so content starts early in DOM #}
     {% block site_search_modal %}
     {% cache 'base-search-modal-' ~ _current_lang ~ '-' ~ (bengal.build.timestamp ?? '') %}
     {% with config.search.ui as ui %}
@@ -398,69 +469,7 @@ HELPER: Render a menu item (desktop/mobile)
     {% end %}{# /cache base-search-modal #}
     {% end %}
 
-    {# Header #}
-    {% let _header_sticky = theme.header_sticky ?? true %}
-    {% let _header_nav_position = theme.header_nav_position ?? 'left' %}
-    <header role="banner" class="header-appshell" data-sticky="{{ _header_sticky | lower }}">
-        <nav role="navigation" aria-label="Main navigation">
-            <div class="header-nav-content" data-nav-position="{{ _header_nav_position }}">
-                <a href="{{ '/' | absolute_url }}" class="logo">
-                    {% match site.logo, site.logo_text %}
-                    {% case logo, _ if logo %}<img src="{{ logo | absolute_url }}" alt="{{ _site_title }}"
-                        class="brand-image" />
-                    {% case _, text if text %}<span class="brand-text">{{ text }}</span>
-                    {% case _ %}<span class="brand-text">{{ _site_title }}</span>
-                    {% end %}
-                </a>
-
-                {% if _main_menu or _auto_nav %}
-                {% spaceless %}
-                <ul class="nav-main hidden-mobile">
-                    {% for item in _main_menu %}{{ render_menu_item(item) }}{% end %}
-                    {% if _auto_nav %}
-                    <li class="{{ ['active' if _page_url == '/'] | classes }}"><a href="{{ '/' | absolute_url }}">Home</a>
-                    </li>
-                    {% for item in _auto_nav %}
-                    <li
-                        class="{{ ['active' if (_page_url is string and item._path is string and _page_url.startswith(item._path) and item._path != '/')] | classes }}">
-                        <a href="{{ item.href | absolute_url }}">{{ item.name }}</a>
-                    </li>
-                    {% end %}
-                    {% end %}
-                    {% with site.params.repo_url as repo_url %}
-                    {% if repo_url and not (site._dev_menu_metadata?.github_bundled ?? false) %}
-                    <li><a href="{{ repo_url }}" target="_blank" rel="noopener" aria-label="GitHub">{{
-                            icon('github-logo', size=16) }} <span>GitHub</span></a></li>
-                    {% end %}
-                    {% end %}
-                    {% block nav_items %}{% end %}
-                </ul>
-                {% end %}
-                {% end %}
-
-                <div class="header-actions hidden-mobile">
-                    {% with config.search.ui as ui %}
-                    {% if ui.modal ?? false %}
-                    <button type="button" class="nav-search-trigger" id="nav-search-trigger" title="Search (⌘K)">{{
-                        icon('magnifying-glass', size=16) }} <span>Search</span> <kbd
-                            class="nav-search-shortcut">⌘K</kbd></button>
-                    {% else %}
-                    <a href="{{ '/search/' | absolute_url }}" class="nav-search-trigger" title="Search (⌘K)">{{
-                        icon('magnifying-glass', size=16) }} <span>Search</span></a>
-                    {% end %}
-                    {% end %}
-                    {% cache 'base-theme-ctrl-d-' ~ _current_lang ~ '-' ~ (bengal.build.timestamp ?? '') %}{% with theme_menu_id='theme-menu-desktop' %}{% include 'partials/theme-controls.html' %}{% end %}{% end %}{# /cache base-theme-ctrl-d #}
-                </div>
-
-                <button class="mobile-nav-toggle visible-mobile" aria-label="Open menu"
-                    onclick="document.getElementById('mobile-nav-dialog').showModal()">
-                    {{ icon('list', size=24) }}
-                </button>
-            </div>
-        </nav>
-    </header>
-
-    {# Mobile Navigation #}
+    {# Mobile Navigation — placed after <main> so content starts early in DOM #}
     <dialog id="mobile-nav-dialog" class="mobile-nav-dialog" aria-label="Mobile navigation">
         <form method="dialog" class="mobile-nav-header">
             <span class="logo">
@@ -505,8 +514,6 @@ HELPER: Render a menu item (desktop/mobile)
         <div class="mobile-nav-footer">{% cache 'base-theme-ctrl-m-' ~ _current_lang ~ '-' ~ (bengal.build.timestamp ?? '') %}{% with theme_menu_id='theme-menu-mobile' %}{% include
             'partials/theme-controls.html' %}{% end %}{% end %}{# /cache base-theme-ctrl-m #}</div>
     </dialog>
-
-    <main id="main-content" role="main">{% block content %}{% end %}</main>
 
     {# Footer #}
     {% block site_footer %}

--- a/site/config/_default/outputs.yaml
+++ b/site/config/_default/outputs.yaml
@@ -11,6 +11,7 @@ features:
   search: true     # Generate search index (index.json)
   json: true       # Generate per-page JSON files (page.json)
   llm_txt: true    # Generate LLM-friendly text files (index.txt, llm-full.txt)
+  markdown: true   # Generate per-page .md files for agent markdown URL support
 
 # Social Cards Configuration
 # ==========================

--- a/tests/integration/test_llm_txt_integration.py
+++ b/tests/integration/test_llm_txt_integration.py
@@ -226,7 +226,8 @@ class TestLLMTextFullBuild:
 
         # Format checks
         assert content.startswith("# Getting Started")
-        assert "URL: /getting-started/" in content
+        # URL includes baseurl (page.href); site config sets baseurl = "https://example.com"
+        assert "URL: https://example.com/getting-started/" in content
         assert "Tags: tutorial, beginner" in content
         assert "This is an introduction" in content
         assert "Metadata:" in content
@@ -250,14 +251,14 @@ class TestLLMTextFullBuild:
         # (The _strip_html function handles this)
 
     def test_llm_txt_urls_are_correct(self, llm_site):
-        """Test that LLM.txt files use correct URLs."""
-        # Check getting-started
+        """Test that LLM.txt files use correct URLs (includes baseurl)."""
+        # Check getting-started — site config sets baseurl = "https://example.com"
         txt1 = (llm_site.output_dir / "getting-started" / "index.txt").read_text()
-        assert "URL: /getting-started/" in txt1
+        assert "URL: https://example.com/getting-started/" in txt1
 
         # Check autodoc/python
         txt2 = (llm_site.output_dir / "autodoc/python" / "index.txt").read_text()
-        assert "URL: /autodoc/python/" in txt2
+        assert "URL: https://example.com/autodoc/python/" in txt2
 
 
 class TestLLMTextIncrementalBuild:
@@ -439,7 +440,8 @@ How to install.
 
         content = txt_path.read_text()
         assert "Installation Guide" in content
-        assert "URL: /docs/guides/install/" in content
+        # URL includes baseurl via page.href; check the path portion
+        assert "/docs/guides/install/" in content
 
 
 class TestLLMTextDisabled:

--- a/tests/unit/postprocess/test_llms_txt.py
+++ b/tests/unit/postprocess/test_llms_txt.py
@@ -266,6 +266,128 @@ class TestLlmsTxtGenerate:
         assert content.startswith("# Empty\n")
 
 
+class TestCuration:
+    """Test page curation: virtual page filtering and max_pages cap."""
+
+    def test_excludes_virtual_pages(self, tmp_path):
+        site = _make_site(title="Site")
+        site.output_dir = tmp_path
+
+        real_page = _make_page(title="Real", path="/real/")
+        real_page.is_virtual = False
+
+        virtual_page = _make_page(title="Virtual", path="/tags/python/")
+        virtual_page.is_virtual = True
+
+        gen = SiteLlmsTxtGenerator(site)
+        result = gen.generate([real_page, virtual_page])
+
+        content = result.read_text(encoding="utf-8")
+        assert "[Real]" in content
+        assert "Virtual" not in content
+
+    def test_max_pages_cap(self, tmp_path):
+        site = _make_site(
+            title="Site",
+            config_overrides={
+                "output_formats": {
+                    "options": {"llms_txt_max_pages": 2},
+                    "site_wide": ["llms_txt"],
+                },
+            },
+        )
+        site.output_dir = tmp_path
+
+        pages = [
+            _make_page(title=f"Page {i}", path=f"/page-{i}/", section_name="docs") for i in range(5)
+        ]
+        for p in pages:
+            p.is_virtual = False
+
+        gen = SiteLlmsTxtGenerator(site)
+        result = gen.generate(pages)
+
+        content = result.read_text(encoding="utf-8")
+        assert "[Page 0]" in content
+        assert "[Page 1]" in content
+        # Pages beyond the cap should be excluded
+        assert "[Page 2]" not in content
+
+
+class TestTruncation:
+    """Test max_chars truncation with rollback and notice."""
+
+    def test_max_chars_truncates_with_notice(self, tmp_path):
+        site = _make_site(
+            title="Site",
+            config_overrides={
+                "output_formats": {
+                    "options": {"llms_txt_max_chars": 200},
+                    "site_wide": ["llms_txt"],
+                },
+            },
+        )
+        site.output_dir = tmp_path
+
+        pages = [
+            _make_page(
+                title=f"Page {i}",
+                path=f"/page-{i}/",
+                description="A" * 50,
+                section_name="docs",
+            )
+            for i in range(20)
+        ]
+        for p in pages:
+            p.is_virtual = False
+
+        gen = SiteLlmsTxtGenerator(site)
+        result = gen.generate(pages)
+
+        content = result.read_text(encoding="utf-8")
+        # Should have truncation notice
+        assert "llm-full.txt" in content
+        assert "more pages" in content
+        # Not all pages should be present
+        assert "[Page 19]" not in content
+
+    def test_output_stays_under_max_chars(self, tmp_path):
+        max_chars = 300
+        site = _make_site(
+            title="S",
+            description="",
+            config_overrides={
+                "output_formats": {
+                    "options": {"llms_txt_max_chars": max_chars},
+                    "site_wide": [],
+                },
+                "content_signals": {"enabled": False},
+            },
+        )
+        site.output_dir = tmp_path
+
+        pages = [
+            _make_page(
+                title=f"Page {i}",
+                path=f"/p{i}/",
+                description="Desc " * 10,
+                section_name="docs",
+            )
+            for i in range(50)
+        ]
+        for p in pages:
+            p.is_virtual = False
+
+        gen = SiteLlmsTxtGenerator(site)
+        result = gen.generate(pages)
+
+        content = result.read_text(encoding="utf-8")
+        # The truncation notice and optional section add some overhead,
+        # but the page entries themselves should have stopped before the cap
+        # (we accept the notice/footer pushing slightly over)
+        assert len(content) < max_chars * 2  # generous bound
+
+
 class TestOutputTypeClassification:
     """Test that llms.txt is classified correctly."""
 

--- a/tests/unit/postprocess/test_md_generator.py
+++ b/tests/unit/postprocess/test_md_generator.py
@@ -1,0 +1,228 @@
+"""Unit tests for bengal/postprocess/output_formats/md_generator.py.
+
+Covers:
+- File path mapping (index.html → index.md, page.html → page.md)
+- Content header with title, URL, section, description
+- H1 deduplication (only stripped when matching page.title)
+- Raw content preservation and plain_text fallback
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from bengal.postprocess.output_formats.md_generator import PageMarkdownGenerator
+
+
+def _make_site(baseurl: str = "") -> MagicMock:
+    site = MagicMock()
+    site.baseurl = baseurl
+    return site
+
+
+def _make_page(
+    title: str = "Page",
+    path: str = "/docs/page/",
+    description: str = "",
+    section_name: str = "docs",
+    output_path: str | None = None,
+    raw_content: str = "",
+    plain_text: str = "",
+) -> MagicMock:
+    page = MagicMock()
+    page.title = title
+    page._path = path
+    page.href = path
+    page.description = description
+    page.output_path = Path(output_path) if output_path else Path(f"public{path}index.html")
+    page._raw_content = raw_content or None
+    page.plain_text = plain_text or None
+
+    if section_name:
+        section = MagicMock()
+        section.name = section_name
+        page._section = section
+    else:
+        page._section = None
+
+    # Prevent MagicMock from creating is_virtual as a truthy mock
+    page.is_virtual = False
+    page.in_ai_input = True
+
+    return page
+
+
+class TestPageToMarkdown:
+    """Test markdown content generation for individual pages."""
+
+    def test_includes_title_header(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(title="Getting Started", raw_content="Some content.")
+
+        result = gen._page_to_markdown(page)
+
+        assert result.startswith("# Getting Started\n")
+
+    def test_includes_url(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(path="/docs/install/", raw_content="Content.")
+
+        result = gen._page_to_markdown(page)
+
+        assert "URL: /docs/install/" in result
+
+    def test_includes_section(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(section_name="guides", raw_content="Content.")
+
+        result = gen._page_to_markdown(page)
+
+        assert "Section: guides" in result
+
+    def test_includes_description(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(description="A helpful guide.", raw_content="Content.")
+
+        result = gen._page_to_markdown(page)
+
+        assert "Description: A helpful guide." in result
+
+    def test_omits_section_when_none(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(section_name="", raw_content="Content.")
+
+        result = gen._page_to_markdown(page)
+
+        assert "Section:" not in result
+
+    def test_omits_description_when_empty(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(description="", raw_content="Content.")
+
+        result = gen._page_to_markdown(page)
+
+        assert "Description:" not in result
+
+    def test_has_separator(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(raw_content="Body text.")
+
+        result = gen._page_to_markdown(page)
+
+        assert "\n---\n" in result
+
+    def test_preserves_raw_content(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        raw = "## Installation\n\nRun `pip install bengal`.\n"
+        page = _make_page(raw_content=raw)
+
+        result = gen._page_to_markdown(page)
+
+        assert "## Installation" in result
+        assert "Run `pip install bengal`." in result
+
+
+class TestH1Deduplication:
+    """Test that H1 stripping only happens when it matches page.title."""
+
+    def test_strips_matching_h1(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(
+            title="Getting Started",
+            raw_content="# Getting Started\n\nBody content here.",
+        )
+
+        result = gen._page_to_markdown(page)
+
+        # Title appears in header, not duplicated in body
+        lines = result.split("\n")
+        assert lines[0] == "# Getting Started"
+        # The raw H1 should be stripped — body should not have another "# Getting Started"
+        body_start = result.index("---\n") + 4
+        body = result[body_start:]
+        assert "# Getting Started" not in body
+        assert "Body content here." in body
+
+    def test_preserves_non_matching_h1(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(
+            title="Install Guide",
+            raw_content="# Different Title\n\nBody content.",
+        )
+
+        result = gen._page_to_markdown(page)
+
+        # Non-matching H1 should be preserved in body
+        body_start = result.index("---\n") + 4
+        body = result[body_start:]
+        assert "# Different Title" in body
+
+    def test_h1_only_content(self):
+        """H1-only content matching title produces empty body."""
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(title="Solo", raw_content="# Solo")
+
+        result = gen._page_to_markdown(page)
+
+        # Should not error out
+        assert "# Solo" in result
+
+
+class TestPlainTextFallback:
+    """Test fallback to plain_text when raw content unavailable."""
+
+    def test_uses_plain_text_when_no_raw(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(raw_content="", plain_text="Fallback plain text.")
+
+        result = gen._page_to_markdown(page)
+
+        assert "Fallback plain text." in result
+
+
+class TestGenerate:
+    """Test the generate() method writes files."""
+
+    def test_writes_md_files(self, tmp_path):
+        site = _make_site()
+        site.output_dir = tmp_path
+        gen = PageMarkdownGenerator(site)
+
+        page = _make_page(
+            title="Test Page",
+            path="/test/",
+            raw_content="# Test Page\n\nContent.",
+            output_path=str(tmp_path / "test" / "index.html"),
+        )
+
+        count = gen.generate([page])
+
+        assert count == 1
+        md_path = tmp_path / "test" / "index.md"
+        assert md_path.exists()
+        content = md_path.read_text()
+        assert "# Test Page" in content
+
+    def test_skips_pages_without_output_path(self):
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+
+        page = _make_page(raw_content="Content.")
+        page.output_path = None
+
+        count = gen.generate([page])
+
+        assert count == 0


### PR DESCRIPTION
## Summary

- **Fix llms.txt size & URLs**: Shrink from 733K to ~12K by filtering virtual pages and adding max_pages/max_chars caps; switch to `get_page_url()` so URLs include baseurl (fixes 10/10 broken URL fetches)
- **Add per-page .md output**: New `PageMarkdownGenerator` writes `.md` files alongside HTML from raw markdown source, enabling AI agent markdown URL support
- **Add `<link rel="alternate" type="text/markdown">` to `<head>`**: Signals markdown availability on static hosting where server-side content negotiation is impossible
- **Move dialogs after `<main>` in base.html**: Search modal and mobile nav dialog now render after `<main>`, pushing content earlier in the DOM to improve the "content start position" check
- **Consolidate path helpers**: Extract generic `get_page_output_path(page, ext)` replacing duplicated json/txt path logic; cache section name map for O(1) lookups

## Test plan

- [x] All 597 related tests pass (0 failures)
- [x] Full site build succeeds (1561 pages in 48s)
- [x] llms.txt output is ~12KB (well under 100K limit)
- [x] `.md` files generated alongside HTML pages
- [x] `<link rel="alternate" type="text/markdown">` present in HTML output
- [x] `<main>` appears earlier in rendered HTML (line 245 vs previously after search modal)
- [ ] Verify agent score improvement on buildwithfern.com after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)