### PR TITLE
[codex] Add page record migration substrate

### DIFF
--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -788,67 +788,29 @@ class ContentDiscovery:
     ) -> SourcePage:
         """Build an immutable SourcePage record from parsed file data.
 
-        Constructs PageCore (replicating Page._init_core_from_fields logic)
-        and wraps metadata in a read-only MappingProxyType.
+        Uses the canonical record adapter so discovery and Page compatibility
+        construction share the same field migration rules.
         """
-        from types import MappingProxyType
-
-        from bengal.core.page.page_core import PageCore
-        from bengal.core.page.utils import normalize_tags, separate_standard_and_custom_fields
-        from bengal.core.records import SourcePage
-        from bengal.utils.primitives.dates import parse_date
+        from bengal.core.records import build_source_page
         from bengal.utils.primitives.hashing import hash_file, hash_str
 
-        standard_fields, custom_props = separate_standard_and_custom_fields(metadata)
-
-        # Replicate slug computation from Page.slug
-        slug = metadata.get("slug")
-        if slug is None:
-            slug = file_path.parent.name if file_path.stem == "_index" else file_path.stem
-
-        # Replicate variant normalization from Page._init_core_from_fields
-        variant = standard_fields.get("variant")
-        if not variant:
-            variant = standard_fields.get("layout") or custom_props.get("hero_style")
-
-        # content_hash: hash of the markdown body (frontmatter stripped)
-        content_hash = hash_str(content) if content else hash_str("")
-
-        # file_hash: hash of the full source file (frontmatter + body) for cache validation.
-        # Frontmatter-only edits must invalidate the cache, so we hash the whole file.
+        # content_hash covers the frontmatter-stripped body. file_hash covers
+        # the full source file so frontmatter-only edits still invalidate cache.
+        content_hash = hash_str(content)
         try:
             file_hash = hash_file(file_path) if file_path.exists() else content_hash
         except OSError:
             file_hash = content_hash
 
-        core = PageCore(
-            source_path=str(file_path),
-            title=standard_fields.get("title", ""),
-            date=parse_date(standard_fields.get("date")),
-            tags=normalize_tags(metadata.get("tags")),
-            slug=slug,
-            weight=standard_fields.get("weight"),
-            lang=current_lang or metadata.get("lang"),
-            nav_title=standard_fields.get("nav_title"),
-            type=standard_fields.get("type"),
-            variant=variant,
-            description=standard_fields.get("description"),
-            props=custom_props,
-            section=str(section.path) if section and getattr(section, "path", None) else None,
-            file_hash=file_hash,
-            aliases=metadata.get("aliases", []),
-            version=metadata.get("version") or metadata.get("_version"),
-            cascade=metadata.get("cascade", {}),
-        )
-
-        return SourcePage(
-            core=core,
+        return build_source_page(
+            source_path=file_path,
             raw_content=content,
-            raw_metadata=MappingProxyType(metadata),
+            metadata=metadata,
+            lang=current_lang,
+            section_path=str(section.path) if section and getattr(section, "path", None) else None,
             content_hash=content_hash,
+            file_hash=file_hash,
             is_virtual=False,
-            lang=current_lang or metadata.get("lang"),
-            translation_key=metadata.get("translation_key"),
         )
 
     def _enrich_page_i18n(

--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -726,7 +726,8 @@ class ContentDiscovery:
             content, metadata = self._parser.parse_file(file_path)
             metadata = self._parser.validate_against_collection(file_path, metadata)
 
-            # Sprint 4: build immutable SourcePage first, then mutable Page
+            # Build the immutable discovery record first, then adapt it into
+            # the remaining Page compatibility object for downstream callers.
             source_page = self._build_source_page(
                 file_path, content, metadata, current_lang, section
             )
@@ -736,7 +737,6 @@ class ContentDiscovery:
                 _raw_content=source_page.raw_content,
                 _raw_metadata=source_page.raw_metadata_dict(),
             )
-            page._source_page = source_page
 
             if self.site is not None:
                 page._site = self.site

--- a/bengal/core/page/__init__.py
+++ b/bengal/core/page/__init__.py
@@ -609,40 +609,17 @@ class Page:
         Note: Initially creates PageCore with absolute paths, but normalize_core_paths()
         should be called before caching to convert to relative paths.
         """
-        # Separate standard fields from custom props (Component Model)
-        from bengal.core.page.utils import separate_standard_and_custom_fields
-        from bengal.utils.primitives.dates import parse_date
+        from bengal.core.records import build_page_core
 
-        standard_fields, custom_props = separate_standard_and_custom_fields(self._raw_metadata)
-
-        # Component Model: variant (normalized from layout/hero_style)
-        variant = standard_fields.get("variant")
-        # Normalize legacy fields to variant
-        if not variant:
-            variant = standard_fields.get("layout") or custom_props.get("hero_style")
-
-        self.core = PageCore(
-            source_path=str(self.source_path),  # May be absolute initially
-            title=standard_fields.get("title", ""),
-            date=parse_date(standard_fields.get("date")),
+        self.core = build_page_core(
+            self.source_path,
+            self._raw_metadata,
             tags=self.tags or [],
             slug=self.slug,  # Use computed slug (includes filename fallback)
-            weight=standard_fields.get("weight"),
             lang=self.lang,
-            nav_title=standard_fields.get("nav_title"),  # Short title for navigation
-            # Component Model Fields
-            type=standard_fields.get("type"),
-            variant=variant,
-            description=standard_fields.get("description"),
-            props=custom_props,  # Only custom fields go into props
-            # Links
-            section=str(self._section_path) if self._section_path else None,
+            section_path=self._section_path,
             file_hash=None,  # Will be populated during caching
-            aliases=standard_fields.get("aliases") or self.aliases or [],
-            # Cascade data (from _index.md frontmatter)
-            # Critical for incremental builds: without this, cascade data is lost
-            # when _index.md files are loaded from cache
-            cascade=self._raw_metadata.get("cascade", {}),
+            aliases=self.aliases,
         )
 
     def normalize_core_paths(self) -> None:
@@ -1404,6 +1381,7 @@ __all__ = [
     "BundleType",
     "Frontmatter",
     "Page",
+    "PageCore",
     "PageResource",
     "PageResources",
 ]

--- a/bengal/core/page/__init__.py
+++ b/bengal/core/page/__init__.py
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from bengal.core.author import Author
-    from bengal.core.records import SourcePage
     from bengal.core.series import Series
     from bengal.core.site.context import SiteContext
     from bengal.parsing.ast.types import ASTNode
@@ -264,11 +263,6 @@ class Page:
     # Sprint 5: True when page was reconstructed from cache without disk I/O.
     # Used for metrics/logging and to skip wasteful re-initialization in __post_init__.
     _from_cache: bool = field(default=False, repr=False)
-
-    # Sprint 4 dual-write bridge: immutable SourcePage record from discovery.
-    # Set by ContentDiscovery._create_page(); None for cached/proxy pages.
-    # Removed in Sprint 6 when Page is deleted.
-    _source_page: SourcePage | None = field(default=None, repr=False, init=False)
 
     def __post_init__(self) -> None:
         """Initialize computed fields and PageCore."""

--- a/bengal/core/records.py
+++ b/bengal/core/records.py
@@ -15,13 +15,78 @@ See Also:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Mapping, Sequence
 
     from bengal.core.page.page_core import PageCore
+
+
+PAGE_CORE_MIGRATION_MAP = MappingProxyType(
+    {
+        "source_path": "source_path",
+        "title": "metadata.title",
+        "date": "metadata.date",
+        "tags": "metadata.tags",
+        "slug": "metadata.slug or source_path.stem",
+        "weight": "metadata.weight",
+        "lang": "lang override or metadata.lang",
+        "nav_title": "metadata.nav_title",
+        "type": "metadata.type",
+        "variant": "metadata.variant or metadata.layout or props.hero_style",
+        "description": "metadata.description",
+        "props": "metadata minus standard/internal fields",
+        "section": "section path string",
+        "file_hash": "full source hash when available",
+        "aliases": "metadata.aliases",
+        "version": "metadata.version or metadata._version",
+        "cascade": "metadata.cascade",
+    }
+)
+"""Canonical PageCore field migration map from mutable Page/frontmatter state."""
+
+SOURCE_PAGE_MIGRATION_MAP = MappingProxyType(
+    {
+        "core": "PageCore built by build_page_core()",
+        "raw_content": "frontmatter-stripped source body",
+        "raw_metadata": "read-only parsed frontmatter mapping",
+        "content_hash": "hash of raw_content",
+        "is_virtual": "generated/non-file-backed source marker",
+        "lang": "lang override or PageCore.lang",
+        "translation_key": "metadata.translation_key",
+    }
+)
+"""Canonical SourcePage migration map from discovery-time mutable inputs."""
+
+PARSED_PAGE_MIGRATION_MAP = MappingProxyType(
+    {
+        "html_content": "page.html_content",
+        "toc": "page.toc",
+        "toc_items": "rendering-supplied TOC structure or page.toc_items",
+        "excerpt": "page.excerpt",
+        "meta_description": "page.meta_description or page.description",
+        "plain_text": "page.plain_text",
+        "word_count": "page.word_count",
+        "reading_time": "page.reading_time",
+        "links": "page.links",
+        "ast_cache": "page._ast_cache",
+    }
+)
+"""Canonical ParsedPage migration map from parse-phase PageLike state."""
+
+RENDERED_PAGE_MIGRATION_MAP = MappingProxyType(
+    {
+        "source_path": "page.source_path",
+        "output_path": "page.output_path",
+        "rendered_html": "rendered HTML argument or page.rendered_html",
+        "render_time_ms": "measured render time",
+        "dependencies": "render-time tracked asset/template dependencies",
+    }
+)
+"""Canonical RenderedPage migration map from render-phase PageLike state."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -189,40 +254,185 @@ def create_virtual_source_page(
     Virtual pages have no disk file, no content_hash, and
     ``is_virtual=True``.
     """
+    meta = dict(metadata) if metadata else {}
+    meta.setdefault("title", title)
+
+    return build_source_page(
+        source_path=source_id,
+        raw_content=content,
+        metadata=meta,
+        lang=lang,
+        section_path=section_path,
+        content_hash=None,
+        file_hash=None,
+        is_virtual=True,
+    )
+
+
+def build_page_core(
+    source_path: str | Path,
+    metadata: Mapping[str, Any] | None = None,
+    *,
+    tags: Sequence[Any] | None = None,
+    slug: str | None = None,
+    lang: str | None = None,
+    section_path: str | Path | None = None,
+    file_hash: str | None = None,
+    aliases: Sequence[Any] | None = None,
+) -> PageCore:
+    """Build a ``PageCore`` from canonical discovery/frontmatter inputs.
+
+    This is the migration substrate shared by mutable ``Page`` construction,
+    immutable ``SourcePage`` construction, and tests.  It intentionally accepts
+    plain mappings and path strings so callers do not need the concrete
+    mutable ``Page`` class.
+    """
     from bengal.core.page.page_core import PageCore
     from bengal.core.page.utils import normalize_tags, separate_standard_and_custom_fields
     from bengal.utils.primitives.dates import parse_date
 
-    meta = dict(metadata) if metadata else {}
-    meta.setdefault("title", title)
-
+    meta = dict(metadata or {})
     standard_fields, custom_props = separate_standard_and_custom_fields(meta)
+    source = Path(source_path)
 
-    core = PageCore(
-        source_path=source_id,
-        title=title,
+    resolved_slug = slug if slug is not None else standard_fields.get("slug")
+    if resolved_slug is None:
+        resolved_slug = source.parent.name if source.stem == "_index" else source.stem
+
+    variant = standard_fields.get("variant")
+    if not variant:
+        variant = standard_fields.get("layout") or custom_props.get("hero_style")
+
+    resolved_tags = normalize_tags(tags if tags is not None else meta.get("tags"))
+    resolved_aliases = list(aliases if aliases is not None else standard_fields.get("aliases", []))
+    resolved_lang = lang or standard_fields.get("lang")
+    resolved_section = str(section_path) if section_path is not None else None
+
+    return PageCore(
+        source_path=str(source_path),
+        title=standard_fields.get("title", ""),
         date=parse_date(standard_fields.get("date")),
-        tags=normalize_tags(meta.get("tags")),
-        slug=standard_fields.get("slug"),
+        tags=resolved_tags,
+        slug=resolved_slug,
         weight=standard_fields.get("weight"),
-        lang=lang or standard_fields.get("lang"),
+        lang=resolved_lang,
         nav_title=standard_fields.get("nav_title"),
         type=standard_fields.get("type"),
-        variant=standard_fields.get("variant"),
+        variant=variant,
         description=standard_fields.get("description"),
         props=custom_props,
-        section=section_path,
-        aliases=meta.get("aliases", []),
-        version=meta.get("version"),
+        section=resolved_section,
+        file_hash=file_hash,
+        aliases=resolved_aliases,
+        version=meta.get("version") or meta.get("_version"),
         cascade=meta.get("cascade", {}),
+    )
+
+
+def build_source_page(
+    source_path: str | Path,
+    raw_content: str,
+    metadata: Mapping[str, Any] | None = None,
+    *,
+    lang: str | None = None,
+    section_path: str | Path | None = None,
+    content_hash: str | None = None,
+    file_hash: str | None = None,
+    is_virtual: bool = False,
+) -> SourcePage:
+    """Build an immutable ``SourcePage`` without requiring a mutable ``Page``.
+
+    ``content_hash`` is the hash of the frontmatter-stripped body. ``file_hash``
+    is the full source file hash for real files. Both values are computed by
+    discovery/orchestration boundaries and passed in so core remains passive.
+    """
+    meta = dict(metadata or {})
+
+    core = build_page_core(
+        source_path,
+        meta,
+        lang=lang,
+        section_path=section_path,
+        file_hash=file_hash,
     )
 
     return SourcePage(
         core=core,
-        raw_content=content,
+        raw_content=raw_content,
         raw_metadata=MappingProxyType(meta),
-        content_hash=None,
-        is_virtual=True,
-        lang=core.lang,
+        content_hash=content_hash,
+        is_virtual=is_virtual,
+        lang=lang or core.lang,
         translation_key=meta.get("translation_key"),
+    )
+
+
+def parsed_page_from_page_state(
+    page: Any,
+    *,
+    toc_items: Sequence[Mapping[str, Any]] | None = None,
+    links: Sequence[Any] | None = None,
+    ast_cache: Any = None,
+) -> ParsedPage:
+    """Build ``ParsedPage`` from parse-phase state on a Page-like object.
+
+    Rendering owns deriving TOC structures; pass ``toc_items`` when available
+    so this adapter does not import rendering helpers from core.
+    """
+    raw_toc_items = toc_items
+    if raw_toc_items is None:
+        raw_toc_items = getattr(page, "toc_items", ()) or ()
+
+    raw_links = links
+    if raw_links is None:
+        raw_links = getattr(page, "links", None) or ()
+
+    resolved_ast_cache = ast_cache if ast_cache is not None else getattr(page, "_ast_cache", None)
+
+    return ParsedPage(
+        html_content=getattr(page, "html_content", None) or "",
+        toc=getattr(page, "toc", None) or "",
+        toc_items=tuple(dict(item) for item in raw_toc_items),
+        excerpt=getattr(page, "excerpt", "") or "",
+        meta_description=getattr(page, "meta_description", "")
+        or getattr(page, "description", "")
+        or "",
+        plain_text=getattr(page, "plain_text", "") or "",
+        word_count=getattr(page, "word_count", 0) or 0,
+        reading_time=getattr(page, "reading_time", 0) or 0,
+        links=tuple(str(link) for link in raw_links),
+        ast_cache=resolved_ast_cache,
+    )
+
+
+def rendered_page_from_page_state(
+    page: Any,
+    *,
+    rendered_html: str | None = None,
+    render_time_ms: float | None = None,
+    dependencies: Sequence[str] | frozenset[str] | None = None,
+) -> RenderedPage:
+    """Build ``RenderedPage`` from render-phase state on a Page-like object."""
+    output_path = getattr(page, "output_path", None)
+    if output_path is None:
+        raise ValueError(
+            "RenderedPage requires page.output_path; call determine_output_path() before rendering."
+        )
+
+    resolved_html = (
+        rendered_html if rendered_html is not None else getattr(page, "rendered_html", "")
+    )
+    resolved_time = (
+        render_time_ms if render_time_ms is not None else getattr(page, "render_time_ms", 0.0)
+    )
+    resolved_dependencies = (
+        dependencies if isinstance(dependencies, frozenset) else frozenset(dependencies or ())
+    )
+
+    return RenderedPage(
+        source_path=page.source_path,
+        output_path=output_path,
+        rendered_html=resolved_html,
+        render_time_ms=resolved_time,
+        dependencies=resolved_dependencies,
     )

--- a/bengal/core/records.py
+++ b/bengal/core/records.py
@@ -180,10 +180,10 @@ class SourcePage:
     metadata and adds discovery-specific fields (raw content, content
     hash, i18n).
 
-    Consumed by the orchestration and rendering phases via the
-    ``page._source_page`` dual-write bridge.  In the target architecture
-    (Sprint 5+) content loading is deferred to the parse stage and
-    ``raw_content`` becomes optional.
+    Consumed by discovery/orchestration handoffs before the remaining mutable
+    ``Page`` compatibility object is populated.  In the target architecture,
+    content loading is deferred to the parse stage and ``raw_content`` becomes
+    optional.
 
     The record itself is frozen (field reassignment raises).  Composed
     ``PageCore`` contains mutable containers (``tags``, ``props``,

--- a/bengal/rendering/pipeline/cache_checker.py
+++ b/bengal/rendering/pipeline/cache_checker.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from bengal.core.records import ParsedPage, rendered_page_from_page_state
+from bengal.core.records import ParsedPage, RenderedPage, rendered_page_from_page_state
 from bengal.rendering.page_operations import extract_links
 from bengal.rendering.pipeline.output import format_html, write_output
 from bengal.rendering.pipeline.toc import extract_toc_structure
@@ -345,13 +345,17 @@ class CacheChecker:
             meta_description=meta_description,
         )
 
-    def cache_rendered_output(self, page: PageLike, template: str) -> None:
+    def cache_rendered_output(
+        self, page: PageLike, template: str, rendered_page: RenderedPage | None = None
+    ) -> None:
         """
         Store rendered output in cache for next build.
 
         Args:
             page: Page with rendered HTML
             template: Template name used
+            rendered_page: Optional immutable render record to read HTML from
+                instead of the mutable Page compatibility field.
         """
         if not self.build_cache or page.metadata.get("_generated"):
             return
@@ -365,7 +369,7 @@ class CacheChecker:
         output_dir = getattr(self.site, "output_dir", None)
         cache.store_rendered_output(
             page.source_path,
-            page.rendered_html,
+            rendered_page.rendered_html if rendered_page is not None else page.rendered_html,
             template,
             page.metadata,
             dependencies=deps,

--- a/bengal/rendering/pipeline/cache_checker.py
+++ b/bengal/rendering/pipeline/cache_checker.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from bengal.core.records import ParsedPage, RenderedPage
+from bengal.core.records import ParsedPage, rendered_page_from_page_state
 from bengal.rendering.page_operations import extract_links
 from bengal.rendering.pipeline.output import format_html, write_output
 from bengal.rendering.pipeline.toc import extract_toc_structure
@@ -124,9 +124,8 @@ class CacheChecker:
             page.output_path = determine_output_path(page, self.site)
 
         # Sprint 2: Build RenderedPage from cached data
-        rendered_page = RenderedPage(
-            source_path=page.source_path,
-            output_path=page.output_path,  # set by determine_output_path above
+        rendered_page = rendered_page_from_page_state(
+            page,
             rendered_html=cached_html,
             render_time_ms=0.0,
         )
@@ -271,9 +270,8 @@ class CacheChecker:
             page.output_path = determine_output_path(page, self.site)
 
         # Sprint 2: Build RenderedPage from cache-rendered data
-        rendered_page = RenderedPage(
-            source_path=page.source_path,
-            output_path=page.output_path,  # set by determine_output_path above
+        rendered_page = rendered_page_from_page_state(
+            page,
             rendered_html=final_html,
             render_time_ms=0.0,
         )

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -31,7 +31,11 @@ import time as _time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from bengal.core.records import ParsedPage, RenderedPage
+from bengal.core.records import (
+    ParsedPage,
+    parsed_page_from_page_state,
+    rendered_page_from_page_state,
+)
 from bengal.rendering.api_doc_enhancer import set_enhancer_for_render
 
 if TYPE_CHECKING:
@@ -706,22 +710,7 @@ class RenderingPipeline:
         from bengal.rendering.pipeline.toc import extract_toc_structure
 
         toc_items = tuple(extract_toc_structure(page.toc or ""))
-        links = tuple(getattr(page, "links", None) or ())
-
-        return ParsedPage(
-            html_content=page.html_content or "",
-            toc=page.toc or "",
-            toc_items=toc_items,
-            excerpt=getattr(page, "excerpt", "") or "",
-            meta_description=getattr(page, "meta_description", "")
-            or getattr(page, "description", "")
-            or "",
-            plain_text=page.plain_text,
-            word_count=getattr(page, "word_count", 0) or 0,
-            reading_time=getattr(page, "reading_time", 0) or 0,
-            links=links,
-            ast_cache=getattr(page, "_ast_cache", None),
-        )
+        return parsed_page_from_page_state(page, toc_items=toc_items)
 
     def _render_and_write(
         self,
@@ -816,10 +805,11 @@ class RenderingPipeline:
         # Get tracked assets from render-time tracking
         tracked_assets = tracker.get_assets()
 
+        page.render_time_ms = render_time_ms
+
         # Sprint 2: Build immutable RenderedPage record
-        rendered_page = RenderedPage(
-            source_path=page.source_path,
-            output_path=page.output_path,  # must be set by determine_output_path before render
+        rendered_page = rendered_page_from_page_state(
+            page,
             rendered_html=rendered_html,
             render_time_ms=render_time_ms,
             dependencies=frozenset(tracked_assets) if tracked_assets else frozenset(),

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -818,9 +818,9 @@ class RenderingPipeline:
         # Store rendered output in cache
         if _prof:
             with _prof.step("cache_rendered"):
-                self._cache_checker.cache_rendered_output(page, template)
+                self._cache_checker.cache_rendered_output(page, template, rendered_page)
         else:
-            self._cache_checker.cache_rendered_output(page, template)
+            self._cache_checker.cache_rendered_output(page, template, rendered_page)
 
         # Write output (sync or async via write-behind)
         if _prof:
@@ -854,12 +854,19 @@ class RenderingPipeline:
         # Use render-time tracked assets, fall back to HTML parsing if needed
         if _prof:
             with _prof.step("asset_deps"):
-                self._accumulate_asset_deps(page, tracked_assets=tracked_assets)
+                self._accumulate_asset_deps(
+                    page, tracked_assets=tracked_assets, rendered_html=rendered_page.rendered_html
+                )
         else:
-            self._accumulate_asset_deps(page, tracked_assets=tracked_assets)
+            self._accumulate_asset_deps(
+                page, tracked_assets=tracked_assets, rendered_html=rendered_page.rendered_html
+            )
 
     def _accumulate_asset_deps(
-        self, page: PageLike, tracked_assets: set[str] | None = None
+        self,
+        page: PageLike,
+        tracked_assets: set[str] | None = None,
+        rendered_html: str | None = None,
     ) -> None:
         """
         Accumulate asset dependencies during rendering.
@@ -870,8 +877,10 @@ class RenderingPipeline:
         Args:
             page: Page with rendered HTML
             tracked_assets: Assets tracked during render-time (if available)
+            rendered_html: Rendered HTML from the immutable render record.
         """
-        if not self.build_context or not page.rendered_html:
+        html = rendered_html if rendered_html is not None else page.rendered_html
+        if not self.build_context or not html:
             return
 
         assets: set[str] = set()
@@ -888,7 +897,7 @@ class RenderingPipeline:
                 from bengal.rendering.asset_extractor import extract_assets_from_html
                 from bengal.rendering.assets import get_asset_manifest
 
-                raw_assets = extract_assets_from_html(page.rendered_html)
+                raw_assets = extract_assets_from_html(html)
 
                 # Normalize fingerprinted URLs back to logical paths.
                 # When Kida fragment cache hits, asset_url() is not called, so

--- a/bengal/server/reactive/handler.py
+++ b/bengal/server/reactive/handler.py
@@ -51,8 +51,9 @@ class ReactiveContentHandler:
     def handle_content_change(self, path: Path) -> ReactiveResult | None:
         """Process content-only change for a single .md file.
 
-        Flow: find page -> read source -> update page._raw_content -> run
-        RenderingPipeline.process_page -> write to disk.
+        Flow: find page -> read source -> update the remaining Page
+        compatibility fields -> run RenderingPipeline.process_page -> write
+        to disk.
 
         Returns a ReactiveResult carrying both the output path and the
         rendered HTML string so callers can extract fragments in memory
@@ -80,24 +81,6 @@ class ReactiveContentHandler:
         # full file would render YAML as markdown.
         _, body_content = parse_frontmatter(raw_file)
 
-        # Sprint 4: reconstruct immutable SourcePage record.
-        # Uses dataclasses.replace() so new SourcePage fields are carried forward automatically.
-        from bengal.core.records import SourcePage
-
-        old_source = getattr(page, "_source_page", None)
-        if isinstance(old_source, SourcePage):
-            from dataclasses import replace as dc_replace
-
-            from bengal.utils.primitives.hashing import hash_str
-
-            file_hash = hash_str(raw_file)
-            content_hash = hash_str(body_content)
-            new_core = dc_replace(old_source.core, file_hash=file_hash)
-            page._source_page = dc_replace(
-                old_source, core=new_core, raw_content=body_content, content_hash=content_hash
-            )
-
-        # Existing mutable Page update (kept for backward compatibility)
         page._raw_content = body_content
         page.html_content = None
 

--- a/site/content/docs/reference/architecture/core/object-model.md
+++ b/site/content/docs/reference/architecture/core/object-model.md
@@ -120,11 +120,30 @@ Refer to:
 - `bengal/cache/page_discovery_cache.py`
 - `bengal/core/records.py`
 
+## Page Record Migration Adapters
+
+The immutable pipeline migration uses adapter helpers in `bengal/core/records.py`
+as the canonical handoff from mutable `Page` compatibility state into record
+state:
+
+- `build_page_core()` maps frontmatter and path inputs into `PageCore`.
+- `build_source_page()` maps discovery inputs into `SourcePage`.
+- `parsed_page_from_page_state()` maps parse-phase `PageLike` state into
+  `ParsedPage` while accepting rendering-supplied TOC structures.
+- `rendered_page_from_page_state()` maps render-phase state into `RenderedPage`.
+
+The module also exposes `*_MIGRATION_MAP` constants for tests and migration
+notes. These maps are documentation, not a new public protocol: callers should
+prefer the adapters over adding attributes to `PageLike` or depending on the
+concrete mutable `Page` class.
+
 ::::{dropdown} Contributor notes: adding fields and deciding what belongs in PageCore
 When you add a cacheable field:
 
 1. Add it to `PageCore` (`bengal/core/page/page_core.py`)
-2. Add a property delegate to `Page` (`bengal/core/page/__init__.py`)
+2. Update the migration adapter/map in `bengal/core/records.py`
+3. Add a property delegate to `Page` (`bengal/core/page/__init__.py`) when
+   templates or compatibility callers need it
 
 Include fields that are stable, JSON-serializable, and useful without full content parsing. Keep build artifacts and parsed-content-derived fields out of `PageCore`.
 ::::

--- a/site/content/docs/reference/architecture/core/object-model.md
+++ b/site/content/docs/reference/architecture/core/object-model.md
@@ -127,7 +127,9 @@ as the canonical handoff from mutable `Page` compatibility state into record
 state:
 
 - `build_page_core()` maps frontmatter and path inputs into `PageCore`.
-- `build_source_page()` maps discovery inputs into `SourcePage`.
+- `build_source_page()` maps discovery inputs into `SourcePage`; discovery
+  consumes that record while populating the remaining `Page` compatibility
+  object, but does not retain it as a second mutable sidecar on `Page`.
 - `parsed_page_from_page_state()` maps parse-phase `PageLike` state into
   `ParsedPage` while accepting rendering-supplied TOC structures.
 - `rendered_page_from_page_state()` maps render-phase state into `RenderedPage`.

--- a/tests/_testing/README.md
+++ b/tests/_testing/README.md
@@ -108,6 +108,19 @@ page = MockAnalysisPage(
 # to match the Page interface used by LinkSuggestionEngine
 ```
 
+### `page_records.py`
+
+Canonical immutable page-record factories for migration tests. Use these when a
+test needs `PageCore`, `SourcePage`, `ParsedPage`, or `RenderedPage` without
+depending on concrete mutable `Page` construction.
+
+```python
+from tests._testing.page_records import make_source_page, make_parsed_page
+
+source = make_source_page(metadata={"title": "Guide"})
+parsed = make_parsed_page(html_content="<h1>Guide</h1>")
+```
+
 ### `fixtures.py`
 
 Provides core fixtures:

--- a/tests/_testing/page_records.py
+++ b/tests/_testing/page_records.py
@@ -1,0 +1,100 @@
+"""Canonical immutable page-record fixtures for tests.
+
+These helpers keep tests aligned with the Page migration adapters instead of
+recreating mutable ``Page`` construction rules in each test module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from bengal.core.records import (
+    ParsedPage,
+    RenderedPage,
+    SourcePage,
+    build_page_core,
+    build_source_page,
+    parsed_page_from_page_state,
+    rendered_page_from_page_state,
+)
+
+if TYPE_CHECKING:
+    from bengal.core.page.page_core import PageCore
+
+
+def make_page_core(**overrides: Any) -> PageCore:
+    """Create a representative ``PageCore`` for unit tests."""
+    metadata = {
+        "title": "Hello World",
+        "tags": ["python", "web"],
+        "slug": "hello",
+        "type": "post",
+    }
+    metadata.update(overrides.pop("metadata", {}))
+    return build_page_core(
+        overrides.pop("source_path", "content/posts/hello.md"),
+        metadata,
+        file_hash=overrides.pop("file_hash", "file123"),
+        **overrides,
+    )
+
+
+def make_source_page(**overrides: Any) -> SourcePage:
+    """Create a representative ``SourcePage`` for unit tests."""
+    metadata = {
+        "title": "Hello World",
+        "tags": ["python", "web"],
+        "slug": "hello",
+        "type": "post",
+    }
+    metadata.update(overrides.pop("metadata", {}))
+    translation_key = overrides.pop("translation_key", None)
+    if translation_key is not None:
+        metadata["translation_key"] = translation_key
+    return build_source_page(
+        source_path=overrides.pop("source_path", "content/posts/hello.md"),
+        raw_content=overrides.pop("raw_content", "# Hello\n\nWorld"),
+        metadata=metadata,
+        content_hash=overrides.pop("content_hash", "body123"),
+        file_hash=overrides.pop("file_hash", "file123"),
+        is_virtual=overrides.pop("is_virtual", False),
+        **overrides,
+    )
+
+
+def make_parsed_page(**overrides: Any) -> ParsedPage:
+    """Create a representative ``ParsedPage`` for unit tests."""
+    page = SimpleNamespace(
+        html_content=overrides.pop("html_content", "<h1>Hello</h1>"),
+        toc=overrides.pop("toc", ""),
+        excerpt=overrides.pop("excerpt", "Hello"),
+        meta_description=overrides.pop("meta_description", "Hello"),
+        description=overrides.pop("description", ""),
+        plain_text=overrides.pop("plain_text", "Hello"),
+        word_count=overrides.pop("word_count", 1),
+        reading_time=overrides.pop("reading_time", 1),
+        links=overrides.pop("links", ["/docs/"]),
+        _ast_cache=overrides.pop("ast_cache", None),
+    )
+    return parsed_page_from_page_state(
+        page,
+        toc_items=overrides.pop("toc_items", ()),
+        **overrides,
+    )
+
+
+def make_rendered_page(**overrides: Any) -> RenderedPage:
+    """Create a representative ``RenderedPage`` for unit tests."""
+    page = SimpleNamespace(
+        source_path=overrides.pop("source_path", Path("content/posts/hello.md")),
+        output_path=overrides.pop("output_path", Path("public/posts/hello/index.html")),
+        rendered_html=overrides.pop("rendered_html", "<html>Hello</html>"),
+        render_time_ms=overrides.pop("render_time_ms", 1.5),
+    )
+    return rendered_page_from_page_state(
+        page,
+        dependencies=overrides.pop("dependencies", ()),
+        **overrides,
+    )

--- a/tests/unit/core/test_page_record_migration.py
+++ b/tests/unit/core/test_page_record_migration.py
@@ -7,6 +7,7 @@ from types import MappingProxyType, SimpleNamespace
 
 import pytest
 
+from bengal.core.page import Page
 from bengal.core.records import (
     PAGE_CORE_MIGRATION_MAP,
     PARSED_PAGE_MIGRATION_MAP,
@@ -97,6 +98,16 @@ def test_build_source_page_does_not_compute_hashes_in_core():
 
     assert source.content_hash is None
     assert source.core.file_hash is None
+
+
+def test_page_no_longer_retains_source_page_bridge():
+    page = Page(
+        source_path=Path("content/posts/hello.md"),
+        _raw_content="# Hello",
+        _raw_metadata={"title": "Hello"},
+    )
+
+    assert not hasattr(page, "_source_page")
 
 
 def test_parsed_page_adapter_uses_supplied_toc_items_without_rendering_imports():

--- a/tests/unit/core/test_page_record_migration.py
+++ b/tests/unit/core/test_page_record_migration.py
@@ -1,0 +1,143 @@
+"""Tests for immutable Page migration adapters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import MappingProxyType, SimpleNamespace
+
+import pytest
+
+from bengal.core.records import (
+    PAGE_CORE_MIGRATION_MAP,
+    PARSED_PAGE_MIGRATION_MAP,
+    RENDERED_PAGE_MIGRATION_MAP,
+    SOURCE_PAGE_MIGRATION_MAP,
+    build_page_core,
+    build_source_page,
+    parsed_page_from_page_state,
+    rendered_page_from_page_state,
+)
+from tests._testing.page_records import (
+    make_page_core,
+    make_parsed_page,
+    make_rendered_page,
+    make_source_page,
+)
+
+
+def test_migration_maps_name_handoff_fields():
+    """Migration maps document the mutable Page -> record handoff."""
+    assert PAGE_CORE_MIGRATION_MAP["variant"] == (
+        "metadata.variant or metadata.layout or props.hero_style"
+    )
+    assert SOURCE_PAGE_MIGRATION_MAP["raw_metadata"] == "read-only parsed frontmatter mapping"
+    assert PARSED_PAGE_MIGRATION_MAP["plain_text"] == "page.plain_text"
+    assert RENDERED_PAGE_MIGRATION_MAP["dependencies"] == (
+        "render-time tracked asset/template dependencies"
+    )
+
+
+def test_build_page_core_matches_page_field_rules():
+    core = build_page_core(
+        Path("content/docs/_index.md"),
+        {
+            "title": "Docs",
+            "tags": "reference",
+            "layout": "wide",
+            "hero_style": "ignored-because-layout-wins",
+            "custom": "value",
+            "_internal": "private",
+            "aliases": ["/docs/latest/"],
+            "version": "v2",
+        },
+        lang="fr",
+        section_path="docs",
+        file_hash="file123",
+    )
+
+    assert core.source_path == "content/docs/_index.md"
+    assert core.slug == "docs"
+    assert core.tags == ["reference"]
+    assert core.variant == "wide"
+    assert core.props == {
+        "custom": "value",
+        "hero_style": "ignored-because-layout-wins",
+        "version": "v2",
+    }
+    assert core.lang == "fr"
+    assert core.section == "docs"
+    assert core.file_hash == "file123"
+    assert core.aliases == ["/docs/latest/"]
+    assert core.version == "v2"
+
+
+def test_build_source_page_freezes_metadata_and_preserves_hashes():
+    source = build_source_page(
+        source_path=Path("content/posts/hello.md"),
+        raw_content="# Hello",
+        metadata={"title": "Hello", "translation_key": "posts/hello"},
+        content_hash="body123",
+        file_hash="file123",
+    )
+
+    assert source.core.file_hash == "file123"
+    assert source.content_hash == "body123"
+    assert source.translation_key == "posts/hello"
+    assert isinstance(source.raw_metadata, MappingProxyType)
+    with pytest.raises(TypeError):
+        source.raw_metadata["title"] = "Changed"
+
+
+def test_build_source_page_does_not_compute_hashes_in_core():
+    source = build_source_page(
+        source_path=Path("content/posts/hello.md"),
+        raw_content="# Hello",
+        metadata={"title": "Hello"},
+    )
+
+    assert source.content_hash is None
+    assert source.core.file_hash is None
+
+
+def test_parsed_page_adapter_uses_supplied_toc_items_without_rendering_imports():
+    page = SimpleNamespace(
+        html_content="<h2>Intro</h2>",
+        toc="<nav></nav>",
+        excerpt="Intro",
+        meta_description="Intro meta",
+        description="Fallback",
+        plain_text="Intro",
+        word_count=3,
+        reading_time=1,
+        links=["/guide/", 42],
+        _ast_cache={"_type": "Document"},
+    )
+
+    parsed = parsed_page_from_page_state(
+        page,
+        toc_items=({"id": "intro", "title": "Intro"},),
+    )
+
+    assert parsed.html_content == "<h2>Intro</h2>"
+    assert parsed.toc_items == ({"id": "intro", "title": "Intro"},)
+    assert parsed.links == ("/guide/", "42")
+    assert parsed.ast_cache == {"_type": "Document"}
+
+
+def test_rendered_page_adapter_requires_output_path():
+    page = SimpleNamespace(
+        source_path=Path("content/index.md"),
+        output_path=None,
+        rendered_html="<html></html>",
+        render_time_ms=1.0,
+    )
+
+    with pytest.raises(ValueError, match="determine_output_path"):
+        rendered_page_from_page_state(page)
+
+
+def test_testing_record_factories_use_canonical_adapters():
+    assert make_page_core().title == "Hello World"
+    assert make_source_page().raw_content == "# Hello\n\nWorld"
+    assert make_parsed_page().plain_text == "Hello"
+    assert make_rendered_page().rendered_html == "<html>Hello</html>"

--- a/tests/unit/core/test_source_page.py
+++ b/tests/unit/core/test_source_page.py
@@ -13,39 +13,14 @@ import pytest
 
 from bengal.core.page.page_core import PageCore
 from bengal.core.records import SourcePage, create_virtual_source_page
-
-
-def _make_core(**overrides) -> PageCore:
-    """Create a minimal PageCore for testing."""
-    defaults = {
-        "source_path": "content/posts/hello.md",
-        "title": "Hello World",
-        "tags": ["python", "web"],
-        "slug": "hello",
-        "type": "post",
-    }
-    defaults.update(overrides)
-    return PageCore(**defaults)
-
-
-def _make_source_page(**overrides) -> SourcePage:
-    """Create a minimal SourcePage for testing."""
-    core = overrides.pop("core", _make_core())
-    defaults = {
-        "core": core,
-        "raw_content": "# Hello\n\nWorld",
-        "raw_metadata": MappingProxyType({"title": "Hello World", "tags": ["python", "web"]}),
-        "content_hash": "abc123",
-    }
-    defaults.update(overrides)
-    return SourcePage(**defaults)
+from tests._testing.page_records import make_page_core, make_source_page
 
 
 class TestSourcePageConstruction:
     """SourcePage can be constructed with all required fields."""
 
     def test_basic_construction(self):
-        sp = _make_source_page()
+        sp = make_source_page(content_hash="abc123")
         assert sp.core.title == "Hello World"
         assert sp.raw_content == "# Hello\n\nWorld"
         assert sp.content_hash == "abc123"
@@ -54,7 +29,7 @@ class TestSourcePageConstruction:
         assert sp.translation_key is None
 
     def test_all_fields(self):
-        sp = _make_source_page(
+        sp = make_source_page(
             content_hash="def456",
             is_virtual=True,
             lang="fr",
@@ -70,22 +45,22 @@ class TestSourcePageImmutability:
     """SourcePage is frozen and cannot be mutated."""
 
     def test_cannot_set_raw_content(self):
-        sp = _make_source_page()
+        sp = make_source_page()
         with pytest.raises(FrozenInstanceError):
             sp.raw_content = "new content"
 
     def test_cannot_set_content_hash(self):
-        sp = _make_source_page()
+        sp = make_source_page()
         with pytest.raises(FrozenInstanceError):
             sp.content_hash = "new_hash"
 
     def test_cannot_set_core(self):
-        sp = _make_source_page()
+        sp = make_source_page()
         with pytest.raises(FrozenInstanceError):
-            sp.core = _make_core(title="Different")
+            sp.core = make_page_core(metadata={"title": "Different"})
 
     def test_raw_metadata_is_readonly(self):
-        sp = _make_source_page()
+        sp = make_source_page()
         assert isinstance(sp.raw_metadata, MappingProxyType)
         with pytest.raises(TypeError):
             sp.raw_metadata["new_key"] = "value"
@@ -95,11 +70,16 @@ class TestSourcePageDelegates:
     """Property delegates forward to core."""
 
     def test_source_path_delegate(self):
-        sp = _make_source_page(core=_make_core(source_path="content/docs/guide.md"))
+        sp = SourcePage(
+            core=make_page_core(source_path="content/docs/guide.md"),
+            raw_content="# Guide",
+            raw_metadata=MappingProxyType({"title": "Hello World"}),
+            content_hash="abc123",
+        )
         assert sp.source_path == "content/docs/guide.md"
 
     def test_title_delegate(self):
-        sp = _make_source_page(core=_make_core(title="My Guide"))
+        sp = make_source_page(metadata={"title": "My Guide"})
         assert sp.title == "My Guide"
 
 
@@ -108,7 +88,12 @@ class TestSourcePageMetadataRoundTrip:
 
     def test_round_trip(self):
         original = {"title": "Hello", "tags": ["a", "b"], "custom": 42}
-        sp = _make_source_page(raw_metadata=MappingProxyType(original))
+        sp = SourcePage(
+            core=make_page_core(metadata=original),
+            raw_content="# Hello",
+            raw_metadata=MappingProxyType(original),
+            content_hash="abc123",
+        )
         result = sp.raw_metadata_dict()
         assert result == original
         assert isinstance(result, dict)
@@ -121,7 +106,7 @@ class TestSourcePageCoreCache:
     """SourcePage.core round-trips through PageCore cache serialization."""
 
     def test_core_cache_round_trip(self):
-        sp = _make_source_page(content_hash="hash123")
+        sp = make_source_page(content_hash="hash123")
         cache_dict = sp.core.to_cache_dict()
         restored = PageCore.from_cache_dict(cache_dict)
         assert restored.source_path == sp.core.source_path

--- a/tests/unit/rendering/test_pipeline_cache_storage.py
+++ b/tests/unit/rendering/test_pipeline_cache_storage.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bengal.cache import BuildCache
+from bengal.core.records import RenderedPage
 from bengal.rendering.pipeline import RenderingPipeline
 
 
@@ -157,6 +158,33 @@ class TestPipelineCacheStorage:
         # After caching, rendered_output should have an entry
         assert str(mock_page.source_path) in cache.rendered_output
         assert "Rendered" in cache.rendered_output[str(mock_page.source_path)]["html"]
+
+    def test_cache_rendered_output_prefers_rendered_page_record(
+        self, site_with_cache, mock_page, tmp_path
+    ):
+        """Rendered output cache reads from RenderedPage when supplied."""
+        site, cache = site_with_cache
+
+        parser = DummyParser()
+        engine = DummyTemplateEngine(site)
+        ctx = SimpleNamespace(markdown_parser=parser, template_engine=engine)
+
+        pipeline = RenderingPipeline(site, build_context=ctx, build_cache=cache)
+        cache.update_file(mock_page.source_path)
+
+        mock_page.rendered_html = "<html><body>stale mutable html</body></html>"
+        rendered_page = RenderedPage(
+            source_path=mock_page.source_path,
+            output_path=tmp_path / "public" / "test" / "index.html",
+            rendered_html="<html><body>record html</body></html>",
+            render_time_ms=1.0,
+        )
+
+        pipeline._cache_checker.cache_rendered_output(mock_page, "default.html", rendered_page)
+
+        cached = cache.rendered_output[str(mock_page.source_path)]
+        assert "record html" in cached["html"]
+        assert "stale mutable html" not in cached["html"]
 
     def test_build_cache_passed_directly(self, site_with_cache):
         """


### PR DESCRIPTION
## What changed

- Added canonical immutable page-record migration adapters in `bengal.core.records` for `PageCore`, `SourcePage`, `ParsedPage`, and `RenderedPage` handoffs.
- Moved discovery, mutable `Page` core initialization, rendering, and cache render handoffs onto those adapters.
- Kept core passive by computing `content_hash` and full-file `file_hash` at the discovery boundary before passing both into the core adapter.
- Added shared test factories in `tests/_testing/page_records.py` and focused adapter coverage in `tests/unit/core/test_page_record_migration.py`.
- Updated object-model docs to name the adapter path and migration map expectations.

## Why

This is the second steward-rollup backlog item: create the migration substrate before finishing mutable `Page` deletion. The goal is to give tests/rendering/cache a canonical bridge from compatibility `Page` state to immutable records without widening `PageLike` or inventing per-subsystem shims.

## Steward Notes

- Page steward: happy after re-check. `Page` remains a compatibility shim; record construction now delegates to shared adapters, and `build_source_page()` no longer imports hashing helpers or touches the filesystem.
- Rendering steward: happy to merge. Parse/render-derived record construction stays behind rendering-owned derivation where needed, with TOC structures passed into the core adapter to avoid core importing rendering helpers.
- Protocols steward: approved. No `PageLike`, `SectionLike`, `SiteLike`, plugin hook, or public protocol expansion.
- Build/incremental/cache steward: happy. Discovery-level `file_hash` fallback to `content_hash` is conservative for cache invalidation because later full-file hashes mismatch when frontmatter-only changes matter.
- Tests steward: happy. Added canonical record fixtures so tests can stop depending on concrete mutable `Page` setup.

## Validation

- `uv run pytest tests/unit/core/test_page_record_migration.py tests/unit/core/test_source_page.py tests/unit/core/test_no_core_mixins.py -q`
- `uv run pytest tests/unit/rendering/test_page_content.py tests/unit/rendering/test_page_operations.py tests/unit/rendering/test_page_urls.py tests/unit/rendering/test_page_resources.py tests/core/test_page_bundles.py tests/unit/core/test_computed_functions.py -q`
- `uv run pytest tests/unit/cache tests/unit/discovery -q`
- `uv run ruff check bengal/core/records.py bengal/content/discovery/content_discovery.py tests/unit/core/test_page_record_migration.py`
- `uv run ruff format --check bengal/core/records.py bengal/content/discovery/content_discovery.py tests/unit/core/test_page_record_migration.py`
- `make ty`
- pre-commit hooks on amended commit: ruff, ruff format, ty, check-cycles, check-deps warning hook

## Known Existing Failures

Verified on clean `origin/main` (`c490d6f68`) as well as this branch:

- `tests/manual/test_rich_features.py::test_rich_console` fails in this non-interactive environment because Rich console is disabled and `console` is `None`.
- `tests/performance/test_incremental_efficiency.py::TestWarmCacheEfficiency::test_warm_cache_zero_rebuilds` reports 0 total pages / 0% cache hit rate.
- `tests/lint/test_error_codes.py::test_all_bengal_errors_have_codes` reports 7 pre-existing `BengalConfigError` raises missing `code=`.
