### PR TITLE
cli; orchestration: add plugin readiness introspection

### DIFF
--- a/bengal/cli/milo_app.py
+++ b/bengal/cli/milo_app.py
@@ -220,6 +220,21 @@ for name, desc in [
         display_result=False,
     )
 
+# --- plugin ---
+plugin = cli.group("plugin", description="Plugin discovery and readiness", aliases=("plugins",))
+
+for name, desc in [
+    ("list", "List installed Bengal plugins"),
+    ("info", "Show plugin capability readiness"),
+    ("validate", "Validate plugin capability wiring"),
+]:
+    plugin.lazy_command(
+        name,
+        import_path=f"bengal.cli.milo_commands.plugin:plugin_{name}",
+        description=desc,
+        display_result=False,
+    )
+
 # ---------------------------------------------------------------------------
 # Tier 3 — Analysis & debugging (power users)
 # ---------------------------------------------------------------------------

--- a/bengal/cli/milo_commands/plugin.py
+++ b/bengal/cli/milo_commands/plugin.py
@@ -1,0 +1,152 @@
+"""Plugin group — discovery and capability readiness."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from milo import Description
+
+
+def _status_label(status: str) -> str:
+    match status:
+        case "ready":
+            return "ready"
+        case "partial":
+            return "partial"
+        case "invalid" | "load_error" | "register_error":
+            return "error"
+        case _:
+            return status
+
+
+def _load_reports() -> list[Any]:
+    from bengal.plugins.inspection import inspect_installed_plugins
+
+    return inspect_installed_plugins()
+
+
+def plugin_list() -> dict:
+    """List installed Bengal plugins and readiness status."""
+    from bengal.cli.utils import get_cli_output
+
+    cli = get_cli_output()
+    reports = _load_reports()
+
+    if not reports:
+        cli.info("No Bengal plugins discovered")
+        return {"plugins": [], "count": 0}
+
+    cli.render_write(
+        "item_list.kida",
+        title="Bengal Plugins",
+        items=[
+            {
+                "name": report.plugin_name or report.entry_point,
+                "description": (
+                    f"{report.version or 'unknown'}  "
+                    f"{_status_label(report.status)}  "
+                    f"{report.entry_point}"
+                ),
+            }
+            for report in reports
+        ],
+    )
+
+    return {
+        "plugins": [report.to_dict() for report in reports],
+        "count": len(reports),
+    }
+
+
+def plugin_info(
+    name: Annotated[str, Description("Plugin name or entry point name")],
+) -> dict:
+    """Show detailed plugin capability readiness."""
+    from bengal.cli.utils import get_cli_output
+    from bengal.plugins.inspection import capability_details
+
+    cli = get_cli_output()
+    reports = _load_reports()
+    report = next(
+        (item for item in reports if item.entry_point == name or item.plugin_name == name),
+        None,
+    )
+
+    if report is None:
+        cli.error(f"Plugin not found: {name}")
+        cli.tip("Run `bengal plugin list` to see installed plugin entry points.")
+        raise SystemExit(1)
+
+    items = [
+        {"label": "Entry point", "value": report.entry_point},
+        {"label": "Object", "value": report.value},
+        {"label": "Name", "value": report.plugin_name or ""},
+        {"label": "Version", "value": report.version or "unknown"},
+        {"label": "Status", "value": _status_label(report.status)},
+    ]
+    if report.errors:
+        items.append({"label": "Errors", "value": "; ".join(report.errors)})
+    pending = report.pending_capabilities
+    if pending:
+        items.append({"label": "Pending capabilities", "value": ", ".join(pending)})
+
+    cli.render_write("kv_detail.kida", title=f"Plugin: {name}", items=items)
+
+    return {
+        "plugin": report.to_dict(),
+        "capabilities": capability_details(report.capabilities),
+    }
+
+
+def plugin_validate() -> dict:
+    """Validate installed plugins against currently wired Bengal capabilities."""
+    from bengal.cli.utils import get_cli_output
+    from bengal.plugins.inspection import capability_details
+
+    cli = get_cli_output()
+    reports = _load_reports()
+    issues: list[dict[str, str]] = []
+
+    for report in reports:
+        label = report.plugin_name or report.entry_point
+        issues.extend({"level": "error", "message": f"{label}: {error}"} for error in report.errors)
+        issues.extend(
+            {
+                "level": "warning",
+                "message": (
+                    f"{label}: {detail['count']} {detail['name']} registered, "
+                    f"but integration is {detail['integration_status']}"
+                ),
+            }
+            for detail in capability_details(report.capabilities)
+            if detail["count"] and not detail["ready"]
+        )
+
+    if not reports:
+        cli.info("No Bengal plugins discovered")
+        return {"valid": True, "plugins": [], "issues": []}
+
+    passed = len(reports) if not issues else 0
+    summary = {
+        "errors": sum(1 for issue in issues if issue["level"] == "error"),
+        "warnings": sum(1 for issue in issues if issue["level"] == "warning"),
+        "passed": passed,
+    }
+
+    cli.render_write(
+        "validation_report.kida",
+        title="Plugin Validation",
+        issues=issues
+        or [{"level": "success", "message": "All installed plugins use wired capabilities"}],
+        summary=summary,
+    )
+
+    result = {
+        "valid": not issues,
+        "plugins": [report.to_dict() for report in reports],
+        "issues": issues,
+        "summary": summary,
+    }
+    if issues:
+        raise SystemExit(1)
+    return result

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -410,9 +410,16 @@ class BuildOrchestrator:
 
         # Phase 0: Plugin Loading
         from bengal.plugins import load_plugins, set_active_registry
+        from bengal.plugins.integration import apply_plugin_phase_hooks
 
         plugin_registry = load_plugins()
         set_active_registry(plugin_registry)
+
+        def run_plugin_phase(phase_name: str) -> None:
+            """Run registered plugin callbacks for a build lifecycle phase."""
+            apply_plugin_phase_hooks(plugin_registry, phase_name, self.site, early_ctx)
+
+        run_plugin_phase("build_start")
 
         # Phase 1: Font Processing
         initialization.phase_fonts(self, cli, collector=output_collector)
@@ -421,6 +428,7 @@ class BuildOrchestrator:
         initialization.phase_template_validation(self, cli, strict=strict)
 
         # === DISCOVERY PHASE GROUP (dashboard-integrated) ===
+        run_plugin_phase("pre_discovery")
         notify_phase_start("discovery")
         discovery_start = time.time()
 
@@ -444,6 +452,7 @@ class BuildOrchestrator:
             discovery_duration_ms,
             f"{len(self.site.pages)} pages, {len(self.site.sections)} sections",
         )
+        run_plugin_phase("post_discovery")
 
         # Phase 4: Config Check and Cleanup
         config_result = initialization.phase_config_check(self, cli, cache, incremental)
@@ -469,6 +478,7 @@ class BuildOrchestrator:
 
         if filter_result is None:
             # No changes detected - early exit
+            run_plugin_phase("build_complete")
             return self.stats
         pages_to_build = filter_result.pages_to_build
         assets_to_process = filter_result.assets_to_process
@@ -482,6 +492,7 @@ class BuildOrchestrator:
         early_ctx.changed_page_paths = set(changed_page_paths)
 
         # === CONTENT PHASE GROUP (dashboard-integrated) ===
+        run_plugin_phase("pre_content")
         notify_phase_start("content")
         content_start = time.time()
 
@@ -544,10 +555,12 @@ class BuildOrchestrator:
             content_duration_ms,
             f"{taxonomy_count} taxonomies, {len(affected_tags)} affected tags",
         )
+        run_plugin_phase("post_content")
 
         # === PARSING PHASE (after all pages known, before snapshot) ===
         # Parse markdown content for ALL pages (including generated taxonomy pages)
         # RFC: rfc-bengal-snapshot-engine - pre-parse to avoid redundant work during rendering
+        run_plugin_phase("pre_parsing")
         parsing_start = time.time()
         with self.logger.phase("parsing"):
             parsing.phase_parse_content(
@@ -563,10 +576,12 @@ class BuildOrchestrator:
         cli.phase(
             "Parsing", duration_ms=parsing_duration_ms, details=f"{len(pages_to_build)} pages"
         )
+        run_plugin_phase("post_parsing")
 
         # === SNAPSHOT CREATION (after parsing, before rendering) ===
         # Create immutable snapshot for lock-free parallel rendering
         # Snapshot now contains pre-parsed HTML content from all pages
+        run_plugin_phase("pre_snapshot")
         from bengal.snapshots import create_site_snapshot
         from bengal.snapshots.persistence import SnapshotCache
 
@@ -618,6 +633,7 @@ class BuildOrchestrator:
                 early_ctx.data_service = DataService.from_root(self.site.root_path)
             except Exception:  # noqa: S110
                 pass  # data/ dir may not exist; service remains None
+        run_plugin_phase("post_snapshot")
 
         # === DRY-RUN MODE: Skip output-producing phases ===
         # RFC: rfc-incremental-build-observability Phase 2
@@ -631,9 +647,11 @@ class BuildOrchestrator:
             # Clear build state (build complete)
             self.site.set_build_state(None)
 
+            run_plugin_phase("build_complete")
             return self.stats
 
         # === ASSETS PHASE GROUP (dashboard-integrated) ===
+        run_plugin_phase("pre_assets")
         notify_phase_start("assets")
         assets_start = time.time()
 
@@ -655,8 +673,11 @@ class BuildOrchestrator:
             assets_duration_ms,
             f"{len(assets_to_process) if assets_to_process else 0} assets processed",
         )
+        run_plugin_phase("post_assets")
 
         # === RENDERING PHASE GROUP (dashboard-integrated) ===
+        run_plugin_phase("pre_render")
+        run_plugin_phase("pre_rendering")
         notify_phase_start("rendering")
         rendering_start = time.time()
 
@@ -715,8 +736,11 @@ class BuildOrchestrator:
             rendering_duration_ms,
             f"{len(pages_to_build) if pages_to_build else 0} pages rendered",
         )
+        run_plugin_phase("post_render")
+        run_plugin_phase("post_rendering")
 
         # === FINALIZATION PHASE GROUP (dashboard-integrated) ===
+        run_plugin_phase("pre_finalization")
         notify_phase_start("finalization")
         finalization_start = time.time()
 
@@ -846,8 +870,10 @@ class BuildOrchestrator:
             finalization_duration_ms,
             "post-processing complete",
         )
+        run_plugin_phase("post_finalization")
 
         # === HEALTH PHASE GROUP (dashboard-integrated) ===
+        run_plugin_phase("pre_health")
         notify_phase_start("health")
         health_start = time.time()
 
@@ -863,6 +889,7 @@ class BuildOrchestrator:
             total = health_report.total_checks
             health_summary = f"{passed}/{total} checks passed"
         notify_phase_complete("health", health_duration_ms, health_summary)
+        run_plugin_phase("post_health")
 
         # Phase 21: Finalize Build
         finalization.phase_finalize(self, verbose, collector)
@@ -883,6 +910,8 @@ class BuildOrchestrator:
 
         # Clear build state (build complete)
         self.site.set_build_state(None)
+
+        run_plugin_phase("build_complete")
 
         return self.stats
 

--- a/bengal/plugins/inspection.py
+++ b/bengal/plugins/inspection.py
@@ -1,0 +1,196 @@
+"""Plugin discovery inspection for CLI and tests."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+
+from bengal.plugins.loader import ENTRY_POINT_GROUP
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import FrozenPluginRegistry, PluginRegistry
+
+CAPABILITY_FIELDS = (
+    "directives",
+    "roles",
+    "template_functions",
+    "template_filters",
+    "template_tests",
+    "content_sources",
+    "health_validators",
+    "shortcodes",
+    "phase_hooks",
+)
+
+CAPABILITY_INTEGRATION_STATUS = MappingProxyType(
+    {
+        "directives": "pending",
+        "roles": "pending",
+        "template_functions": "ready",
+        "template_filters": "ready",
+        "template_tests": "ready",
+        "content_sources": "pending",
+        "health_validators": "pending",
+        "shortcodes": "pending",
+        "phase_hooks": "ready",
+    }
+)
+"""Whether each registered plugin capability is currently wired into builds."""
+
+CAPABILITY_NOTES = MappingProxyType(
+    {
+        "directives": "Registered, but directive builder plugin hooks are not wired yet.",
+        "roles": "Registered, but role builder plugin hooks are not wired yet.",
+        "template_functions": "Applied to template environments during registration.",
+        "template_filters": "Applied to template environments during registration.",
+        "template_tests": "Applied to template environments during registration.",
+        "content_sources": "Registered, but content source discovery is not wired yet.",
+        "health_validators": "Registered, but health validator injection is not wired yet.",
+        "shortcodes": "Registered, but shortcode registry injection is not wired yet.",
+        "phase_hooks": "Executed by build lifecycle phase hooks.",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PluginInspection:
+    """Result of inspecting one plugin entry point."""
+
+    entry_point: str
+    value: str
+    plugin_name: str | None = None
+    version: str | None = None
+    status: str = "unknown"
+    capabilities: dict[str, int] = field(default_factory=dict)
+    errors: tuple[str, ...] = ()
+
+    @property
+    def ready(self) -> bool:
+        """True when the plugin loads, registers, and uses only wired capabilities."""
+        return self.status == "ready"
+
+    @property
+    def has_load_error(self) -> bool:
+        """True when the plugin failed protocol or registration validation."""
+        return self.status in {"load_error", "invalid", "register_error"}
+
+    @property
+    def pending_capabilities(self) -> tuple[str, ...]:
+        """Capabilities this plugin registers that Bengal does not wire yet."""
+        return tuple(
+            name
+            for name, count in self.capabilities.items()
+            if count and CAPABILITY_INTEGRATION_STATUS.get(name) != "ready"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for CLI structured output."""
+        return {
+            "entry_point": self.entry_point,
+            "value": self.value,
+            "name": self.plugin_name,
+            "version": self.version,
+            "status": self.status,
+            "ready": self.ready,
+            "capabilities": self.capabilities,
+            "pending_capabilities": list(self.pending_capabilities),
+            "errors": list(self.errors),
+        }
+
+
+def capability_counts(registry: FrozenPluginRegistry) -> dict[str, int]:
+    """Return per-capability counts from a frozen plugin registry."""
+    return {field_name: len(getattr(registry, field_name)) for field_name in CAPABILITY_FIELDS}
+
+
+def capability_details(counts: dict[str, int]) -> list[dict[str, Any]]:
+    """Return capability count plus integration readiness details."""
+    details: list[dict[str, Any]] = []
+    for name in CAPABILITY_FIELDS:
+        count = counts.get(name, 0)
+        status = CAPABILITY_INTEGRATION_STATUS[name]
+        details.append(
+            {
+                "name": name,
+                "count": count,
+                "integration_status": status,
+                "ready": count == 0 or status == "ready",
+                "note": CAPABILITY_NOTES[name],
+            }
+        )
+    return details
+
+
+def _entry_points() -> list[Any]:
+    """Return entry points for the Bengal plugin group."""
+    try:
+        return list(importlib.metadata.entry_points(group=ENTRY_POINT_GROUP))
+    except TypeError:
+        return list(importlib.metadata.entry_points().get(ENTRY_POINT_GROUP, []))
+
+
+def inspect_entry_point(entry_point: Any) -> PluginInspection:
+    """Load and validate one plugin entry point without mutating global state."""
+    entry_name = str(getattr(entry_point, "name", "<unknown>"))
+    entry_value = str(getattr(entry_point, "value", ""))
+    try:
+        plugin_obj = entry_point.load()
+        plugin = plugin_obj() if isinstance(plugin_obj, type) else plugin_obj
+    except Exception as exc:
+        return PluginInspection(
+            entry_point=entry_name,
+            value=entry_value,
+            status="load_error",
+            errors=(f"{type(exc).__name__}: {exc}",),
+        )
+
+    plugin_name = str(getattr(plugin, "name", entry_name))
+    version = str(getattr(plugin, "version", "unknown"))
+
+    if not isinstance(plugin, Plugin):
+        return PluginInspection(
+            entry_point=entry_name,
+            value=entry_value,
+            plugin_name=plugin_name,
+            version=version,
+            status="invalid",
+            errors=("Does not implement bengal.plugins.Plugin",),
+        )
+
+    registry = PluginRegistry()
+    try:
+        plugin.register(registry)
+    except Exception as exc:
+        return PluginInspection(
+            entry_point=entry_name,
+            value=entry_value,
+            plugin_name=plugin_name,
+            version=version,
+            status="register_error",
+            errors=(f"{type(exc).__name__}: {exc}",),
+        )
+
+    counts = capability_counts(registry.freeze())
+    status = (
+        "partial"
+        if any(
+            counts[name] and CAPABILITY_INTEGRATION_STATUS[name] != "ready"
+            for name in CAPABILITY_FIELDS
+        )
+        else "ready"
+    )
+
+    return PluginInspection(
+        entry_point=entry_name,
+        value=entry_value,
+        plugin_name=plugin_name,
+        version=version,
+        status=status,
+        capabilities=counts,
+    )
+
+
+def inspect_installed_plugins() -> list[PluginInspection]:
+    """Inspect all installed Bengal plugin entry points."""
+    return [inspect_entry_point(entry_point) for entry_point in _entry_points()]

--- a/bengal/plugins/inspection.py
+++ b/bengal/plugins/inspection.py
@@ -23,6 +23,7 @@ CAPABILITY_FIELDS = (
     "phase_hooks",
 )
 
+# Whether each registered plugin capability is currently wired into builds.
 CAPABILITY_INTEGRATION_STATUS = MappingProxyType(
     {
         "directives": "pending",
@@ -36,7 +37,6 @@ CAPABILITY_INTEGRATION_STATUS = MappingProxyType(
         "phase_hooks": "ready",
     }
 )
-"""Whether each registered plugin capability is currently wired into builds."""
 
 CAPABILITY_NOTES = MappingProxyType(
     {
@@ -72,8 +72,8 @@ class PluginInspection:
 
     @property
     def has_load_error(self) -> bool:
-        """True when the plugin failed protocol or registration validation."""
-        return self.status in {"load_error", "invalid", "register_error"}
+        """True when the plugin failed to load from its entry point."""
+        return self.status == "load_error"
 
     @property
     def pending_capabilities(self) -> tuple[str, ...]:

--- a/bengal/plugins/integration.py
+++ b/bengal/plugins/integration.py
@@ -7,11 +7,11 @@ Bengal subsystem (directive builder, template environment, etc.).
 Currently wired:
 - Template extensions (functions, filters, tests) — via register_all() in
   bengal.rendering.template_functions
+- Phase hooks — via BuildOrchestrator lifecycle phase groups
 
 Scaffolding for future subsystem integration:
 - Directives and roles — pending directive/role builder plugin hooks
 - Content sources — pending content source registry plugin hooks
-- Phase hooks — pending build orchestrator phase hook wiring
 
 """
 

--- a/changelog.d/plugin-cli-introspection.added.md
+++ b/changelog.d/plugin-cli-introspection.added.md
@@ -1,0 +1,1 @@
+Added `bengal plugin list`, `bengal plugin info`, and `bengal plugin validate` to report installed plugin readiness and distinguish wired capabilities from pending registry surfaces.

--- a/site/content/docs/extending/plugins.md
+++ b/site/content/docs/extending/plugins.md
@@ -84,6 +84,15 @@ class MyPlugin(Plugin):
 
 The `PluginRegistry` provides 9 registration methods:
 
+Current integration status:
+
+- Ready in builds: template functions, template filters, template tests, build phase hooks
+- Registered but pending subsystem wiring: directives, roles, content sources, health validators, shortcodes
+
+Use `bengal plugin list`, `bengal plugin info <name>`, and
+`bengal plugin validate` to inspect installed plugins and see whether their
+registered capabilities are active in the current Bengal build pipeline.
+
 ### Template Extensions
 
 ```python
@@ -111,6 +120,9 @@ def register(self, registry: PluginRegistry) -> None:
     registry.add_role(MyRoleHandler)
 ```
 
+Directive and role registration is discoverable through plugin introspection,
+but parser injection is not wired yet.
+
 ### Content Sources
 
 ```python
@@ -118,12 +130,18 @@ def register(self, registry: PluginRegistry) -> None:
     registry.add_content_source("my-source", MyContentSource)
 ```
 
+Content source registration is discoverable through plugin introspection, but
+content discovery does not consume plugin sources yet.
+
 ### Health Validators
 
 ```python
 def register(self, registry: PluginRegistry) -> None:
     registry.add_health_validator(MyValidator())
 ```
+
+Health validator registration is discoverable through plugin introspection, but
+health checks do not consume plugin validators yet.
 
 ### Shortcodes
 
@@ -134,6 +152,9 @@ def register(self, registry: PluginRegistry) -> None:
         '<div class="alert alert-{{ type | default("info") }}">{{ content }}</div>',
     )
 ```
+
+Shortcode registration is discoverable through plugin introspection, but the
+shortcode registry does not consume plugin shortcodes yet.
 
 ### Build Phase Hooks
 
@@ -148,6 +169,19 @@ def before_render(self, site, build_context):
 def after_render(self, site, build_context):
     print("Render complete")
 ```
+
+Lifecycle hook names currently emitted by builds:
+
+- `build_start`, `build_complete`
+- `pre_discovery`, `post_discovery`
+- `pre_content`, `post_content`
+- `pre_parsing`, `post_parsing`
+- `pre_snapshot`, `post_snapshot`
+- `pre_assets`, `post_assets`
+- `pre_render`, `post_render`
+- `pre_rendering`, `post_rendering`
+- `pre_finalization`, `post_finalization`
+- `pre_health`, `post_health`
 
 ## How Discovery Works
 

--- a/site/content/docs/reference/architecture/core/orchestration.md
+++ b/site/content/docs/reference/architecture/core/orchestration.md
@@ -207,6 +207,26 @@ notify_phase_complete("discovery", duration_ms, "150 pages, 12 sections")
 
 Groups: `discovery`, `content`, `assets`, `rendering`, `finalization`, `health`
 
+## Plugin Lifecycle Hooks
+
+Builds load the frozen plugin registry during setup, then execute registered
+`PluginRegistry.on_phase()` callbacks around the existing phase groups. Hooks
+receive `(site, build_context)` and run through the same build context object
+that later phases enrich.
+
+Emitted lifecycle hooks:
+
+- `build_start`, `build_complete`
+- `pre_discovery`, `post_discovery`
+- `pre_content`, `post_content`
+- `pre_parsing`, `post_parsing`
+- `pre_snapshot`, `post_snapshot`
+- `pre_assets`, `post_assets`
+- `pre_render`, `post_render`
+- `pre_rendering`, `post_rendering`
+- `pre_finalization`, `post_finalization`
+- `pre_health`, `post_health`
+
 :::{seealso}
 - [Pipeline](pipeline.md) — Streaming and memory optimization
 - [Cache](cache.md) — Build caching

--- a/site/content/docs/reference/architecture/meta/extension-points.md
+++ b/site/content/docs/reference/architecture/meta/extension-points.md
@@ -358,6 +358,25 @@ my-plugin = "my_package:MyPlugin"
 | `add_shortcode()` | Shortcode templates |
 | `on_phase()` | Build phase lifecycle hooks |
 
+**Lifecycle hook names currently wired into builds:**
+
+- `build_start`, `build_complete`
+- `pre_discovery`, `post_discovery`
+- `pre_content`, `post_content`
+- `pre_parsing`, `post_parsing`
+- `pre_snapshot`, `post_snapshot`
+- `pre_assets`, `post_assets`
+- `pre_render`, `post_render` (`pre_rendering` and `post_rendering` are also emitted)
+- `pre_finalization`, `post_finalization`
+- `pre_health`, `post_health`
+
+Use `bengal plugin list`, `bengal plugin info <name>`, and
+`bengal plugin validate` to inspect installed plugins. The CLI reports both
+registered capabilities and whether each capability is currently wired. For
+example, template filters and phase hooks are active; directive, role, content
+source, health validator, and shortcode injection are still reported as pending
+until those subsystem hooks are wired.
+
 ## Future: Custom CLI Commands
 
 **Purpose**: Add custom commands to Bengal CLI

--- a/site/content/docs/reference/architecture/tooling/cli.md
+++ b/site/content/docs/reference/architecture/tooling/cli.md
@@ -197,6 +197,23 @@ bengal --version
 bengal --help
 ```
 
+**Plugin Commands**:
+```bash
+# List installed plugins and readiness
+bengal plugin list
+
+# Show capability details for one plugin
+bengal plugin info my-plugin
+
+# Validate plugins against capabilities Bengal currently wires
+bengal plugin validate
+```
+
+Plugin introspection is intentionally conservative: it loads the same
+`bengal.plugins` entry points as a build, runs each plugin's `register()` method
+against a temporary registry, and reports capability counts plus whether each
+capability is actually integrated today.
+
 **Upgrade Commands**:
 ```bash
 # Check for updates and upgrade interactively

--- a/tests/unit/cli/test_milo_parser_construction.py
+++ b/tests/unit/cli/test_milo_parser_construction.py
@@ -49,8 +49,16 @@ def test_milo_cli_walk_commands_resolves_every_lazy_import():
         ["build", "--help"],
         ["cache", "hash", "--help"],
         ["check", "--help"],
+        ["plugin", "list", "--help"],
     ],
-    ids=["root-version", "root-help", "build-help", "cache-hash-help", "check-help"],
+    ids=[
+        "root-version",
+        "root-help",
+        "build-help",
+        "cache-hash-help",
+        "check-help",
+        "plugin-list-help",
+    ],
 )
 def test_milo_cli_parse_args_never_raises_argparse_error(argv):
     """Parsing canonical help/version invocations must not raise ArgumentError.

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -1,0 +1,60 @@
+"""Tests for the plugin introspection CLI command handlers."""
+
+from __future__ import annotations
+
+import pytest
+
+from bengal.cli.milo_commands import plugin as plugin_command
+from bengal.plugins.inspection import PluginInspection
+
+
+class FakeCLI:
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+        self.renders: list[tuple[str, dict]] = []
+
+    def info(self, message: str) -> None:
+        self.infos.append(message)
+
+    def render_write(self, template: str, **context: object) -> None:
+        self.renders.append((template, context))
+
+    def error(self, message: str) -> None:
+        self.infos.append(message)
+
+    def tip(self, message: str) -> None:
+        self.infos.append(message)
+
+
+def test_plugin_list_reports_no_plugins(monkeypatch) -> None:
+    cli = FakeCLI()
+    monkeypatch.setattr(plugin_command, "_load_reports", list)
+    monkeypatch.setattr("bengal.cli.utils.get_cli_output", lambda: cli)
+
+    result = plugin_command.plugin_list()
+
+    assert result == {"plugins": [], "count": 0}
+    assert cli.infos == ["No Bengal plugins discovered"]
+    assert cli.renders == []
+
+
+def test_plugin_validate_fails_on_pending_capability(monkeypatch) -> None:
+    cli = FakeCLI()
+    report = PluginInspection(
+        entry_point="directive",
+        value="example:DirectivePlugin",
+        plugin_name="directive-plugin",
+        version="1.0.0",
+        status="partial",
+        capabilities={"directives": 1},
+    )
+    monkeypatch.setattr(plugin_command, "_load_reports", lambda: [report])
+    monkeypatch.setattr("bengal.cli.utils.get_cli_output", lambda: cli)
+
+    with pytest.raises(SystemExit):
+        plugin_command.plugin_validate()
+
+    assert cli.renders
+    _template, context = cli.renders[0]
+    assert context["summary"]["warnings"] == 1
+    assert "directives registered" in context["issues"][0]["message"]

--- a/tests/unit/orchestration/test_build_orchestrator.py
+++ b/tests/unit/orchestration/test_build_orchestrator.py
@@ -9,6 +9,7 @@ import pytest
 from bengal.orchestration.build import BuildOrchestrator
 from bengal.orchestration.build.options import BuildOptions
 from bengal.orchestration.stats import BuildStats
+from bengal.plugins.registry import PluginRegistry
 
 
 class TestBuildOrchestrator:
@@ -121,6 +122,70 @@ class TestBuildOrchestrator:
         mock_orchestrators["incremental"].return_value.save_cache.assert_called_once()
 
         assert isinstance(stats, BuildStats)
+
+    def test_full_build_runs_plugin_phase_hooks(self, mock_site, mock_orchestrators):
+        """Plugin lifecycle hooks run around the build phase groups."""
+        orchestrator = BuildOrchestrator(mock_site)
+        registry = PluginRegistry()
+        observed: list[tuple[str, object, object]] = []
+        hook_phases = (
+            "build_start",
+            "pre_discovery",
+            "post_discovery",
+            "pre_content",
+            "post_content",
+            "pre_parsing",
+            "post_parsing",
+            "pre_snapshot",
+            "post_snapshot",
+            "pre_assets",
+            "post_assets",
+            "pre_render",
+            "pre_rendering",
+            "post_render",
+            "post_rendering",
+            "pre_finalization",
+            "post_finalization",
+            "pre_health",
+            "post_health",
+            "build_complete",
+        )
+        for phase_name in hook_phases:
+            registry.on_phase(
+                phase_name,
+                lambda site, context, phase_name=phase_name: observed.append(
+                    (phase_name, site, context)
+                ),
+            )
+        plugin_registry = registry.freeze()
+
+        mock_cache = MagicMock()
+        mock_cache.parsed_content = {}
+        mock_orchestrators["incremental"].return_value.initialize.return_value = mock_cache
+        mock_orchestrators["incremental"].return_value.check_config_changed.return_value = False
+        mock_orchestrators["section"].return_value.validate_sections.return_value = []
+
+        from bengal.orchestration.build.results import FilterResult
+
+        filter_result = FilterResult(
+            pages_to_build=[],
+            assets_to_process=[],
+            affected_tags=set(),
+            changed_page_paths=set(),
+            affected_sections=None,
+        )
+        with (
+            patch("bengal.plugins.load_plugins", return_value=plugin_registry),
+            patch(
+                "bengal.orchestration.build.provenance_filter.phase_incremental_filter_provenance",
+                return_value=filter_result,
+            ),
+        ):
+            orchestrator.build(BuildOptions(incremental=False, force_sequential=True))
+
+        assert [phase for phase, _, _ in observed] == list(hook_phases)
+        assert all(site is mock_site for _, site, _ in observed)
+        assert all(context is not None for _, _, context in observed)
 
     def test_incremental_build_sequence(self, mock_site, mock_orchestrators):
         """Test incremental build flow."""

--- a/tests/unit/plugins/test_plugin_inspection.py
+++ b/tests/unit/plugins/test_plugin_inspection.py
@@ -80,6 +80,13 @@ def test_load_error_is_reported_without_raising() -> None:
     assert report.errors == ("RuntimeError: nope",)
 
 
+def test_invalid_plugin_is_not_reported_as_load_error() -> None:
+    report = inspect_entry_point(FakeEntryPoint("invalid", "example:Invalid", object()))
+
+    assert report.status == "invalid"
+    assert report.has_load_error is False
+
+
 def test_instantiation_error_is_reported_without_raising() -> None:
     report = inspect_entry_point(
         FakeEntryPoint("exploding", "example:ExplodingPlugin", ExplodingPlugin)

--- a/tests/unit/plugins/test_plugin_inspection.py
+++ b/tests/unit/plugins/test_plugin_inspection.py
@@ -1,0 +1,99 @@
+"""Tests for plugin discovery inspection and capability readiness."""
+
+from __future__ import annotations
+
+from bengal.plugins.inspection import (
+    CAPABILITY_INTEGRATION_STATUS,
+    capability_details,
+    inspect_entry_point,
+)
+
+
+class FakeEntryPoint:
+    """Minimal importlib.metadata.EntryPoint stand-in."""
+
+    def __init__(self, name: str, value: str, loaded: object):
+        self.name = name
+        self.value = value
+        self._loaded = loaded
+
+    def load(self) -> object:
+        if isinstance(self._loaded, BaseException):
+            raise self._loaded
+        return self._loaded
+
+
+class TemplatePlugin:
+    name = "template-plugin"
+    version = "1.0.0"
+
+    def register(self, registry):
+        registry.add_template_filter("shout", lambda value: str(value).upper())
+        registry.on_phase("pre_render", lambda site, context: None)
+
+
+class DirectivePlugin:
+    name = "directive-plugin"
+    version = "1.0.0"
+
+    def register(self, registry):
+        registry.add_directive(object())
+
+
+class ExplodingPlugin:
+    def __init__(self):
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    def register(self, registry):
+        raise AssertionError("unreachable")
+
+
+def test_template_and_phase_plugin_reports_ready_capabilities() -> None:
+    report = inspect_entry_point(
+        FakeEntryPoint("template", "example:TemplatePlugin", TemplatePlugin)
+    )
+
+    assert report.status == "ready"
+    assert report.ready is True
+    assert report.capabilities["template_filters"] == 1
+    assert report.capabilities["phase_hooks"] == 1
+    assert report.pending_capabilities == ()
+
+
+def test_pending_capability_reports_partial_status() -> None:
+    report = inspect_entry_point(
+        FakeEntryPoint("directive", "example:DirectivePlugin", DirectivePlugin)
+    )
+
+    assert report.status == "partial"
+    assert report.ready is False
+    assert report.capabilities["directives"] == 1
+    assert report.pending_capabilities == ("directives",)
+
+
+def test_load_error_is_reported_without_raising() -> None:
+    report = inspect_entry_point(FakeEntryPoint("broken", "example:Missing", RuntimeError("nope")))
+
+    assert report.status == "load_error"
+    assert report.has_load_error is True
+    assert report.errors == ("RuntimeError: nope",)
+
+
+def test_instantiation_error_is_reported_without_raising() -> None:
+    report = inspect_entry_point(
+        FakeEntryPoint("exploding", "example:ExplodingPlugin", ExplodingPlugin)
+    )
+
+    assert report.status == "load_error"
+    assert report.has_load_error is True
+    assert report.errors == ("RuntimeError: boom",)
+
+
+def test_capability_details_mark_pending_integrations() -> None:
+    details = capability_details({"directives": 1, "template_filters": 1})
+    by_name = {item["name"]: item for item in details}
+
+    assert CAPABILITY_INTEGRATION_STATUS["directives"] == "pending"
+    assert by_name["directives"]["ready"] is False
+    assert by_name["template_filters"]["ready"] is True


### PR DESCRIPTION
## Summary

- Wire plugin `on_phase()` callbacks into the existing build lifecycle groups.
- Add `bengal plugin list`, `bengal plugin info`, and `bengal plugin validate` with capability readiness reporting.
- Document which plugin registry surfaces are currently wired versus pending, and add focused CLI/plugin/build tests.

## Steward Notes

- CLI steward: added a lazy Milo `plugin` group with dict-returning command handlers and no broad startup imports.
- Protocols/plugins steward: kept the `Plugin` protocol unchanged; introspection loads entry points into a temporary registry and reports actual readiness.
- Orchestration/build steward: used existing phase groups and `on_phase()` hooks without inserting or reordering numbered build phases.
- Docs steward: updated plugin, extension-point, CLI, and orchestration docs to distinguish active surfaces from pending registry methods.

## Validation

- `uv run pytest tests/unit/cli tests/integration/test_cli_help.py tests/unit/plugins tests/unit/orchestration/test_build_orchestrator.py tests/unit/protocols tests/core/test_type_safety.py tests/integration/test_incremental_invariants.py -q` (234 passed, 1 skipped, 1 existing warning)
- `uv run ruff check bengal/plugins/inspection.py bengal/plugins/integration.py bengal/orchestration/build/__init__.py bengal/cli/milo_app.py bengal/cli/milo_commands/plugin.py tests/unit/plugins/test_plugin_inspection.py tests/unit/cli/test_milo_parser_construction.py tests/unit/cli/test_plugin_command.py tests/unit/orchestration/test_build_orchestrator.py`
- `uv run ruff format --check bengal/plugins/inspection.py bengal/plugins/integration.py bengal/orchestration/build/__init__.py bengal/cli/milo_app.py bengal/cli/milo_commands/plugin.py tests/unit/plugins/test_plugin_inspection.py tests/unit/cli/test_milo_parser_construction.py tests/unit/cli/test_plugin_command.py tests/unit/orchestration/test_build_orchestrator.py`
- `make ty` (exits 0 on the existing 545-diagnostic warning floor)
- `make changelog-check`
- `uv run bengal plugin list`

## Notes

- Full `make test` was attempted but hit the 5-minute command timeout after reaching roughly 37% of the suite with no failures shown before timeout.
- The build steward's broad `uv run pytest tests/unit/orchestration/build -q` check currently has pre-existing stale-test failures unrelated to this patch (old imports/signatures and MagicMock fixture drift); the incremental invariant integration check passed.
