### PR TITLE
[codex] Trim page dual-write bridges

### DIFF
--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -726,7 +726,8 @@ class ContentDiscovery:
             content, metadata = self._parser.parse_file(file_path)
             metadata = self._parser.validate_against_collection(file_path, metadata)
 
-            # Sprint 4: build immutable SourcePage first, then mutable Page
+            # Build the immutable discovery record first, then adapt it into
+            # the remaining Page compatibility object for downstream callers.
             source_page = self._build_source_page(
                 file_path, content, metadata, current_lang, section
             )
@@ -736,7 +737,6 @@ class ContentDiscovery:
                 _raw_content=source_page.raw_content,
                 _raw_metadata=source_page.raw_metadata_dict(),
             )
-            page._source_page = source_page
 
             if self.site is not None:
                 page._site = self.site

--- a/bengal/core/page/__init__.py
+++ b/bengal/core/page/__init__.py
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from bengal.core.author import Author
-    from bengal.core.records import SourcePage
     from bengal.core.series import Series
     from bengal.core.site.context import SiteContext
     from bengal.parsing.ast.types import ASTNode
@@ -264,11 +263,6 @@ class Page:
     # Sprint 5: True when page was reconstructed from cache without disk I/O.
     # Used for metrics/logging and to skip wasteful re-initialization in __post_init__.
     _from_cache: bool = field(default=False, repr=False)
-
-    # Sprint 4 dual-write bridge: immutable SourcePage record from discovery.
-    # Set by ContentDiscovery._create_page(); None for cached/proxy pages.
-    # Removed in Sprint 6 when Page is deleted.
-    _source_page: SourcePage | None = field(default=None, repr=False, init=False)
 
     def __post_init__(self) -> None:
         """Initialize computed fields and PageCore."""

--- a/bengal/core/records.py
+++ b/bengal/core/records.py
@@ -180,10 +180,10 @@ class SourcePage:
     metadata and adds discovery-specific fields (raw content, content
     hash, i18n).
 
-    Consumed by the orchestration and rendering phases via the
-    ``page._source_page`` dual-write bridge.  In the target architecture
-    (Sprint 5+) content loading is deferred to the parse stage and
-    ``raw_content`` becomes optional.
+    Consumed by discovery/orchestration handoffs before the remaining mutable
+    ``Page`` compatibility object is populated.  In the target architecture,
+    content loading is deferred to the parse stage and ``raw_content`` becomes
+    optional.
 
     The record itself is frozen (field reassignment raises).  Composed
     ``PageCore`` contains mutable containers (``tags``, ``props``,

--- a/bengal/rendering/pipeline/cache_checker.py
+++ b/bengal/rendering/pipeline/cache_checker.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from bengal.core.records import ParsedPage, rendered_page_from_page_state
+from bengal.core.records import ParsedPage, RenderedPage, rendered_page_from_page_state
 from bengal.rendering.page_operations import extract_links
 from bengal.rendering.pipeline.output import format_html, write_output
 from bengal.rendering.pipeline.toc import extract_toc_structure
@@ -345,13 +345,17 @@ class CacheChecker:
             meta_description=meta_description,
         )
 
-    def cache_rendered_output(self, page: PageLike, template: str) -> None:
+    def cache_rendered_output(
+        self, page: PageLike, template: str, rendered_page: RenderedPage | None = None
+    ) -> None:
         """
         Store rendered output in cache for next build.
 
         Args:
             page: Page with rendered HTML
             template: Template name used
+            rendered_page: Optional immutable render record to read HTML from
+                instead of the mutable Page compatibility field.
         """
         if not self.build_cache or page.metadata.get("_generated"):
             return
@@ -365,7 +369,7 @@ class CacheChecker:
         output_dir = getattr(self.site, "output_dir", None)
         cache.store_rendered_output(
             page.source_path,
-            page.rendered_html,
+            rendered_page.rendered_html if rendered_page is not None else page.rendered_html,
             template,
             page.metadata,
             dependencies=deps,

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -818,9 +818,9 @@ class RenderingPipeline:
         # Store rendered output in cache
         if _prof:
             with _prof.step("cache_rendered"):
-                self._cache_checker.cache_rendered_output(page, template)
+                self._cache_checker.cache_rendered_output(page, template, rendered_page)
         else:
-            self._cache_checker.cache_rendered_output(page, template)
+            self._cache_checker.cache_rendered_output(page, template, rendered_page)
 
         # Write output (sync or async via write-behind)
         if _prof:
@@ -854,12 +854,19 @@ class RenderingPipeline:
         # Use render-time tracked assets, fall back to HTML parsing if needed
         if _prof:
             with _prof.step("asset_deps"):
-                self._accumulate_asset_deps(page, tracked_assets=tracked_assets)
+                self._accumulate_asset_deps(
+                    page, tracked_assets=tracked_assets, rendered_html=rendered_page.rendered_html
+                )
         else:
-            self._accumulate_asset_deps(page, tracked_assets=tracked_assets)
+            self._accumulate_asset_deps(
+                page, tracked_assets=tracked_assets, rendered_html=rendered_page.rendered_html
+            )
 
     def _accumulate_asset_deps(
-        self, page: PageLike, tracked_assets: set[str] | None = None
+        self,
+        page: PageLike,
+        tracked_assets: set[str] | None = None,
+        rendered_html: str | None = None,
     ) -> None:
         """
         Accumulate asset dependencies during rendering.
@@ -870,8 +877,10 @@ class RenderingPipeline:
         Args:
             page: Page with rendered HTML
             tracked_assets: Assets tracked during render-time (if available)
+            rendered_html: Rendered HTML from the immutable render record.
         """
-        if not self.build_context or not page.rendered_html:
+        html = rendered_html if rendered_html is not None else page.rendered_html
+        if not self.build_context or not html:
             return
 
         assets: set[str] = set()
@@ -888,7 +897,7 @@ class RenderingPipeline:
                 from bengal.rendering.asset_extractor import extract_assets_from_html
                 from bengal.rendering.assets import get_asset_manifest
 
-                raw_assets = extract_assets_from_html(page.rendered_html)
+                raw_assets = extract_assets_from_html(html)
 
                 # Normalize fingerprinted URLs back to logical paths.
                 # When Kida fragment cache hits, asset_url() is not called, so

--- a/bengal/server/reactive/handler.py
+++ b/bengal/server/reactive/handler.py
@@ -51,8 +51,9 @@ class ReactiveContentHandler:
     def handle_content_change(self, path: Path) -> ReactiveResult | None:
         """Process content-only change for a single .md file.
 
-        Flow: find page -> read source -> update page._raw_content -> run
-        RenderingPipeline.process_page -> write to disk.
+        Flow: find page -> read source -> update the remaining Page
+        compatibility fields -> run RenderingPipeline.process_page -> write
+        to disk.
 
         Returns a ReactiveResult carrying both the output path and the
         rendered HTML string so callers can extract fragments in memory
@@ -80,24 +81,6 @@ class ReactiveContentHandler:
         # full file would render YAML as markdown.
         _, body_content = parse_frontmatter(raw_file)
 
-        # Sprint 4: reconstruct immutable SourcePage record.
-        # Uses dataclasses.replace() so new SourcePage fields are carried forward automatically.
-        from bengal.core.records import SourcePage
-
-        old_source = getattr(page, "_source_page", None)
-        if isinstance(old_source, SourcePage):
-            from dataclasses import replace as dc_replace
-
-            from bengal.utils.primitives.hashing import hash_str
-
-            file_hash = hash_str(raw_file)
-            content_hash = hash_str(body_content)
-            new_core = dc_replace(old_source.core, file_hash=file_hash)
-            page._source_page = dc_replace(
-                old_source, core=new_core, raw_content=body_content, content_hash=content_hash
-            )
-
-        # Existing mutable Page update (kept for backward compatibility)
         page._raw_content = body_content
         page.html_content = None
 

--- a/site/content/docs/reference/architecture/core/object-model.md
+++ b/site/content/docs/reference/architecture/core/object-model.md
@@ -127,7 +127,9 @@ as the canonical handoff from mutable `Page` compatibility state into record
 state:
 
 - `build_page_core()` maps frontmatter and path inputs into `PageCore`.
-- `build_source_page()` maps discovery inputs into `SourcePage`.
+- `build_source_page()` maps discovery inputs into `SourcePage`; discovery
+  consumes that record while populating the remaining `Page` compatibility
+  object, but does not retain it as a second mutable sidecar on `Page`.
 - `parsed_page_from_page_state()` maps parse-phase `PageLike` state into
   `ParsedPage` while accepting rendering-supplied TOC structures.
 - `rendered_page_from_page_state()` maps render-phase state into `RenderedPage`.

--- a/tests/unit/core/test_page_record_migration.py
+++ b/tests/unit/core/test_page_record_migration.py
@@ -7,6 +7,7 @@ from types import MappingProxyType, SimpleNamespace
 
 import pytest
 
+from bengal.core.page import Page
 from bengal.core.records import (
     PAGE_CORE_MIGRATION_MAP,
     PARSED_PAGE_MIGRATION_MAP,
@@ -97,6 +98,16 @@ def test_build_source_page_does_not_compute_hashes_in_core():
 
     assert source.content_hash is None
     assert source.core.file_hash is None
+
+
+def test_page_no_longer_retains_source_page_bridge():
+    page = Page(
+        source_path=Path("content/posts/hello.md"),
+        _raw_content="# Hello",
+        _raw_metadata={"title": "Hello"},
+    )
+
+    assert not hasattr(page, "_source_page")
 
 
 def test_parsed_page_adapter_uses_supplied_toc_items_without_rendering_imports():

--- a/tests/unit/rendering/test_pipeline_cache_storage.py
+++ b/tests/unit/rendering/test_pipeline_cache_storage.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bengal.cache import BuildCache
+from bengal.core.records import RenderedPage
 from bengal.rendering.pipeline import RenderingPipeline
 
 
@@ -157,6 +158,33 @@ class TestPipelineCacheStorage:
         # After caching, rendered_output should have an entry
         assert str(mock_page.source_path) in cache.rendered_output
         assert "Rendered" in cache.rendered_output[str(mock_page.source_path)]["html"]
+
+    def test_cache_rendered_output_prefers_rendered_page_record(
+        self, site_with_cache, mock_page, tmp_path
+    ):
+        """Rendered output cache reads from RenderedPage when supplied."""
+        site, cache = site_with_cache
+
+        parser = DummyParser()
+        engine = DummyTemplateEngine(site)
+        ctx = SimpleNamespace(markdown_parser=parser, template_engine=engine)
+
+        pipeline = RenderingPipeline(site, build_context=ctx, build_cache=cache)
+        cache.update_file(mock_page.source_path)
+
+        mock_page.rendered_html = "<html><body>stale mutable html</body></html>"
+        rendered_page = RenderedPage(
+            source_path=mock_page.source_path,
+            output_path=tmp_path / "public" / "test" / "index.html",
+            rendered_html="<html><body>record html</body></html>",
+            render_time_ms=1.0,
+        )
+
+        pipeline._cache_checker.cache_rendered_output(mock_page, "default.html", rendered_page)
+
+        cached = cache.rendered_output[str(mock_page.source_path)]
+        assert "record html" in cached["html"]
+        assert "stale mutable html" not in cached["html"]
 
     def test_build_cache_passed_directly(self, site_with_cache):
         """


### PR DESCRIPTION
## What changed

- Removed the retained `page._source_page` dual-write bridge from the mutable `Page` compatibility object.
- Kept `SourcePage` as a discovery handoff record: discovery builds it first, then adapts it into the remaining `Page` object without storing a second sidecar.
- Changed rendered-output caching and asset dependency fallback parsing to read from `RenderedPage` when available instead of trusting `page.rendered_html`.
- Updated the object-model docs and focused tests for the migration contract.

## Why

This is the next steward-rollup priority after the migration substrate: start trimming mutable `Page` deletion and dual-write debt in small, reviewable pieces. The compatibility `Page` still exists, but this removes one stale sidecar and shifts two render downstream consumers toward immutable records.

Stacked on #250 (`codex/page-migration-substrate`).

## Steward Notes

- Page steward: `Page` keeps compatibility fields, but no longer retains the discovery `SourcePage` sidecar.
- Rendering steward: cache storage and asset fallback parsing now use `RenderedPage` record data where available.
- Cache steward: rendered-output cache remains schema-compatible; only the source of the HTML value changes when a render record is supplied.
- Tests steward: added focused assertions that `Page` no longer has `_source_page` and rendered cache storage prefers record HTML over stale mutable HTML.

## Validation

- `uv run pytest tests/unit/core/test_page_record_migration.py tests/unit/core/test_source_page.py tests/unit/core/test_no_core_mixins.py -q`
- `uv run pytest tests/unit/rendering/test_page_content.py tests/unit/rendering/test_page_operations.py tests/unit/rendering/test_page_urls.py tests/unit/rendering/test_page_resources.py tests/core/test_page_bundles.py tests/unit/core/test_computed_functions.py -q`
- `uv run pytest tests/unit/cache tests/unit/discovery -q`
- `uv run pytest tests/unit/server/test_reactive_handler.py tests/integration/warm_build/test_build_trigger_reactive.py -q`
- `uv run pytest tests/unit/rendering/test_pipeline_cache_storage.py tests/unit/rendering/test_write_output_rendered_page.py tests/unit/rendering/test_pipeline_reporter_output.py -q`
- `uv run ruff check bengal/core/page/__init__.py bengal/core/records.py bengal/content/discovery/content_discovery.py bengal/server/reactive/handler.py bengal/rendering/pipeline/cache_checker.py bengal/rendering/pipeline/core.py tests/unit/core/test_page_record_migration.py tests/unit/rendering/test_pipeline_cache_storage.py`
- `uv run ruff format --check bengal/core/page/__init__.py bengal/core/records.py bengal/content/discovery/content_discovery.py bengal/server/reactive/handler.py bengal/rendering/pipeline/cache_checker.py bengal/rendering/pipeline/core.py tests/unit/core/test_page_record_migration.py tests/unit/rendering/test_pipeline_cache_storage.py`
- `make ty`
- pre-commit hooks on commit: ruff, ruff format, ty, check-cycles, check-deps warning hook

## Notes

- `make ty` passes with the configured diagnostic floor and reports 541 existing diagnostics.
- `check-deps` still reports the repo's existing 4 dependency-layer warnings, but the warning hook exits successfully.
