### PR TITLE
fix: update stale `bengal site` CLI references to flattened commands

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build site
         working-directory: site
-        run: uv run bengal site build --environment production --clean-output
+        run: uv run bengal build --environment production --clean-output
         env:
           PYTHON_GIL: "0"
 

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,11 @@ install:
 
 build:
 	@echo "Building site..."
-	uv run bengal site build site
+	uv run bengal build site
 
 serve:
 	@echo "Starting development server..."
-	uv run bengal site serve site
+	uv run bengal serve site
 
 deploy-test:
 	@echo "Building with production config (simulates GitHub Pages)..."

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -51,10 +51,10 @@ After your first build, Bengal creates a `.bengal/` directory for caches and sta
 
 ```bash
 # Build the site
-bengal site build
+bengal build
 
 # Start development server with hot reload
-bengal site serve
+bengal serve
 
 # Visit http://localhost:5173 (or the URL printed in the console)
 ```
@@ -188,7 +188,7 @@ After building, deploy the `public/` directory to your hosting provider:
 
 ```bash
 # Build for production
-bengal site build
+bengal build
 
 # The public/ directory contains your complete site
 # Upload it to:
@@ -202,7 +202,7 @@ bengal site build
 
 ```bash
 # Build site
-bengal site build
+bengal build
 
 # Deploy to gh-pages branch
 git subtree push --prefix public origin gh-pages
@@ -226,9 +226,9 @@ template: custom.html         # Custom template
 ### Available CLI Commands
 
 ```bash
-bengal site build              # Build the site
-bengal site serve              # Start dev server
-bengal site clean              # Clean output directory
+bengal build              # Build the site
+bengal serve              # Start dev server
+bengal clean              # Clean output directory
 bengal new site <name>    # Create new site
 bengal new page <name>    # Create new page
 bengal --version          # Show version
@@ -239,19 +239,19 @@ bengal --help             # Show help
 
 ```bash
 # Custom host and port
-bengal site serve --host 0.0.0.0 --port 3000
+bengal serve --host 0.0.0.0 --port 3000
 
 # Disable file watching
-bengal site serve --no-watch
+bengal serve --no-watch
 
 # Show detailed server activity
-bengal site serve --verbose
+bengal serve --verbose
 
 # Show debug output (port checks, file changes, etc.)
-bengal site serve --debug
+bengal serve --debug
 
 # Use custom config file
-bengal site serve --config custom-config.toml
+bengal serve --config custom-config.toml
 ```
 
 ## Example Sites
@@ -260,7 +260,7 @@ Check out example sites in the `examples/` directory:
 
 ```bash
 cd examples/quickstart
-bengal site serve
+bengal serve
 ```
 
 ## Next Steps
@@ -277,8 +277,8 @@ bengal site serve
 
 ```bash
 # Clean and rebuild
-bengal site clean
-bengal site build
+bengal clean
+bengal build
 ```
 
 ### Template Not Found

--- a/UV_QUICK_REFERENCE.md
+++ b/UV_QUICK_REFERENCE.md
@@ -82,11 +82,11 @@ make build                         # Build the documentation site
 make serve                         # Start dev server
 
 # Or directly:
-uv run bengal site build site
-uv run bengal site serve site
+uv run bengal build site
+uv run bengal serve site
 
 # Run any bengal command:
-make run ARGS="site build site"
+make run ARGS="build site"
 ```
 
 ## Clean Start

--- a/bengal/debug/explainer.py
+++ b/bengal/debug/explainer.py
@@ -144,8 +144,8 @@ class PageExplainer:
             raise BengalContentError(
                 f"Page not found: {page_path}\n"
                 f"Searched in {len(self.site.pages)} pages\n"
-                f"Tip: Run 'bengal site build' first to discover content",
-                suggestion="Run 'bengal site build' first to discover content, or check the page path",
+                f"Tip: Run 'bengal build' first to discover content",
+                suggestion="Run 'bengal build' first to discover content, or check the page path",
                 code=ErrorCode.N004,
             )
 

--- a/bengal/health/validators/assets.py
+++ b/bengal/health/validators/assets.py
@@ -114,7 +114,7 @@ class AssetValidator(BaseValidator):
                         "Theme CSS was not copied to output. Possible causes:\n"
                         "  1. Theme assets not discovered (check theme config)\n"
                         "  2. AssetDiscovery skipping files incorrectly\n"
-                        "  3. Build cache/output mismatch (try: bengal site clean --cache)"
+                        "  3. Build cache/output mismatch (try: bengal clean --cache)"
                     ),
                 )
             )
@@ -139,7 +139,7 @@ class AssetValidator(BaseValidator):
                         "Theme JavaScript was not copied to output. Possible causes:\n"
                         "  1. Theme assets not discovered (check theme config)\n"
                         "  2. AssetDiscovery skipping files incorrectly\n"
-                        "  3. Build cache/output mismatch (try: bengal site clean --cache)"
+                        "  3. Build cache/output mismatch (try: bengal clean --cache)"
                     ),
                 )
             )
@@ -193,7 +193,7 @@ class AssetValidator(BaseValidator):
                     recommendation=(
                         "Empty CSS files are included in HTML but provide no styles. "
                         "This usually means asset copying or bundling failed.\n"
-                        "  Try: bengal site clean --cache"
+                        "  Try: bengal clean --cache"
                     ),
                     details=empty_css[:5],
                 )
@@ -208,7 +208,7 @@ class AssetValidator(BaseValidator):
                     recommendation=(
                         "Empty JS files are included in HTML but do nothing. "
                         "This usually means asset copying or bundling failed.\n"
-                        "  Try: bengal site clean --cache"
+                        "  Try: bengal clean --cache"
                     ),
                     details=empty_js[:5],
                 )

--- a/bengal/themes/default/templates/SAFE_PATTERNS.md
+++ b/bengal/themes/default/templates/SAFE_PATTERNS.md
@@ -420,7 +420,7 @@ Use this checklist when creating new templates:
 
 3. **Test in serve mode:**
    ```bash
-   bengal site serve  # Catches template errors in dev
+   bengal serve  # Catches template errors in dev
    ```
 
 ### Common Test Cases

--- a/changelog.d/fix-stale-cli-refs.fixed.md
+++ b/changelog.d/fix-stale-cli-refs.fixed.md
@@ -1,0 +1,1 @@
+Update stale `bengal site {build,serve,clean}` references to flattened top-level commands across CI, tooling, source code, and documentation.

--- a/plan/rfc-ci-cache-inputs.md
+++ b/plan/rfc-ci-cache-inputs.md
@@ -565,7 +565,7 @@ jobs:
 
       - name: Build site
         working-directory: site
-        run: uv run bengal site build --environment production
+        run: uv run bengal build --environment production
 
       # ... deploy steps
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -384,11 +384,11 @@ showcontent = true
 
 [tool.poe.tasks]
 # Development Server
-serve = { cmd = "bengal site serve site", help = "Start development server for site/" }
+serve = { cmd = "bengal serve site", help = "Start development server for site/" }
 dev = { cmd = "bengal serve", help = "Start dev server (auto-detects site)" }
 
 # Building
-build = { cmd = "bengal site build site", help = "Build the documentation site" }
+build = { cmd = "bengal build site", help = "Build the documentation site" }
 build-prod = { cmd = "bengal build -e production", help = "Build with production config", cwd = "site" }
 
 # Testing

--- a/tests/manual/test_dev_server_incremental.md
+++ b/tests/manual/test_dev_server_incremental.md
@@ -8,7 +8,7 @@
 ### ✅ Test 1: Single File Change
 ```bash
 cd examples/showcase
-bengal site serve
+bengal serve
 
 # In another terminal:
 echo "# Test change $(date +%s)" >> content/index.md

--- a/tests/performance/PROFILING_GUIDE.md
+++ b/tests/performance/PROFILING_GUIDE.md
@@ -195,7 +195,7 @@ python tests/performance/flamegraph.py $PROFILE --tool gprof2dot --output graph.
 
 ```bash
 # Profile with python -X importtime
-python -X importtime -m bengal site build 2> imports.log
+python -X importtime -m bengal build 2> imports.log
 
 # Analyze
 cat imports.log | grep "cumulative"


### PR DESCRIPTION
## Summary

The CLI was restructured from `bengal site {build,serve,clean}` to top-level `bengal {build,serve,clean}`, but references across the codebase were not updated. This fixes the broken GitHub Pages CI workflow and updates all stale references in tooling (Makefile, pyproject.toml poe tasks), source code (error messages/hints in `explainer.py` and `assets.py`), and documentation (QUICKSTART.md, UV_QUICK_REFERENCE.md, profiling/testing guides).

- **CI fix**: `.github/workflows/pages.yml` now runs `bengal build` instead of `bengal site build`
- **11 files updated**, release notes left unchanged since they document historical behavior

## Test plan
- [ ] Verify `uv run bengal build --environment production --clean-output` works in `site/`
- [ ] Verify GitHub Pages workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)