### PR TITLE
fix: harden CLI user-facing edges across error handling, flags, and validation

### DIFF
--- a/bengal/cli/milo_commands/build.py
+++ b/bengal/cli/milo_commands/build.py
@@ -92,8 +92,9 @@ def build(
     if fast:
         quiet = True
 
+    cli = get_cli_output(quiet=quiet, verbose=verbose)
+
     if memory_optimized and perf_profile_path:
-        cli = get_cli_output()
         cli.error("--memory-optimized and --perf-profile cannot be used together")
         raise SystemExit(2)
 
@@ -114,8 +115,6 @@ def build(
         track_memory=profile_config.get("track_memory", False),
     )
     configure_traceback(debug=debug, traceback=traceback_val)
-
-    cli = get_cli_output(quiet=quiet, verbose=verbose)
 
     if memory_optimized and incremental_val is True:
         cli.warning("--memory-optimized with --incremental may not fully utilize cache")

--- a/bengal/cli/milo_commands/build.py
+++ b/bengal/cli/milo_commands/build.py
@@ -93,7 +93,9 @@ def build(
         quiet = True
 
     if memory_optimized and perf_profile_path:
-        raise SystemExit("Error: --memory-optimized and --perf-profile cannot be used together")
+        cli = get_cli_output()
+        cli.error("--memory-optimized and --perf-profile cannot be used together")
+        raise SystemExit(2)
 
     # Determine build profile
     build_profile = BuildProfile.from_cli_args(

--- a/bengal/cli/milo_commands/codemod.py
+++ b/bengal/cli/milo_commands/codemod.py
@@ -9,7 +9,7 @@ from milo import Description
 
 
 def codemod(
-    path: Annotated[str, Description("Directory path to process recursively")] = "",
+    path: Annotated[str, Description("Directory path to process recursively")],
     dry_run: Annotated[bool, Description("Preview changes without modifying files")] = False,
     diff: Annotated[bool, Description("Show unified diff of changes")] = False,
 ) -> dict:
@@ -22,9 +22,6 @@ def codemod(
 
     from bengal.cli.utils import get_cli_output
     from bengal.utils.io.atomic_write import atomic_write_text
-
-    if not path:
-        raise SystemExit("Error: --path is required")
 
     cli = get_cli_output()
     target = Path(path).resolve()

--- a/bengal/cli/milo_commands/config.py
+++ b/bengal/cli/milo_commands/config.py
@@ -160,8 +160,8 @@ def config_doctor(
 
 
 def config_diff(
+    against: Annotated[str, Description("Environment to compare against (e.g. production)")],
     source: Annotated[str, Description("Source directory path")] = "",
-    against: Annotated[str, Description("Environment to compare against (required)")] = "",
     environment: Annotated[str, Description("Environment to compare (default: local)")] = "",
 ) -> dict:
     """Compare configurations between environments."""
@@ -172,10 +172,6 @@ def config_diff(
     from bengal.config.unified_loader import UnifiedConfigLoader
 
     source = source or "."
-
-    if not against:
-        raise SystemExit("Error: --against is required (e.g. --against production)")
-
     cli = get_cli_output()
     root_path = Path(source).resolve()
     config_dir = root_path / "config"

--- a/bengal/cli/milo_commands/i18n.py
+++ b/bengal/cli/milo_commands/i18n.py
@@ -228,7 +228,7 @@ def i18n_status(
 
 
 def i18n_init(
-    locale_codes: Annotated[str, Description("Locale codes, comma-separated (e.g. es,fr,de)")] = "",
+    locale_codes: Annotated[str, Description("Locale codes, comma-separated (e.g. es,fr,de)")],
     source: Annotated[str, Description("Source directory path")] = "",
     domain: Annotated[str, Description("Gettext domain")] = "messages",
 ) -> dict:
@@ -238,10 +238,6 @@ def i18n_init(
     from bengal.cli.utils import get_cli_output
 
     source = source or "."
-
-    if not locale_codes:
-        raise SystemExit("Error: locale_codes is required (e.g. --locale-codes es,fr,de)")
-
     codes = [c.strip() for c in locale_codes.split(",") if c.strip()]
 
     cli = get_cli_output()

--- a/bengal/cli/milo_commands/inspect.py
+++ b/bengal/cli/milo_commands/inspect.py
@@ -10,7 +10,7 @@ from milo import Description
 def inspect_page(
     page_path: Annotated[
         str, Description("Page path (relative to content dir, full, or partial match)")
-    ] = "",
+    ],
     source: Annotated[str, Description("Source directory path")] = "",
     verbose: Annotated[
         bool, Description("Show additional details (timing, template variables)")
@@ -28,9 +28,6 @@ def inspect_page(
     from bengal.utils.observability.profile import BuildProfile
 
     source = source or "."
-    if not page_path:
-        raise SystemExit("Error: page_path is required")
-
     cli = get_cli_output()
     cli.header("Page Explanation")
     cli.info("Loading site...")

--- a/bengal/cli/milo_commands/serve.py
+++ b/bengal/cli/milo_commands/serve.py
@@ -12,17 +12,14 @@ def serve(
     host: Annotated[str, Description("Server host address")] = "localhost",
     port: Annotated[int, Description("Server port number")] = 5173,
     watch: Annotated[bool, Description("Watch for file changes and rebuild")] = True,
-    no_watch: Annotated[bool, Description("Disable file watching")] = False,
     auto_port: Annotated[
         bool, Description("Find available port if specified port is taken")
     ] = True,
-    no_auto_port: Annotated[bool, Description("Don't auto-find available port")] = False,
     open_browser: Annotated[bool, Description("Open browser after server starts")] = True,
-    no_open: Annotated[bool, Description("Don't open browser")] = False,
     environment: Annotated[str, Description("Environment: local, preview, production")] = "",
     profile: Annotated[str, Description("Config profile: writer, theme-dev, dev")] = "",
     version_scope: Annotated[str, Description("Focus on single version (e.g., v2, latest)")] = "",
-    all_versions: Annotated[bool, Description("Build all versions (default behavior)")] = False,
+    all_versions: Annotated[bool, Description("Build all versions (git versioning mode)")] = False,
     dashboard: Annotated[bool, Description("Launch interactive Textual dashboard")] = False,
     verbose: Annotated[bool, Description("Show detailed server activity")] = False,
     debug: Annotated[bool, Description("Show debug output and full tracebacks")] = False,
@@ -36,23 +33,27 @@ def serve(
     Watches for changes in content, assets, and templates,
     automatically rebuilding the site when files are modified.
     """
-    from bengal.cli.utils import configure_cli_logging, configure_traceback, load_site_from_cli
+    from bengal.cli.utils import (
+        configure_cli_logging,
+        configure_traceback,
+        get_cli_output,
+        load_site_from_cli,
+    )
 
     source = source or "."
     config_path = config or None
     traceback_val = traceback or None
     version_scope_val = version_scope or None
 
-    # Resolve tri-state flags
-    watch_enabled = not no_watch and watch
-    auto_port_enabled = not no_auto_port and auto_port
-    open_browser_enabled = not no_open and open_browser
+    cli = get_cli_output()
 
     if verbose and debug:
-        raise SystemExit("Error: --verbose and --debug cannot be used together")
+        cli.error("--verbose and --debug cannot be used together")
+        raise SystemExit(2)
 
     if version_scope_val and all_versions:
-        raise SystemExit("Error: --version-scope and --all-versions cannot be used together")
+        cli.error("--version-scope and --all-versions cannot be used together")
+        raise SystemExit(2)
 
     configure_cli_logging(
         source=source,
@@ -87,17 +88,17 @@ def serve(
             site=site,
             host=host,
             port=port,
-            watch=watch_enabled,
-            open_browser=open_browser_enabled,
+            watch=watch,
+            open_browser=open_browser,
         )
         return None
 
     site.serve(
         host=host,
         port=port,
-        watch=watch_enabled,
-        auto_port=auto_port_enabled,
-        open_browser=open_browser_enabled,
+        watch=watch,
+        auto_port=auto_port,
+        open_browser=open_browser,
         version_scope=version_scope_val,
     )
 

--- a/bengal/cli/milo_commands/theme.py
+++ b/bengal/cli/milo_commands/theme.py
@@ -32,7 +32,7 @@ def theme_list(
 
 
 def theme_info(
-    slug: Annotated[str, Description("Theme identifier")] = "",
+    slug: Annotated[str, Description("Theme identifier")],
     source: Annotated[str, Description("Source directory path")] = "",
 ) -> dict:
     """Show theme details."""
@@ -40,9 +40,6 @@ def theme_info(
     from bengal.themes import get_theme_package
 
     source = source or "."
-    if not slug:
-        raise SystemExit("Error: slug is required")
-
     cli = get_cli_output()
     site = load_site_from_cli(source=source, config=None, environment=None, profile=None, cli=cli)
     theme = get_theme_package(slug, site)
@@ -81,7 +78,7 @@ def theme_discover(
 
 
 def theme_swizzle(
-    template_path: Annotated[str, Description("Template path (e.g. layouts/article.html)")] = "",
+    template_path: Annotated[str, Description("Template path (e.g. layouts/article.html)")],
     source: Annotated[str, Description("Source directory path")] = "",
 ) -> dict:
     """Copy a theme template to project for customization."""
@@ -89,9 +86,6 @@ def theme_swizzle(
     from bengal.themes.swizzle import SwizzleManager
 
     source = source or "."
-    if not template_path:
-        raise SystemExit("Error: template_path is required")
-
     cli = get_cli_output()
     site = load_site_from_cli(source=source, config=None, environment=None, profile=None, cli=cli)
     manager = SwizzleManager(site)
@@ -102,7 +96,7 @@ def theme_swizzle(
 
 
 def theme_install(
-    name: Annotated[str, Description("Package name or slug")] = "",
+    name: Annotated[str, Description("Package name or slug")],
     force: Annotated[bool, Description("Install even if name is non-canonical")] = False,
 ) -> dict:
     """Install a theme from PyPI."""
@@ -110,9 +104,6 @@ def theme_install(
     import subprocess
 
     from bengal.cli.utils import get_cli_output
-
-    if not name:
-        raise SystemExit("Error: name is required")
 
     cli = get_cli_output()
     SAFE_PACKAGE_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -133,15 +124,12 @@ def theme_install(
 
 
 def theme_validate(
-    theme_path: Annotated[str, Description("Path to theme directory")] = "",
+    theme_path: Annotated[str, Description("Path to theme directory")],
 ) -> dict:
     """Validate theme directory structure."""
     from pathlib import Path
 
     from bengal.cli.utils import get_cli_output
-
-    if not theme_path:
-        raise SystemExit("Error: theme_path is required")
 
     cli = get_cli_output()
     path = Path(theme_path).resolve()
@@ -185,7 +173,7 @@ def theme_validate(
 
 
 def theme_new(
-    slug: Annotated[str, Description("Theme identifier")] = "",
+    slug: Annotated[str, Description("Theme identifier")],
     mode: Annotated[str, Description("Scaffold mode: site or package")] = "site",
     output: Annotated[str, Description("Output directory")] = ".",
     extends: Annotated[str, Description("Parent theme to extend")] = "default",
@@ -196,9 +184,6 @@ def theme_new(
     from pathlib import Path
 
     from bengal.cli.utils import get_cli_output
-
-    if not slug:
-        raise SystemExit("Error: slug is required")
 
     cli = get_cli_output()
     slug = re.sub(r"[^a-z0-9_-]", "-", slug.lower().strip())

--- a/bengal/cli/milo_commands/version.py
+++ b/bengal/cli/milo_commands/version.py
@@ -70,7 +70,7 @@ def version_list(
 
 
 def version_info(
-    version_id: Annotated[str, Description("Version ID or alias (e.g. v2, latest)")] = "",
+    version_id: Annotated[str, Description("Version ID or alias (e.g. v2, latest)")],
     source: Annotated[str, Description("Source directory path")] = "",
 ) -> dict:
     """Show details about a specific version."""
@@ -79,10 +79,6 @@ def version_info(
     from bengal.cli.utils import get_cli_output
 
     source = source or "."
-
-    if not version_id:
-        raise SystemExit("Error: version_id is required")
-
     cli = get_cli_output()
     root_path = Path(source).resolve()
     version_config = _load_version_config(root_path)
@@ -131,7 +127,7 @@ def version_info(
 
 
 def version_create(
-    version_id: Annotated[str, Description("New version identifier")] = "",
+    version_id: Annotated[str, Description("New version identifier")],
     source: Annotated[str, Description("Source directory path")] = "",
     label: Annotated[str, Description("Human-readable label (default: version ID)")] = "",
     from_path: Annotated[str, Description("Source directory to snapshot (default: docs)")] = "docs",
@@ -145,10 +141,6 @@ def version_create(
     from bengal.cli.utils import get_cli_output
 
     source = source or "."
-
-    if not version_id:
-        raise SystemExit("Error: version_id is required")
-
     label_val = label or None
     to_path_val = to_path or None
 
@@ -231,8 +223,8 @@ def version_create(
 
 
 def version_diff(
-    old_version: Annotated[str, Description("Old version ID or git ref")] = "",
-    new_version: Annotated[str, Description("New version ID or git ref")] = "",
+    old_version: Annotated[str, Description("Old version ID or git ref")],
+    new_version: Annotated[str, Description("New version ID or git ref")],
     source: Annotated[str, Description("Source directory path")] = "",
     git: Annotated[bool, Description("Compare git refs instead of folder versions")] = False,
     output: Annotated[str, Description("Output format: summary, markdown, json")] = "summary",
@@ -243,10 +235,6 @@ def version_diff(
     from bengal.cli.utils import get_cli_output
 
     source = source or "."
-
-    if not old_version or not new_version:
-        raise SystemExit("Error: both old_version and new_version are required")
-
     cli = get_cli_output()
     root_path = Path(source).resolve()
 

--- a/bengal/cli/utils/errors.py
+++ b/bengal/cli/utils/errors.py
@@ -13,7 +13,6 @@ Functions:
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -71,10 +70,14 @@ def display_traceback(exception: BaseException, show_traceback: bool | None) -> 
     if not should_show_traceback(show_traceback, is_bengal):
         return
 
-    with contextlib.suppress(Exception):
+    try:
         from bengal.errors.traceback import TracebackConfig
 
         TracebackConfig.from_environment().get_renderer().display_exception(exception)
+    except Exception:
+        import traceback as tb
+
+        tb.print_exception(exception)
 
 
 def handle_exception(

--- a/bengal/cli/utils/site.py
+++ b/bengal/cli/utils/site.py
@@ -294,9 +294,14 @@ def load_site_from_cli(
         cli.error(f"Config file does not exist: {config_path}")
         sys.exit(1)
 
-    from bengal.cli.helpers.error_handling import cli_error_context
+    from bengal.cli.utils.errors import handle_exception
 
-    with cli_error_context("loading site configuration"):
+    try:
         return Site.from_config(
             root_path, config_path, environment=environment, profile=profile_name
         )
+    except SystemExit, KeyboardInterrupt:
+        raise
+    except Exception as e:
+        handle_exception(e, cli, operation="loading site configuration")
+        raise SystemExit(1) from e

--- a/bengal/cli/utils/site.py
+++ b/bengal/cli/utils/site.py
@@ -294,11 +294,9 @@ def load_site_from_cli(
         cli.error(f"Config file does not exist: {config_path}")
         sys.exit(1)
 
-    try:
-        site = Site.from_config(
+    from bengal.cli.helpers.error_handling import cli_error_context
+
+    with cli_error_context("loading site configuration"):
+        return Site.from_config(
             root_path, config_path, environment=environment, profile=profile_name
         )
-        return site
-    except Exception as e:
-        cli.error(f"Failed to load site from {root_path}: {e}")
-        sys.exit(1)

--- a/changelog.d/cli-sharp-edges.fixed.md
+++ b/changelog.d/cli-sharp-edges.fixed.md
@@ -1,0 +1,1 @@
+Harden CLI user-facing edges: route site-loading errors through existing error infrastructure, make required args enforced by argparse, remove double-negative boolean flags in serve, add traceback fallback when renderer fails, and fix misleading help text.


### PR DESCRIPTION
## Summary

- Route site-loading errors through the existing `cli_error_context` infrastructure instead of a generic `except Exception: cli.error(str(e))` catch-all — YAML, TOML, and file errors now get beautified output with suggestions
- Make 13 required CLI args actually required via milo (remove `= ""` defaults, delete manual `SystemExit` guards) across theme, version, inspect, config, codemod, and i18n commands
- Remove double-negative boolean flags (`no_watch`, `no_auto_port`, `no_open`) from `serve` — milo generates `--no-*` flags automatically from `default=True`
- Add `traceback.print_exception()` fallback in `errors.py` when the fancy renderer fails, instead of `contextlib.suppress(Exception)` which silently swallowed errors
- Fix misleading `all_versions` help text ("default behavior" → "git versioning mode") and format flag-conflict errors through `cli.error()` with exit code 2

## Test plan

- [x] Full test suite: 4927 passed, 3 failed (all pre-existing), 38 skipped
- [x] All 10 modified modules import cleanly
- [x] All 13 required params verified via `inspect.signature`
- [ ] Manual: `bengal theme info` (no slug) shows argparse required-arg error
- [ ] Manual: `bengal serve --help` shows single `--no-watch` flag (no duplicates)
- [ ] Manual: broken YAML config → beautified error with suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)