### PR TITLE
[codex] docs: strengthen steward guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,271 +1,190 @@
-# AGENTS.md
+# Bengal Agent Constitution
 
-Bengal builds the sites people read documentation on. Bugs you introduce here reach end users through someone else's content — readers who can't see Bengal, can't audit it, and notice only when a link breaks, a code block renders wrong, or a search index goes empty. Treat the rules below as safety rules, not style rules.
+Bengal builds the sites people read documentation on. Bugs here reach end users
+through someone else's content: broken links, wrong code blocks, stale pages,
+empty search indexes. Treat these as safety rules, not style rules.
 
----
+## North Star
 
-## North star
+Make free-threaded Python worth deploying for content tooling. Bengal should
+prove that a documentation generator can be pure Python, scale with cores on
+3.14t, and ship zero npm. Favor readable Python, real parallelism, measurable
+performance, and user-visible correctness.
 
-**Make free-threaded Python worth deploying for content tooling.** Bengal exists to prove that a documentation generator can be pure Python, scale with cores on 3.14t, and ship zero npm. Every decision routes back to that: parallelism that's real, a Python stack you can read, performance you can measure. If a change doesn't serve that goal, it isn't worth shipping.
+## Non-Negotiables
 
----
+- **Pure Python:** no npm, Node, or JS toolchain in the build path.
+- **Core is passive:** `bengal/core/` does no I/O and no direct logging. Use
+  diagnostics such as `emit(self, "warning", ...)`.
+- **Rendering owns presentation:** HTML, excerpts, TOCs, template URLs,
+  shortcode/link extraction, page bundle views, and section URL ergonomics
+  belong under `bengal/rendering/`.
+- **Pipeline records are immutable:** `SourcePage -> ParsedPage -> RenderedPage`
+  stay frozen. Do not add setters, plugin state, or late mutation.
+- **Writes are atomic:** use `atomic_write_text`, `atomic_write_bytes`, or
+  `json_compat.dump` for outputs and caches.
+- **Sharp edges are bugs:** no silent `except`, no casual `# type: ignore`, no
+  vague flags, no errors that fail to say what to do next.
+- **PEP 758 syntax is valid here:** `except OSError, ValueError:` is correct
+  Python 3.14+ multi-catch. Do not wrap it in parentheses.
 
-## Design philosophy
+## Architecture Boundaries
 
-- **Pure Python is a constraint.** No npm, no Node, no JS toolchain. The whole B-stack (Patitas, Rosettes, Kida, Pounce, Milo) exists to make that viable — keep it that way. Faster path = better Python.
-- **Core is passive.** `bengal/core/` does no I/O and no logging. Use the diagnostics sink (`emit(self, "warning", ...)`), not loggers. Orchestration coordinates; core models hold state. Rendering services derive presentation: HTML, excerpts, template URLs, and content views belong under `bengal/rendering/`, with core keeping only compatibility shims where callers already depend on them.
-- **Immutable pipelines.** `SourcePage → ParsedPage → RenderedPage` is frozen on purpose. Mutation in the pipeline is a thread-safety bug waiting for 3.14t to find it. Don't add setters to `*Page` records.
-- **Atomic writes everywhere.** `bengal.utils.io.atomic_write_text` / `atomic_write_bytes` / `json_compat.dump`. A crash mid-build must not corrupt outputs.
-- **Sharp edges are bugs.** Silent `except`, `# type: ignore`, ambiguous flags, unhelpful errors, fuzzy "did you mean" omitted — not taste, bugs. Use `BengalError` with `code`, `context`, `suggestion`, `debug_payload`.
-- **PEP 758 except syntax is correct.** `except OSError, ValueError:` is Python 3.14+ multi-catch. Do not "fix" to `except (OSError, ValueError):` — ruff will reformat it back. Wasted significant effort on this once.
-
----
+- `Page`, `Section`, and `Site` are compatibility surfaces and coordinators, not
+  dumping grounds for rendering or forwarding wrappers.
+- `Page` template-facing properties may remain as shims, but should delegate to
+  rendering helpers.
+- `Section` stays mixin-free. URL and theme/navigation ergonomics delegate to
+  rendering-side helpers.
+- `Site` coordinates registries, services, and orchestration. Do not rebuild old
+  forwarding layers around it.
+- `bengal/protocols/` and plugin hooks are public contracts. Prefer adapters or
+  internal helpers over widening `SiteLike`, `PageLike`, `SectionLike`, or
+  `Plugin`.
 
 ## Stakes
 
-When you change something in Bengal, the blast radius is:
-
-- **Rendering bugs** (markdown, templates, syntax highlighting, xrefs) → wrong content shipped to readers, broken anchors, leaked template syntax. Often invisible to the author until someone reports it.
-- **Incremental build bugs** (provenance, cache keys, dependency tracking) → stale pages survive a rebuild. The site looks built, the content is wrong. The author trusts the build and doesn't notice.
-- **Free-threaded races** (3.14t, no GIL) — Bengal is a canary for the ecosystem. A race we ship normalizes "free-threading is flaky" for everyone. Shared mutable state in rendering, effects, or cache is the danger zone.
-- **Plugin contract breaks** → 9 extension points, third-party plugins discovered via `bengal.plugins` entry-point. Changing the `Plugin` protocol or any of the 9 hook surfaces breaks people you'll never meet.
-- **Performance regressions** → "scales with cores" and "sub-second rebuilds" are load-bearing claims. CI doesn't catch a 20% regression in the orchestration hot path. You do.
-
-Bengal is alpha but published on PyPI and used. Calibrate accordingly.
-
----
-
-## Current architecture spine
-
-The current shape to preserve:
-
-- `SourcePage → ParsedPage → RenderedPage` records are the immutable pipeline. They are not the place for convenience fields, late mutation, or plugin-specific state.
-- `Page` is a compatibility surface for templates and older callers, not a renderer. Template-facing properties such as `content`, `html`, `plain_text`, `toc_items`, `excerpt`, `meta_description`, `href`, `_path`, `absolute_href`, and page bundle resource access/classification should delegate to rendering-side helpers.
-- `Site` coordinates through registries, services, and orchestration. It should not reacquire forwarding wrappers just because an internal service exists.
-- `Section` is mixin-free; hierarchy, query, and structural version-navigation helpers sit behind Section shims instead of base classes. Section URL presentation delegates to `bengal/rendering/section_urls.py`; theme/navigation ergonomic helpers such as icons, `has_nav_children`, `recent_pages()`, `featured_posts()`, content stats, and section template application delegate to `bengal/rendering/section_ergonomics.py`.
-- Rendering owns parser, template, shortcode, AST/HTML, and URL presentation behavior. Core may call into rendering lazily from a compatibility shim; it should not import rendering helpers at module load time.
-- Protocols and plugin hooks are public contracts. Prefer internal adapters or rendering services over widening `SiteLike`, `PageLike`, or `Plugin`.
-
-Scoped `AGENTS.md` files act as local stewards. The root file is the
-constitution; nested files explain what a package protects, what it refuses to
-become, and which local checks best defend that boundary. When editing a
-subtree, read the closest `AGENTS.md` in addition to this one.
-Stewards also own the documentation that explains their subsystem. If a code
-change alters a package's behavior, boundary, or extension story, update the
-nearest architecture/reference docs in the same PR.
-When a change crosses a scoped steward area, add brief `Steward Notes` to the
-PR description. Name the steward area and one sentence about how its invariants
-were protected; this is a lightweight sign-off, not a new gate.
-
-When prioritizing backlog or planning cross-cutting work, consult the stewards
-as domain owners rather than treating the root file or roadmap as the only
-authority:
-
-Trigger phrase: **"ask stewards"** means run this consultation workflow. For a
-specific implementation, consult only affected scoped stewards. For backlog,
-roadmap, or prioritization work, consult all scoped stewards and produce the
-rollup report.
-
-1. Verify the checkout is current before asking for priorities; stale steward
-   files produce plausible but wrong answers.
-2. Enumerate scoped `AGENTS.md` files first, then group related stewards
-   (core/page/site/protocols, build/incremental/cache, rendering/templates,
-   CLI/errors, tests/performance) so parallel consultation stays focused.
-3. Ask each steward for one top priority with evidence, dependencies, and
-   risks. Also ask for confidence, dependency edges, and one tempting
-   "not now" item when useful. Ask what the domain could do to better serve
-   its upstream and downstream neighbors. Favor the nearest scoped steward over
-   generic audit personas.
-4. Separate raw steward signals from the final ranking. Steward consultation is
-   weighted voting, not majority rule: synthesize by convergence, blast radius,
-   dependency order, risk reduction, reversibility, and user-visible
-   correctness. Priorities named by multiple stewards or protecting public
-   contracts/free-threading outrank isolated polish.
-5. Preserve minority reports. A single steward can still identify urgent work
-   when it owns a safety boundary, public contract, or stale-output risk.
-6. Timebox consultation. A backlog pulse should answer priority questions, not
-   rediscover the whole repo.
-7. Carry the synthesis into the backlog or PR description as steward notes, so
-   future readers can see which boundaries shaped the decision.
-8. For backlog or roadmap consultations, produce a short rollup report. Include
-   the checkout/ref, stewards consulted, raw steward signals with confidence,
-   convergence points, dependency graph, upstream/downstream service
-   opportunities, ranked backlog, deferred/not-now items, minority reports, and
-   any steward notes that should carry into follow-up PRs.
-
----
-
-## Who reads your output
-
-- **Site authors** — want `bengal serve` to just work and the traceback to tell them which file broke. They read errors, the dev server output, and `--help`.
-- **Plugin developers** — read protocol definitions in `bengal/protocols/`, the `Plugin` framework, and entry-point examples. Stability of these surfaces is the contract.
-- **Contributors** — know Python and markdown, not our internals. They read `bengal/core/`, `bengal/orchestration/`, and the CONTRIBUTING / THREAD_SAFETY guides.
-- **Me (Lawrence)** — read diffs. Put the what in code, the why in the PR.
-
----
-
-## Escape hatches — stop and ask
-
-Forks where I want a check-in, not a judgment call:
-
-- **Reintroducing a mixin in `bengal/core/`.** Site, Page, and Section are mixin-free after epic-delete-forwarding-wrappers and the follow-up boundary cleanups. `tests/unit/core/test_no_core_mixins.py` enforces an empty `LEGACY_MIXINS` allow-list. Adding to that list, or adding new core mixins, needs a check-in.
-- **Moving a deferred import to module level.** Bengal has multiple deferred-only import cycles. The `check-cycles` pre-commit hook catches some; not all. If you see `from bengal.X import Y` inside a function and want to hoist it, run check-cycles first and ask.
-- **Touching the immutable page pipeline.** `SourcePage` / `ParsedPage` / `RenderedPage` are frozen on purpose. Adding fields, mutability, or new pipeline stages is a design conversation, not a patch.
-- **Changing the `Plugin` protocol or any of the 9 extension points.** Public surface; breaks unknown third parties. Sketch the change first.
-- **Public API change** (`bengal` CLI commands/flags, `bengal.plugins` entry-point shape, `BengalError` constructor). Ask whether the break is worth it.
-- **New runtime dependency.** Default is no. The B-stack is deliberately small. Reach for an existing dep, then ask.
-- **New config option.** Reshape an existing one first. Configs are easier to add than to remove.
-- **Chasing ty diagnostics below the floor (~570).** Remaining ones are ty checker limitations, optional dependency modeling, structural matching, hasattr narrowing, or protocol/test-double mismatches. Don't expand `SiteLike` — it backfires because test mocks don't implement new attrs. Ask before opening a "reduce ty diagnostics" branch.
-- **Refactoring methods on Site/Page/Section.** Run each through the greenfield-design test (see `feedback_domain_facets_vs_vestiges`): would you name it this, here, designing fresh? If no → it's a vestige, delete + migrate callers, don't relocate. Ask before opening a "reorganize" PR.
-- **Test disagrees with code.** Ask which is authoritative before "fixing" either.
-- **Can't reproduce a reported bug.** Stop. Ask for a minimal repro (a `tests/roots/` fixture is ideal). Don't guess.
-- **Adjacent issues found mid-task.** List in the PR description. Don't fold them in — exception: refactors renaming a concept across many files, where one bundled PR beats review churn.
-
----
-
-## Anti-patterns
-
-Things that look reasonable and are wrong here:
-
-- **Adding npm/JS to the build path.** No. The whole point is a pure-Python content stack.
-- **Reintroducing core mixins.** PR #194 dissolved Site mixins deliberately over 10+ commits, and Page/Section mixins have since been dissolved. The allow-list is empty — not an invitation to add more.
-- **Moving rendering behavior back into Page.** Page may keep template-facing compatibility properties, but the work behind rendered content, excerpts, meta descriptions, shortcode checks, link extraction, TOC structures, template URLs, and page bundle resource access/classification belongs in `bengal/rendering/`.
-- **`try: ... except Exception: pass`.** S110 is enabled. If you must swallow, log via diagnostics with what + why.
-- **Wrapping `except A, B:` in parens.** Valid PEP 758 syntax in 3.14+. Ruff will undo your "fix."
-- **`# type: ignore` to clear a ty diagnostic.** Floor is ty-limitation territory. Either narrow the type properly or leave it; don't ignore.
-- **Speculative config options.** If no one's asking for it, don't add it. The surface is already wide.
-- **Defensive validation inside core.** `bengal/core/` trusts callers and stays passive (no I/O, no logging). Validate at the boundary.
-- **Hoisting deferred imports without testing.** Will trigger circular imports. Run `check-cycles` before assuming a deferred import is "just" defensive.
-- **Surface-level refactors.** ~50% of "obvious" simplifications turn out to break callers (functools.partial vs nonlocal, base classes vs Kida `??` semantics, config merge vs immutability). Trace the actual call paths before committing.
-- **Direct `logger.X` inside `bengal/core/`.** Use `from bengal.core.diagnostics import emit` instead. Decoupling core from logging infra is load-bearing.
-- **Non-atomic file writes.** Every output write in Bengal is atomic for crash safety. Don't open a file and write directly — use the helpers.
-- **Refactoring during a bug fix.** Separate PR. Exception: the refactor *is* the fix.
-
----
-
-## Extending Bengal
-
-Four extension points. Pick the one that matches your need. If none fit, ask before changing the `Plugin` protocol or any of the 9 hook surfaces (`bengal/protocols/`) — see "Escape hatches."
-
-### 1. Template function or filter
-
-**When:** You need a new Jinja filter or global usable in `.html` templates (e.g. `{{ posts | my_sort }}`).
-
-**Where:** Add a module under `bengal/rendering/template_functions/`. Each module exports a `register(env, site)` function and is wired into `register_all()` in that package's `__init__.py`. No decorator, no auto-discovery — append your `register()` call to the coordinator.
-
-```python
-# bengal/rendering/template_functions/my_funcs.py
-from __future__ import annotations
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from bengal.protocols import SiteLike, TemplateEnvironment
-
-def register(env: TemplateEnvironment, site: SiteLike) -> None:
-    env.filters["my_filter"] = lambda v: v.upper()
-```
-
-Then add `my_funcs.register(env, site)` to the appropriate phase in `register_all()`. Canonical example: `bengal/rendering/template_functions/strings.py`.
-
-### 2. Content type strategy
-
-**When:** A section needs custom sorting, pagination, filtering, or template defaults that built-in `content_type` strategies (`blog`, `doc`, `tutorial`, `changelog`, `archive`, `notebook`, `track`, `page`, `autodoc-python`, `autodoc-cli`) don't cover.
-
-**Fastest path:** `bengal new content-type <name>` — scaffolds a `ContentTypeStrategy` subclass in the right place with `When to use:`, `default_template`, `allows_pagination`, `sort_pages()`, `detect_from_section()`, and the `register_strategy()` call already wired up. Then edit the TODOs.
-
-**Manual path** (or to understand what the scaffold gives you): subclass `ContentTypeStrategy` from `bengal/content_types/base.py`, register the instance via `register_strategy()` from `bengal/content_types/registry.py`. Built-in strategies live in `bengal/content_types/strategies.py` — read `BlogStrategy` first, it's the canonical short example.
-
-```python
-from bengal.content_types import ContentTypeStrategy, register_strategy
-
-class RecipeStrategy(ContentTypeStrategy):
-    default_template = "recipes/list.html"
-    allows_pagination = True
-    def sort_pages(self, pages):
-        return sorted(pages, key=lambda p: p.metadata.get("difficulty", 99))
-
-register_strategy("recipe", RecipeStrategy())
-```
-
-Sections opt in by setting `type = "recipe"` in their `_index.md` frontmatter, or by `detect_from_section()` returning `True`.
-
-### 3. CLI command
-
-**When:** A new `bengal <verb>` operation — top-level command or subcommand under an existing group (`config`, `theme`, `content`, `version`, etc.).
-
-**Where:** Write a function in `bengal/cli/milo_commands/`, then register it in `bengal/cli/milo_app.py` via `cli.lazy_command(...)`. There is **no filesystem auto-discovery** — the file has to be wired in `milo_app.py` to be reachable.
-
-```python
-# bengal/cli/milo_commands/hello.py
-from __future__ import annotations
-from typing import Annotated
-from milo import Description
-
-def hello(name: Annotated[str, Description("Who to greet")] = "world") -> dict:
-    """Say hi."""
-    return {"status": "ok", "message": f"hello, {name}"}
-```
-
-Then in `bengal/cli/milo_app.py`:
-
-```python
-cli.lazy_command(
-    "hello",
-    import_path="bengal.cli.milo_commands.hello:hello",
-    description="Say hi",
-)
-```
-
-**Milo ≠ Click — three things to know**:
-
-- **Args:** `Annotated[type, Description("...")]` parameters with defaults — not `@click.option` decorators stacked above the function.
-- **Discovery:** explicit `cli.lazy_command(name, import_path="module:fn")` in `milo_app.py`. Lazy import avoids the cold-start tax; the function isn't loaded until the command runs.
-- **Output:** commands return `dict`. Milo handles structured output, MCP serialization, and `--json` for free. Don't `print()` — use `cli.render_write(template, ...)` for human output and the dict return for machine output.
-
-Canonical example: `bengal/cli/milo_commands/clean.py` — small, real, exercises the full pattern (annotated args, dict return, `cli.error()` / `cli.tip()` for failure paths).
-
-### 4. Build phase
-
-**When:** You think you need to insert a custom step into the build pipeline.
-
-**Where:** You don't. Build phases are hardcoded in `bengal/orchestration/build/__init__.py` — 21 numbered phases, called sequentially. Adding one is a design conversation, not a patch (see "Escape hatches").
-
-**For observability** (timing, progress reporting): use `BuildOptions.on_phase_start` / `on_phase_complete` callbacks.
-
-**For behavior changes mid-build**: use one of the 9 plugin hook surfaces in `bengal/protocols/` — those *are* the supported extension surface. Custom orchestration phases bypass the plugin contract and free-threading guarantees.
-
----
-
-## Done criteria
-
-A change is done when all of these hold:
-
-- [ ] `make test` passes (fast tests). Hot-path / threading change → also `pytest -m "not performance"` or the relevant marker.
-- [ ] `make ty` doesn't regress the diagnostic floor. No new `# type: ignore` or `noqa: S110` suppressions.
-- [ ] `ruff format` + `ruff check --fix` clean.
-- [ ] Tests exercise the *interesting* path: both branches of a config flag, the failure path for incremental rebuild, malformed input for parsers/templates.
-- [ ] Free-threading sensitive? Note what shared mutable state you considered. If you added a global, it's locked or justified.
-- [ ] User-facing change under `bengal/` → news fragment in `changelog.d/<issue-or-branch>.<type>.md`. `make changelog-check` confirms.
-- [ ] Public API or plugin protocol changed → migration note in the PR, news fragment marked `changed` or `removed`.
-- [ ] Error messages tell the reader what to do next, not just what went wrong. `BengalError` with `suggestion=` is the standard.
-- [ ] `check-cycles` passes — no new import cycles introduced.
-- [ ] PR description explains *why*. The diff explains what.
-
-"Tests pass" is not "done." Tests pass on broken code all the time.
-
----
-
-## Review and assimilation
-
-- **I read diff-first, description-second.** Tight diff + clear why merges fast; sprawling diff gets questions.
-- **One concern per PR.** If the diff needs section headers, it's two PRs. Exception: refactors renaming a concept across many files — one bundled PR beats review churn.
-- **Commit style:** see `git log`. `<scope>: <description>` — scope is `core` / `orchestration` / `rendering` / `cache` / `cli` / `tests` / `docs` / `deps` / `release`. Imperative. Multi-area: separate with `;`.
-- **Steward notes:** when scoped `AGENTS.md` guidance applies, include a short PR section such as `Page steward: compatibility shim preserved; Rendering steward: behavior stays behind helper.`
-- **Don't trailing-summary me.** If the diff is readable, I can read it.
-- **Flag surprises.** Weird test, unused config, dead code, an allow-list that grew — put it in the PR description. Don't fix silently, don't ignore.
-- **Dead code you found.** Flag in the PR, let me decide. Bengal has had vestiges from prior extractions (ConfigService, PageCacheManager, PageProxy — finally deleted in #200) that lingered. Most are deletable; some are load-bearing for a transport, plugin, or example.
-
----
-
-## When this file is wrong
-
-It will be. Tell me. The worst outcome is that it sits here for a year contradicting how the project actually works. Updates to AGENTS.md are a first-class PR — short, focused, and welcome.
+- Rendering bugs ship wrong content to readers.
+- Incremental bugs leave stale pages that authors trust.
+- Free-threading races make 3.14t look flaky.
+- Plugin contract breaks affect third-party extensions discovered through
+  `bengal.plugins`.
+- Performance regressions weaken Bengal's "scales with cores" claim.
+
+Bengal is alpha, published on PyPI, and used. Calibrate accordingly.
+
+## Stop And Ask
+
+Check in before doing any of these:
+
+- Reintroducing core mixins or growing the empty mixin allow-list.
+- Hoisting a deferred import to module level. Run `check-cycles` first.
+- Touching immutable pipeline records or adding a pipeline stage.
+- Changing `Plugin`, any of the 9 hook surfaces, CLI flags/commands,
+  `bengal.plugins` entry points, or `BengalError` construction.
+- Adding a runtime dependency, config option, or build phase.
+- Chasing ty diagnostics below the floor around 570.
+- Reorganizing methods on `Site`, `Page`, or `Section` instead of deleting
+  vestiges and migrating callers.
+- Fixing a test/code disagreement without knowing which one is authoritative.
+- Guessing at an unreproduced bug. Ask for a minimal repro, ideally a
+  `tests/roots/` fixture.
+- Folding adjacent issues into a bug fix. Flag them for the PR instead.
+
+## Anti-Patterns
+
+- Adding npm or JS tooling to make the frontend path easier.
+- Moving rendering behavior back into core.
+- `try: ... except Exception: pass`; if swallowing is intentional, emit a
+  diagnostic with what and why.
+- `# type: ignore` or `noqa: S110` to clear noise.
+- Defensive validation inside core instead of at boundaries.
+- Direct `logger.X` inside `bengal/core/`.
+- Non-atomic output or cache writes.
+- Refactoring during a bug fix unless the refactor is the fix.
+
+## Steward System
+
+Read this root file plus the closest scoped `AGENTS.md` before editing a tree.
+The root is the constitution; scoped files are stewards for concrete domains.
+
+Keep root guidance for rules that apply everywhere: north star, safety
+invariants, public escape hatches, extension routing, done criteria, and steward
+consultation. Move directory-specific ownership, refusal patterns, examples,
+docs, and local checks into the nearest scoped steward.
+
+Each steward should be able to answer:
+
+- **Point of view:** who or what the domain represents.
+- **Protect:** invariants, contracts, quality bars, and failure modes.
+- **Advocate:** features, fixes, and investments the domain should push for.
+- **Serve peers:** upstream and downstream domains that need clearer contracts,
+  diagnostics, docs, tests, or ergonomics from this domain.
+- **Own:** tests, docs, examples, fixtures, and maintenance chores that keep the
+  domain truthful.
+
+Stewards may represent product perspectives, such as documentation quality or
+default-theme UX, but they still protect a concrete tree. They do not override
+the implementation steward that owns an affected code boundary.
+
+When work crosses steward areas, add `Steward Notes` to the PR description:
+name each area and one sentence about how its invariants were protected.
+
+### When To Consult
+
+Consult stewards proactively when a change is cross-boundary, public-facing,
+hard to reverse, performance-sensitive, free-threading-sensitive, or likely to
+change docs, tests, fixtures, template context, cache keys, plugin contracts, or
+build outputs.
+
+Use the nearest steward for local work. Use multiple stewards when work crosses
+ownership lines, such as core/rendering, build/incremental/cache,
+protocols/tests, or site/default-theme. Parallelize steward consultation only
+when the questions are independent; otherwise start with the steward that owns
+the safety boundary and let its answer shape the next consultation.
+
+Delegate specialist investigation when a steward has a bounded question with a
+clear output, such as "which fixtures prove this invariant?", "which docs become
+wrong?", or "which downstream contract changes?". Keep final synthesis with the
+implementing agent so tradeoffs are resolved in one place.
+
+### Ask Stewards
+
+Trigger phrase: **"ask stewards"**.
+
+- For implementation work, consult only affected scoped stewards.
+- For backlog, roadmap, or prioritization, consult all scoped stewards and
+  produce a short rollup.
+- Verify the checkout is current, enumerate scoped `AGENTS.md` files, group
+  related stewards, and ask for top priority, evidence, dependencies, risks,
+  confidence, peer-service opportunities, and tempting "not now" work.
+- Synthesize by convergence, blast radius, dependency order, risk reduction,
+  reversibility, public contracts, free-threading, and user-visible correctness.
+- Preserve minority reports when a steward owns a safety boundary.
+
+## Extension Routing
+
+- **Template function or filter:** add a module under
+  `bengal/rendering/template_functions/` with `register(env, site)` and wire it
+  in `register_all()`. No auto-discovery.
+- **Content type strategy:** use `bengal new content-type <name>` or register a
+  `ContentTypeStrategy` from `bengal/content_types/`.
+- **CLI command:** add a Milo command under `bengal/cli/milo_commands/` and
+  register it with `cli.lazy_command(...)` in `bengal/cli/milo_app.py`. Use
+  annotated parameters, dict returns, and CLI render helpers; do not `print()`.
+- **Build phase:** stop and ask. Build phases are hardcoded in
+  `bengal/orchestration/build/__init__.py`; behavior changes should usually use
+  plugin hooks.
+
+## Done Criteria
+
+- `make test` passes. Hot-path or threading changes need the relevant broader
+  pytest marker too.
+- `make ty` does not regress the diagnostic floor.
+- `ruff format` and `ruff check --fix` are clean.
+- Tests cover the interesting path, including failure paths and malformed input
+  where relevant.
+- Free-threading-sensitive changes state what shared mutable state was
+  considered.
+- User-facing changes under `bengal/` include a `changelog.d/` fragment.
+- Public API or plugin protocol changes include migration notes.
+- Errors use `BengalError` with useful `code`, `context`, `suggestion`, and
+  `debug_payload` where appropriate.
+- `check-cycles` passes when imports move.
+- PR description explains why. The diff explains what.
+
+Tests passing is not the same as done.
+
+## Review Notes
+
+- One concern per PR unless a broad rename is the concern.
+- Commit style: `<scope>: <description>`, using scopes such as `core`,
+  `orchestration`, `rendering`, `cache`, `cli`, `tests`, `docs`, `deps`,
+  or `release`.
+- Flag surprises: weird tests, dead code, unused config, changed allow-lists,
+  stale docs, or anything that looked load-bearing.
+- Do not silently delete dead code you found while doing unrelated work.
+
+## When This File Is Wrong
+
+Update it. A stale constitution is worse than a short corrective PR.

--- a/bengal/cache/AGENTS.md
+++ b/bengal/cache/AGENTS.md
@@ -8,12 +8,32 @@ Related architecture docs:
 - `../../AGENTS.md`
 - `../../site/content/docs/reference/architecture/core/cache.md`
 
+## Point Of View
+
+Cache code represents the durable memory of prior builds. It should be boring,
+atomic, deterministic, and honest about whether a hit can be trusted.
+
 ## Protect
 
 - Stable cache keys and schema compatibility.
 - Atomic persistence and crash safety.
 - Explicit migration paths for old cache shapes.
 - Deterministic serialization for free-threaded builds.
+
+## Advocate
+
+- Conservative misses when cache shape, provenance, or dependencies are
+  uncertain.
+- Schema/version tests before persistence formats change.
+- Clear corruption, migration, and fallback diagnostics instead of treating all
+  cache failures alike.
+
+## Serve Peers
+
+- Give incremental rebuilds trustworthy keys, snapshots, and migration behavior.
+- Give build phases atomic persistence helpers and predictable failure modes.
+- Give tests fixtures that distinguish cache miss, stale cache, corrupt cache,
+  and schema migration behavior.
 
 ## Do Not
 
@@ -22,14 +42,11 @@ Related architecture docs:
 - Store mutable live domain objects when snapshots or records should be used.
 - Add compression or persistence behavior without tests for fallback paths.
 
-## Documentation Ownership
+## Own
 
 - Own `site/content/docs/reference/architecture/core/cache.md`.
 - Keep performance docs accurate when cache behavior changes rebuild speed or storage.
 - Update migration notes when cache schema compatibility changes.
-
-## Local Checks
-
 - `uv run pytest tests/unit/cache tests/unit/discovery -q`
 - `uv run pytest tests/integration/test_phase2b_cache_integration.py -q`
 - `uv run ruff check bengal/cache tests/unit/cache`

--- a/bengal/core/AGENTS.md
+++ b/bengal/core/AGENTS.md
@@ -7,12 +7,35 @@ log directly, or own rendering behavior.
 Start with the root guidance in `../../AGENTS.md`, then use this file for the
 local boundary.
 
+## Point Of View
+
+Core represents the stable domain model that other systems can trust. It should
+make state and relationships clear without knowing how files are read, pages are
+rendered, logs are emitted, or outputs are written.
+
 ## Protect
 
 - Passive objects: `Site`, `Page`, `Section`, `PageCore`, records, registries.
 - Compatibility shims that preserve existing template/plugin access.
 - Deferred imports where core reaches into rendering only from a shim.
 - The empty core mixin allow-list in `tests/unit/core/test_no_core_mixins.py`.
+
+## Advocate
+
+- Smaller passive records and clearer ownership when behavior starts collecting
+  on `Site`, `Page`, or `Section`.
+- Rendering, orchestration, or boundary services when a feature needs effects,
+  validation, presentation, or diagnostics.
+- Compatibility shims with tests and a retirement path instead of new core
+  convenience surfaces.
+
+## Serve Peers
+
+- Give rendering stable, lazy access points for template-facing compatibility
+  without importing rendering at module load time.
+- Give protocols and tests narrow object contracts that are easy to mock.
+- Give docs clear object-model boundaries so contributors know where behavior
+  belongs.
 
 ## Do Not
 
@@ -21,14 +44,11 @@ local boundary.
 - Add fields to immutable pipeline records without a design conversation.
 - Widen public protocols to make one core call site easier.
 
-## Documentation Ownership
+## Own
 
 - Keep `site/content/docs/reference/architecture/core/` aligned with core boundaries.
 - Update `site/content/docs/reference/architecture/design-principles.md` when core's role changes.
 - Keep object model docs honest when `Page`, `Section`, `Site`, or records move behavior.
-
-## Local Checks
-
 - `uv run pytest tests/unit/core tests/core -q`
 - `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
 - `uv run ruff check bengal/core tests/unit/core tests/core`

--- a/bengal/orchestration/build/AGENTS.md
+++ b/bengal/orchestration/build/AGENTS.md
@@ -8,12 +8,35 @@ Related architecture docs:
 - `../../../AGENTS.md`
 - `../../../site/content/docs/reference/architecture/core/orchestration.md`
 
+## Point Of View
+
+Build phases represent the ordered contract that turns inputs into trustworthy
+outputs. They should make effects, hook timing, and observability explicit
+without hiding behavior in phase coordinators.
+
 ## Protect
 
 - The existing phase order and hook timing.
 - Clear inputs and outputs for each phase.
 - Atomic finalization and output safety.
 - Explicit callbacks for observability instead of hidden side effects.
+
+## Advocate
+
+- Observable phase inputs, outputs, timing, and diagnostics when authors need to
+  understand what happened.
+- Plugin hook usage over custom phase additions when extension behavior is
+  needed mid-build.
+- Integration tests for phase changes that affect caches, generated artifacts,
+  command output, or incremental rebuilds.
+
+## Serve Peers
+
+- Give incremental and cache stewards precise invalidation and provenance
+  events instead of inferred side effects.
+- Give rendering clear handoff points and avoid mixing presentation work into
+  orchestration.
+- Give CLI and site docs stable build output behavior to explain.
 
 ## Do Not
 
@@ -22,14 +45,11 @@ Related architecture docs:
 - Mix rendering implementation details into phase coordinators.
 - Treat a passing fast test as proof that incremental behavior is correct.
 
-## Documentation Ownership
+## Own
 
 - Own build-phase descriptions in `site/content/docs/reference/architecture/core/orchestration.md`.
 - Keep `site/content/docs/reference/architecture/core/pipeline.md` aligned with phase inputs/outputs.
 - Update user-facing build docs when phase behavior affects command output or artifacts.
-
-## Local Checks
-
 - `uv run pytest tests/unit/orchestration/build -q`
 - `uv run pytest tests/integration/test_incremental_invariants.py -q`
 - `uv run ruff check bengal/orchestration/build`

--- a/bengal/orchestration/incremental/AGENTS.md
+++ b/bengal/orchestration/incremental/AGENTS.md
@@ -8,12 +8,31 @@ Related architecture docs:
 - `../../../AGENTS.md`
 - `../../../site/content/docs/reference/architecture/core/cache.md`
 
+## Point Of View
+
+Incremental build represents the author's trust that fast rebuilds are still
+correct rebuilds. When uncertain, it should rebuild and explain why.
+
 ## Protect
 
 - Dependency tracking and invalidation correctness.
 - Provenance of content, templates, data, assets, and config.
 - Conservative rebuilds when uncertainty exists.
 - Clear diagnostics for why a page did or did not rebuild.
+
+## Advocate
+
+- Explicit dependency edges and invalidation reasons over broad dirty flags.
+- Diagnostics that let authors understand stale-output prevention.
+- Tests that prove both the fast path and the conservative rebuild path.
+
+## Serve Peers
+
+- Give build phases and cache code clear provenance contracts and invalidation
+  boundaries.
+- Give rendering and theme work dependency tracking for templates, assets, data,
+  and generated content.
+- Give docs concrete explanations for why a warm build rebuilt or skipped work.
 
 ## Do Not
 
@@ -22,14 +41,11 @@ Related architecture docs:
 - Use non-atomic cache writes.
 - Hide stale-output risk in broad exception handling.
 
-## Documentation Ownership
+## Own
 
 - Own incremental sections in `site/content/docs/reference/architecture/core/cache.md`.
 - Keep `site/content/docs/building/performance/template-deps.md` accurate for dependency behavior.
 - Update troubleshooting docs when invalidation diagnostics change.
-
-## Local Checks
-
 - `uv run pytest tests/unit/orchestration/incremental tests/integration/warm_build -q`
 - `uv run pytest tests/integration/test_incremental_invariants.py -q`
 - `uv run ruff check bengal/orchestration/incremental`

--- a/bengal/protocols/AGENTS.md
+++ b/bengal/protocols/AGENTS.md
@@ -9,12 +9,34 @@ Related architecture docs:
 - `../../site/content/docs/reference/architecture/meta/protocols.md`
 - `../../site/content/docs/reference/architecture/meta/extension-points.md`
 
+## Point Of View
+
+Protocols represent the smallest public shape Bengal asks plugins, tests, and
+internal adapters to rely on. They should make extension possible without
+turning private convenience into permanent API.
+
 ## Protect
 
 - The `Plugin` protocol and the 9 supported hook surfaces.
 - Narrow `PageLike`, `SectionLike`, and `SiteLike` contracts.
 - Test-double compatibility.
 - Backward-compatible evolution through adapters where possible.
+
+## Advocate
+
+- Internal adapters, helper functions, or rendering services before protocol
+  widening.
+- Migration notes, changelog fragments, and compatibility tests when public
+  contracts must change.
+- Contract tests that prove plugins can keep working across internal cleanup.
+
+## Serve Peers
+
+- Give core, rendering, and orchestration stable minimal interfaces instead of
+  broad object coupling.
+- Give tests mocks and fakes that model public contracts rather than internal
+  implementation detail.
+- Give docs exact extension-point language that plugin developers can trust.
 
 ## Do Not
 
@@ -23,14 +45,11 @@ Related architecture docs:
 - Use protocols as a dumping ground for private conveniences.
 - Break third-party plugins for internal cleanup.
 
-## Documentation Ownership
+## Own
 
 - Own `site/content/docs/reference/architecture/meta/protocols.md`.
 - Own plugin-contract material in `site/content/docs/reference/architecture/meta/extension-points.md`.
 - Update migration docs/changelog notes for public protocol or hook changes.
-
-## Local Checks
-
 - `uv run pytest tests/unit/protocols tests/core/test_type_safety.py -q`
 - `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
 - `uv run ruff check bengal/protocols tests/unit/protocols`

--- a/bengal/rendering/AGENTS.md
+++ b/bengal/rendering/AGENTS.md
@@ -10,12 +10,35 @@ Related architecture docs:
 - `../../site/content/docs/reference/architecture/design-principles.md`
 - `../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
 
+## Point Of View
+
+Rendering represents the promise that domain state becomes correct, stable,
+themeable output. It should absorb presentation complexity so core stays passive
+and themes get dependable data.
+
 ## Protect
 
 - Template compatibility for existing themes and plugins.
 - Clear helper/service boundaries behind core compatibility shims.
 - Deferred imports where rendering and core need to see each other.
 - Rendering behavior that is deterministic under parallel builds.
+
+## Advocate
+
+- Rendering-side helpers when templates or core shims need derived content,
+  URLs, excerpts, resource views, or safe presentation defaults.
+- Better diagnostics and fixtures for parser/template failures instead of
+  silent fallback behavior.
+- Deterministic, thread-aware services when derived presentation data is cached
+  or reused.
+
+## Serve Peers
+
+- Give core small lazy shims instead of asking it to own presentation.
+- Give default theme and site docs stable template context, filters, globals,
+  and failure behavior they can document.
+- Give tests focused fixtures for template, shortcode, URL, and content-view
+  regressions.
 
 ## Do Not
 
@@ -24,14 +47,11 @@ Related architecture docs:
 - Widen `PageLike`, `SectionLike`, or `SiteLike` just to satisfy one helper.
 - Hide parser/template failures behind silent fallbacks.
 
-## Documentation Ownership
+## Own
 
 - Own `site/content/docs/reference/architecture/rendering/`.
 - Keep `site/content/docs/reference/template-functions/` accurate for template-facing behavior.
 - Update theming docs when rendering helpers change what themes can rely on.
-
-## Local Checks
-
 - `uv run pytest tests/unit/rendering -q`
 - `uv run pytest tests/rendering -q`
 - `uv run ruff check bengal/rendering tests/unit/rendering tests/rendering`

--- a/bengal/themes/default/AGENTS.md
+++ b/bengal/themes/default/AGENTS.md
@@ -1,0 +1,69 @@
+# Default Theme UX Steward
+
+The default theme is Bengal's shipped user experience. It should make real
+documentation readable, navigable, accessible, and fast without adding a Node or
+npm build path.
+
+Related architecture docs:
+
+- `../../../AGENTS.md`
+- `README.md`
+- `templates/README.md`
+- `templates/SAFE_PATTERNS.md`
+- `templates/TEMPLATE-CONTEXT.md`
+
+## Protect
+
+- Reader ergonomics for documentation, blogs, release notes, API references,
+  CLI references, search, navigation, and code-heavy pages.
+- Semantic HTML, keyboard navigation, focus states, contrast, and responsive
+  behavior.
+- Pure-Python delivery: no npm, no Node build step, and no theme asset pipeline
+  that depends on external JavaScript tooling.
+- Stable template contracts and swizzle-friendly template structure.
+- CSS token discipline and component scoping that prevents site-authored
+  content from being accidentally restyled.
+- Asset weight and rendering performance on mobile and low-power devices.
+
+## Advocate
+
+- Reader-first layouts for long-form docs, API references, code-heavy pages,
+  release notes, and search results.
+- Theme primitives that make common documentation patterns easy without custom
+  CSS.
+- Accessibility and responsive fixes as correctness work, not cosmetic polish.
+
+## Serve Peers
+
+- Give rendering and template-function stewards clear needs for template
+  context, filters, URLs, and content views.
+- Give the site documentation steward accurate theming examples and migration
+  notes when theme contracts change.
+- Provide tests or fixtures when a theme bug exposes a rendering or content
+  model ambiguity.
+
+## Do Not
+
+- Treat visual polish as separate from correctness; unreadable content, broken
+  nav, and clipped code blocks are product bugs.
+- Add broad CSS selectors that leak into prose or user content.
+- Move template-facing behavior into core objects when a rendering helper or
+  template function belongs there.
+- Let default-theme docs describe files, context values, or components that no
+  longer exist.
+- Add decorative complexity that makes documentation harder to scan.
+
+## Own
+
+- Own `README.md`, `templates/README.md`, `templates/SAFE_PATTERNS.md`, and
+  `templates/TEMPLATE-CONTEXT.md`.
+- Keep `site/content/docs/theming/`,
+  `site/content/docs/reference/theme-variables.md`, and theme customization
+  docs accurate when default theme behavior changes.
+- Coordinate with the rendering steward when template context or helper
+  behavior changes.
+- `uv run pytest tests/unit/themes tests/themes -q`
+- `uv run bengal build site`
+- Inspect representative pages for docs, release notes, search, tags,
+  autodoc/API reference, and narrow mobile layouts.
+- `rg "^[^@#][^{]*\b(ul|ol|a|pre|code|table)\b" bengal/themes/default`

--- a/plan/AGENTS.md
+++ b/plan/AGENTS.md
@@ -1,0 +1,60 @@
+# Planning Steward
+
+Planning files turn steward signals, architecture risks, and roadmap intent into
+work that can be executed without rediscovering the same context. This steward
+protects decision quality and archive hygiene; it does not outrank the package
+stewards that own implementation boundaries.
+
+Related architecture docs:
+
+- `../AGENTS.md`
+- `README.md`
+- `ROADMAP.md`
+
+## Protect
+
+- Clear problem statements, goals, non-goals, and decision records.
+- Dependency order across epics, RFCs, stale work, and superseded proposals.
+- Explicit ties back to Bengal's north star: pure Python, free-threading,
+  measurable performance, and user-visible documentation correctness.
+- Steward notes for cross-boundary work, especially public contracts,
+  rendering behavior, incremental correctness, and free-threading safety.
+- Archive status that stays truthful: drafted, evaluated, stale, superseded,
+  or complete.
+
+## Advocate
+
+- Plans that reduce stale-output risk, public contract risk, and free-threading
+  risk before isolated polish.
+- Smaller executable slices when an RFC tries to solve too many concerns.
+- Explicit not-now calls when the tradeoff is real but the timing is wrong.
+
+## Serve Peers
+
+- Give package stewards dependency maps, sequencing notes, and known risks
+  before implementation starts.
+- Feed docs and theme stewards the user-facing story for shipped architecture
+  work.
+- Surface upstream blockers instead of turning them into vague roadmap items.
+
+## Do Not
+
+- Treat a plan as authoritative when the nearest code steward disagrees.
+- Promote speculative config, new dependencies, or public API changes without
+  routing through the root escape hatches.
+- Let stale architecture names survive in active plans without a verification
+  note.
+- Hide deferred work in vague "later" language; name the tradeoff or move it
+  to a not-now section.
+
+## Own
+
+- Own `plan/README.md` and `plan/ROADMAP.md`.
+- Keep RFC, epic, sprint, stale, superseded, evaluated, and complete buckets
+  consistent with the actual implementation state.
+- Carry steward consultation rollups into follow-up plans or PR descriptions
+  when planning work crosses scoped steward areas.
+- `rg "^\*\*Status\*\*" plan`
+- `rg "bengal/build|dependency_tracker|PageCacheManager|ConfigService" plan`
+- Re-read affected scoped `AGENTS.md` files before promoting a plan from draft
+  to active work.

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -1,0 +1,65 @@
+# Site Documentation Steward
+
+The `site/` tree is Bengal's dogfood documentation site. It represents the
+reader, site author, plugin developer, and contributor experience before the
+project asks anyone else to trust the tool.
+
+Related architecture docs:
+
+- `../AGENTS.md`
+- `content/docs/about/philosophy.md`
+- `content/docs/get-started/`
+- `content/docs/reference/`
+
+## Protect
+
+- Docs that match current CLI behavior, config shape, template context, and
+  extension contracts.
+- Reader task completion: install, scaffold, build, theme, extend, debug, and
+  migrate.
+- Runnable examples and snippets that do not depend on unstated local state.
+- Clear audience paths for site authors, plugin developers, theme developers,
+  and contributors.
+- Release notes and migration guidance that say what changed, who is affected,
+  and what to do next.
+
+## Advocate
+
+- Docs that reveal the fastest successful path for each audience before diving
+  into internals.
+- Better diagnostics, examples, snippets, and commands when documentation has
+  to explain around product friction.
+- Migration notes and release pages that treat breaking or surprising behavior
+  as reader work, not maintainer trivia.
+
+## Serve Peers
+
+- Give CLI, rendering, theme, protocol, and orchestration stewards feedback
+  when their behavior is hard to explain.
+- Keep docs examples aligned with real commands, template context, and config
+  so package stewards do not inherit outdated promises.
+- Turn recurring support questions into docs issues or clearer examples.
+
+## Do Not
+
+- Document aspirational behavior as shipped behavior.
+- Let generated output under `.bengal/` or `public/` become the source of truth
+  for authored docs.
+- Add prose that requires knowing Bengal internals before completing a user
+  task.
+- Hide sharp edges behind marketing language; if the behavior is limited,
+  document the limit.
+
+## Own
+
+- Own authored content under `site/content/`, `site/config/`, `site/data/`, and
+  hand-maintained site assets.
+- Keep snippets in `site/content/_snippets/` synchronized with installation,
+  configuration, and command examples.
+- Coordinate with package stewards when docs explain architecture, public API,
+  plugin hooks, or theme behavior owned outside `site/`.
+- `uv run bengal build site`
+- `uv run bengal serve site`
+- `rg "TODO|TBD|coming soon|not yet implemented" site/content`
+- For command docs, compare examples with `uv run bengal --help` or the
+  relevant subcommand help.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -9,12 +9,34 @@ Related architecture docs:
 - `../AGENTS.md`
 - `../site/content/docs/reference/architecture/meta/testing.md`
 
+## Point Of View
+
+Tests represent the project's memory of intended behavior. They should make
+real regressions obvious while keeping production contracts narrow and fixtures
+easy to reason about.
+
 ## Protect
 
 - Focused unit tests for interesting branches.
 - Integration tests for user-visible workflows and build correctness.
 - `tests/roots/` fixtures as intentional, minimal sites.
 - Existing markers and parallel-safety expectations.
+
+## Advocate
+
+- Regression tests that describe user-visible failure modes, not implementation
+  trivia.
+- Small fixtures and explicit assertions before broad snapshots.
+- Test doubles that adapt to public contracts instead of forcing production
+  protocols wider.
+
+## Serve Peers
+
+- Give package stewards focused checks that defend their boundaries without
+  making every change run the whole suite.
+- Give docs and planning stewards evidence about covered behavior and risky
+  gaps.
+- Give protocol stewards feedback when mocks are drifting from real contracts.
 
 ## Do Not
 
@@ -23,14 +45,11 @@ Related architecture docs:
 - Fold unrelated cleanup into a bug/regression test PR.
 - Leave slow or parallel-unsafe tests unmarked.
 
-## Documentation Ownership
+## Own
 
 - Own `site/content/docs/reference/architecture/meta/testing.md`.
 - Keep `tests/README.md` and `tests/roots/README.md` accurate when fixture/test patterns change.
 - Update docs when markers, shared mocks, or test-layer expectations change.
-
-## Local Checks
-
 - `uv run pytest tests/unit -q`
 - `uv run pytest tests/integration -q`
 - `uv run ruff check tests`


### PR DESCRIPTION
## Summary

- Compact the root AGENTS.md into a shorter constitution and routing guide.
- Add scoped stewards for plan/, site/, and the default theme.
- Update high-leverage stewards to include point of view, advocacy, peer service, and ownership responsibilities.
- Add root guidance for when to proactively consult, parallelize, or delegate steward investigation.

## Validation

- `git diff --check`
- Commit hooks ran during `git commit`: whitespace, EOF, merge-conflict, private-key, check-cycles, and check-deps hooks completed. `check-cycles` reported deferred-only cycles as warnings; `check-deps` reported four existing dependency-layer warnings while still passing.

## Steward Notes

- Root steward: global guidance stays focused on constitutional rules, extension routing, done criteria, and steward consultation.
- Planning steward: new scope protects RFC hygiene, dependency order, not-now decisions, and steward rollups.
- Site documentation steward: new scope protects dogfood docs, runnable examples, release notes, and reader task completion.
- Default theme UX steward: new scope protects shipped documentation UX, accessibility, template contracts, CSS discipline, and no npm/Node path.
- Core/rendering/protocols/build/incremental/cache/tests stewards: existing safety boundaries preserved while adding advocacy, peer-service, and ownership responsibilities.