### PR TITLE
fix: bump milo-cli to v0.2.2, fix argparse conflict

### DIFF
--- a/bengal/cli/milo_commands/cache.py
+++ b/bengal/cli/milo_commands/cache.py
@@ -50,7 +50,6 @@ def cache_hash(
     include_version: Annotated[
         bool, Description("Include Bengal version in hash (recommended)")
     ] = True,
-    no_include_version: Annotated[bool, Description("Exclude Bengal version from hash")] = False,
     config: Annotated[str, Description("Path to config file")] = "",
 ) -> dict:
     """Compute deterministic hash of build inputs for CI cache keys."""
@@ -64,9 +63,6 @@ def cache_hash(
     config_val = config or None
     cli = get_cli_output()
 
-    # --no-include-version overrides --include-version
-    should_include_version = include_version and not no_include_version
-
     site = load_site_from_cli(
         source=source, config=config_val, environment=None, profile=None, cli=cli
     )
@@ -74,7 +70,7 @@ def cache_hash(
 
     hasher = hashlib.sha256()
 
-    if should_include_version:
+    if include_version:
         hasher.update(f"bengal:{bengal.__version__}".encode())
 
     for glob_pattern, _source in input_globs:
@@ -122,4 +118,4 @@ def cache_hash(
     result = hasher.hexdigest()[:16]
     cli.info(result)
 
-    return {"hash": result, "include_version": should_include_version}
+    return {"hash": result, "include_version": include_version}

--- a/changelog.d/bump-milo-cli-0.2.2.changed.md
+++ b/changelog.d/bump-milo-cli-0.2.2.changed.md
@@ -1,0 +1,1 @@
+Bump milo-cli to v0.2.2; remove redundant `no_include_version` param that now conflicts with milo's auto-generated `--no-` flags for boolean defaults.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.7",
-    "milo-cli>=0.2.1",                         # B-stack CLI framework (replaces Click — migration in progress)
+    "milo-cli>=0.2.2",                         # B-stack CLI framework (replaces Click — migration in progress)
 
     "rosettes>=0.2.0",
     "kida-templates>=0.6.0",                   # Kida template engine (AST-native, free-threading ready)
@@ -93,7 +93,7 @@ Repository = "https://github.com/lbliii/bengal"
 "Bug Tracker" = "https://github.com/lbliii/bengal/issues"
 
 [tool.uv.sources]
-milo-cli = { git = "https://github.com/lbliii/milo-cli.git", rev = "d929be6cfac3152ee3549604b52e0aec66e396c8" }
+milo-cli = { git = "https://github.com/lbliii/milo-cli.git", rev = "db0426e823abec0f853804ec7490e60847560bb9" }
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/uv.lock
+++ b/uv.lock
@@ -227,7 +227,7 @@ requires-dist = [
     { name = "jsmin", specifier = ">=3.0.1" },
     { name = "kida-templates", specifier = ">=0.6.0" },
     { name = "lunr", marker = "extra == 'search'", specifier = ">=0.7.0" },
-    { name = "milo-cli", git = "https://github.com/lbliii/milo-cli.git?rev=d929be6cfac3152ee3549604b52e0aec66e396c8" },
+    { name = "milo-cli", git = "https://github.com/lbliii/milo-cli.git?rev=db0426e823abec0f853804ec7490e60847560bb9" },
     { name = "packaging", specifier = ">=23.0" },
     { name = "patitas", specifier = ">=0.3.5" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -660,8 +660,8 @@ wheels = [
 
 [[package]]
 name = "milo-cli"
-version = "0.2.1"
-source = { git = "https://github.com/lbliii/milo-cli.git?rev=d929be6cfac3152ee3549604b52e0aec66e396c8#d929be6cfac3152ee3549604b52e0aec66e396c8" }
+version = "0.2.2"
+source = { git = "https://github.com/lbliii/milo-cli.git?rev=db0426e823abec0f853804ec7490e60847560bb9#db0426e823abec0f853804ec7490e60847560bb9" }
 dependencies = [
     { name = "kida-templates" },
 ]


### PR DESCRIPTION
## Summary

- Bumps milo-cli from v0.2.1 to v0.2.2 (version floor + git rev pin)
- Removes the explicit `no_include_version` param in `cache_hash` — milo-cli 0.2.2 now auto-generates `--no-<flag>` for boolean params with `default=True`, causing an argparse conflict
- Updates `uv.lock` to match

## Test plan

- [x] `bengal --version` runs cleanly
- [x] Full test suite: 3527 passed (3 pre-existing failures unrelated to this change)
- [x] Pre-commit hooks pass (ruff, ty, layer checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)