### PR TITLE
[codex] server: restore template dependency rebuild path

### DIFF
--- a/bengal/orchestration/incremental/orchestrator.py
+++ b/bengal/orchestration/incremental/orchestrator.py
@@ -251,23 +251,66 @@ class IncrementalOrchestrator:
         template_changes: list[Path] = []
         affected_pages: set[Path] = set()
 
-        templates_dir = self._cache_manager._get_theme_templates_dir()
-        if not templates_dir or not templates_dir.exists():
+        template_dirs = self._get_template_dirs()
+        if not template_dirs:
             return template_changes, affected_pages
 
-        can_get_affected = self.cache and hasattr(self.cache, "get_affected_pages")
+        seen_template_files: set[Path] = set()
+        for templates_dir in template_dirs:
+            for template_file in templates_dir.rglob("*.html"):
+                if template_file in seen_template_files:
+                    continue
+                seen_template_files.add(template_file)
+                if not self.cache or not self.cache.is_changed(template_file):
+                    continue
 
-        for template_file in templates_dir.rglob("*.html"):
-            if not self.cache or not self.cache.is_changed(template_file):
-                continue
-
-            template_changes.append(template_file)
-
-            if can_get_affected:
-                for path_str in self.cache.get_affected_pages(str(template_file)):
-                    affected_pages.add(Path(path_str))
+                template_changes.append(template_file)
+                affected_pages.update(self._pages_for_template(template_file, template_dirs))
 
         return template_changes, affected_pages
+
+    def _get_template_dirs(self) -> list[Path]:
+        """Return site and theme template directories that exist."""
+        template_dirs = [self.site.root_path / "templates"]
+        theme_templates_dir = self._cache_manager._get_theme_templates_dir()
+        if theme_templates_dir is not None:
+            template_dirs.append(theme_templates_dir)
+
+        existing_dirs: list[Path] = []
+        seen: set[Path] = set()
+        for path in template_dirs:
+            if not path.exists():
+                continue
+            try:
+                key = path.resolve()
+            except OSError, ValueError:
+                key = path
+            if key in seen:
+                continue
+            seen.add(key)
+            existing_dirs.append(path)
+        return existing_dirs
+
+    def _template_name_for_path(self, path: Path, template_dirs: list[Path]) -> str:
+        """Return the template dependency key for a template path."""
+        for template_dir in template_dirs:
+            try:
+                return to_posix(path.resolve().relative_to(template_dir.resolve()))
+            except OSError, ValueError:
+                continue
+        return path.name
+
+    def _pages_for_template(self, template_file: Path, template_dirs: list[Path]) -> set[Path]:
+        """Return cached page source paths affected by a template file."""
+        if not self.cache:
+            return set()
+
+        template_name = self._template_name_for_path(template_file, template_dirs)
+        template_dependencies = getattr(self.cache, "template_dependencies", None)
+        if isinstance(template_dependencies, dict) and template_dependencies:
+            return {Path(path_str) for path_str in self.cache.get_pages_for_template(template_name)}
+
+        return {Path(path_str) for path_str in self.cache.get_affected_pages(template_file)}
 
     def find_work(self, verbose: bool = False) -> tuple[list[PageLike], list[Asset], ChangeSummary]:
         """

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -1030,20 +1030,29 @@ class BuildTrigger:
             if not self._is_in_template_dir(path, template_dirs):
                 continue
 
-            # Check if template has any dependents
-            affected: set[str] = set()
-            if cache is not None:
-                with suppress(Exception):
-                    affected = cache.get_affected_pages(path)
+            affected, dependency_data_known = self._get_template_dependents(
+                path,
+                cache,
+                template_dirs,
+            )
 
             if not affected:
-                # Template has no dependents - skip entirely
+                if dependency_data_known:
+                    # Template has no dependents - skip entirely
+                    logger.debug(
+                        "template_change_ignored",
+                        template=str(path),
+                        reason="no_dependents",
+                    )
+                    continue
+
                 logger.debug(
-                    "template_change_ignored",
+                    "template_change_full_rebuild",
                     template=str(path),
-                    reason="no_dependents",
+                    affected_pages=0,
+                    reason="dependency_data_missing",
                 )
-                continue
+                return True
 
             # Has dependents - check if we can do incremental update
             if self._can_use_incremental_template_update(path, cache):
@@ -1064,6 +1073,49 @@ class BuildTrigger:
             return True
 
         return False
+
+    def _template_name_for_path(self, path: Path, template_dirs: list[Path]) -> str:
+        """Return the template name used by BuildCache dependency indexes."""
+        for template_dir in template_dirs:
+            try:
+                return to_posix(path.resolve().relative_to(template_dir.resolve()))
+            except OSError, ValueError:
+                continue
+        return path.name
+
+    def _get_template_dependents(
+        self,
+        path: Path,
+        cache: Any,
+        template_dirs: list[Path],
+    ) -> tuple[set[str], bool]:
+        """Return pages affected by a template and whether dependency data was known."""
+        if cache is None:
+            return set(), False
+
+        template_name = self._template_name_for_path(path, template_dirs)
+        template_dependencies = getattr(cache, "template_dependencies", None)
+        if isinstance(template_dependencies, dict) and template_dependencies:
+            try:
+                return set(cache.get_pages_for_template(template_name)), True
+            except Exception as exc:
+                logger.debug(
+                    "template_dependency_lookup_failed",
+                    template=template_name,
+                    error=str(exc),
+                )
+
+        try:
+            affected = set(cache.get_affected_pages(path))
+        except Exception as exc:
+            logger.debug(
+                "template_reverse_dependency_lookup_failed",
+                template=str(path),
+                error=str(exc),
+            )
+            return set(), False
+
+        return affected, bool(affected)
 
     def _is_in_template_dir(self, path: Path, template_dirs: list[Path]) -> bool:
         """Check if path is within any template directory."""
@@ -1106,14 +1158,14 @@ class BuildTrigger:
             if not engine.has_capability(EngineCapability.BLOCK_LEVEL_DETECTION):
                 return False
 
-            # Check if we have block cache support
-            from bengal.orchestration.incremental.template_detector import (
-                TemplateChangeDetector,
+            template_dependencies = getattr(cache, "template_dependencies", None)
+            return isinstance(template_dependencies, dict) and bool(template_dependencies)
+        except Exception as exc:
+            logger.debug(
+                "template_incremental_check_failed",
+                template=str(template_path),
+                error=str(exc),
             )
-
-            detector = TemplateChangeDetector(self.site, cache, block_cache=None)
-            return detector._can_use_block_detection()
-        except Exception:
             return False
 
     def _should_regenerate_autodoc(self, changed_paths: set[Path]) -> bool:

--- a/changelog.d/template-hmr-steward-slice.fixed.md
+++ b/changelog.d/template-hmr-steward-slice.fixed.md
@@ -1,0 +1,1 @@
+Template changes in the dev server now use existing template dependency data instead of importing the removed legacy template detector, keeping selective rebuilds available when dependencies are known and falling back conservatively when they are not.

--- a/tests/unit/orchestration/test_incremental_orchestrator.py
+++ b/tests/unit/orchestration/test_incremental_orchestrator.py
@@ -80,6 +80,28 @@ class TestIncrementalOrchestrator:
         assert orchestrator.cache is None
         assert orchestrator.effect_tracer is None
 
+    def test_detect_template_changes_uses_template_dependency_index(
+        self, orchestrator, mock_site, tmp_path
+    ):
+        """Template changes map to affected pages through cached template dependencies."""
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        template_file = templates_dir / "base.html"
+        template_file.write_text("<html></html>")
+
+        cache = BuildCache(site_root=tmp_path)
+        cache.record_page_templates(
+            str(mock_site.pages[0].source_path),
+            frozenset({"base.html"}),
+        )
+        cache.is_changed = Mock(return_value=True)
+        orchestrator.cache = cache
+
+        changed_templates, affected_pages = orchestrator._detect_template_changes()
+
+        assert changed_templates == [template_file]
+        assert affected_pages == {mock_site.pages[0].source_path}
+
     def test_initialize_with_cache_disabled(self, orchestrator):
         """Test initialization with caching disabled."""
         cache = orchestrator.initialize(enabled=False)

--- a/tests/unit/server/test_build_trigger.py
+++ b/tests/unit/server/test_build_trigger.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from bengal.cache import BuildCache
 from bengal.orchestration.stats import ReloadHint
 from bengal.server.build_trigger import BuildTrigger
 from bengal.server.reload_types import BuildReloadInfo, SerializedOutputRecord
@@ -237,6 +238,67 @@ class TestBuildTrigger:
         trigger = BuildTrigger(site=mock_site, executor=mock_executor)
 
         assert trigger._is_template_change({template_file}) is True
+
+    @patch("bengal.rendering.engines.create_engine")
+    def test_template_change_uses_incremental_when_dependents_are_known(
+        self,
+        mock_create_engine: MagicMock,
+        mock_site: MagicMock,
+        mock_executor: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Known template dependents can be handled by an incremental rebuild."""
+        mock_site.root_path = tmp_path
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        template_file = templates_dir / "base.html"
+        template_file.write_text("<html></html>")
+
+        page_path = tmp_path / "content" / "page.md"
+        cache = BuildCache(site_root=tmp_path)
+        cache.record_page_templates(str(page_path), frozenset({"base.html"}))
+        mock_site._cache = cache
+        mock_create_engine.return_value.has_capability.return_value = True
+
+        trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+        assert trigger._is_template_change({template_file}) is False
+
+    def test_template_change_without_dependency_data_stays_conservative(
+        self, mock_site: MagicMock, mock_executor: MagicMock, tmp_path: Path
+    ) -> None:
+        """Template changes fall back to full rebuild when dependency data is missing."""
+        mock_site.root_path = tmp_path
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        template_file = templates_dir / "base.html"
+        template_file.write_text("<html></html>")
+        mock_site._cache = BuildCache(site_root=tmp_path)
+
+        trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+        assert trigger._is_template_change({template_file}) is True
+
+    def test_template_change_with_known_orphan_template_is_ignored(
+        self, mock_site: MagicMock, mock_executor: MagicMock, tmp_path: Path
+    ) -> None:
+        """A changed template with known empty dependents does not force a rebuild."""
+        mock_site.root_path = tmp_path
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        template_file = templates_dir / "orphan.html"
+        template_file.write_text("<html></html>")
+
+        cache = BuildCache(site_root=tmp_path)
+        cache.record_page_templates(
+            str(tmp_path / "content" / "page.md"),
+            frozenset({"base.html"}),
+        )
+        mock_site._cache = cache
+
+        trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+        assert trigger._is_template_change({template_file}) is False
 
     def test_detect_nav_changes_finds_nav_frontmatter(
         self, mock_site: MagicMock, mock_executor: MagicMock, tmp_path: Path


### PR DESCRIPTION
## What changed

- Removed the dev-server dependency on the deleted legacy `template_detector` module.
- Taught `BuildTrigger` to use existing `BuildCache.template_dependencies` for template dependents, while falling back to full rebuilds when dependency data is missing.
- Updated `IncrementalOrchestrator` to scan site and theme template dirs, de-duplicate template changes, and map changed templates through `get_pages_for_template`.
- Added targeted unit coverage and a news fragment.

## Why

The steward rollup identified template-granular rebuild/HMR as the strongest cross-domain priority after scoped steward consultation. The previous path silently fell back because it imported a removed detector, which made template rebuild behavior both over-broad and hard to reason about.

## Steward Notes

- Build steward: no phases were added or reordered; this uses existing cache/effect data.
- Incremental steward: missing dependency data remains conservative and triggers full rebuilds.
- Tests steward: added focused unit coverage for known dependents, missing dependency data, known orphan templates, and incremental template dependency lookup.

## Validation

- `uv run pytest tests/unit/server/test_build_trigger.py tests/unit/orchestration/test_incremental_orchestrator.py -q`
- `uv run pytest tests/integration/test_incremental_invariants.py -q`
- `uv run ruff check bengal/server/build_trigger.py bengal/orchestration/incremental/orchestrator.py tests/unit/server/test_build_trigger.py tests/unit/orchestration/test_incremental_orchestrator.py`
- `uv run ruff format --check bengal/server/build_trigger.py bengal/orchestration/incremental/orchestrator.py tests/unit/server/test_build_trigger.py tests/unit/orchestration/test_incremental_orchestrator.py`
- `git diff --check`
- `make changelog-check`

Note: `uv run pytest tests/unit/orchestration/incremental -q` hit a Hypothesis deadline flake in `test_fingerprint_changes_with_content`; the isolated rerun passed.