### PR TITLE
[codex] Add scoped steward agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,17 @@ The current shape to preserve:
 - Rendering owns parser, template, shortcode, AST/HTML, and URL presentation behavior. Core may call into rendering lazily from a compatibility shim; it should not import rendering helpers at module load time.
 - Protocols and plugin hooks are public contracts. Prefer internal adapters or rendering services over widening `SiteLike`, `PageLike`, or `Plugin`.
 
+Scoped `AGENTS.md` files act as local stewards. The root file is the
+constitution; nested files explain what a package protects, what it refuses to
+become, and which local checks best defend that boundary. When editing a
+subtree, read the closest `AGENTS.md` in addition to this one.
+Stewards also own the documentation that explains their subsystem. If a code
+change alters a package's behavior, boundary, or extension story, update the
+nearest architecture/reference docs in the same PR.
+When a change crosses a scoped steward area, add brief `Steward Notes` to the
+PR description. Name the steward area and one sentence about how its invariants
+were protected; this is a lightweight sign-off, not a new gate.
+
 ---
 
 ## Who reads your output
@@ -212,6 +223,7 @@ A change is done when all of these hold:
 - **I read diff-first, description-second.** Tight diff + clear why merges fast; sprawling diff gets questions.
 - **One concern per PR.** If the diff needs section headers, it's two PRs. Exception: refactors renaming a concept across many files — one bundled PR beats review churn.
 - **Commit style:** see `git log`. `<scope>: <description>` — scope is `core` / `orchestration` / `rendering` / `cache` / `cli` / `tests` / `docs` / `deps` / `release`. Imperative. Multi-area: separate with `;`.
+- **Steward notes:** when scoped `AGENTS.md` guidance applies, include a short PR section such as `Page steward: compatibility shim preserved; Rendering steward: behavior stays behind helper.`
 - **Don't trailing-summary me.** If the diff is readable, I can read it.
 - **Flag surprises.** Weird test, unused config, dead code, an allow-list that grew — put it in the PR description. Don't fix silently, don't ignore.
 - **Dead code you found.** Flag in the PR, let me decide. Bengal has had vestiges from prior extractions (ConfigService, PageCacheManager, PageProxy — finally deleted in #200) that lingered. Most are deletable; some are load-bearing for a transport, plugin, or example.

--- a/bengal/cache/AGENTS.md
+++ b/bengal/cache/AGENTS.md
@@ -1,0 +1,35 @@
+# Cache Steward
+
+Cache code protects rebuild correctness and repeatability. A cache hit is a
+claim that the rendered output is still trustworthy.
+
+Related architecture docs:
+
+- `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/core/cache.md`
+
+## Protect
+
+- Stable cache keys and schema compatibility.
+- Atomic persistence and crash safety.
+- Explicit migration paths for old cache shapes.
+- Deterministic serialization for free-threaded builds.
+
+## Do Not
+
+- Write cache files directly with `Path.write_text()` or `open()`.
+- Treat cache misses and corrupt cache files the same.
+- Store mutable live domain objects when snapshots or records should be used.
+- Add compression or persistence behavior without tests for fallback paths.
+
+## Documentation Ownership
+
+- Own `site/content/docs/reference/architecture/core/cache.md`.
+- Keep performance docs accurate when cache behavior changes rebuild speed or storage.
+- Update migration notes when cache schema compatibility changes.
+
+## Local Checks
+
+- `uv run pytest tests/unit/cache tests/unit/discovery -q`
+- `uv run pytest tests/integration/test_phase2b_cache_integration.py -q`
+- `uv run ruff check bengal/cache tests/unit/cache`

--- a/bengal/cli/AGENTS.md
+++ b/bengal/cli/AGENTS.md
@@ -1,0 +1,35 @@
+# CLI Steward
+
+The CLI is a user-facing contract. Commands should be fast to import, explicit
+to discover, structured for machines, and helpful for humans.
+
+Related architecture docs:
+
+- `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/tooling/cli.md`
+
+## Protect
+
+- Milo command patterns: annotated parameters, lazy registration, dict returns.
+- Stable command names, flags, and structured output.
+- Clear errors and tips for site authors.
+- Cold-start performance.
+
+## Do Not
+
+- Add Click-style decorators or parser construction shortcuts.
+- `print()` command results instead of returning structured data or using CLI render helpers.
+- Add broad imports at CLI startup.
+- Change public flags without migration notes.
+
+## Documentation Ownership
+
+- Own `site/content/docs/reference/architecture/tooling/cli.md`.
+- Keep command examples and help-output docs in sync with Milo command changes.
+- Update migration notes when flags, command names, or structured output changes.
+
+## Local Checks
+
+- `uv run pytest tests/unit/cli tests/integration/test_cli_help.py -q`
+- `uv run ruff check bengal/cli tests/unit/cli`
+- Run wheel/install smoke tests for packaging-visible command changes.

--- a/bengal/core/AGENTS.md
+++ b/bengal/core/AGENTS.md
@@ -1,0 +1,34 @@
+# Core Steward
+
+This directory protects Bengal's passive domain model. Core objects describe
+state, identity, relationships, and cacheable facts. They do not perform I/O,
+log directly, or own rendering behavior.
+
+Start with the root guidance in `../../AGENTS.md`, then use this file for the
+local boundary.
+
+## Protect
+
+- Passive objects: `Site`, `Page`, `Section`, `PageCore`, records, registries.
+- Compatibility shims that preserve existing template/plugin access.
+- Deferred imports where core reaches into rendering only from a shim.
+- The empty core mixin allow-list in `tests/unit/core/test_no_core_mixins.py`.
+
+## Do Not
+
+- Add filesystem I/O, direct logging, rendering, parsing, or template behavior.
+- Reintroduce inheritance mixins.
+- Add fields to immutable pipeline records without a design conversation.
+- Widen public protocols to make one core call site easier.
+
+## Documentation Ownership
+
+- Keep `site/content/docs/reference/architecture/core/` aligned with core boundaries.
+- Update `site/content/docs/reference/architecture/design-principles.md` when core's role changes.
+- Keep object model docs honest when `Page`, `Section`, `Site`, or records move behavior.
+
+## Local Checks
+
+- `uv run pytest tests/unit/core tests/core -q`
+- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
+- `uv run ruff check bengal/core tests/unit/core tests/core`

--- a/bengal/core/page/AGENTS.md
+++ b/bengal/core/page/AGENTS.md
@@ -1,0 +1,38 @@
+# Page Steward
+
+`Page` is a compatibility surface, not a renderer. It may expose stable
+template-facing properties, but the work behind rendered content, URLs, TOC,
+excerpts, shortcode/link extraction, and bundle resource views belongs under
+`bengal/rendering/`.
+
+Related architecture docs:
+
+- `../../../AGENTS.md`
+- `../../../site/content/docs/reference/architecture/core/object-model.md`
+- `../../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
+
+## Protect
+
+- `PageCore` as the cacheable metadata shape.
+- `Page` properties that older templates and plugins already call.
+- Thin deferred shims from `Page` to rendering helpers.
+- Bundle/resource compatibility without putting filesystem or image behavior in core.
+
+## Do Not
+
+- Move parser, HTML, excerpt, TOC, shortcode, URL, or resource I/O logic into `Page`.
+- Add broad convenience fields to `PageCore` for values that require parsing/rendering.
+- Recreate deleted `content.py`, `metadata.py`, or relationship mixin modules as behavior sinks.
+- Add `# type: ignore` to quiet Page protocol friction.
+
+## Documentation Ownership
+
+- Own Page sections in `site/content/docs/reference/architecture/core/object-model.md`.
+- Keep `site/content/docs/reference/architecture/rendering/content-processing-api.md` accurate for Page shims.
+- Update `site/content/docs/reference/template-functions/page-properties.md` when template-facing Page access changes.
+
+## Local Checks
+
+- `uv run pytest tests/unit/rendering/test_page_content.py tests/unit/rendering/test_page_operations.py tests/unit/rendering/test_page_urls.py tests/unit/rendering/test_page_resources.py -q`
+- `uv run pytest tests/core/test_page_bundles.py tests/unit/core/test_computed_functions.py -q`
+- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`

--- a/bengal/core/section/AGENTS.md
+++ b/bengal/core/section/AGENTS.md
@@ -1,0 +1,37 @@
+# Section Steward
+
+`Section` protects structural hierarchy, page membership, query/sort behavior,
+and version-aware structural navigation. Presentation belongs in rendering.
+
+Related architecture docs:
+
+- `../../../AGENTS.md`
+- `../../../site/content/docs/reference/architecture/core/object-model.md`
+- `../../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
+
+## Protect
+
+- Parent/child relationships, section walking, and structural identity.
+- Page retrieval, sorting, and index-page decisions.
+- Version filters that describe content membership.
+- Compatibility shims for older imports and template access.
+
+## Do Not
+
+- Put URL presentation, icon/nav display logic, content stats, or template
+  application back into core.
+- Reintroduce Section mixins.
+- Hoist rendering imports to module level.
+- Treat theme ergonomics as structural domain logic.
+
+## Documentation Ownership
+
+- Own Section sections in `site/content/docs/reference/architecture/core/object-model.md`.
+- Keep `site/content/docs/reference/architecture/rendering/content-processing-api.md` accurate for Section shims.
+- Update `site/content/docs/reference/template-functions/navigation-functions.md` when navigation-facing behavior changes.
+
+## Local Checks
+
+- `uv run pytest tests/unit/rendering/test_section_urls.py tests/unit/rendering/test_section_ergonomics.py -q`
+- `uv run pytest tests/unit/core/test_section_sorting.py tests/unit/core/test_section_versioning.py tests/unit/test_nav_tree.py -q`
+- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`

--- a/bengal/core/site/AGENTS.md
+++ b/bengal/core/site/AGENTS.md
@@ -1,0 +1,37 @@
+# Site Steward
+
+`Site` holds the site graph and coordinates through registries, services, and
+orchestration. It is not a place to reacquire forwarding wrappers just because a
+service exists.
+
+Related architecture docs:
+
+- `../../../AGENTS.md`
+- `../../../site/content/docs/reference/architecture/core/object-model.md`
+- `../../../site/content/docs/reference/architecture/core/orchestration.md`
+
+## Protect
+
+- Site state, registries, and lookup surfaces used by orchestration/rendering.
+- Stable compatibility behavior expected by themes and plugins.
+- The post-mixin shape of `bengal/core/site/`.
+- Clear handoff to orchestration for build work.
+
+## Do Not
+
+- Add build-phase logic, output writes, rendering behavior, or logging here.
+- Add broad forwarding methods to mirror internal services.
+- Expand `SiteLike` as a shortcut for one implementation detail.
+- Reintroduce Site mixins.
+
+## Documentation Ownership
+
+- Own Site sections in `site/content/docs/reference/architecture/core/object-model.md`.
+- Keep `site/content/docs/reference/architecture/core/orchestration.md` honest about what Site delegates.
+- Update `site/content/docs/reference/architecture/core/data-flow.md` when Site state handoffs change.
+
+## Local Checks
+
+- `uv run pytest tests/unit/core tests/core -q`
+- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
+- `uv run ruff check bengal/core/site`

--- a/bengal/errors/AGENTS.md
+++ b/bengal/errors/AGENTS.md
@@ -1,0 +1,34 @@
+# Errors Steward
+
+Errors are documentation for people under stress. Bengal errors should identify
+what broke, where it broke, and what the author can do next.
+
+Related architecture docs:
+
+- `../../AGENTS.md`
+
+## Protect
+
+- `BengalError` with `code`, `context`, `suggestion`, and `debug_payload`.
+- Reader-facing messages with concrete next steps.
+- Diagnostics that preserve source path and phase context.
+- Error rendering that does not introduce rendering/core import cycles.
+
+## Do Not
+
+- Add silent `except Exception: pass`.
+- Replace actionable errors with generic `ValueError` or raw tracebacks.
+- Log directly from `bengal/core/`.
+- Hide malformed user input behind fallback behavior.
+
+## Documentation Ownership
+
+- Own `site/content/docs/reference/errors/`.
+- Keep troubleshooting docs, including `site/content/docs/building/troubleshooting/template-errors.md`, aligned with user-facing errors.
+- Update examples when `BengalError` context, codes, or suggestions change.
+
+## Local Checks
+
+- `uv run pytest tests/unit/errors tests/unit/health -q`
+- `uv run ruff check bengal/errors tests/unit/errors`
+- Search for broad exception handling when touching error paths.

--- a/bengal/orchestration/AGENTS.md
+++ b/bengal/orchestration/AGENTS.md
@@ -1,0 +1,37 @@
+# Orchestration Steward
+
+Orchestration coordinates discovery, build phases, rendering batches,
+provenance, cache policy, and output writing. It should make sequencing clear
+without absorbing domain or rendering behavior.
+
+Related architecture docs:
+
+- `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/core/orchestration.md`
+- `../../site/content/docs/reference/architecture/core/data-flow.md`
+
+## Protect
+
+- Build phase clarity and ordering.
+- Plugin hook timing and compatibility.
+- Atomic output writes through approved helpers.
+- Boundaries between discovery, rendering, postprocess, and cache/provenance.
+
+## Do Not
+
+- Add a new build phase without a design conversation.
+- Bypass plugin hook surfaces for behavior extensions.
+- Write files non-atomically.
+- Move domain convenience behavior into orchestration just to share it.
+
+## Documentation Ownership
+
+- Own `site/content/docs/reference/architecture/core/orchestration.md`.
+- Keep `site/content/docs/reference/architecture/core/data-flow.md` accurate for phase handoffs.
+- Update extension-point docs when orchestration changes plugin hook timing.
+
+## Local Checks
+
+- `uv run pytest tests/unit/orchestration tests/integration -q`
+- `uv run ruff check bengal/orchestration tests/unit/orchestration`
+- `make changelog-check` for behavior-visible changes.

--- a/bengal/orchestration/build/AGENTS.md
+++ b/bengal/orchestration/build/AGENTS.md
@@ -1,0 +1,35 @@
+# Build Phase Steward
+
+The numbered build pipeline is intentionally explicit. Phase changes affect
+cache correctness, plugin hook timing, user output, and incremental rebuilds.
+
+Related architecture docs:
+
+- `../../../AGENTS.md`
+- `../../../site/content/docs/reference/architecture/core/orchestration.md`
+
+## Protect
+
+- The existing phase order and hook timing.
+- Clear inputs and outputs for each phase.
+- Atomic finalization and output safety.
+- Explicit callbacks for observability instead of hidden side effects.
+
+## Do Not
+
+- Insert or reorder phases casually.
+- Add behavior that bypasses existing plugin hook surfaces.
+- Mix rendering implementation details into phase coordinators.
+- Treat a passing fast test as proof that incremental behavior is correct.
+
+## Documentation Ownership
+
+- Own build-phase descriptions in `site/content/docs/reference/architecture/core/orchestration.md`.
+- Keep `site/content/docs/reference/architecture/core/pipeline.md` aligned with phase inputs/outputs.
+- Update user-facing build docs when phase behavior affects command output or artifacts.
+
+## Local Checks
+
+- `uv run pytest tests/unit/orchestration/build -q`
+- `uv run pytest tests/integration/test_incremental_invariants.py -q`
+- `uv run ruff check bengal/orchestration/build`

--- a/bengal/orchestration/incremental/AGENTS.md
+++ b/bengal/orchestration/incremental/AGENTS.md
@@ -1,0 +1,35 @@
+# Incremental Build Steward
+
+Incremental orchestration protects the promise that a rebuild is both fast and
+correct. Stale content is worse than a failed build because authors trust it.
+
+Related architecture docs:
+
+- `../../../AGENTS.md`
+- `../../../site/content/docs/reference/architecture/core/cache.md`
+
+## Protect
+
+- Dependency tracking and invalidation correctness.
+- Provenance of content, templates, data, assets, and config.
+- Conservative rebuilds when uncertainty exists.
+- Clear diagnostics for why a page did or did not rebuild.
+
+## Do Not
+
+- Optimize by skipping a dependency edge unless a test proves it is safe.
+- Collapse distinct invalidation reasons into vague flags.
+- Use non-atomic cache writes.
+- Hide stale-output risk in broad exception handling.
+
+## Documentation Ownership
+
+- Own incremental sections in `site/content/docs/reference/architecture/core/cache.md`.
+- Keep `site/content/docs/building/performance/template-deps.md` accurate for dependency behavior.
+- Update troubleshooting docs when invalidation diagnostics change.
+
+## Local Checks
+
+- `uv run pytest tests/unit/orchestration/incremental tests/integration/warm_build -q`
+- `uv run pytest tests/integration/test_incremental_invariants.py -q`
+- `uv run ruff check bengal/orchestration/incremental`

--- a/bengal/protocols/AGENTS.md
+++ b/bengal/protocols/AGENTS.md
@@ -1,0 +1,36 @@
+# Protocols Steward
+
+Protocols and plugin hook shapes are public contracts. They are read by plugin
+developers and mocked throughout tests, so casual widening is expensive.
+
+Related architecture docs:
+
+- `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/meta/protocols.md`
+- `../../site/content/docs/reference/architecture/meta/extension-points.md`
+
+## Protect
+
+- The `Plugin` protocol and the 9 supported hook surfaces.
+- Narrow `PageLike`, `SectionLike`, and `SiteLike` contracts.
+- Test-double compatibility.
+- Backward-compatible evolution through adapters where possible.
+
+## Do Not
+
+- Add protocol attributes to satisfy one implementation detail.
+- Change hook signatures without a migration note and design discussion.
+- Use protocols as a dumping ground for private conveniences.
+- Break third-party plugins for internal cleanup.
+
+## Documentation Ownership
+
+- Own `site/content/docs/reference/architecture/meta/protocols.md`.
+- Own plugin-contract material in `site/content/docs/reference/architecture/meta/extension-points.md`.
+- Update migration docs/changelog notes for public protocol or hook changes.
+
+## Local Checks
+
+- `uv run pytest tests/unit/protocols tests/core/test_type_safety.py -q`
+- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
+- `uv run ruff check bengal/protocols tests/unit/protocols`

--- a/bengal/rendering/AGENTS.md
+++ b/bengal/rendering/AGENTS.md
@@ -1,0 +1,38 @@
+# Rendering Steward
+
+Rendering owns the work that turns domain state into presentation: HTML,
+template views, excerpts, TOC structures, URLs, shortcode/link extraction, and
+page/section resource views.
+
+Related architecture docs:
+
+- `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/design-principles.md`
+- `../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
+
+## Protect
+
+- Template compatibility for existing themes and plugins.
+- Clear helper/service boundaries behind core compatibility shims.
+- Deferred imports where rendering and core need to see each other.
+- Rendering behavior that is deterministic under parallel builds.
+
+## Do Not
+
+- Push rendering-derived fields back into `bengal/core/`.
+- Add shared mutable state without a thread-safety reason.
+- Widen `PageLike`, `SectionLike`, or `SiteLike` just to satisfy one helper.
+- Hide parser/template failures behind silent fallbacks.
+
+## Documentation Ownership
+
+- Own `site/content/docs/reference/architecture/rendering/`.
+- Keep `site/content/docs/reference/template-functions/` accurate for template-facing behavior.
+- Update theming docs when rendering helpers change what themes can rely on.
+
+## Local Checks
+
+- `uv run pytest tests/unit/rendering -q`
+- `uv run pytest tests/rendering -q`
+- `uv run ruff check bengal/rendering tests/unit/rendering tests/rendering`
+- Run `check-cycles` before hoisting any deferred import across core/rendering.

--- a/bengal/rendering/pipeline/AGENTS.md
+++ b/bengal/rendering/pipeline/AGENTS.md
@@ -1,0 +1,37 @@
+# Rendering Pipeline Steward
+
+The rendering pipeline protects the phase where pages become output-ready
+content. This is free-threading sensitive: avoid hidden shared state, late
+mutation surprises, and cache writes that depend on task timing.
+
+Related architecture docs:
+
+- `../../../AGENTS.md`
+- `../../../site/content/docs/reference/architecture/core/pipeline.md`
+- `../../../site/content/docs/reference/architecture/rendering/rendering.md`
+
+## Protect
+
+- Deterministic page rendering under parallel execution.
+- Clear use of build context and accumulated output data.
+- Separation between immutable pipeline records and mutable compatibility pages.
+- Cache/provenance updates that are explicit and testable.
+
+## Do Not
+
+- Add global mutable caches without locks or a written reason.
+- Mutate frozen `SourcePage`, `ParsedPage`, or `RenderedPage` records.
+- Swallow rendering errors without diagnostics and context.
+- Make output writes directly from ad hoc code paths.
+
+## Documentation Ownership
+
+- Own pipeline details in `site/content/docs/reference/architecture/core/pipeline.md`.
+- Keep `site/content/docs/reference/architecture/rendering/rendering.md` current.
+- Update cache/provenance docs when pipeline scheduling changes invalidation behavior.
+
+## Local Checks
+
+- `uv run pytest tests/unit/rendering tests/unit/orchestration -q`
+- `uv run pytest tests/integration/test_incremental_invariants.py -q`
+- `uv run ruff check bengal/rendering/pipeline bengal/orchestration/build`

--- a/bengal/rendering/template_functions/AGENTS.md
+++ b/bengal/rendering/template_functions/AGENTS.md
@@ -1,0 +1,34 @@
+# Template Functions Steward
+
+Template functions are the supported ergonomic surface for themes. They should
+be explicit, registered intentionally, and safe for template authors to compose.
+
+Related architecture docs:
+
+- `../../../AGENTS.md`
+- `../../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
+
+## Protect
+
+- The explicit `register(env, site)` pattern.
+- Stable filter/global names used by bundled and user themes.
+- Small helpers that delegate domain-heavy work elsewhere.
+- Clear template-facing behavior and useful errors.
+
+## Do Not
+
+- Add filesystem auto-discovery for template helpers.
+- Reach into private core internals when a rendering/helper API exists.
+- Add helper names casually; template APIs are public enough to preserve.
+- Hide missing data or broken links with silent empty output.
+
+## Documentation Ownership
+
+- Own `site/content/docs/reference/template-functions/`.
+- Keep `site/content/docs/theming/templating/` and theming recipes accurate when helper behavior changes.
+- Update generated/reference docs when adding, renaming, or removing filters/globals.
+
+## Local Checks
+
+- `uv run pytest tests/unit/rendering tests/unit/template_functions -q`
+- `uv run ruff check bengal/rendering/template_functions tests/unit/template_functions`

--- a/bengal/snapshots/AGENTS.md
+++ b/bengal/snapshots/AGENTS.md
@@ -1,0 +1,36 @@
+# Snapshots Steward
+
+Snapshots protect a stable, render-ready view of a site for scheduling and
+parallel rendering. They should make shared state explicit and immutable where
+possible.
+
+Related architecture docs:
+
+- `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/core/pipeline.md`
+
+## Protect
+
+- Immutable or effectively immutable snapshot data.
+- Safe handoff between mutable compatibility pages and render scheduling.
+- Deterministic navigation/template/cache snapshots.
+- Thread-safe progress and error handling.
+
+## Do Not
+
+- Store live mutable objects when a snapshot value should be captured.
+- Add shared mutable scheduler state without synchronization.
+- Mutate page pipeline records.
+- Hide worker exceptions without page/source context.
+
+## Documentation Ownership
+
+- Own snapshot-related explanations in `site/content/docs/reference/architecture/core/pipeline.md`.
+- Keep cache and warm-build docs aligned when snapshot reuse behavior changes.
+- Update architecture docs when mutable Page compatibility and immutable snapshot handoffs move.
+
+## Local Checks
+
+- `uv run pytest tests/unit/snapshots -q`
+- `uv run pytest tests/integration/warm_build -q`
+- `uv run ruff check bengal/snapshots tests/unit/snapshots`

--- a/changelog.d/contributor-stewards.changed.md
+++ b/changelog.d/contributor-stewards.changed.md
@@ -1,0 +1,1 @@
+Add scoped AGENTS.md steward guidance for Bengal's highest-risk packages and test layers.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,36 @@
+# Tests Steward
+
+Tests protect behavior, not implementation trivia. They should make regressions
+obvious, keep fixtures understandable, and avoid widening production contracts
+just to satisfy mocks.
+
+Related architecture docs:
+
+- `../AGENTS.md`
+- `../site/content/docs/reference/architecture/meta/testing.md`
+
+## Protect
+
+- Focused unit tests for interesting branches.
+- Integration tests for user-visible workflows and build correctness.
+- `tests/roots/` fixtures as intentional, minimal sites.
+- Existing markers and parallel-safety expectations.
+
+## Do Not
+
+- Patch production protocols because a test double lacks an attribute.
+- Add broad snapshots where a small assertion would catch the behavior.
+- Fold unrelated cleanup into a bug/regression test PR.
+- Leave slow or parallel-unsafe tests unmarked.
+
+## Documentation Ownership
+
+- Own `site/content/docs/reference/architecture/meta/testing.md`.
+- Keep `tests/README.md` and `tests/roots/README.md` accurate when fixture/test patterns change.
+- Update docs when markers, shared mocks, or test-layer expectations change.
+
+## Local Checks
+
+- `uv run pytest tests/unit -q`
+- `uv run pytest tests/integration -q`
+- `uv run ruff check tests`

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -1,0 +1,28 @@
+# Integration Tests Steward
+
+Integration tests protect workflows: content in, site out, cache behavior
+preserved. They should catch what unit tests cannot see across subsystem seams.
+
+## Protect
+
+- Realistic site builds using focused `tests/roots/` fixtures.
+- Output correctness for pages, assets, indexes, feeds, and incremental rebuilds.
+- Regression tests for user-visible failures.
+- Clear fixture ownership and cleanup.
+
+## Do Not
+
+- Add a new large fixture when a smaller root can demonstrate the behavior.
+- Assert broad HTML blobs when a targeted output assertion is enough.
+- Depend on test order or leftover build artifacts.
+- Use integration tests for pure helper behavior.
+
+## Documentation Ownership
+
+- Keep integration-test guidance in `site/content/docs/reference/architecture/meta/testing.md` current.
+- Own fixture documentation in `tests/roots/README.md` when roots are added or reshaped.
+
+## Local Checks
+
+- `uv run pytest tests/integration -q`
+- `uv run ruff check tests/integration`

--- a/tests/performance/AGENTS.md
+++ b/tests/performance/AGENTS.md
@@ -1,0 +1,29 @@
+# Performance Tests Steward
+
+Performance tests protect Bengal's claim that pure Python can scale with cores.
+Treat regressions as product risk, not benchmark trivia.
+
+## Protect
+
+- Stable benchmark setup and repeatable fixture sizes.
+- Clear distinction between smoke checks and measured comparisons.
+- Incremental rebuild and parallel rendering hot paths.
+- Notes when a benchmark result is noisy or environment-sensitive.
+
+## Do Not
+
+- Mix correctness assertions with expensive benchmark loops when setup can be separated.
+- Add broad sleeps or machine-specific thresholds.
+- Delete historical fixtures without explaining what claim changed.
+- Treat a faster result as good if it skips required work.
+
+## Documentation Ownership
+
+- Own performance testing guidance in `site/content/docs/reference/architecture/meta/testing.md`.
+- Keep `site/content/docs/building/performance/` honest when benchmark claims or hot paths change.
+
+## Local Checks
+
+- `uv run pytest tests/performance -q`
+- Relevant benchmark scripts under `tests/performance/`
+- `make test-cov` only when coverage impact matters.

--- a/tests/unit/AGENTS.md
+++ b/tests/unit/AGENTS.md
@@ -1,0 +1,28 @@
+# Unit Tests Steward
+
+Unit tests should pin small contracts and architectural boundaries. They are
+the fast feedback loop contributors should trust while editing.
+
+## Protect
+
+- Tests that name the behavior and the boundary being guarded.
+- Small fixtures and shared mocks from `tests/_testing` where possible.
+- Architectural guards for core/rendering/protocol drift.
+- Deterministic assertions that run well in parallel.
+
+## Do Not
+
+- Spin up full sites when a direct helper test would prove the behavior.
+- Overfit assertions to private implementation details unless guarding architecture.
+- Add sleeps or timing assumptions.
+- Use private mutation in tests when a public constructor/API exists.
+
+## Documentation Ownership
+
+- Keep unit-test guidance in `site/content/docs/reference/architecture/meta/testing.md` current.
+- Update shared-mock guidance when `tests/_testing` patterns change.
+
+## Local Checks
+
+- `uv run pytest tests/unit -q`
+- `uv run ruff check tests/unit`


### PR DESCRIPTION
## What changed

Adds scoped `AGENTS.md` steward guidance for Bengal's highest-risk packages and test layers.

The root `AGENTS.md` now explains that nested files act as local stewards while the root file remains the project constitution. Each steward card names what it protects, what it refuses to become, which docs it owns, and which local checks defend the boundary.

## Why

Scoped agent guidance gives future contributors and coding agents a local code-owner voice for each neighborhood without turning the root file into a giant directory manual.

## Steward Notes

- Docs steward: scoped `AGENTS.md` files now own the documentation that explains their subsystem.
- Core/rendering stewards: guidance preserves the passive-core/rendering-owned-presentation boundary.
- Tests steward: test-layer guidance owns testing docs and fixture documentation.

## Validation

- `git diff --check`
- `make changelog-check`
- `uv run ruff format --check .`
- commit hooks