### PR TITLE
fix: repair live progress bar, sharpen warnings, add milo CLI autodoc

### DIFF
--- a/bengal/autodoc/extractors/cli.py
+++ b/bengal/autodoc/extractors/cli.py
@@ -682,9 +682,11 @@ class CLIExtractor(Extractor):
         is_lazy = hasattr(cmd_def, "import_path")
 
         if is_lazy:
-            # Try pre-computed schema first (no import needed)
-            if cmd_def._schema is not None:
-                schema = cmd_def._schema
+            # Try pre-computed schema first (no import needed).
+            # Use getattr for safety in case internals change.
+            cached_schema = getattr(cmd_def, "_schema", None)
+            if cached_schema is not None:
+                schema = cached_schema
             else:
                 try:
                     resolved = cmd_def.resolve()
@@ -839,7 +841,7 @@ class CLIExtractor(Extractor):
 
         typed_meta = CLIOptionMetadata(
             name=opt.name,
-            param_type="GlobalOption",
+            param_type="option",
             type_name=type_name,
             required=False,
             default=default_str,
@@ -859,7 +861,8 @@ class CLIExtractor(Extractor):
             source_file=None,
             line_number=None,
             metadata={
-                "param_type": "GlobalOption",
+                "param_type": "option",
+                "source": "global",
                 "type": type_name,
                 "required": False,
                 "default": default_str,

--- a/bengal/autodoc/extractors/cli.py
+++ b/bengal/autodoc/extractors/cli.py
@@ -1,7 +1,8 @@
 """
 CLI documentation extractor for autodoc system.
 
-Extracts documentation from command-line applications built with Click, argparse, or Typer.
+Extracts documentation from command-line applications built with
+Click, argparse, Typer, or milo.
 """
 
 from __future__ import annotations
@@ -9,8 +10,6 @@ from __future__ import annotations
 import inspect
 from pathlib import Path
 from typing import Any, override
-
-import click
 
 from bengal.autodoc.base import DocElement, Extractor
 from bengal.autodoc.models import CLICommandMetadata, CLIGroupMetadata, CLIOptionMetadata
@@ -45,6 +44,8 @@ def _is_sentinel_value(value: Any) -> bool:
         return True
 
     # Check if it's Click's actual _missing sentinel
+    import click
+
     return (
         hasattr(click, "core") and hasattr(click.core, "_missing") and value is click.core._missing
     )
@@ -72,20 +73,21 @@ def _format_default_value(value: Any) -> str | None:
 
 class CLIExtractor(Extractor):
     """
-    Extract CLI documentation from Click/argparse/typer applications.
+    Extract CLI documentation from Click/argparse/typer/milo applications.
 
     This extractor introspects CLI frameworks to build comprehensive documentation
     for commands, options, arguments, and their relationships.
 
-    Currently supported frameworks:
+    Supported frameworks:
     - Click (full support)
+    - milo (full support)
     - argparse (planned)
     - Typer (planned)
 
     Example:
-            >>> from bengal.cli import main
-            >>> extractor = CLIExtractor(framework='click')
-            >>> elements = extractor.extract(main)
+            >>> from bengal.cli import cli
+            >>> extractor = CLIExtractor(framework='milo')
+            >>> elements = extractor.extract(cli)
             >>> # Returns list of DocElements for all commands
 
     """
@@ -95,18 +97,18 @@ class CLIExtractor(Extractor):
         Initialize CLI extractor.
 
         Args:
-            framework: CLI framework to extract from ('click', 'argparse', 'typer')
+            framework: CLI framework to extract from ('click', 'argparse', 'typer', 'milo')
             include_hidden: Include hidden commands (default: False)
         """
         self.framework = framework
         self.include_hidden = include_hidden
 
-        if framework not in ("click", "argparse", "typer"):
+        if framework not in ("click", "argparse", "typer", "milo"):
             from bengal.errors import BengalConfigError, ErrorCode
 
             raise BengalConfigError(
-                f"Unsupported framework: {framework}. Use 'click', 'argparse', or 'typer'",
-                suggestion="Set framework to 'click', 'argparse', or 'typer'",
+                f"Unsupported framework: {framework}. Use 'click', 'argparse', 'typer', or 'milo'",
+                suggestion="Set framework to 'click', 'argparse', 'typer', or 'milo'",
                 code=ErrorCode.C003,
             )
 
@@ -120,6 +122,7 @@ class CLIExtractor(Extractor):
                 - For Click: click.Group or click.Command
                 - For argparse: ArgumentParser instance
                 - For Typer: Typer app instance
+                - For milo: milo.commands.CLI instance
 
         Returns:
             List of DocElements representing the CLI structure
@@ -133,15 +136,17 @@ class CLIExtractor(Extractor):
             return self._extract_from_argparse(source)
         if self.framework == "typer":
             return self._extract_from_typer(source)
+        if self.framework == "milo":
+            return self._extract_from_milo(source)
         from bengal.errors import BengalConfigError, ErrorCode
 
         raise BengalConfigError(
             f"Unknown framework: {self.framework}",
-            suggestion="Set framework to 'click', 'argparse', or 'typer'",
+            suggestion="Set framework to 'click', 'argparse', 'typer', or 'milo'",
             code=ErrorCode.C003,
         )
 
-    def _extract_from_click(self, cli: click.Group) -> list[DocElement]:
+    def _extract_from_click(self, cli: Any) -> list[DocElement]:
         """
         Extract documentation from Click command group.
 
@@ -178,9 +183,7 @@ class CLIExtractor(Extractor):
 
         return elements
 
-    def _extract_click_group(
-        self, group: click.Group, parent_name: str | None = None
-    ) -> DocElement:
+    def _extract_click_group(self, group: Any, parent_name: str | None = None) -> DocElement:
         """
         Extract Click command group documentation.
 
@@ -211,6 +214,8 @@ class CLIExtractor(Extractor):
         # Build children (subcommands)
         # Use list_commands + get_command to support lazy-loaded groups (e.g. Bengal CLI).
         # group.commands is empty for lazy groups that defer loading until invocation.
+        import click
+
         children = []
         seen_command_ids: set[int] = set()
         if isinstance(group, click.Group):
@@ -273,9 +278,7 @@ class CLIExtractor(Extractor):
             deprecated=None,
         )
 
-    def _extract_click_command(
-        self, cmd: click.Command, parent_name: str | None = None
-    ) -> DocElement:
+    def _extract_click_command(self, cmd: Any, parent_name: str | None = None) -> DocElement:
         """
         Extract Click command documentation.
 
@@ -300,6 +303,8 @@ class CLIExtractor(Extractor):
                 pass
 
         # Extract options and arguments
+        import click
+
         options = []
         arguments = []
 
@@ -364,7 +369,7 @@ class CLIExtractor(Extractor):
             deprecated=deprecated,
         )
 
-    def _extract_click_parameter(self, param: click.Parameter, parent_name: str) -> DocElement:
+    def _extract_click_parameter(self, param: Any, parent_name: str) -> DocElement:
         """
         Extract Click parameter (option or argument) documentation.
 
@@ -376,6 +381,8 @@ class CLIExtractor(Extractor):
             DocElement representing the parameter
         """
         # Determine element type
+        import click
+
         if isinstance(param, click.Argument):
             element_type = "argument"
         elif isinstance(param, click.Option):
@@ -422,7 +429,7 @@ class CLIExtractor(Extractor):
         # Build typed metadata
         typed_meta = CLIOptionMetadata(
             name=param.name or "",
-            param_type="argument" if isinstance(param, click.Argument) else "option",
+            param_type="argument" if element_type == "argument" else "option",
             type_name=type_name.upper() if type_name else "STRING",
             required=param.required,
             default=_format_default_value(param.default),
@@ -514,6 +521,375 @@ class CLIExtractor(Extractor):
             examples.append("\n".join(current_example))
 
         return examples
+
+    # ------------------------------------------------------------------
+    # Milo extraction
+    # ------------------------------------------------------------------
+
+    def _extract_from_milo(self, cli: Any) -> list[DocElement]:
+        """
+        Extract documentation from a milo CLI instance.
+
+        Args:
+            cli: milo.commands.CLI instance
+
+        Returns:
+            Flat list of DocElements (root group + all commands/groups)
+        """
+        elements: list[DocElement] = []
+
+        root = self._extract_milo_group_root(cli)
+        elements.append(root)
+
+        # Flatten children into top-level list for individual pages
+        def flatten(children: list[DocElement]) -> None:
+            for child in children:
+                elements.append(child)
+                if child.element_type == "command-group" and child.children:
+                    flatten(child.children)
+
+        flatten(root.children)
+        return elements
+
+    def _extract_milo_group_root(self, cli: Any) -> DocElement:
+        """
+        Extract root CLI object as a command-group DocElement.
+
+        Args:
+            cli: milo.commands.CLI instance
+
+        Returns:
+            Root DocElement with children for all commands and groups
+        """
+        name = cli.name or "cli"
+
+        children: list[DocElement] = []
+
+        # Extract top-level commands
+        for cmd_name in sorted(cli._commands):
+            cmd_def = cli._commands[cmd_name]
+            if getattr(cmd_def, "hidden", False) and not self.include_hidden:
+                continue
+            children.append(self._extract_milo_command(cmd_def, name))
+
+        # Extract groups (recursive)
+        for group_name in sorted(cli._groups):
+            group = cli._groups[group_name]
+            if getattr(group, "hidden", False) and not self.include_hidden:
+                continue
+            children.append(self._extract_milo_group(group, name))
+
+        typed_meta = CLIGroupMetadata(
+            callback=None,
+            command_count=len(children),
+        )
+
+        return DocElement(
+            name=name,
+            qualified_name=name,
+            description=sanitize_text(cli.description),
+            element_type="command-group",
+            source_file=None,
+            line_number=None,
+            metadata={
+                "callback": None,
+                "command_count": len(children),
+                "version": getattr(cli, "version", ""),
+            },
+            typed_metadata=typed_meta,
+            children=children,
+            examples=[],
+            see_also=[],
+            deprecated=None,
+        )
+
+    def _extract_milo_group(self, group: Any, parent_name: str) -> DocElement:
+        """
+        Extract a milo Group as a command-group DocElement (recursive).
+
+        Args:
+            group: milo.groups.Group instance
+            parent_name: Parent qualified name
+
+        Returns:
+            DocElement for the group with its children
+        """
+        name = group.name
+        qualified_name = f"{parent_name}.{name}"
+
+        children: list[DocElement] = []
+
+        for cmd_name in sorted(group._commands):
+            cmd_def = group._commands[cmd_name]
+            if getattr(cmd_def, "hidden", False) and not self.include_hidden:
+                continue
+            children.append(self._extract_milo_command(cmd_def, qualified_name))
+
+        for sub_name in sorted(group._groups):
+            sub = group._groups[sub_name]
+            if getattr(sub, "hidden", False) and not self.include_hidden:
+                continue
+            children.append(self._extract_milo_group(sub, qualified_name))
+
+        typed_meta = CLIGroupMetadata(
+            callback=None,
+            command_count=len(children),
+        )
+
+        return DocElement(
+            name=name,
+            qualified_name=qualified_name,
+            description=sanitize_text(group.description),
+            element_type="command-group",
+            source_file=None,
+            line_number=None,
+            metadata={
+                "callback": None,
+                "command_count": len(children),
+            },
+            typed_metadata=typed_meta,
+            children=children,
+            examples=[],
+            see_also=[],
+            deprecated=None,
+        )
+
+    def _extract_milo_command(self, cmd_def: Any, parent_name: str) -> DocElement:
+        """
+        Extract a milo CommandDef or LazyCommandDef as a command DocElement.
+
+        For LazyCommandDef, tries pre-computed _schema first to avoid
+        importing the handler module. Falls back to resolve(), and if
+        that fails, creates the element with description only.
+
+        Args:
+            cmd_def: CommandDef or LazyCommandDef instance
+            parent_name: Parent qualified name
+
+        Returns:
+            DocElement for the command
+        """
+        name = cmd_def.name
+        qualified_name = f"{parent_name}.{name}"
+        description = sanitize_text(cmd_def.description)
+
+        # Get schema — may require resolving lazy commands
+        schema: dict[str, Any] = {}
+        source_file = None
+        line_number = None
+
+        # Check for LazyCommandDef by attribute (avoid importing milo types)
+        is_lazy = hasattr(cmd_def, "import_path")
+
+        if is_lazy:
+            # Try pre-computed schema first (no import needed)
+            if cmd_def._schema is not None:
+                schema = cmd_def._schema
+            else:
+                try:
+                    resolved = cmd_def.resolve()
+                    schema = resolved.schema
+                    source_file, line_number = self._get_handler_source(resolved.handler)
+                except Exception as e:
+                    logger.debug(
+                        "cli_extractor_lazy_resolve_failed",
+                        command=name,
+                        import_path=cmd_def.import_path,
+                        error=str(e),
+                    )
+        else:
+            # Regular CommandDef — schema and handler always available
+            schema = cmd_def.schema
+            source_file, line_number = self._get_handler_source(cmd_def.handler)
+
+        # Extract parameters from JSON Schema properties
+        options: list[DocElement] = []
+        properties = schema.get("properties", {})
+        required_params = set(schema.get("required", []))
+
+        for prop_name, prop_schema in properties.items():
+            options.append(
+                self._extract_milo_parameter(
+                    prop_name, prop_schema, prop_name in required_params, qualified_name
+                )
+            )
+
+        # Extract examples from command def
+        examples: list[str] = []
+        for ex in getattr(cmd_def, "examples", ()):
+            if isinstance(ex, dict):
+                # milo examples are dicts with 'command' and optional 'description'
+                cmd_str = ex.get("command", "")
+                desc = ex.get("description", "")
+                if desc and cmd_str:
+                    examples.append(f"# {desc}\n{cmd_str}")
+                elif cmd_str:
+                    examples.append(cmd_str)
+            elif isinstance(ex, str):
+                examples.append(ex)
+
+        typed_meta = CLICommandMetadata(
+            callback=None,
+            option_count=len(options),
+            argument_count=0,  # milo uses keyword args only
+            is_group=False,
+            is_hidden=getattr(cmd_def, "hidden", False),
+        )
+
+        return DocElement(
+            name=name,
+            qualified_name=qualified_name,
+            description=description,
+            element_type="command",
+            source_file=source_file,
+            line_number=line_number,
+            metadata={
+                "callback": None,
+                "option_count": len(options),
+                "argument_count": 0,
+            },
+            typed_metadata=typed_meta,
+            children=options,
+            examples=examples,
+            see_also=[],
+            deprecated=None,
+        )
+
+    def _extract_milo_parameter(
+        self,
+        name: str,
+        prop_schema: dict[str, Any],
+        required: bool,
+        parent_name: str,
+    ) -> DocElement:
+        """
+        Extract a parameter from a JSON Schema property.
+
+        Args:
+            name: Parameter name
+            prop_schema: JSON Schema property definition
+            required: Whether the parameter is required
+            parent_name: Parent command qualified name
+
+        Returns:
+            DocElement for the option
+        """
+        type_name = prop_schema.get("type", "string").upper()
+        description = sanitize_text(prop_schema.get("description"))
+        default = prop_schema.get("default")
+        default_str = str(default) if default is not None else None
+
+        # Detect boolean flags
+        is_flag = type_name == "BOOLEAN"
+
+        typed_meta = CLIOptionMetadata(
+            name=name,
+            param_type="option",
+            type_name=type_name,
+            required=required,
+            default=default_str,
+            multiple=False,
+            is_flag=is_flag,
+            count=False,
+            opts=(f"--{name.replace('_', '-')}",),
+            envvar=None,
+            help_text=description or "",
+        )
+
+        return DocElement(
+            name=name,
+            qualified_name=f"{parent_name}.{name}",
+            description=description,
+            element_type="option",
+            source_file=None,
+            line_number=None,
+            metadata={
+                "param_type": "option",
+                "type": type_name,
+                "required": required,
+                "default": default_str,
+                "multiple": False,
+                "is_flag": is_flag,
+                "count": False,
+                "opts": [f"--{name.replace('_', '-')}"],
+            },
+            typed_metadata=typed_meta,
+            children=[],
+            examples=[],
+            see_also=[],
+            deprecated=None,
+        )
+
+    def _extract_milo_global_option(self, opt: Any, parent_name: str) -> DocElement:
+        """
+        Extract a milo GlobalOption as an option DocElement.
+
+        Args:
+            opt: milo GlobalOption instance
+            parent_name: Root CLI qualified name
+
+        Returns:
+            DocElement for the global option
+        """
+        type_name = getattr(opt.option_type, "__name__", "str").upper()
+        default_str = str(opt.default) if opt.default is not None else None
+        opts: list[str] = [f"--{opt.name.replace('_', '-')}"]
+        if opt.short:
+            opts.append(opt.short)
+
+        typed_meta = CLIOptionMetadata(
+            name=opt.name,
+            param_type="GlobalOption",
+            type_name=type_name,
+            required=False,
+            default=default_str,
+            multiple=False,
+            is_flag=opt.is_flag,
+            count=False,
+            opts=tuple(opts),
+            envvar=None,
+            help_text=opt.description or "",
+        )
+
+        return DocElement(
+            name=opt.name,
+            qualified_name=f"{parent_name}.{opt.name}",
+            description=sanitize_text(opt.description),
+            element_type="option",
+            source_file=None,
+            line_number=None,
+            metadata={
+                "param_type": "GlobalOption",
+                "type": type_name,
+                "required": False,
+                "default": default_str,
+                "is_flag": opt.is_flag,
+                "opts": opts,
+            },
+            typed_metadata=typed_meta,
+            children=[],
+            examples=[],
+            see_also=[],
+            deprecated=None,
+        )
+
+    @staticmethod
+    def _get_handler_source(handler: Any) -> tuple[Path | None, int | None]:
+        """
+        Extract source file and line number from a handler function.
+
+        Args:
+            handler: Callable to inspect
+
+        Returns:
+            (source_file, line_number) tuple; either may be None
+        """
+        try:
+            source_file = Path(inspect.getfile(handler))
+            line_number = inspect.getsourcelines(handler)[1]
+            return source_file, line_number
+        except TypeError, OSError:
+            return None, None
 
     def _extract_from_argparse(self, parser: Any) -> list[DocElement]:
         """

--- a/bengal/build/provenance/filter.py
+++ b/bengal/build/provenance/filter.py
@@ -483,10 +483,12 @@ class ProvenanceFilter:
 
             # Check if section has an index page
             index_page = getattr(section, "index_page", None)
-            if index_page is not None:
+            if index_page is not None and not getattr(index_page, "_virtual", False):
+                # Only check filesystem for real (non-virtual) pages.
+                # Virtual pages (autodoc, section-indexes) have synthetic
+                # source paths that intentionally don't exist on disk.
                 index_path = getattr(index_page, "source_path", None)
                 if index_path is not None and isinstance(index_path, Path):
-                    # Verify file exists (could be virtual or deleted)
                     try:
                         if index_path.exists():
                             sources.append(index_path)
@@ -494,18 +496,16 @@ class ProvenanceFilter:
                             self._warned_cascade_paths.add(index_path)
                             logger.warning(
                                 "cascade_source_missing",
-                                index_path=str(index_path),
-                                page=str(getattr(page, "source_path", "unknown")),
-                                reason="Cascade source file not found — descendant pages may not rebuild correctly",
+                                path=str(index_path),
+                                hint=f"Expected _index.md at {index_path} — add it or check the content hierarchy",
                             )
                     except OSError:
                         if index_path not in self._warned_cascade_paths:
                             self._warned_cascade_paths.add(index_path)
                             logger.warning(
                                 "cascade_source_inaccessible",
-                                index_path=str(index_path),
-                                page=str(getattr(page, "source_path", "unknown")),
-                                reason="File system error accessing cascade source",
+                                path=str(index_path),
+                                hint="File system error — check permissions on the content directory",
                             )
 
             # Move to parent section

--- a/bengal/parsing/backends/patitas/renderers/directives.py
+++ b/bengal/parsing/backends/patitas/renderers/directives.py
@@ -254,8 +254,6 @@ class DirectiveRendererMixin:
             if matches:
                 match = matches[0]
 
-        suggestion_text = f" — did you mean '{match}'?" if match else ""
-
         # Extract source location from page context if available
         source_hint = ""
         page = self._page_context
@@ -272,7 +270,7 @@ class DirectiveRendererMixin:
             extra["source"] = source
 
         logger.warning(
-            f'Unknown directive "{node.name}"{source_hint}{suggestion_text}',
+            f'Unknown directive "{node.name}"{source_hint}',
             **extra,
         )
 

--- a/bengal/parsing/backends/patitas/renderers/directives.py
+++ b/bengal/parsing/backends/patitas/renderers/directives.py
@@ -262,11 +262,18 @@ class DirectiveRendererMixin:
         if page and hasattr(page, "source_path"):
             source_hint = f" in {page.source_path}"
 
+        extra: dict[str, Any] = {"directive": node.name}
+        if match:
+            extra["suggestion"] = f"Did you mean '{match}'?"
+        else:
+            extra["hint"] = "Check spelling or register a custom directive for this name"
+        source = getattr(page, "source_path", None) if page else None
+        if source:
+            extra["source"] = source
+
         logger.warning(
             f'Unknown directive "{node.name}"{source_hint}{suggestion_text}',
-            directive=node.name,
-            suggestion=match,
-            source=getattr(page, "source_path", None) if page else None,
+            **extra,
         )
 
     def _directive_ast_cache_key(self: HtmlRendererProtocol, node: Directive) -> str:

--- a/bengal/utils/observability/cli_progress.py
+++ b/bengal/utils/observability/cli_progress.py
@@ -221,10 +221,11 @@ class LiveProgressManager:
             sys.stdout.flush()
             self._prev_frame_lines = 0
 
-        # Replay warnings that were buffered during live progress.
-        from bengal.utils.observability.logger import flush_deferred_output
+        # Only flush deferred output if this instance enabled deferral.
+        if self.use_live:
+            from bengal.utils.observability.logger import flush_deferred_output
 
-        flush_deferred_output()
+            flush_deferred_output()
 
     def __enter__(self) -> LiveProgressManager:
         """Enter context manager."""
@@ -470,7 +471,8 @@ class LiveProgressManager:
 
     def _render_live(self) -> None:
         """Render progress with ANSI cursor control for in-place updates."""
-        state = self._build_state()
+        with self._lock:
+            state = self._build_state()
         frame = self._render_frame(state)
 
         lines = frame.split("\n")

--- a/bengal/utils/observability/cli_progress.py
+++ b/bengal/utils/observability/cli_progress.py
@@ -189,6 +189,10 @@ class LiveProgressManager:
         # Lock protecting phase state mutations.
         self._lock = threading.Lock()
 
+        # Throttle live rendering to avoid excessive redraws.
+        self._last_render_time: float = 0.0
+        self._render_interval: float = 0.1  # seconds
+
         # Track last printed state for fallback
         self._last_fallback_phase: str | None = None
 
@@ -196,18 +200,31 @@ class LiveProgressManager:
         """
         Start the progress display.
 
+        When live mode is active, defers logger console output so that
+        warnings don't corrupt ANSI cursor control.  Deferred lines are
+        flushed when ``stop()`` is called.
+
         Returns:
             Self for method chaining.
         """
+        if self.use_live:
+            from bengal.utils.observability.logger import defer_console_output
+
+            defer_console_output(True)
         return self
 
     def stop(self) -> None:
-        """Stop the progress display."""
+        """Stop the progress display and flush any deferred warnings."""
         if self._prev_frame_lines > 0:
             # Ensure the cursor is below the last rendered frame.
             sys.stdout.write("\n")
             sys.stdout.flush()
             self._prev_frame_lines = 0
+
+        # Replay warnings that were buffered during live progress.
+        from bengal.utils.observability.logger import flush_deferred_output
+
+        flush_deferred_output()
 
     def __enter__(self) -> LiveProgressManager:
         """Enter context manager."""
@@ -285,6 +302,12 @@ class LiveProgressManager:
             if phase.status == PhaseStatus.RUNNING and phase.start_time:
                 phase.elapsed_ms = (time.time() - phase.start_time) * 1000
 
+        # Throttled live render so the progress bar updates in place
+        now = time.time()
+        if self.use_live and now - self._last_render_time >= self._render_interval:
+            self._last_render_time = now
+            self._render_live()
+
     def complete_phase(self, phase_id: str, elapsed_ms: float | None = None) -> None:
         """
         Mark phase as complete.
@@ -358,7 +381,21 @@ class LiveProgressManager:
         else:
             overall = "running"
 
-        progress = completed / total if total > 0 else 0.0
+        # Use per-item progress from the running phase when available,
+        # otherwise fall back to phase-count ratio.
+        progress: float
+        running_phase = next(
+            (
+                self.phases[pid]
+                for pid in self.phase_order
+                if self.phases[pid].status == PhaseStatus.RUNNING
+            ),
+            None,
+        )
+        if running_phase and running_phase.total and running_phase.total > 0:
+            progress = running_phase.current / running_phase.total
+        else:
+            progress = completed / total if total > 0 else 0.0
 
         return {
             "status": overall,
@@ -367,25 +404,85 @@ class LiveProgressManager:
             "phases": phases,
         }
 
-    def _render_live(self) -> None:
-        """Render progress with kida template and ANSI cursor control."""
-        if not self._render_fn:
-            return
+    def _format_time(self, seconds: float) -> str:
+        """Format seconds as MM:SS.CC."""
+        m = int(seconds // 60)
+        s = int(seconds % 60)
+        c = int((seconds * 100) % 100)
+        return f"{m:02d}:{s:02d}.{c:02d}"
 
+    def _render_frame(self, state: dict[str, Any]) -> str:
+        """Render progress frame, using template with Python fallback."""
+        if self._render_fn:
+            try:
+                return self._render_fn("build_progress.kida", state=state).strip("\n")
+            except Exception:
+                pass
+
+        import os
+
+        use_color = not os.environ.get("NO_COLOR")
+
+        # ANSI helpers — collapse to empty strings when NO_COLOR is set.
+        _R = "\033[0m" if use_color else ""
+        _B = "\033[1m" if use_color else ""
+        _D = "\033[2m" if use_color else ""
+        _GRN = "\033[32m" if use_color else ""
+        _CYN = "\033[36m" if use_color else ""
+        _BCYN = "\033[1;36m" if use_color else ""
+        _BRED = "\033[1;31m" if use_color else ""
+        _BGRN = "\033[1;32m" if use_color else ""
+
+        # Python fallback matching milo's pipeline_progress format
+        lines: list[str] = []
+        for phase in state["phases"]:
+            name = phase["name"]
+            pad = " " * max(16 - len(name), 1)
+            match phase["status"]:
+                case "completed":
+                    lines.append(
+                        f"  {_GRN}✓{_R} {_B}{name}{_R}{pad}{_D}{self._format_time(phase['elapsed'])}{_R}"
+                    )
+                case "running":
+                    lines.append(f"  {_BCYN}●{_R} {_BCYN}{name}{_R}{pad}{_D}...{_R}")
+                case "failed":
+                    lines.append(
+                        f"  {_BRED}✗{_R} {_BRED}{name}{_R}{pad}{_D}{phase.get('error', '')}{_R}"
+                    )
+                case _:
+                    lines.append(f"  {_D}· {name}{_R}")
+
+        pct = max(0, min(int(state["progress"] * 100), 100))
+        filled = max(0, min(pct // 2, 50))
+        match state["status"]:
+            case "running":
+                bar = "█" * filled + "░" * (50 - filled)
+                lines.append(f"  {_CYN}{bar}{_R}  {pct}%")
+            case "completed":
+                bar = "█" * 50
+                lines.append(
+                    f"  {_GRN}{bar}{_R}  {_BGRN}done{_R} {_D}{self._format_time(state['elapsed'])}{_R}"
+                )
+            case "failed":
+                lines.append(f"  {_BRED}pipeline failed{_R}")
+
+        return "\n".join(lines)
+
+    def _render_live(self) -> None:
+        """Render progress with ANSI cursor control for in-place updates."""
         state = self._build_state()
-        try:
-            frame = self._render_fn("build_progress.kida", state=state).strip("\n")
-        except Exception:
-            return  # Silently fall back if template rendering fails
+        frame = self._render_frame(state)
 
         lines = frame.split("\n")
 
-        # Move cursor up to overwrite previous frame
+        # Move cursor up to overwrite previous frame.
+        # Use \033[J (erase below) to clean up any warning lines that
+        # were printed to stdout between frames.
         if self._prev_frame_lines > 0:
-            sys.stdout.write(f"\033[{self._prev_frame_lines}A")
+            sys.stdout.write(f"\033[{self._prev_frame_lines}A\033[J")
 
         for line in lines:
-            sys.stdout.write(f"\033[2K{line}\n")
+            sys.stdout.write(f"{line}\n")
         sys.stdout.flush()
 
         self._prev_frame_lines = len(lines)
@@ -398,7 +495,7 @@ class LiveProgressManager:
         in an interactive terminal, otherwise prints traditional
         sequential lines showing phase starts and completions.
         """
-        if self.use_live and self._render_fn:
+        if self.use_live:
             self._render_live()
             return
 

--- a/bengal/utils/observability/logger.py
+++ b/bengal/utils/observability/logger.py
@@ -490,8 +490,16 @@ class BengalLogger:
             import sys
 
             formatted = event.format_console(verbose=self.verbose)
-            sys.stdout.write(formatted + "\n")
-            sys.stdout.flush()
+            line = formatted + "\n"
+            # Capture reference locally to avoid TOCTOU race under
+            # free-threading: flush_deferred_output can set the global
+            # to None between our check and the append.
+            buf = _deferred_console
+            if buf is not None:
+                buf.append(line)
+            else:
+                sys.stdout.write(line)
+                sys.stdout.flush()
 
         # Output to file (JSON format)
         if self._file_handle:
@@ -628,6 +636,13 @@ _global_config: _GlobalConfig = {
     "verbose": False,
     "quiet_console": False,
 }
+
+# Deferred console output buffer.  When non-None, formatted warning/error
+# strings are appended here instead of being written to stdout.  This
+# allows the live progress bar to prevent interleaved output that corrupts
+# ANSI cursor control.  Use ``defer_console_output`` / ``flush_deferred``
+# to manage this.
+_deferred_console: list[str] | None = None
 
 
 def _get_actual_logger(name: str) -> BengalLogger:
@@ -810,6 +825,36 @@ def set_console_quiet(quiet: bool = True) -> None:
         # Update existing loggers
         for logger in _loggers.values():
             logger.quiet_console = quiet
+
+
+def defer_console_output(enabled: bool = True) -> None:
+    """Enable or disable console output deferral.
+
+    When enabled, formatted log lines that would go to stdout are
+    buffered instead.  Call ``flush_deferred_output`` to replay them.
+    Used by the live progress bar to prevent interleaved warnings from
+    corrupting ANSI cursor control.
+    """
+    global _deferred_console
+    with _logger_lock:
+        if enabled:
+            if _deferred_console is None:
+                _deferred_console = []
+        else:
+            _deferred_console = None
+
+
+def flush_deferred_output() -> None:
+    """Write all buffered console lines to stdout and disable deferral."""
+    global _deferred_console
+    with _logger_lock:
+        buf = _deferred_console
+        _deferred_console = None
+    if buf:
+        import sys
+
+        sys.stdout.write("".join(buf))
+        sys.stdout.flush()
 
 
 def close_all_loggers() -> None:

--- a/bengal/utils/observability/logger.py
+++ b/bengal/utils/observability/logger.py
@@ -491,15 +491,15 @@ class BengalLogger:
 
             formatted = event.format_console(verbose=self.verbose)
             line = formatted + "\n"
-            # Capture reference locally to avoid TOCTOU race under
-            # free-threading: flush_deferred_output can set the global
-            # to None between our check and the append.
-            buf = _deferred_console
-            if buf is not None:
-                buf.append(line)
-            else:
-                sys.stdout.write(line)
-                sys.stdout.flush()
+            # Synchronize with flush_deferred_output() so we cannot append
+            # to a detached deferred buffer after it has been swapped out.
+            with _logger_lock:
+                buf = _deferred_console
+                if buf is not None:
+                    buf.append(line)
+                else:
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
 
         # Output to file (JSON format)
         if self._file_handle:

--- a/changelog.d/milo-cli-autodoc.added.md
+++ b/changelog.d/milo-cli-autodoc.added.md
@@ -1,0 +1,1 @@
+Add milo as a first-class CLI autodoc framework, enabling automatic CLI reference documentation generation from milo-based CLIs with JSON Schema parameter extraction and lazy command support.

--- a/changelog.d/progress-bar-and-warnings.fixed.md
+++ b/changelog.d/progress-bar-and-warnings.fixed.md
@@ -1,0 +1,1 @@
+Fix live progress bar not updating in place by adding throttled ANSI rendering with deferred logger output, and eliminate false-positive cascade and directive warnings for virtual autodoc pages.

--- a/site/config/_default/autodoc.yaml
+++ b/site/config/_default/autodoc.yaml
@@ -59,8 +59,8 @@ autodoc:
   # CLI Documentation
   cli:
     enabled: true
-    app_module: "bengal.cli:main"
-    framework: click
+    app_module: "bengal.cli:cli"
+    framework: milo
 
     # Output prefix for CLI docs
     # This creates the section at /cli/...

--- a/tests/unit/autodoc/test_cli_extractor.py
+++ b/tests/unit/autodoc/test_cli_extractor.py
@@ -691,3 +691,313 @@ class TestTyperExtractor:
 
         # Success if we got here without duplicate paths
         assert len(paths) == len(elements)
+
+
+# ============================================================================
+# Milo Tests
+# ============================================================================
+
+try:
+    from milo._command_defs import CommandDef, GlobalOption, LazyCommandDef
+    from milo.commands import CLI
+    from milo.groups import Group
+
+    MILO_AVAILABLE = True
+except ImportError:
+    MILO_AVAILABLE = False
+
+
+def _build_sample_milo_cli() -> Any:
+    """Build a sample milo CLI for testing (avoids module-level import)."""
+    cli = CLI(name="testapp", description="A test application", version="1.0.0")
+
+    # Register a command with a real handler
+    def greet(name: str, loud: bool = False) -> str:
+        """Say hello."""
+        msg = f"Hello, {name}!"
+        return msg.upper() if loud else msg
+
+    from milo.schema import function_to_schema
+
+    greet_schema = function_to_schema(greet)
+    cli._commands["greet"] = CommandDef(
+        name="greet",
+        description="Say hello",
+        handler=greet,
+        schema=greet_schema,
+    )
+
+    # Register a lazy command with pre-computed schema
+    cli._commands["lazy-cmd"] = LazyCommandDef(
+        name="lazy-cmd",
+        import_path="os.path:exists",  # valid import for testing
+        description="A lazy command",
+        schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "File path to check"},
+            },
+            "required": ["path"],
+        },
+    )
+
+    # Register a group with subcommands
+    site_group = Group("site", description="Site operations")
+
+    def build_site(output: str = "_site") -> str:
+        """Build the site."""
+        return f"Building to {output}"
+
+    build_schema = function_to_schema(build_site)
+    site_group._commands["build"] = CommandDef(
+        name="build",
+        description="Build the site",
+        handler=build_site,
+        schema=build_schema,
+    )
+
+    def serve_site(port: int = 8000, host: str = "localhost") -> str:
+        """Serve the site locally."""
+        return f"Serving on {host}:{port}"
+
+    serve_schema = function_to_schema(serve_site)
+    site_group._commands["serve"] = CommandDef(
+        name="serve",
+        description="Serve the site locally",
+        handler=serve_site,
+        schema=serve_schema,
+    )
+
+    cli._groups["site"] = site_group
+
+    # Add a global option
+    cli._global_options.append(
+        GlobalOption(
+            name="verbose",
+            short="-v",
+            option_type=bool,
+            default=False,
+            description="Enable verbose output",
+            is_flag=True,
+        )
+    )
+
+    return cli
+
+
+if MILO_AVAILABLE:
+    # Need this import at module level for type annotation in test fixtures
+    from typing import Any
+
+
+@pytest.mark.skipif(not MILO_AVAILABLE, reason="milo not installed")
+class TestMiloExtractor:
+    """Tests for milo CLI extraction."""
+
+    def test_extract_root(self):
+        """Test extracting milo CLI root."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        assert len(elements) >= 1
+        root = elements[0]
+
+        assert root.name == "testapp"
+        assert root.element_type == "command-group"
+        assert "test application" in root.description
+
+    def test_extract_commands(self):
+        """Test that top-level commands are extracted."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        command_names = [e.name for e in elements if e.element_type == "command"]
+        assert "greet" in command_names
+        assert "lazy-cmd" in command_names
+
+    def test_extract_command_parameters(self):
+        """Test that command parameters are extracted from JSON Schema."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        greet_cmd = next(e for e in elements if e.name == "greet")
+        param_names = [p.name for p in greet_cmd.children]
+        assert "name" in param_names
+        assert "loud" in param_names
+
+        # Check types
+        name_param = next(p for p in greet_cmd.children if p.name == "name")
+        assert name_param.metadata["type"] == "STRING"
+        assert name_param.metadata["required"] is True
+
+        loud_param = next(p for p in greet_cmd.children if p.name == "loud")
+        assert loud_param.metadata["type"] == "BOOLEAN"
+        assert loud_param.metadata["is_flag"] is True
+
+    def test_extract_lazy_command_with_precomputed_schema(self):
+        """Test lazy commands with pre-computed schema don't import handler."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        lazy_cmd = next(e for e in elements if e.name == "lazy-cmd")
+        assert lazy_cmd.element_type == "command"
+        assert lazy_cmd.description == "A lazy command"
+
+        # Should have extracted the parameter from pre-computed schema
+        param_names = [p.name for p in lazy_cmd.children]
+        assert "path" in param_names
+
+        path_param = next(p for p in lazy_cmd.children if p.name == "path")
+        assert path_param.metadata["required"] is True
+
+    def test_extract_group(self):
+        """Test that groups are extracted as command-groups."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        group_names = [e.name for e in elements if e.element_type == "command-group"]
+        assert "site" in group_names
+
+        site_group = next(e for e in elements if e.name == "site")
+        assert site_group.qualified_name == "testapp.site"
+
+    def test_extract_group_subcommands(self):
+        """Test that subcommands within groups are extracted."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        command_names = [e.name for e in elements if e.element_type == "command"]
+        assert "build" in command_names
+        assert "serve" in command_names
+
+    def test_qualified_names(self):
+        """Test that qualified names are hierarchical."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        greet = next(e for e in elements if e.name == "greet")
+        assert greet.qualified_name == "testapp.greet"
+
+        build = next(e for e in elements if e.name == "build")
+        assert build.qualified_name == "testapp.site.build"
+
+    def test_output_paths(self):
+        """Test that output paths are correct."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        root = elements[0]
+        assert extractor.get_output_path(root) == Path("_index.md")
+
+        site_group = next(
+            e for e in elements if e.name == "site" and e.element_type == "command-group"
+        )
+        assert extractor.get_output_path(site_group) == Path("site/_index.md")
+
+        build_cmd = next(e for e in elements if e.name == "build")
+        assert extractor.get_output_path(build_cmd) == Path("site/build.md")
+
+    def test_flattened_element_count(self):
+        """Test total flattened element count."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        # Root (testapp) + greet + lazy-cmd + site group + build + serve = 6
+        assert len(elements) == 6
+
+    def test_hidden_commands_excluded_by_default(self):
+        """Test that hidden commands are excluded."""
+        cli = _build_sample_milo_cli()
+
+        from milo.schema import function_to_schema
+
+        def secret():
+            """Secret command."""
+
+        cli._commands["secret"] = CommandDef(
+            name="secret",
+            description="Secret",
+            handler=secret,
+            schema=function_to_schema(secret),
+            hidden=True,
+        )
+
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        command_names = [e.name for e in elements if e.element_type == "command"]
+        assert "secret" not in command_names
+
+    def test_hidden_commands_included_when_requested(self):
+        """Test that hidden commands are included with include_hidden."""
+        cli = _build_sample_milo_cli()
+
+        from milo.schema import function_to_schema
+
+        def secret():
+            """Secret command."""
+
+        cli._commands["secret"] = CommandDef(
+            name="secret",
+            description="Secret",
+            handler=secret,
+            schema=function_to_schema(secret),
+            hidden=True,
+        )
+
+        extractor = CLIExtractor(framework="milo", include_hidden=True)
+        elements = extractor.extract(cli)
+
+        command_names = [e.name for e in elements if e.element_type == "command"]
+        assert "secret" in command_names
+
+    def test_lazy_command_graceful_failure(self):
+        """Test that a lazy command with bad import_path doesn't crash."""
+        cli = CLI(name="testapp", description="Test")
+        cli._commands["broken"] = LazyCommandDef(
+            name="broken",
+            import_path="nonexistent.module:func",
+            description="This will fail to resolve",
+            # No pre-computed schema — resolve() will fail
+        )
+
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        broken = next(e for e in elements if e.name == "broken")
+        assert broken.element_type == "command"
+        assert broken.description == "This will fail to resolve"
+        # Should have 0 params since schema couldn't be retrieved
+        assert len(broken.children) == 0
+
+    def test_parameter_default_values(self):
+        """Test that default values are extracted from schema."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        serve = next(e for e in elements if e.name == "serve")
+        port_param = next(p for p in serve.children if p.name == "port")
+        assert port_param.metadata["default"] == "8000"
+
+        host_param = next(p for p in serve.children if p.name == "host")
+        assert host_param.metadata["default"] == "localhost"
+
+    def test_parameter_cli_flag_format(self):
+        """Test that parameter opts use kebab-case CLI flags."""
+        cli = _build_sample_milo_cli()
+        extractor = CLIExtractor(framework="milo")
+        elements = extractor.extract(cli)
+
+        greet = next(e for e in elements if e.name == "greet")
+        loud_param = next(p for p in greet.children if p.name == "loud")
+        assert "--loud" in loud_param.metadata["opts"]

--- a/tests/unit/autodoc/test_cli_extractor.py
+++ b/tests/unit/autodoc/test_cli_extractor.py
@@ -707,7 +707,7 @@ except ImportError:
     MILO_AVAILABLE = False
 
 
-def _build_sample_milo_cli() -> Any:
+def _build_sample_milo_cli():
     """Build a sample milo CLI for testing (avoids module-level import)."""
     cli = CLI(name="testapp", description="A test application", version="1.0.0")
 
@@ -783,11 +783,6 @@ def _build_sample_milo_cli() -> Any:
     )
 
     return cli
-
-
-if MILO_AVAILABLE:
-    # Need this import at module level for type annotation in test fixtures
-    from typing import Any
 
 
 @pytest.mark.skipif(not MILO_AVAILABLE, reason="milo not installed")


### PR DESCRIPTION
## Summary

- **Progress bar**: Fix live progress not updating in place by adding throttled ANSI rendering with cursor rewind, deferred logger output to prevent warning interleaving, a Python fallback renderer when kida templates are unavailable, and NO_COLOR support.
- **Warnings**: Eliminate false-positive "Cascade source missing" warnings for virtual/autodoc pages; only show fuzzy-match suggestions in directive warnings when a match exists; add actionable hints.
- **Milo CLI autodoc**: Add `milo` as a first-class CLI autodoc framework alongside Click/Typer/argparse. The extractor walks milo's `CLI`/`Group`/`CommandDef` hierarchy and extracts parameters from JSON Schema. Lazy commands use pre-computed schemas and degrade gracefully on resolve failure.
- **Config fix**: Update `autodoc.yaml` entry point from `bengal.cli:main` (nonexistent) to `bengal.cli:cli` and framework from `click` to `milo`, unblocking CLI reference doc generation.

## Test plan

- [x] All 45 CLI extractor tests pass (14 new milo tests + 31 existing Click/Typer tests)
- [ ] Run `bengal build` and verify CLI docs appear under `/cli/` with no cascade warnings
- [ ] Spot-check a generated CLI page (e.g. `/cli/build/`) has parameters with descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)