### PR TITLE
fix: recompute stale asset_integrity + harden integrity tests

### DIFF
--- a/bengal/orchestration/build/provenance_filter.py
+++ b/bengal/orchestration/build/provenance_filter.py
@@ -760,6 +760,7 @@ def phase_incremental_filter_provenance(
         # Check if output directory is missing
         output_dir = site.output_dir
         output_html_missing = not output_dir.exists() or len(list(output_dir.iterdir())) == 0
+        asset_integrity = inspect_asset_outputs(output_dir)
         output_assets_missing = not asset_integrity.is_complete
 
         if (output_html_missing or output_assets_missing) and site.pages:

--- a/tests/unit/assets/test_manifest.py
+++ b/tests/unit/assets/test_manifest.py
@@ -82,3 +82,35 @@ def test_inspect_asset_outputs_accepts_complete_manifest_outputs(tmp_path: Path)
     integrity = inspect_asset_outputs(tmp_path)
     assert integrity.is_complete is True
     assert integrity.missing_count == 0
+
+
+def test_inspect_asset_outputs_nonexistent_dir(tmp_path: Path) -> None:
+    """Non-existent output directory is reported as incomplete."""
+    integrity = inspect_asset_outputs(tmp_path / "does_not_exist")
+    assert integrity.output_dir_exists is False
+    assert integrity.manifest_present is False
+    assert integrity.total_entries == 0
+    assert integrity.missing_count == 0
+    assert integrity.is_complete is False
+
+
+def test_inspect_asset_outputs_corrupted_manifest_treated_as_absent(tmp_path: Path) -> None:
+    """Corrupted manifest JSON is treated as absent."""
+    (tmp_path / "asset-manifest.json").write_text("{not json", encoding="utf-8")
+    integrity = inspect_asset_outputs(tmp_path)
+    assert integrity.output_dir_exists is True
+    assert integrity.manifest_present is False
+    assert integrity.total_entries == 0
+    assert integrity.is_complete is False
+
+
+def test_inspect_asset_outputs_empty_manifest_is_complete(tmp_path: Path) -> None:
+    """Valid manifest with zero entries is treated as complete."""
+    manifest = AssetManifest()
+    manifest.write(tmp_path / "asset-manifest.json")
+    integrity = inspect_asset_outputs(tmp_path)
+    assert integrity.output_dir_exists is True
+    assert integrity.manifest_present is True
+    assert integrity.total_entries == 0
+    assert integrity.missing_count == 0
+    assert integrity.is_complete is True


### PR DESCRIPTION
## Summary

- Recomputes `asset_integrity` before the warm-cache-cold-output check in `provenance_filter.py`, fixing a stale-data bug where the variable was computed ~300 lines earlier and reused without refresh (while `output_html_missing` on the adjacent line was already recomputed)
- Adds three edge-case tests for `inspect_asset_outputs`: non-existent directory, corrupted JSON manifest, and valid empty manifest

## Test plan

- [x] All 81 PR-related unit tests pass (78 existing + 3 new)
- [x] Pre-commit hooks pass (ruff, ty, cycle checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)