### PR TITLE
chore(deps): upgrade kida-templates 0.6.0 → 0.7.0 + adapt to strict_undefined

### DIFF
--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -9,10 +9,12 @@ Cache expensive function calls once per render. Page properties like title,
 _path, kind, tags are always defined - no defensive checks needed.
 ================================================================================
 #}
-{# Template-wide variables using {% let %} for explicit scope #}
+{# Template-wide variables using {% let %} for explicit scope
+   NOTE: `page` can be None in some render contexts (e.g., error shells, test fixtures).
+   Kida 0.7.0 strict_undefined requires guarded access. #}
 {% let params = params ?? {} %}
-{% let _page_title = page.title %}
-{% let _page_url = page._path %}
+{% let _page_title = page?.title ?? none %}
+{% let _page_url = page?._path ?? none %}
 
 {# Navigation - cache function calls #}
 {% let _current_lang = current_lang() %}
@@ -23,16 +25,16 @@ _path, kind, tags are always defined - no defensive checks needed.
 {% let _build_badge = site.build_badge %}
 {% let _doc_app = site.document_application %}
 {% let _link_previews = site.link_previews %}
-{% let _per_page_json = 'json' in (config.output_formats.per_page ?? []) %}
-{% let _per_page_md = 'markdown' in (config.output_formats.per_page ?? []) %}
+{% let _per_page_json = 'json' in ((config?.output_formats ?? {})?.per_page ?? []) %}
+{% let _per_page_md = 'markdown' in ((config?.output_formats ?? {})?.per_page ?? []) %}
 
 {# Derived values #}
 {% let _main_menu = get_menu_lang('main', _current_lang) %}
 {% let _footer_menu = get_menu_lang('footer', _current_lang) %}
 
-{% let _doc_app_nav = _doc_app?.navigation %}
-{% let _view_transitions = _doc_app.enabled and _doc_app_nav?.view_transitions %}
-{% let _transition_style = _doc_app_nav?.transition_style %}
+{% let _doc_app_nav = _doc_app?.navigation ?? {} %}
+{% let _view_transitions = (_doc_app?.enabled ?? false) and (_doc_app_nav?.view_transitions ?? false) %}
+{% let _transition_style = _doc_app_nav?.transition_style ?? none %}
 
 {# Auto navigation if main menu is empty #}
 {% let _auto_nav = get_auto_nav() if _main_menu | length == 0 else [] %}
@@ -42,7 +44,7 @@ HELPER: Render a menu item (desktop/mobile)
 ============================================================================= #}
 {% def render_menu_item(item, is_mobile=false) %}
 {% let has_children = item.children | length > 0 %}
-{% let is_active = item.active or (_page_url == item.href) %}
+{% let is_active = (item?.active ?? false) or (_page_url == item?.href) %}
 {% let is_trail = item.active_trail ?? false %}
 
 <li
@@ -110,7 +112,7 @@ HELPER: Render a menu item (desktop/mobile)
     {# Title - captured for reuse in Open Graph and Twitter Card #}
     {% capture page_title %}
     {% block title %}
-    {% match page.title %}
+    {% match page?.title ?? none %}
     {% case title if title and _site_title %}{{ title }} - {{ _site_title }}
     {% case title if title %}{{ title }}
     {% case _ %}{{ _site_title }}
@@ -126,21 +128,23 @@ HELPER: Render a menu item (desktop/mobile)
     <meta name="description" content="{{ meta_desc | trim }}">
 
     {# Meta Keywords - use page.keywords or fallback to tags #}
-    {% if page.keywords %}
+    {% if page?.keywords ?? none %}
     <meta name="keywords" content="{{ page.keywords | join(', ') }}">
-    {% elif page.tags %}
+    {% elif page?.tags ?? none %}
     <meta name="keywords" content="{{ page.tags | meta_keywords(10) }}">
     {% end %}
 
     {# Robots directive for hidden/unlisted pages #}
-    {% if page.robots_meta and page.robots_meta != 'index, follow' %}
+    {% if (page?.robots_meta ?? none) and page.robots_meta != 'index, follow' %}
     <meta name="robots" content="{{ page.robots_meta }}">
     {% end %}
 
     {# Content Signals — per-page AI directives (only when restricted) #}
-    {% if not page.in_ai_train or not page.in_ai_input %}
-    <meta name="content-signal:ai-train" content="{{ 'yes' if page.in_ai_train else 'no' }}">
-    <meta name="content-signal:ai-input" content="{{ 'yes' if page.in_ai_input else 'no' }}">
+    {% let _ai_train = page?.in_ai_train ?? true %}
+    {% let _ai_input = page?.in_ai_input ?? true %}
+    {% if not _ai_train or not _ai_input %}
+    <meta name="content-signal:ai-train" content="{{ 'yes' if _ai_train else 'no' }}">
+    <meta name="content-signal:ai-input" content="{{ 'yes' if _ai_input else 'no' }}">
     {% end %}
 
     {# Open Graph / Facebook #}
@@ -172,10 +176,10 @@ HELPER: Render a menu item (desktop/mobile)
     <meta name="bengal:search_preload" content="{{ config.search_preload ?? 'smart' }}">
     <meta name="bengal:baseurl" content="{{ site.baseurl }}">
     <meta name="bengal:index_url" content="{{ '/index.json' | absolute_url }}">
-    {% if bengal.capabilities.prebuilt_search %}
+    {% if bengal?.capabilities?.prebuilt_search ?? false %}
     <meta name="bengal:search_index_url" content="{{ '/search-index.json' | absolute_url }}">
     {% end %}
-    {% if page.version %}
+    {% if page?.version ?? none %}
     <meta name="bengal:version" content="{{ page.version }}">
     {% end %}
 
@@ -185,7 +189,7 @@ HELPER: Render a menu item (desktop/mobile)
     {% end %}
 
     {# RSS Feed #}
-    {% with config.i18n as i18n %}
+    {% with (config?.i18n ?? none) as i18n %}
     {% let rss_href = '/rss.xml' %}
     {% if i18n and i18n.strategy == 'prefix' %}
     {% let default_lang = i18n.default_language ?? 'en' %}
@@ -220,7 +224,7 @@ HELPER: Render a menu item (desktop/mobile)
     <link rel="preconnect" href="https://d3js.org" crossorigin>
 
     {# Fonts #}
-    {% if config.fonts %}
+    {% if config?.fonts ?? none %}
     <link rel="preload" href="{{ asset_url('fonts/outfit-700.woff2') }}" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="{{ asset_url('fonts.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript>
@@ -292,8 +296,8 @@ HELPER: Render a menu item (desktop/mobile)
 
 </head>
 
-<body data-type="{{ page.type }}" data-variant="{{ page.variant or '' }}"
-    class="page-kind-{{ page.kind or 'page' }}{% if page.is_draft %} draft-page{% end %}{% if page.hidden %} hidden-page{% end %}{% if page.is_featured %} featured-content{% end %}">
+<body data-type="{{ page?.type ?? '' }}" data-variant="{{ (page?.variant ?? '') or '' }}"
+    class="page-kind-{{ (page?.kind ?? none) or 'page' }}{% if page?.is_draft ?? false %} draft-page{% end %}{% if page?.hidden ?? false %} hidden-page{% end %}{% if page?.is_featured ?? false %} featured-content{% end %}">
 
     {% if 'accessibility.skip_link' in (theme.features ?? []) %}
     <a href="#main-content" class="skip-link">Skip to main content</a>
@@ -328,7 +332,7 @@ HELPER: Render a menu item (desktop/mobile)
                     </li>
                     {% end %}
                     {% end %}
-                    {% with site.params.repo_url as repo_url %}
+                    {% with (site?.params?.repo_url ?? none) as repo_url %}
                     {% if repo_url and not (site._dev_menu_metadata?.github_bundled ?? false) %}
                     <li><a href="{{ repo_url }}" target="_blank" rel="noopener" aria-label="GitHub">{{
                             icon('github-logo', size=16) }} <span>GitHub</span></a></li>
@@ -340,8 +344,8 @@ HELPER: Render a menu item (desktop/mobile)
                 {% end %}
 
                 <div class="header-actions hidden-mobile">
-                    {% with config.search.ui as ui %}
-                    {% if ui.modal ?? false %}
+                    {% with (config?.search?.ui ?? none) as ui %}
+                    {% if ui and (ui?.modal ?? false) %}
                     <button type="button" class="nav-search-trigger" id="nav-search-trigger" title="Search (⌘K)">{{
                         icon('magnifying-glass', size=16) }} <span>Search</span> <kbd
                             class="nav-search-shortcut">⌘K</kbd></button>
@@ -366,8 +370,8 @@ HELPER: Render a menu item (desktop/mobile)
     {# Search Modal Block — placed after <main> so content starts early in DOM #}
     {% block site_search_modal %}
     {% cache 'base-search-modal-' ~ _current_lang ~ '-' ~ (bengal.build.timestamp ?? '') %}
-    {% with config.search.ui as ui %}
-    {% if ui.modal ?? false %}
+    {% with (config?.search?.ui ?? none) as ui %}
+    {% if ui and (ui?.modal ?? false) %}
     <dialog id="search-modal" class="search-modal"
         aria-label="{{ t('search.aria_label', default='Search documentation') }}">
         <div class="search-modal__backdrop" data-close-modal></div>
@@ -462,7 +466,7 @@ HELPER: Render a menu item (desktop/mobile)
                     <a href="{{ item.href | absolute_url }}">{{ item.name }}</a>
                 </li>{% end %}
                 {% end %}
-                {% with site.params.repo_url as repo_url %}
+                {% with (site?.params?.repo_url ?? none) as repo_url %}
                 {% if repo_url and not (site._dev_menu_metadata?.github_bundled ?? false) %}
                 <li><a href="{{ repo_url }}" target="_blank" rel="noopener">{{ icon('github-logo', size=16) }}
                         GitHub</a></li>
@@ -589,7 +593,7 @@ HELPER: Render a menu item (desktop/mobile)
     {% end %}{# /cache base-speculation #}
 
     {# Bootstrap metadata — moved after content for faster content-start position #}
-    {% if config.expose_metadata_json %}
+    {% if config?.expose_metadata_json ?? false %}
     <script id="bengal-bootstrap" type="application/json">{{ bengal | tojson }}</script>
     <script>
         (function () {

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -72,12 +72,12 @@ HELPER: Render a menu item (desktop/mobile)
     {% if has_children %}
     <ul class="submenu">
         {% for child in item.children %}
-        <li class="{{ ['active' if child.active] | classes }}">
-            <a href="{{ child.href | absolute_url }}">
-                {% with child.icon as icon_name %}
+        <li class="{{ ['active' if (child?.active ?? false)] | classes }}">
+            <a href="{{ (child?.href ?? '') | absolute_url }}">
+                {% with (child?.icon ?? none) as icon_name %}
                 {% if icon_name %}<span class="submenu-icon">{{ icon(icon_name, size=16) }}</span>{% end %}
                 {% end %}
-                <span class="submenu-text"><bdi>{{ child.name }}</bdi></span>
+                <span class="submenu-text"><bdi>{{ child?.name ?? '' }}</bdi></span>
             </a>
         </li>
         {% end %}

--- a/bengal/themes/default/templates/index.html
+++ b/bengal/themes/default/templates/index.html
@@ -34,9 +34,9 @@ related: false # disable related entirely
     <header class="section-header">
         <h1>{{ page.title if page else section.title if section else site.title }}</h1>
 
-        {% if page and params.description %}
+        {% if page and (params?.description ?? none) %}
         <p class="section-description">{{ params.description }}</p>
-        {% elif section and section.params.description %}
+        {% elif section and (section?.params?.description ?? none) %}
         <p class="section-description">{{ section.params.description }}</p>
         {% end %}
     </header>

--- a/bengal/themes/default/templates/partials/action-bar.html
+++ b/bengal/themes/default/templates/partials/action-bar.html
@@ -66,7 +66,7 @@ BREADCRUMB ITEM HELPER
     {% let breadcrumb_items = get_breadcrumbs(page) ?? [] %}
 
     {% let params = params ?? {} %}
-    {% let has_metadata = params?.author or page?.date or page?.content or params?.lastmod %}
+    {% let has_metadata = (params?.author ?? none) or (page?.date ?? none) or (page?.content ?? none) or (params?.lastmod ?? none) %}
     {% let theme_features = theme?.features ?? [] %}
 
     <div class="action-bar-container">
@@ -154,7 +154,7 @@ BREADCRUMB ITEM HELPER
         {% if has_metadata %}
         <div id="action-bar-metadata-popover" popover class="action-bar-metadata--popover">
             <div class="action-bar-metadata-content">
-                {% with params?.author as author %}
+                {% with (params?.author ?? none) as author %}
                 {% if author and 'content.author' in theme_features %}
                 <span class="action-bar-meta-item">
                     {{ icon("user", size=16) }}
@@ -181,7 +181,7 @@ BREADCRUMB ITEM HELPER
                 {% end %}
                 {% end %}
 
-                {% with params?.lastmod ?? page?.date as last_updated %}
+                {% with (params?.lastmod ?? page?.date ?? none) as last_updated %}
                 {% if last_updated %}
                 <span class="action-bar-meta-item">
                     {{ icon("arrow-clockwise", size=16) }}

--- a/bengal/themes/default/templates/partials/article-jsonld.html
+++ b/bengal/themes/default/templates/partials/article-jsonld.html
@@ -12,8 +12,8 @@ Usage in base.html head:
 -#}
 
 {%- set article_enabled = (config.structured_data ?? {}).article ?? true %}
-{%- set is_doc = page.type == 'doc' or page.kind == 'doc' %}
-{%- set is_post = page.type == 'post' or page.kind == 'post' %}
+{%- set is_doc = (page?.type ?? '') == 'doc' or (page?.kind ?? '') == 'doc' %}
+{%- set is_post = (page?.type ?? '') == 'post' or (page?.kind ?? '') == 'post' %}
 {%- set _toc = page.toc_items ?? toc_items ?? [] %}
 {%- if article_enabled and (is_doc or is_post) %}
 <script type="application/ld+json">

--- a/bengal/themes/default/templates/partials/components/helpers.html
+++ b/bengal/themes/default/templates/partials/components/helpers.html
@@ -23,7 +23,7 @@ Usage with {% call %}:
 {% def for_each_item_excluding_current(items) %}
 {% let page_path = page?._path ?? '' %}
 {% for item in items %}
-{% if item?._path != page_path %}
+{% if (item?._path ?? '') != page_path %}
 {{ caller(item) }}
 {% end %}
 {% end %}

--- a/bengal/themes/default/templates/partials/components/tiles.html
+++ b/bengal/themes/default/templates/partials/components/tiles.html
@@ -48,6 +48,7 @@ page=none
 'description': subsection?.metadata?.description ?? '',
 'weight': subsection?.weight ?? 999,
 'page_count': sub_pages | length,
+'date': none,
 'icon': subsection?.metadata?.icon ?? ''
 }) %}
 {% end %}
@@ -57,7 +58,7 @@ page=none
 {% if children %}
 {% for post in children %}
 {# Skip the current page #}
-{% if post?._path != page_path %}
+{% if (post?._path ?? '') != page_path %}
 {% let post_content = post?.content ?? '' %}
 {% let post_desc = post?.metadata?.description ?? '' %}
 {% let desc = post_desc ?? (post_content | strip_html | excerpt(120) if post_content else '') %}
@@ -69,7 +70,8 @@ page=none
 'href': post?.href ?? post?._path ?? '',
 'description': desc,
 'weight': post?.weight ?? 999,
-'date': post?.date,
+'page_count': 0,
+'date': post?.date ?? none,
 'icon': post?.metadata?.icon ?? ''
 }) %}
 {% end %}
@@ -108,7 +110,8 @@ page=none
 'href': rel_href,
 'description': desc,
 'weight': rel_page?.weight ?? 999,
-'date': rel_page?.date,
+'page_count': 0,
+'date': rel_page?.date ?? none,
 'icon': rel_page?.metadata?.icon ?? ''
 }) %}
 {% end %}
@@ -181,7 +184,9 @@ sort(attribute='weight,title') %}
   {# ===== COMPACT VARIANT (default) ===== #}
   {% case _ %}
   <div class="content-tiles-list">
-    {% for group_name, group_items in sorted_items | groupby('group') %}
+    {% for group in sorted_items | groupby('group') %}
+    {% let group_name = group.grouper %}
+    {% let group_items = group.list %}
     {# Group headers when group_by='type' #}
     {% if group_by == 'type' and group_name == 'related' and related_title %}
     <div class="content-tiles-group-header">

--- a/bengal/themes/default/templates/partials/meta-generator.html
+++ b/bengal/themes/default/templates/partials/meta-generator.html
@@ -6,22 +6,25 @@ Defaults to minimal (generator only).
 <meta name="generator" content="{{ bengal.engine.name }} {{ bengal.engine.version }}">
 
 {# Standard/Extended extras #}
-{% if bengal.theme.name %}
+{% let _theme = bengal?.theme ?? none %}
+{% if _theme and (_theme?.name ?? none) %}
 <meta name="bengal:theme"
-    content="{{ bengal.theme.name }}{% if bengal.theme.version %}@{{ bengal.theme.version }}{% end %}">
+    content="{{ _theme.name }}{% if _theme?.version ?? none %}@{{ _theme.version }}{% end %}">
 {% end %}
 
 {# Suppress build timestamp in dev to avoid content churn and spurious reloads #}
-{% if (not config.dev_server) and bengal.build.timestamp %}
-<meta name="bengal:build" content="{{ bengal.build.timestamp }}">
+{% let _build = bengal?.build ?? none %}
+{% if (not (config?.dev_server ?? false)) and _build and (_build?.timestamp ?? none) %}
+<meta name="bengal:build" content="{{ _build.timestamp }}">
 {% end %}
 
 {# Extended extras #}
-{% if bengal.rendering.markdown %}
+{% let _rendering = bengal?.rendering ?? none %}
+{% if _rendering and (_rendering?.markdown ?? none) %}
 <meta name="bengal:markdown"
-    content="{{ bengal.rendering.markdown }}{% if bengal.rendering.markdownVersion %}@{{ bengal.rendering.markdownVersion }}{% end %}">
+    content="{{ _rendering.markdown }}{% if _rendering?.markdownVersion ?? none %}@{{ _rendering.markdownVersion }}{% end %}">
 {% end %}
-{% if bengal.rendering.highlighter %}
+{% if _rendering and (_rendering?.highlighter ?? none) %}
 <meta name="bengal:highlighter"
-    content="{{ bengal.rendering.highlighter }}{% if bengal.rendering.highlighterVersion %}@{{ bengal.rendering.highlighterVersion }}{% end %}">
+    content="{{ _rendering.highlighter }}{% if _rendering?.highlighterVersion ?? none %}@{{ _rendering.highlighterVersion }}{% end %}">
 {% end %}

--- a/bengal/themes/default/templates/partials/page-hero/_macros.html
+++ b/bengal/themes/default/templates/partials/page-hero/_macros.html
@@ -469,7 +469,7 @@ KIDA FEATURES:
         {% if source_file and config?.github_repo %}
         {% let branch = config?.github_branch ?? 'main' %}
         {% let line_anchor = '#L' ~ element.line_number if element?.line_number else '' %}
-        {% let source_url = config.params.github_repo ~ '/blob/' ~ branch ~ '/' ~ source_file ~ line_anchor %}
+        {% let source_url = config.github_repo ~ '/blob/' ~ branch ~ '/' ~ source_file ~ line_anchor %}
         <a href="{{ source_url }}" class="page-hero__source-link" target="_blank" rel="noopener">
             {{ icon('file-code', size=14) }}
             <span>{{ t('source.view', default='View source') }}</span>
@@ -504,7 +504,7 @@ KIDA FEATURES:
 
 {% def hero_section(section, page, hero_context) %}
 {# Determine section type from explicit context, page type, or URL (fallback) #}
-{% let is_cli = hero_context?.is_cli or (page?.type == 'autodoc-cli') or (page?.href and '/cli' in page.href) or false
+{% let is_cli = (hero_context?.is_cli ?? false) or (page?.type == 'autodoc-cli') or (page?.href and '/cli' in page.href) or false
 %}
 {% let section_type = 'cli' if is_cli else 'api' %}
 {% let labels = SECTION_LABELS[section_type] %}

--- a/bengal/themes/default/templates/partials/product-jsonld.html
+++ b/bengal/themes/default/templates/partials/product-jsonld.html
@@ -32,7 +32,7 @@ Usage in base.html or product layout:
   {% include "partials/product-jsonld.html" %}
 -#}
 
-{%- if page.structured_data and page.type == 'product' %}
+{%- if (page?.structured_data ?? none) and (page?.type ?? '') == 'product' %}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org/",

--- a/changelog.d/kida-0.7.0-upgrade.changed.md
+++ b/changelog.d/kida-0.7.0-upgrade.changed.md
@@ -1,0 +1,1 @@
+Upgrade kida-templates to 0.7.0. The new default `strict_undefined=True` now raises `UndefinedError` on missing attrs/keys instead of rendering empty — default-theme templates were updated to use `?.` optional chaining with `?? default` fallbacks, and `tiles.html` was updated for the new `groupby` iteration shape (`{grouper, list}` dicts instead of `(key, items)` tuples).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "milo-cli>=0.2.2",                         # B-stack CLI framework (replaces Click — migration in progress)
 
     "rosettes>=0.2.0",
-    "kida-templates>=0.6.0",                   # Kida template engine (AST-native, free-threading ready)
+    "kida-templates>=0.7.0",                   # Kida template engine (AST-native, free-threading ready)
     "patitas>=0.3.5",                          # Markdown + notebook + frontmatter parser
     "pyyaml>=6.0",
     "jsmin>=3.0.1",

--- a/tests/themes/test_default_theme_kida.py
+++ b/tests/themes/test_default_theme_kida.py
@@ -115,12 +115,13 @@ class TestKidaNativeFeatures:
         # Block renders default content when not extended
         assert "default" in tmpl.render()
 
-    def test_do_statement(self, env: Environment):
-        """Test {% do %} for side effects."""
+    def test_set_append_for_side_effects(self, env: Environment):
+        """Test {% set _ = list.append(...) %} — kida 0.7.0 dropped {% do %}
+        in favor of set-with-discard and the | compact filter."""
         tmpl = env.from_string("""
 {%- set items = [] -%}
-{%- do items.append(1) -%}
-{%- do items.append(2) -%}
+{%- set _ = items.append(1) -%}
+{%- set _ = items.append(2) -%}
 {{ items | length }}
 """)
         assert tmpl.render().strip() == "2"
@@ -184,10 +185,13 @@ class TestKidaNativeFeatures:
         assert tmpl.render().strip() == "10-20-30"
 
     def test_with_as_nil_resilient(self, env: Environment):
-        """Test {% with expr as name %} for nil-resilient binding."""
-        # When value exists, block renders
+        """Test {% with expr as name %} for nil-resilient binding.
+
+        Under kida 0.7.0 strict_undefined, missing-key access raises; pair
+        {% with %} with `?? none` so an absent key is treated as nil by the block.
+        """
         tmpl = env.from_string("""
-{%- with user.name as name -%}
+{%- with (user?.name ?? none) as name -%}
 Hello, {{ name }}!
 {%- end -%}
 """)

--- a/tests/unit/rendering/test_autodoc_layout_contract.py
+++ b/tests/unit/rendering/test_autodoc_layout_contract.py
@@ -52,6 +52,10 @@ def test_base_template_does_not_render_none_variant_attribute() -> None:
     base_path = Path("bengal/themes/default/templates/base.html")
     base = base_path.read_text(encoding="utf-8")
 
-    # Require a guard that emits an empty string when variant is falsy.
-    # Pattern: page.variant or '' (Jinja2 shorthand for fallback)
-    assert re.search(r'data-variant="\{\{\s*page\.variant\s+or\s+\'\'\s*\}\}"', base)
+    # Require a guard that emits an empty string when variant is None/absent.
+    # Kida 0.7.0 strict_undefined requires `page?.variant ?? ''` for safe access;
+    # the trailing `or ''` further coerces a stored None to an empty string.
+    assert re.search(
+        r"data-variant=\"\{\{\s*\(\s*page\?\.variant\s*\?\?\s*''\s*\)\s+or\s+''\s*\}\}\"",
+        base,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.7" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jsmin", specifier = ">=3.0.1" },
-    { name = "kida-templates", specifier = ">=0.6.0" },
+    { name = "kida-templates", specifier = ">=0.7.0" },
     { name = "lunr", marker = "extra == 'search'", specifier = ">=0.7.0" },
     { name = "milo-cli", git = "https://github.com/lbliii/milo-cli.git?rev=db0426e823abec0f853804ec7490e60847560bb9" },
     { name = "packaging", specifier = ">=23.0" },
@@ -592,11 +592,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f
 
 [[package]]
 name = "kida-templates"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/3a/07c7cdd1ff8a96ca277663cb5358a3104ee115a0b5a98a5540a82111a31c/kida_templates-0.6.0.tar.gz", hash = "sha256:d01b38442cd0d2f10dfaa0215f6aeb474577596081486b23b482309bf8d68c3f", size = 529973, upload-time = "2026-04-13T22:32:35.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/d0/261198d9c8667272ee87c2012fa42fea6628053e34c1ec7bf66ed147ece8/kida_templates-0.7.0.tar.gz", hash = "sha256:81fcbc167f9754e0fc503d46ea50b4e558f0da1c468bcf28b57f670152856f65", size = 570668, upload-time = "2026-04-20T21:40:22.864Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/07/4d08e9333f009cf578e557f28dfa22a190af89c4c4ac9934848528c66309/kida_templates-0.6.0-py3-none-any.whl", hash = "sha256:e5da2e0531c9256e0db19b6c7afc4b9220eb426677f9b4ed0ac12ee59a56b5f3", size = 384796, upload-time = "2026-04-13T22:32:33.668Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/fb/52359cf08ed6547f03be43958af2ebfd5df2bb65cda08e68dd3e6ab6f27b/kida_templates-0.7.0-py3-none-any.whl", hash = "sha256:b7b7e1061dbf21ba5ba296efcba40f003576c4428006ff4531fa5861e34dbc60", size = 400534, upload-time = "2026-04-20T21:40:20.927Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `kida-templates` from 0.6.0 → 0.7.0, which flips `strict_undefined` to default-True (missing attrs/keys now raise `UndefinedError` instead of silently rendering empty).
- Updates ~9 default-theme templates to use `?.` optional chaining with `?? default` fallbacks wherever metadata-proxy / snapshot fields may be absent.
- Fixes the `| groupby` iteration pattern in `tiles.html` — kida 0.7.0's `groupby` returns `{grouper, list}` dicts rather than `(key, items)` tuples.
- Updates three tests: `with`-as nil-resilience now needs `?? none`, `{% do %}` was removed in favor of `{% set _ = ... %}` / `| compact`, and the variant-attribute contract regex matches the new safe-access form.

## Test plan

- [x] `pytest tests/themes tests/unit/rendering` — 1887 passed, 3 skipped
- [ ] Smoke-build the example site and confirm no `UndefinedError` in the default theme