### PR TITLE
feat: improve agent score — content negotiation, DOM reorder, md parity

### DIFF
--- a/bengal/postprocess/output_formats/md_generator.py
+++ b/bengal/postprocess/output_formats/md_generator.py
@@ -117,8 +117,10 @@ class PageMarkdownGenerator:
     def _page_to_markdown(self, page: PageLike) -> str:
         """Convert a page to its markdown output format.
 
-        Uses the page's raw markdown source content. Falls back to
-        plain_text if raw source is unavailable.
+        Uses the page's raw markdown source content when it provides good
+        coverage of the rendered HTML content. Falls back to plain_text
+        when raw content is incomplete (e.g., shortcodes or includes
+        expanded significant additional content during rendering).
 
         Args:
             page: Page to convert.
@@ -147,25 +149,53 @@ class PageMarkdownGenerator:
         lines.append("---")
         lines.append("")
 
-        # Raw markdown content (preferred) or plain text fallback
-        raw = getattr(page, "_raw_content", None) or ""
-        if raw:
-            content = raw.strip()
-            # Only strip leading H1 if it duplicates the title we already wrote
-            if content.startswith("# "):
-                first_line_end = content.find("\n")
-                h1_text = (
-                    content[2:first_line_end].strip()
-                    if first_line_end != -1
-                    else content[2:].strip()
-                )
-                if h1_text == page.title:
-                    content = content[first_line_end:].lstrip("\n") if first_line_end != -1 else ""
-        else:
-            # Fallback to plain text
-            content = getattr(page, "plain_text", "") or ""
-
+        content = self._get_best_content(page)
         lines.append(content)
         lines.append("")
 
         return "\n".join(lines)
+
+    def _get_best_content(self, page: PageLike) -> str:
+        """Select the best content source for markdown parity.
+
+        Prefers raw markdown (preserves formatting), but falls back to
+        plain_text when raw content is significantly shorter than the
+        rendered output — indicating shortcodes, includes, or directives
+        expanded substantial content during rendering.
+
+        Args:
+            page: Page to get content for.
+
+        Returns:
+            Best available content string.
+        """
+        raw = getattr(page, "_raw_content", None) or ""
+        plain = getattr(page, "plain_text", "") or ""
+
+        if not raw:
+            return plain
+
+        content = raw.strip()
+
+        # Strip leading H1 if it duplicates the title we already wrote
+        if content.startswith("# "):
+            first_line_end = content.find("\n")
+            h1_text = (
+                content[2:first_line_end].strip() if first_line_end != -1 else content[2:].strip()
+            )
+            if h1_text == page.title:
+                content = content[first_line_end:].lstrip("\n") if first_line_end != -1 else ""
+
+        # Check content parity: if plain_text is significantly longer
+        # than raw content, shortcodes/includes added substantial content.
+        # Use plain_text for better parity with the rendered HTML.
+        raw_len = len(content)
+        plain_len = len(plain)
+        if plain_len > 0 and raw_len > 0:
+            coverage = raw_len / plain_len
+            if coverage < 0.75:
+                # Raw markdown covers <75% of rendered content — fall back
+                # to plain text for better parity with HTML output
+                return plain
+
+        return content

--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -84,10 +84,10 @@ def create_bengal_dev_app(
         serving_dir = _resolve_dir()
 
         if method == "GET":
-            # Content negotiation: serve .md when Accept: text/markdown
+            # Content negotiation: serve .md when Accept prefers text/markdown
             headers = dict(scope.get("headers", []))
             accept = (headers.get(b"accept", b"")).decode("utf-8", errors="replace")
-            if "text/markdown" in accept:
+            if "text/markdown" in accept and _prefers_markdown(accept):
                 served = await _serve_markdown_negotiated(send, output_dir=serving_dir, path=path)
                 if served:
                     return
@@ -106,6 +106,47 @@ def create_bengal_dev_app(
     if request_callback is not None:
         return _request_logging_middleware(app, request_callback)
     return app
+
+
+def _prefers_markdown(accept: str) -> bool:
+    """Check if Accept header prefers text/markdown over text/html.
+
+    Parses q-values per RFC 9110. Returns True only when text/markdown
+    is explicitly listed with q > 0 and its quality is >= text/html's.
+    """
+    md_q = -1.0
+    html_q = -1.0
+
+    for part in accept.split(","):
+        part = part.strip()
+        if not part:
+            continue
+
+        # Split "type/subtype;q=0.8;other=x" into media type and params
+        segments = part.split(";")
+        media = segments[0].strip().lower()
+
+        # Extract q-value (default 1.0 per RFC 9110)
+        q = 1.0
+        for seg in segments[1:]:
+            seg = seg.strip()
+            if seg.startswith("q="):
+                try:
+                    q = float(seg[2:])
+                except ValueError:
+                    q = 0.0
+                break
+
+        if media == "text/markdown":
+            md_q = q
+        elif media == "text/html":
+            html_q = q
+
+    # Only negotiate if markdown was explicitly requested with q > 0
+    # and is preferred over (or equal to) HTML
+    if md_q <= 0:
+        return False
+    return not (html_q >= 0 and html_q > md_q)
 
 
 def _is_document_request(path: str) -> bool:

--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -84,6 +84,14 @@ def create_bengal_dev_app(
         serving_dir = _resolve_dir()
 
         if method == "GET":
+            # Content negotiation: serve .md when Accept: text/markdown
+            headers = dict(scope.get("headers", []))
+            accept = (headers.get(b"accept", b"")).decode("utf-8", errors="replace")
+            if "text/markdown" in accept:
+                served = await _serve_markdown_negotiated(send, output_dir=serving_dir, path=path)
+                if served:
+                    return
+
             await _serve_static(
                 send,
                 output_dir=serving_dir,
@@ -208,6 +216,54 @@ def _resolve_file_path(output_dir: Path, path: str) -> Path | None:
     except ValueError:
         return None
     return full
+
+
+async def _serve_markdown_negotiated(
+    send: Any,
+    *,
+    output_dir: Path,
+    path: str,
+) -> bool:
+    """Serve .md file when client sends Accept: text/markdown.
+
+    Resolves the corresponding .md file for HTML paths (e.g.,
+    /docs/getting-started/ → /docs/getting-started/index.md).
+
+    Returns True if a markdown file was served, False to fall through.
+    """
+    if not _is_html_path(path):
+        return False
+
+    resolved = _resolve_file_path(output_dir, path)
+    if resolved is None:
+        return False
+
+    # For directory paths, resolved points to index.html — find index.md
+    if resolved.is_dir():
+        md_path = resolved / "index.md"
+    elif resolved.suffix in (".html", ".htm"):
+        md_path = resolved.with_suffix(".md")
+    else:
+        md_path = resolved.parent / "index.md"
+
+    if not md_path.is_file():
+        return False
+
+    content = await asyncio.to_thread(md_path.read_bytes)
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [
+                [b"content-type", b"text/markdown; charset=utf-8"],
+                [b"content-length", str(len(content)).encode()],
+                [b"cache-control", b"no-store, no-cache, must-revalidate, max-age=0"],
+                [b"vary", b"Accept"],
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": content})
+    return True
 
 
 async def _serve_static(

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -92,6 +92,16 @@ HELPER: Render a menu item (desktop/mobile)
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
+    {# AI/Agent discovery — early in <head> for fast detection #}
+    {% if _per_page_md and page.href is defined and page.href is string %}
+    {% let _href_early = page.href %}
+    {% let _md_url_early = _href_early | replace('.html', '.md') if _href_early.endswith('.html') else (_href_early ~ 'index.md' if _href_early.endswith('/') else _href_early ~ '/index.md') %}
+    <link rel="alternate" type="text/markdown" href="{{ _md_url_early }}">
+    {% end %}
+    {% if 'llms_txt' in (config.output_formats.site_wide ?? []) %}
+    <link rel="help" type="text/markdown" href="{{ '/llms.txt' | absolute_url }}" title="LLM-friendly site overview">
+    {% end %}
+
     {# Document Application: View Transitions meta tag #}
     {% if _view_transitions %}
     <meta name="view-transition" content="same-origin">
@@ -191,13 +201,6 @@ HELPER: Render a menu item (desktop/mobile)
     <link rel="alternate" hreflang="{{ alt.hreflang }}" href="{{ alt.href }}">
     {% end %}
 
-    {# Markdown alternate for AI agent content negotiation #}
-    {% if _per_page_md and page.href is defined and page.href is string %}
-    {% let _href = page.href %}
-    {% let _md_url = _href | replace('.html', '.md') if _href.endswith('.html') else (_href ~ 'index.md' if _href.endswith('/') else _href ~ '/index.md') %}
-    <link rel="alternate" type="text/markdown" href="{{ _md_url }}">
-    {% end %}
-
     {# Favicon, preconnect, fonts, stylesheets — site-stable, same for every page in a build #}
     {% cache 'base-head-assets-' ~ (bengal.build.timestamp ?? '') %}
     {# Favicon - use let for safer nil handling #}
@@ -280,40 +283,6 @@ HELPER: Render a menu item (desktop/mobile)
     </script>
     {% end %}{# /cache base-theme-init #}
 
-    {# Speculation Rules — site-stable, same for every page in a build #}
-    {% cache 'base-speculation-' ~ (bengal.build.timestamp ?? '') %}
-    {% with _doc_app.speculation as speculation %}
-    {% if _doc_app.enabled and speculation.enabled and (_doc_app.features?.speculation_rules ?? true) %}
-    <script type="speculationrules">
-    {
-      "prerender": [
-        {
-          "where": {
-            "and": [
-              { "href_matches": "{{ speculation.prerender.patterns | join('", "') }}" },
-              { "not": { "selector_matches": "[data-external], [target=_blank], .external" } }
-            ]
-          },
-          "eagerness": "{{ speculation.prerender.eagerness }}"
-        }
-      ],
-      "prefetch": [
-        {
-          "where": {
-            "and": [
-              { "href_matches": "{{ speculation.prefetch.patterns | join('", "') }}" },
-              { "not": { "selector_matches": "[data-external], [target=_blank], .external" } }
-            ]
-          },
-          "eagerness": "{{ speculation.prefetch.eagerness }}"
-        }
-      ]
-    }
-    </script>
-    {% end %}
-    {% end %}
-    {% end %}{# /cache base-speculation #}
-
     {% block extra_head %}{% end %}
     {% cache 'base-meta-generator-' ~ (bengal.build.timestamp ?? '') %}
     {% include 'partials/meta-generator.html' %}
@@ -321,15 +290,6 @@ HELPER: Render a menu item (desktop/mobile)
     {% include 'partials/article-jsonld.html' %}
     {% include 'partials/product-jsonld.html' %}
 
-    {% if config.expose_metadata_json %}
-    <script id="bengal-bootstrap" type="application/json">{{ bengal | tojson }}</script>
-    <script>
-        (function () {
-            var el = document.getElementById('bengal-bootstrap');
-            if (el) { window.__BENGAL__ = JSON.parse(el.textContent || '{}'); }
-        })();
-    </script>
-    {% end %}
 </head>
 
 <body data-type="{{ page.type }}" data-variant="{{ page.variant or '' }}"
@@ -593,6 +553,51 @@ HELPER: Render a menu item (desktop/mobile)
     {% end %}
 
     {% block extra_js %}{% end %}
+
+    {# Speculation Rules — moved after content for faster content-start position #}
+    {% cache 'base-speculation-' ~ (bengal.build.timestamp ?? '') %}
+    {% with _doc_app.speculation as speculation %}
+    {% if _doc_app.enabled and speculation.enabled and (_doc_app.features?.speculation_rules ?? true) %}
+    <script type="speculationrules">
+    {
+      "prerender": [
+        {
+          "where": {
+            "and": [
+              { "href_matches": "{{ speculation.prerender.patterns | join('", "') }}" },
+              { "not": { "selector_matches": "[data-external], [target=_blank], .external" } }
+            ]
+          },
+          "eagerness": "{{ speculation.prerender.eagerness }}"
+        }
+      ],
+      "prefetch": [
+        {
+          "where": {
+            "and": [
+              { "href_matches": "{{ speculation.prefetch.patterns | join('", "') }}" },
+              { "not": { "selector_matches": "[data-external], [target=_blank], .external" } }
+            ]
+          },
+          "eagerness": "{{ speculation.prefetch.eagerness }}"
+        }
+      ]
+    }
+    </script>
+    {% end %}
+    {% end %}
+    {% end %}{# /cache base-speculation #}
+
+    {# Bootstrap metadata — moved after content for faster content-start position #}
+    {% if config.expose_metadata_json %}
+    <script id="bengal-bootstrap" type="application/json">{{ bengal | tojson }}</script>
+    <script>
+        (function () {
+            var el = document.getElementById('bengal-bootstrap');
+            if (el) { window.__BENGAL__ = JSON.parse(el.textContent || '{}'); }
+        })();
+    </script>
+    {% end %}
 
     {% block site_dialogs %}
     {% if 'navigation.back_to_top' in theme.features %}<button class="back-to-top" aria-label="Scroll to top">{{

--- a/site/config/_default/features.yaml
+++ b/site/config/_default/features.yaml
@@ -10,6 +10,7 @@ features:
   search: true     # Generate search index (index.json)
   json: true       # Generate per-page JSON files (page.json)
   llm_txt: true    # Generate LLM-friendly text files (index.txt, llm-full.txt)
+  markdown: true   # Generate per-page .md files for agent markdown URL support
 
 # Social Cards Configuration
 # ==========================

--- a/tests/unit/postprocess/test_md_generator.py
+++ b/tests/unit/postprocess/test_md_generator.py
@@ -193,6 +193,73 @@ class TestPlainTextFallback:
         assert "Fallback plain text." in result
 
 
+class TestContentParityThreshold:
+    """Test _get_best_content falls back to plain_text when raw is incomplete."""
+
+    def test_uses_raw_when_coverage_high(self):
+        """Raw content covering >=75% of plain_text is preserved."""
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        raw = "## Setup\n\nInstall with pip.\n\n## Usage\n\nRun the command."
+        # plain_text is similar length — raw has good coverage
+        plain = "Setup\nInstall with pip.\nUsage\nRun the command."
+        page = _make_page(title="Guide", raw_content=raw, plain_text=plain)
+
+        result = gen._page_to_markdown(page)
+
+        # Should use raw (has markdown formatting)
+        assert "## Setup" in result
+        assert "## Usage" in result
+
+    def test_falls_back_to_plain_when_coverage_low(self):
+        """Raw content covering <75% of plain_text triggers fallback."""
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        # Raw has shortcode syntax, not real content
+        raw = "## Intro\n\nShort intro.\n\n{{< tabs >}}\n{{< /tabs >}}"
+        # plain_text has the full expanded content from shortcodes
+        plain = (
+            "Intro\nShort intro.\n\n"
+            "Python\nInstall with pip install bengal.\n"
+            "Run bengal serve to start.\n\n"
+            "JavaScript\nInstall with npm install bengal.\n"
+            "Run npx bengal serve to start.\n\n"
+            "Go\nInstall with go install bengal.\n"
+            "Run bengal serve to start."
+        )
+        page = _make_page(title="Guide", raw_content=raw, plain_text=plain)
+
+        result = gen._page_to_markdown(page)
+
+        # Should fall back to plain_text (has full content)
+        assert "Python" in result
+        assert "JavaScript" in result
+        assert "{{< tabs >}}" not in result
+
+    def test_uses_plain_text_when_no_raw(self):
+        """Empty raw content always falls back to plain_text."""
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        page = _make_page(raw_content="", plain_text="Full plain text content.")
+
+        result = gen._get_best_content(page)
+
+        assert result == "Full plain text content."
+
+    def test_threshold_boundary_at_75_percent(self):
+        """Coverage exactly at 75% should use raw content."""
+        site = _make_site()
+        gen = PageMarkdownGenerator(site)
+        # Create content where raw is exactly 75% of plain length
+        plain = "a" * 100
+        raw = "b" * 75  # 75/100 = 0.75, not < 0.75
+        page = _make_page(title="Test", raw_content=raw, plain_text=plain)
+
+        result = gen._get_best_content(page)
+
+        assert result == raw
+
+
 class TestGenerate:
     """Test the generate() method writes files."""
 

--- a/tests/unit/server/test_asgi_app.py
+++ b/tests/unit/server/test_asgi_app.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from bengal.server.asgi_app import create_bengal_dev_app
+from bengal.server.asgi_app import _prefers_markdown, create_bengal_dev_app
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -352,3 +352,126 @@ async def test_callable_output_dir_resolves_per_request(tmp_path: Path) -> None:
     await app(scope=scope, receive=_noop_receive, send=send2)
     body_b = sent2[1]["body"]
     assert b"buffer-b" in body_b
+
+
+# ---------------------------------------------------------------------------
+# Accept header parsing (_prefers_markdown)
+# ---------------------------------------------------------------------------
+
+
+class TestPrefersMarkdown:
+    """Test Accept header q-value parsing for content negotiation."""
+
+    def test_explicit_markdown_only(self):
+        assert _prefers_markdown("text/markdown") is True
+
+    def test_markdown_with_html_lower_q(self):
+        assert _prefers_markdown("text/markdown, text/html;q=0.5") is True
+
+    def test_html_preferred_over_markdown(self):
+        assert _prefers_markdown("text/html, text/markdown;q=0.5") is False
+
+    def test_markdown_with_q_zero(self):
+        assert _prefers_markdown("text/markdown;q=0") is False
+
+    def test_equal_q_values(self):
+        assert _prefers_markdown("text/html;q=0.9, text/markdown;q=0.9") is True
+
+    def test_no_markdown_in_accept(self):
+        assert _prefers_markdown("text/html, application/json") is False
+
+    def test_wildcard_does_not_trigger(self):
+        assert _prefers_markdown("*/*") is False
+
+    def test_empty_accept(self):
+        assert _prefers_markdown("") is False
+
+
+# ---------------------------------------------------------------------------
+# Content negotiation integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_content_negotiation_serves_markdown(tmp_path: Path) -> None:
+    """Accept: text/markdown serves the .md file when available."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "index.html").write_text("<html><body>HTML</body></html>")
+    (docs / "index.md").write_text("# Docs\n\nMarkdown content.")
+
+    app = create_bengal_dev_app(
+        output_dir=tmp_path,
+        build_in_progress=lambda: False,
+    )
+    sent, send = _make_send_capture()
+
+    await app(
+        scope={
+            "type": "http",
+            "method": "GET",
+            "path": "/docs/",
+            "headers": [(b"accept", b"text/markdown")],
+        },
+        receive=_noop_receive,
+        send=send,
+    )
+
+    assert sent[0]["status"] == 200
+    assert any(h[0] == b"content-type" and b"text/markdown" in h[1] for h in sent[0]["headers"])
+    assert b"Markdown content." in sent[1]["body"]
+
+
+@pytest.mark.asyncio
+async def test_content_negotiation_falls_through_when_no_md(tmp_path: Path) -> None:
+    """Accept: text/markdown falls through to HTML when no .md file exists."""
+    (tmp_path / "index.html").write_text("<html><body>HTML only</body></html>")
+
+    app = create_bengal_dev_app(
+        output_dir=tmp_path,
+        build_in_progress=lambda: False,
+    )
+    sent, send = _make_send_capture()
+
+    await app(
+        scope={
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [(b"accept", b"text/markdown")],
+        },
+        receive=_noop_receive,
+        send=send,
+    )
+
+    assert sent[0]["status"] == 200
+    assert b"HTML only" in sent[1]["body"]
+
+
+@pytest.mark.asyncio
+async def test_content_negotiation_respects_q_values(tmp_path: Path) -> None:
+    """HTML preferred (higher q) — should serve HTML, not markdown."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "index.html").write_text("<html><body>HTML</body></html>")
+    (docs / "index.md").write_text("# Docs\n\nMarkdown.")
+
+    app = create_bengal_dev_app(
+        output_dir=tmp_path,
+        build_in_progress=lambda: False,
+    )
+    sent, send = _make_send_capture()
+
+    await app(
+        scope={
+            "type": "http",
+            "method": "GET",
+            "path": "/docs/",
+            "headers": [(b"accept", b"text/html, text/markdown;q=0.5")],
+        },
+        receive=_noop_receive,
+        send=send,
+    )
+
+    assert sent[0]["status"] == 200
+    assert b"HTML" in sent[1]["body"]


### PR DESCRIPTION
## Summary

- Move AI discovery links (`<link rel="alternate" type="text/markdown">` and `<link rel="help" href="/llms.txt">`) to the top of `<head>` for fast agent detection
- Relocate speculation rules and metadata bootstrap JSON from `<head>` to end of `<body>`, reducing bytes before `<main>` to improve content-start position
- Add `Accept: text/markdown` content negotiation to the dev server ASGI app, serving `.md` files when agents request markdown
- Improve markdown output parity: fall back to `plain_text` when raw markdown covers <75% of rendered content (shortcodes/includes)
- Add missing `markdown: true` to `features.yaml` for consistency with `outputs.yaml`

## Test plan

- [x] All 89 markdown/ASGI tests pass
- [x] All 353 server tests pass
- [x] All 401 postprocess tests pass
- [x] Pre-commit hooks pass (ruff, ty, cycle check)
- [ ] Re-run `npx afdocs https://lbliii.github.io/bengal/ --fixes --verbose` after deploy to verify score improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)