### PR TITLE
cli: make Kida terminal output beautiful

### DIFF
--- a/bengal/output/templates/_bengal.kida
+++ b/bengal/output/templates/_bengal.kida
@@ -21,6 +21,29 @@
 {{ mouse_str }}{{ text | red | bold }}
 {%- enddef -%}
 
+{#- ── Open report rule inspired by Milo output gallery ───────────── -#}
+{%- def open_rule(title="", width=72, color="cyan") -%}
+{%- set label = (" " ~ title ~ " ") if title else "" -%}
+{%- set fill = [width - (label | length) - 2, 2] | max -%}
+{{ "╭" | dim }}{{ "─" | dim }}{{ label | fg(color) | bold }}{{ ("─" * fill) | dim }}{{ "╮" | dim }}
+{%- enddef -%}
+
+{%- def close_rule(width=72) -%}
+{{ "╰" | dim }}{{ ("─" * width) | dim }}{{ "╯" | dim }}
+{%- enddef -%}
+
+{#- ── Framed row with a visual rail ─────────────────────────────── -#}
+{%- def rail_line(text, level="info") -%}
+{%- set rail_color = "red" if level == "error" else ("yellow" if level == "warning" else ("green" if level == "success" else "cyan")) -%}
+{{ "│" | fg(rail_color) }} {{ text }}
+{%- enddef -%}
+
+{#- ── Compact metric row for framed reports ─────────────────────── -#}
+{%- def report_metric(label, value, level="info", width=22) -%}
+{%- set color = "red" if level == "error" else ("yellow" if level == "warning" else ("green" if level == "success" else "cyan")) -%}
+{{ "│" | fg(color) }} {{ label | pad(width) | dim }} {{ value | string | bold }}
+{%- enddef -%}
+
 {#- ── Build phase line with aligned columns ──────────────────────── -#}
 {%- def phase_line(name, status="Done", duration_ms=none, details=none, icon=none) -%}
 {%- set phase_icon = icon | default(icons.check) -%}

--- a/bengal/output/templates/build_progress.kida
+++ b/bengal/output/templates/build_progress.kida
@@ -10,6 +10,9 @@
             elapsed: float (seconds)
             phases: list[{name, status, elapsed, error}]
 -#}
+{% from "_bengal.kida" import close_rule, open_rule %}
 {% from "components/_defs.kida" import pipeline_progress %}
 
+{{ open_rule("Build Progress") }}
 {{ pipeline_progress(state) }}
+{{ close_rule() }}

--- a/bengal/output/templates/build_report.kida
+++ b/bengal/output/templates/build_report.kida
@@ -23,18 +23,29 @@
         progress: Float 0-1 for progress bar
         elapsed: Total elapsed seconds
 -#}
-{% from "components/_defs.kida" import pipeline_progress, kv_list, status_line %}
-{%- if phases -%}
+{% from "_bengal.kida" import close_rule, open_rule, rail_line %}
+{% from "components/_defs.kida" import pipeline_progress %}
+{% if phases -%}
+{{ open_rule("Pipeline") }}
 {{ pipeline_progress({"phases": phases, "status": status | default("completed"), "progress": progress | default(1.0), "elapsed": elapsed | default(0)}) }}
-{%- endif %}
-{%- if metrics %}
+{{ close_rule() }}
+{% endif -%}
+{% if metrics -%}
 
-{{ kv_list(metrics) }}
-{%- endif -%}
-{%- if rebuild_reasons | default(none) %}
+{{ open_rule("Metrics") }}
+{% for item in metrics -%}
+{{ rail_line(item.label | kv(item.value | string, width=40), "info") }}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}
+{% if rebuild_reasons | default(none) -%}
 
-{{ "Rebuild reasons" | yellow | bold }}:
-{%- for r in rebuild_reasons %}
-  {{ r.reason | bold }}{{ " " * ([25 - (r.reason | length), 1] | max) }}{{ r.count | string | dim }}  {{ r.pages | dim }}
-{%- endfor -%}
-{%- endif -%}
+{{ open_rule("Rebuild Reasons", color="yellow") }}
+{% for r in rebuild_reasons -%}
+{% set reason_line = r.reason | bold -%}
+{% set reason_line = reason_line ~ (" " * ([25 - (r.reason | length), 1] | max)) -%}
+{% set reason_line = reason_line ~ ((r.count | string) | dim) ~ "  " ~ (r.pages | dim) -%}
+{{ rail_line(reason_line, "warning") }}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}

--- a/bengal/output/templates/build_summary.kida
+++ b/bengal/output/templates/build_summary.kida
@@ -47,81 +47,119 @@
         # Error-code breakdown (Sprint A4.3, optional)
         error_code_summary: str — e.g. "3 errors (2 [R022], 1 [R024])"
 -#}
-{% from "_bengal.kida" import bengal_header, error_header %}
+{% from "_bengal.kida" import close_rule, error_header, open_rule, rail_line, report_metric %}
 
-{%- if skipped -%}
+{% if skipped -%}
 
-{{ icons.check | green }} {{ "No changes detected — build skipped!" | dim }}
+{{ open_rule("Build Signal") }}
+{{ rail_line((icons.check ~ " No changes detected") | green | bold, "success") }}
+{{ rail_line("Build skipped because inputs are unchanged." | dim, "success") }}
+{{ close_rule() }}
 
-{%- elif has_errors and not total_pages -%}
+{% elif has_errors and not total_pages -%}
 
-{{ error_header("Build Failed") }}
+{{ open_rule("Build Signal", color="red") }}
+{{ rail_line((icons.cross ~ " Build failed before pages were written") | red | bold, "error") }}
+{{ close_rule() }}
 
-{%- elif has_errors -%}
+{% elif has_errors -%}
 {#- Built with errors -#}
-{{ (icons.dot | yellow) }} {{ ("ᓚᘏᗢ" | fg("#FF9D00") | bold) }}  {{ ("Built with " ~ (error_count | string) ~ " error(s), " ~ (warning_count | string) ~ " warning(s)") | yellow }}
+{{ open_rule("Build Signal", color="red") }}
+{{ rail_line((icons.cross ~ " Built with " ~ (error_count | string) ~ " error(s), " ~ (warning_count | string) ~ " warning(s)") | red | bold, "error") }}
+{% if total_pages -%}
+{{ report_metric("Pages", total_pages, "info") }}
+{% endif -%}
+{% if build_time -%}
+{{ report_metric("Elapsed", build_time, "info") }}
+{% endif -%}
+{{ close_rule() }}
 
-{%- elif has_warnings -%}
+{% elif has_warnings -%}
 {#- Built with warnings -#}
-{{ (icons.dot | yellow) }} {{ ("ᓚᘏᗢ" | fg("#FF9D00") | bold) }}  {{ ("Built " ~ (total_pages | string) ~ " pages in " ~ build_time ~ " (" ~ mode ~ ") with warnings") | yellow }}
-   {{ content_parts | join(", ") | dim }}
-{%- if phases %}
-   {{ phases | join(", ") | dim }}
-{%- endif -%}
+{{ open_rule("Build Signal", color="yellow") }}
+{{ rail_line((icons.dot ~ " Built " ~ (total_pages | string) ~ " pages in " ~ build_time ~ " with warnings") | yellow | bold, "warning") }}
+{{ report_metric("Mode", mode, "info") }}
+{% if pages_per_sec | default(none) -%}
+{{ report_metric("Throughput", (pages_per_sec | round(1) | string) ~ " pages/sec", "info") }}
+{% endif -%}
+{% if content_parts -%}
+{{ rail_line(content_parts | join(", ") | dim, "info") }}
+{% endif -%}
+{% if phases -%}
+{{ rail_line(phases | join(", ") | dim, "info") }}
+{% endif -%}
+{{ close_rule() }}
 
-{%- else -%}
+{% else -%}
 {#- Clean success -#}
-{{ (icons.check | green) }} {{ ("ᓚᘏᗢ" | fg("#FF9D00") | bold) }}  {{ ("Built " ~ (total_pages | string) ~ " pages") | green }} {{ ("(" ~ breakdown ~ ")") | dim }} in {{ build_time | fg("#F1C40F") | bold }} {{ ("(" ~ mode ~ ")") | dim }} │ {{ (pages_per_sec | round(1) | string) | fg("#F1C40F") | bold }} {{ "pages/sec" | dim }}
-   {{ content_parts | join(", ") | dim }}
-{%- if phases %}
-   {{ phases | join(", ") | dim }}
-{%- endif -%}
-{%- if render_dist %}
-   {{ ("Render/page: " ~ render_dist) | dim }}
-{%- endif -%}
-{%- endif -%}
+{{ open_rule("Build Signal", color="green") }}
+{% set success_line = (icons.check ~ " Built " ~ (total_pages | string) ~ " pages") | green | bold -%}
+{% set success_line = success_line ~ " " ~ (("(" ~ breakdown ~ ")") | dim) -%}
+{{ rail_line(success_line, "success") }}
+{{ report_metric("Elapsed", build_time, "success") }}
+{{ report_metric("Mode", mode, "info") }}
+{{ report_metric("Throughput", (pages_per_sec | round(1) | string) ~ " pages/sec", "success") }}
+{% if content_parts -%}
+{{ rail_line(content_parts | join(", ") | dim, "info") }}
+{% endif -%}
+{% if phases -%}
+{{ rail_line(phases | join(", ") | dim, "info") }}
+{% endif -%}
+{% if render_dist -%}
+{{ rail_line(("Render/page: " ~ render_dist) | dim, "info") }}
+{% endif -%}
+{{ close_rule() }}
+{% endif -%}
 
-{%- if regression | default(none) %}
-   {{ regression | fg("yellow" if regression_positive | default(false) else "green") }}
-{%- endif -%}
-{%- if cache_line | default(none) %}
-   {{ cache_line | dim }}
-{%- endif -%}
-{%- if output_dir | default(none) %}
-   {{ "↪" | dim }} {{ output_dir | dim }}
-{%- endif -%}
+{% if regression | default(none) or cache_line | default(none) or output_dir | default(none) or error_code_summary | default("") -%}
+{{ open_rule("Build Notes") }}
+{% if regression | default(none) -%}
+{{ rail_line(regression | fg("yellow" if regression_positive | default(false) else "green"), "warning" if regression_positive | default(false) else "success") }}
+{% endif -%}
+{% if cache_line | default(none) -%}
+{{ rail_line(cache_line | dim, "info") }}
+{% endif -%}
+{% if output_dir | default(none) -%}
+{{ rail_line(("Output  " ~ output_dir) | dim, "info") }}
+{% endif -%}
 
-{%- if error_code_summary | default("") %}
-   {{ ("By code: " ~ error_code_summary) | red }}
-{%- endif -%}
+{% if error_code_summary | default("") -%}
+{{ rail_line(("By code: " ~ error_code_summary) | red, "error") }}
+{% endif -%}
+{{ close_rule() }}
+{% endif -%}
 
-{%- if error_lines | default(none) %}
+{% if error_lines | default(none) -%}
 
-{%- for line in error_lines %}
-{%- if line.level == "error" %}
-   {{ line.text | red }}
-{%- elif line.level == "warning" %}
-   {{ line.text | yellow }}
-{%- elif line.level == "header" %}
-   {{ line.text | bold }}
-{%- elif line.level == "dim" %}
-   {{ line.text | dim }}
-{%- else %}
-   {{ line.text }}
-{%- endif -%}
-{%- endfor %}
-{%- endif -%}
+{{ open_rule("Diagnostics", color="red") }}
+{% for line in error_lines -%}
+{% if line.level == "error" -%}
+{{ rail_line(line.text | red, "error") }}
+{% elif line.level == "warning" -%}
+{{ rail_line(line.text | yellow, "warning") }}
+{% elif line.level == "header" -%}
+{{ rail_line(line.text | bold, "info") }}
+{% elif line.level == "dim" -%}
+{{ rail_line(line.text | dim, "info") }}
+{% else -%}
+{{ rail_line(line.text, "info") }}
+{% endif -%}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}
 
-{%- if warning_groups | default(none) %}
+{% if warning_groups | default(none) -%}
 
 {{ error_header("Build completed with warnings (" ~ (warning_count | string) ~ ")") }}
-{%- for group in warning_groups %}
-   {{ (group.type_name ~ " (" ~ (group.warnings | length | string) ~ "):") | bold }}
-{%- for w in group.warnings %}
-{%- set prefix = "└─" if loop.last else "├─" %}
-   {{ prefix | dim }} {{ w.short_path | yellow }}
-{%- set msg_prefix = "   " if loop.last else "│  " %}
-   {{ msg_prefix | dim }}{{ "└─" | dim }} {{ w.message | red }}
-{%- endfor %}
-{%- endfor %}
-{%- endif -%}
+{{ open_rule("Warning Queue", color="yellow") }}
+{% for group in warning_groups -%}
+{{ rail_line((group.type_name ~ " (" ~ (group.warnings | length | string) ~ ")") | yellow | bold, "warning") }}
+{% for w in group.warnings -%}
+{% set prefix = "└─" if loop.last else "├─" -%}
+{{ rail_line((prefix ~ " " ~ w.short_path) | yellow, "warning") }}
+{% set msg_prefix = "   " if loop.last else "│  " -%}
+{{ rail_line((msg_prefix ~ "└─ " ~ w.message) | dim, "warning") }}
+{% endfor -%}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}

--- a/bengal/output/templates/diff_view.kida
+++ b/bengal/output/templates/diff_view.kida
@@ -16,24 +16,23 @@
         summary: Summary line (optional)
         labels: Tuple of (old_label, new_label) for changed items
 -#}
-{% from "_bengal.kida" import bengal_header %}
-{% from "components/_defs.kida" import status_line %}
-{%- if title | default(false) %}
-{{ bengal_header(title, mascot=false) }}
+{% from "_bengal.kida" import close_rule, open_rule, rail_line %}
+{{ open_rule(title | default("Diff"), color="yellow") }}
+{% set label_pair = labels | default(false) -%}
+{% set old_label = label_pair[0] if label_pair else "old" -%}
+{% set new_label = label_pair[1] if label_pair else "new" -%}
+{% for change in changes -%}
+{{ rail_line(change.path | bold, "info") }}
+{% if change.type == "changed" -%}
+{{ rail_line(("- " ~ change.old) | red ~ "  " ~ (("[" ~ old_label ~ "]") | dim), "error") }}
+{{ rail_line(("+ " ~ change.new) | green ~ "  " ~ (("[" ~ new_label ~ "]") | dim), "success") }}
+{% elif change.type == "added" -%}
+{{ rail_line(("+ " ~ change.value) | green ~ "  " ~ (("[" ~ new_label ~ "]") | dim), "success") }}
+{% elif change.type == "removed" -%}
+{{ rail_line(("- " ~ change.value) | red ~ "  " ~ (("[" ~ old_label ~ "]") | dim), "error") }}
 {% endif -%}
-{%- set old_label = labels[0] if labels | default(false) else "old" -%}
-{%- set new_label = labels[1] if labels | default(false) else "new" -%}
-{%- for change in changes %}
-{{ change.path | bold }}:
-{%- if change.type == "changed" %}
-  {{ ("- " ~ change.old) | red }}  {{ ("[" ~ old_label ~ "]") | dim }}
-  {{ ("+ " ~ change.new) | green }}  {{ ("[" ~ new_label ~ "]") | dim }}
-{%- elif change.type == "added" %}
-  {{ ("+ " ~ change.value) | green }}  {{ ("[" ~ new_label ~ "]") | dim }}
-{%- elif change.type == "removed" %}
-  {{ ("- " ~ change.value) | red }}  {{ ("[" ~ old_label ~ "]") | dim }}
-{%- endif %}
 {% endfor -%}
-{%- if summary | default(false) %}
-{{ summary | dim }}
-{%- endif -%}
+{% if summary | default(false) -%}
+{{ rail_line(summary | dim, "info") }}
+{% endif -%}
+{{ close_rule() }}

--- a/bengal/output/templates/error_panel.kida
+++ b/bengal/output/templates/error_panel.kida
@@ -16,27 +16,32 @@
         hints: List of hint strings (optional)
         suggestions: List of "did you mean" suggestions (optional)
 -#}
-{% from "_bengal.kida" import error_header %}
-{% from "components/_defs.kida" import status_line, next_steps %}
+{% from "_bengal.kida" import close_rule, error_header, open_rule, rail_line %}
+{% from "components/_defs.kida" import status_line %}
 {{ error_header(title | default("Error")) }}
-{%- if message %}
-{{ status_line("error", message) }}
-{%- endif -%}
-{%- if details | default(none) %}
-{%- for d in details %}
-  {{ d | dim }}
-{%- endfor -%}
-{%- endif -%}
-{%- if suggestions | default(none) %}
+{{ open_rule("Failure", color="red") }}
+{% if message -%}
+{{ rail_line(status_line("error", message), "error") }}
+{% endif -%}
+{% if details | default(none) -%}
+{% for d in details -%}
+{{ rail_line(d | dim, "error") }}
+{% endfor -%}
+{% endif -%}
+{{ close_rule() }}
+{% if suggestions | default(none) -%}
 
-{%- for s in suggestions %}
-  {{ icons.arrow_r | cyan }} {{ s }}
-{%- endfor -%}
-{%- endif -%}
-{%- if hints | default(none) %}
+{{ open_rule("Suggestions") }}
+{% for s in suggestions -%}
+{{ rail_line((icons.arrow_r ~ " " ~ s) | cyan, "info") }}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}
+{% if hints | default(none) -%}
 
-{{ "Hints" | yellow | bold }}:
-{%- for h in hints %}
-  {{ icons.info | cyan }} {{ h }}
-{%- endfor -%}
-{%- endif -%}
+{{ open_rule("Hints", color="yellow") }}
+{% for h in hints -%}
+{{ rail_line((icons.info ~ " " ~ h) | yellow, "warning") }}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}

--- a/bengal/output/templates/graph_view.kida
+++ b/bengal/output/templates/graph_view.kida
@@ -16,21 +16,21 @@
         data: Nested dict for tree mode
         file, affected, count: For blast radius mode
 -#}
-{% from "_bengal.kida" import bengal_header %}
-{% from "components/_defs.kida" import status_line, kv_pair %}
-{%- if title %}
-{{ bengal_header(title) }}
-{% endif -%}
-{%- if mode == "blast" %}
-{{ kv_pair("If changed", file) }}
-{{ kv_pair("Pages affected", count | string) }}
+{% from "_bengal.kida" import close_rule, open_rule, rail_line %}
+{% if mode == "blast" -%}
+{{ open_rule(title | default("Blast Radius"), color="yellow") }}
+{{ rail_line("If changed" | kv(file, width=36), "warning") }}
+{{ rail_line("Pages affected" | kv(count | string, width=36), "warning") }}
 
-{%- for page in affected[:20] %}
-  {{ icons.dot | yellow }} {{ page }}
-{%- endfor -%}
-{%- if affected | length > 20 %}
-  {{ ("... and " ~ ((affected | length) - 20) | string ~ " more") | dim }}
-{%- endif -%}
-{%- elif mode == "tree" %}
+{% for page in affected[:20] -%}
+{{ rail_line((icons.dot ~ " " ~ page) | yellow, "warning") }}
+{% endfor -%}
+{% if affected | length > 20 -%}
+{{ rail_line(("... and " ~ ((affected | length) - 20) | string ~ " more") | dim, "warning") }}
+{% endif -%}
+{{ close_rule() }}
+{% elif mode == "tree" -%}
+{{ open_rule(title | default("Dependency Tree")) }}
 {{ data | tree }}
-{%- endif -%}
+{{ close_rule() }}
+{% endif -%}

--- a/bengal/output/templates/i18n_coverage.kida
+++ b/bengal/output/templates/i18n_coverage.kida
@@ -16,19 +16,25 @@
         locales: List of {name, translated, missing, coverage} dicts
         missing_keys: Dict of {locale: [key1, key2, ...]} for verbose mode (optional)
 -#}
-{% from "components/_defs.kida" import kv_pair, status_line %}
-{{ kv_pair("Translation coverage", (total_keys | string) ~ " keys, domain=" ~ domain) }}
+{% from "_bengal.kida" import close_rule, open_rule, rail_line %}
+{{ open_rule("Translation Coverage") }}
+{{ rail_line("Domain" | kv(domain, width=24), "info") }}
+{{ rail_line("Total keys" | kv(total_keys | string, width=24), "info") }}
 
-{%- for loc in locales %}
-  {{ loc.name | bold | pad(8) }}{{ loc.coverage | bar(width=20) }}  {{ ((loc.coverage * 100) | int | string ~ "%") | pad(5) }}  {{ (loc.translated | string ~ "/" ~ total_keys | string) | dim }}
-{%- if loc.missing > 0 %}  {{ (loc.missing | string ~ " missing") | yellow }}{% endif %}
-{%- endfor -%}
-{%- if missing_keys | default(none) %}
+{% for loc in locales -%}
+{% set level = "warning" if loc.missing > 0 else "success" -%}
+{% set missing = ("  " ~ (loc.missing | string) ~ " missing") | yellow if loc.missing > 0 else "" -%}
+{{ rail_line((loc.name | bold | pad(8)) ~ (loc.coverage | bar(width=20)) ~ "  " ~ ((loc.translated | string ~ "/" ~ total_keys | string) | dim) ~ missing, level) }}
+{% endfor -%}
+{{ close_rule() }}
+{% if missing_keys | default(none) -%}
 
-{%- for locale, keys in missing_keys.items() %}
-  {{ locale | bold }}:
-{%- for key in keys %}
-    {{ key | dim }}
-{%- endfor %}
-{%- endfor -%}
-{%- endif -%}
+{{ open_rule("Missing Keys", color="yellow") }}
+{% for locale, keys in missing_keys.items() -%}
+{{ rail_line(locale | yellow | bold, "warning") }}
+{% for key in keys -%}
+{{ rail_line(("  " ~ key) | dim, "warning") }}
+{% endfor -%}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}

--- a/bengal/output/templates/item_list.kida
+++ b/bengal/output/templates/item_list.kida
@@ -13,17 +13,27 @@
         headers: Column headers for table mode (optional)
         table_data: Row data for table mode (list of lists)
 -#}
-{% from "components/_defs.kida" import section, def_list %}
-{%- if title | default(false) %}
-{{ section(title) }}
-{%- endif %}
-{%- set display_mode = mode | default("simple") -%}
-{%- if display_mode == "table" and table_data | default(false) -%}
+{% from "components/_defs.kida" import def_list %}
+{% from "_bengal.kida" import close_rule, open_rule, rail_line %}
+{% set display_mode = mode | default("simple") -%}
+{% if display_mode == "table" and table_data | default(false) -%}
+{% if title | default(false) -%}
+{{ open_rule(title) }}
+{{ close_rule() }}
+{% endif -%}
 {{ table_data | table(headers=headers, border="light") }}
-{%- elif display_mode == "def" -%}
+{% elif display_mode == "def" -%}
+{% if title | default(false) -%}
+{{ open_rule(title) }}
+{% endif -%}
 {{ def_list(items) }}
-{%- else -%}
-{%- for item in items %}
-  {{ item.name | green | bold }}{% if item.description %}  {{ item.description | dim }}{% endif %}
-{%- endfor %}
-{%- endif -%}
+{% if title | default(false) -%}
+{{ close_rule() }}
+{% endif -%}
+{% else -%}
+{{ open_rule(title | default("Items")) }}
+{% for item in items -%}
+{{ rail_line((item.name | green | bold) ~ (("  " ~ (item.description | dim)) if item.description else ""), "success") }}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}

--- a/bengal/output/templates/kv_detail.kida
+++ b/bengal/output/templates/kv_detail.kida
@@ -12,12 +12,17 @@
         badge: Optional {level, text} for status badge
         width: Column width for kv alignment (default: 40)
 -#}
-{% from "components/_defs.kida" import kv_list, status_line %}
-{% from "_bengal.kida" import bengal_header %}
-{%- if title | default(false) %}
-{{ bengal_header(title, mascot=false) }}
+{% from "components/_defs.kida" import status_line %}
+{% from "_bengal.kida" import close_rule, open_rule, rail_line %}
+{% if title | default(false) -%}
+{{ open_rule(title) }}
+{% else -%}
+{{ open_rule("Details") }}
 {% endif -%}
-{%- if badge | default(false) %}
-{{ status_line(badge.level, badge.text) }}
+{% if badge | default(false) -%}
+{{ rail_line(status_line(badge.level, badge.text), badge.level) }}
 {% endif -%}
-{{ kv_list(items, width=width | default(40)) }}
+{% for item in items -%}
+{{ rail_line(item.label | kv(item.value | string, width=width | default(40)), "info") }}
+{% endfor -%}
+{{ close_rule() }}

--- a/bengal/output/templates/page_explanation.kida
+++ b/bengal/output/templates/page_explanation.kida
@@ -14,127 +14,127 @@
         issues: list[{level, message, detail}]|none
         performance: {total_ms, breakdown: list[{label, value}]}|none
 -#}
-{% from "_bengal.kida" import bengal_header %}
-{% from "components/_defs.kida" import section, kv_list, kv_pair, panel, summary_box, issue_list, status_line %}
+{% from "_bengal.kida" import bengal_header, close_rule, open_rule, rail_line %}
 
 {{ bengal_header("Page Explanation: " ~ source.path) }}
 
 {#- ── Source ──────────────────────────────────────────── -#}
-{%- capture source_content -%}
-{{ "Path" | kv(source.path, width=40) }}
-{{ "Size" | kv(source.size ~ " (" ~ (source.lines | string) ~ " lines)", width=40) }}
-{%- if source.modified %}
-{{ "Modified" | kv(source.modified, width=40) }}
-{%- endif %}
-{{ "Encoding" | kv(source.encoding, width=40) }}
-{%- endcapture -%}
-{{ panel(source_content | trim, title="Source") }}
+{{ open_rule("Source") }}
+{{ rail_line("Path" | kv(source.path, width=40), "info") }}
+{{ rail_line("Size" | kv(source.size ~ " (" ~ (source.lines | string) ~ " lines)", width=40), "info") }}
+{% if source.modified -%}
+{{ rail_line("Modified" | kv(source.modified, width=40), "info") }}
+{% endif -%}
+{{ rail_line("Encoding" | kv(source.encoding, width=40), "info") }}
+{{ close_rule() }}
 
 {#- ── Frontmatter ─────────────────────────────────────── -#}
-{%- if frontmatter %}
+{% if frontmatter -%}
 
-{%- capture fm_content -%}
-{%- for item in frontmatter -%}
-{{ item.label | kv(item.value, width=40) }}
+{{ open_rule("Frontmatter") }}
+{% for item in frontmatter -%}
+{{ rail_line(item.label | kv(item.value, width=40), "info") }}
 {% endfor -%}
-{%- endcapture -%}
-{{ panel(fm_content | trim, title="Frontmatter") }}
-{%- endif -%}
+{{ close_rule() }}
+{% endif -%}
 
 {#- ── Template Chain ──────────────────────────────────── -#}
-{%- if template_chain %}
+{% if template_chain -%}
 
-{%- capture chain_content -%}
-{%- for tpl in template_chain -%}
-{%- set indent = "  " * tpl.depth -%}
-{%- set prefix = "" if tpl.depth == 0 else "extends: " -%}
-{%- set theme_str = " (" ~ tpl.theme ~ ")" if tpl.theme else "" -%}
-{{ indent }}{{ prefix | dim }}{{ tpl.name | bold }}{{ theme_str | dim }}
-{%- for inc in tpl.includes %}
-{{ indent }}  {{ "includes:" | dim }} {{ inc }}
-{%- endfor -%}
-{%- endfor -%}
-{%- endcapture -%}
-{{ panel(chain_content | trim, title="Template Chain") }}
-{%- endif -%}
+{{ open_rule("Template Chain") }}
+{% for tpl in template_chain -%}
+{% set indent = "  " * tpl.depth -%}
+{% set prefix = "" if tpl.depth == 0 else "extends: " -%}
+{% set theme_str = " (" ~ tpl.theme ~ ")" if tpl.theme else "" -%}
+{{ rail_line(indent ~ (prefix | dim) ~ (tpl.name | bold) ~ (theme_str | dim), "info") }}
+{% for inc in tpl.includes -%}
+{{ rail_line(indent ~ "  " ~ ("includes:" | dim) ~ " " ~ inc, "info") }}
+{% endfor -%}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}
 
 {#- ── Dependencies ────────────────────────────────────── -#}
-{%- if deps %}
+{% if deps -%}
 
-{%- capture deps_content -%}
-{%- for group in deps %}
-{{ group.section | bold }}:
-{%- for item in group.items %}
-  {{ icons.dot | dim }} {{ item }}
-{%- endfor -%}
-{%- endfor -%}
-{%- endcapture -%}
-{{ panel(deps_content | trim, title="Dependencies") }}
-{%- endif -%}
+{{ open_rule("Dependencies") }}
+{% for group in deps -%}
+{{ rail_line(group.section | bold, "info") }}
+{% for item in group.items -%}
+{{ rail_line(("  " ~ icons.dot ~ " " ~ item) | dim, "info") }}
+{% endfor -%}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}
 
 {#- ── Shortcodes ──────────────────────────────────────── -#}
-{%- if shortcodes %}
+{% if shortcodes -%}
 
-{%- capture sc_content -%}
-{%- for sc in shortcodes -%}
-{{ sc.name | pad(20) }} {{ (sc.count | string) | pad(5) }}  {{ sc.lines_str | dim }}
+{{ open_rule("Directives") }}
+{% for sc in shortcodes -%}
+{{ rail_line((sc.name | pad(20)) ~ " " ~ ((sc.count | string) | pad(5)) ~ "  " ~ (sc.lines_str | dim), "info") }}
 {% endfor -%}
-{%- endcapture -%}
-{{ panel(sc_content | trim, title="Directives") }}
-{%- endif -%}
+{{ close_rule() }}
+{% endif -%}
 
 {#- ── Cache Status ────────────────────────────────────── -#}
 
-{%- capture cache_content -%}
-{%- if cache.status == "HIT" -%}
-{{ "Status" | kv((icons.check ~ " " ~ cache.status) | green, width=40) }}
-{%- elif cache.status == "STALE" -%}
-{{ "Status" | kv(cache.status | yellow, width=40) }}
-{%- elif cache.status == "MISS" -%}
-{{ "Status" | kv((icons.cross ~ " " ~ cache.status) | red, width=40) }}
-{%- else -%}
-{{ "Status" | kv(cache.status, width=40) }}
-{%- endif -%}
-{%- if cache.reason %}
-{{ "Reason" | kv(cache.reason, width=40) }}
-{%- endif -%}
-{%- if cache.key %}
-{{ "Cache Key" | kv(cache.key | dim, width=40) }}
-{%- endif -%}
-{%- if cache.layers %}
-{{ "Cached" | kv(cache.layers | join(", "), width=40) }}
-{%- endif -%}
-{%- endcapture -%}
-{{ panel(cache_content | trim, title="Cache") }}
+{{ open_rule("Cache") }}
+{% if cache.status == "HIT" -%}
+{{ rail_line("Status" | kv((icons.check ~ " " ~ cache.status) | green, width=40), "success") }}
+{% elif cache.status == "STALE" -%}
+{{ rail_line("Status" | kv(cache.status | yellow, width=40), "warning") }}
+{% elif cache.status == "MISS" -%}
+{{ rail_line("Status" | kv((icons.cross ~ " " ~ cache.status) | red, width=40), "error") }}
+{% else -%}
+{{ rail_line("Status" | kv(cache.status, width=40), "info") }}
+{% endif -%}
+{% if cache.reason -%}
+{{ rail_line("Reason" | kv(cache.reason, width=40), "info") }}
+{% endif -%}
+{% if cache.key -%}
+{{ rail_line("Cache Key" | kv(cache.key | dim, width=40), "info") }}
+{% endif -%}
+{% if cache.layers -%}
+{{ rail_line("Cached" | kv(cache.layers | join(", "), width=40), "info") }}
+{% endif -%}
+{{ close_rule() }}
 
 {#- ── Output ──────────────────────────────────────────── -#}
 
-{%- capture output_content -%}
-{{ "URL" | kv(output.url, width=40) }}
-{%- if output.path %}
-{{ "Path" | kv(output.path, width=40) }}
-{%- endif -%}
-{%- if output.size %}
-{{ "Size" | kv(output.size, width=40) }}
-{%- endif -%}
-{%- endcapture -%}
-{{ panel(output_content | trim, title="Output") }}
+{{ open_rule("Output") }}
+{{ rail_line("URL" | kv(output.url, width=40), "info") }}
+{% if output.path -%}
+{{ rail_line("Path" | kv(output.path, width=40), "info") }}
+{% endif -%}
+{% if output.size -%}
+{{ rail_line("Size" | kv(output.size, width=40), "info") }}
+{% endif -%}
+{{ close_rule() }}
 
 {#- ── Issues ──────────────────────────────────────────── -#}
-{%- if issues %}
+{% if issues -%}
 
-{{ section("Issues") }}
-{{ issue_list(issues) }}
-{%- endif -%}
+{{ open_rule("Issues", color="yellow") }}
+{% for issue in issues -%}
+{% set level = issue.level | default("info") -%}
+{% set glyph = icons.cross if level == "error" else (icons.dot if level == "warning" else icons.info) -%}
+{% set color = "red" if level == "error" else ("yellow" if level == "warning" else "cyan") -%}
+{{ rail_line((glyph ~ " " ~ issue.message) | fg(color) | bold, level) }}
+{% if issue.detail | default(false) -%}
+{{ rail_line(("  " ~ issue.detail) | dim, level) }}
+{% endif -%}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}
 
 {#- ── Performance ─────────────────────────────────────── -#}
-{%- if performance %}
+{% if performance -%}
 
-{%- capture perf_content -%}
-{{ "Total" | kv((performance.total_ms | round(1) | string ~ "ms"), width=40) }}
-{%- for item in performance.breakdown %}
-{{ ("  " ~ item.label) | kv(item.value, width=38) }}
-{%- endfor -%}
-{%- endcapture -%}
-{{ panel(perf_content | trim, title="Performance") }}
-{%- endif -%}
+{{ open_rule("Performance") }}
+{{ rail_line("Total" | kv((performance.total_ms | round(1) | string ~ "ms"), width=40), "info") }}
+{% for item in performance.breakdown -%}
+{{ rail_line(("  " ~ item.label) | kv(item.value, width=38), "info") }}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}

--- a/bengal/output/templates/scaffold_result.kida
+++ b/bengal/output/templates/scaffold_result.kida
@@ -14,13 +14,23 @@
         steps: List of step strings for next steps
         summary: Success message (optional)
 -#}
-{% from "_bengal.kida" import bengal_header, file_tree %}
+{% from "_bengal.kida" import close_rule, open_rule, rail_line %}
 {% from "components/_defs.kida" import status_line, next_steps %}
-{{ bengal_header(title) }}
-{{ file_tree(entries) }}
-{%- if summary | default(false) %}
-{{ status_line("success", summary) }}
-{%- endif -%}
-{%- if steps | default(false) %}
-{{ next_steps(steps) }}
-{%- endif -%}
+{{ open_rule(title | default("Created"), color="green") }}
+{% if summary | default(false) -%}
+{{ rail_line(status_line("success", summary), "success") }}
+{% endif -%}
+{% for entry in entries -%}
+{% set connector = "└─" if loop.last else "├─" -%}
+{% set note = ("  " ~ (entry.note | dim)) if entry.note | default(false) else "" -%}
+{{ rail_line((connector | dim) ~ " " ~ entry.name ~ note, "success") }}
+{% endfor -%}
+{{ close_rule() }}
+{% if steps | default(false) -%}
+
+{{ open_rule("Next Steps") }}
+{% for step in steps -%}
+{{ rail_line(((loop.index | string ~ ".") | bold | cyan) ~ " " ~ step, "info") }}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}

--- a/bengal/output/templates/server_dashboard.kida
+++ b/bengal/output/templates/server_dashboard.kida
@@ -19,8 +19,9 @@
         host, port: for url mode
 -#}
 {%- if mode == "header" -%}
-  {{ ("TIME" | pad(8) ~ " │ " ~ "METHOD" | pad(6) ~ " │ " ~ "STA" | pad(3) ~ " │ PATH") | dim }}
-  {{ (("─" * 8) ~ "─┼─" ~ ("─" * 6) ~ "─┼─" ~ ("─" * 3) ~ "─┼─" ~ ("─" * 60)) | dim }}
+{{ "╭─ Dev Server Traffic " | cyan | bold }}{{ ("─" * 55) | dim }}{{ "╮" | dim }}
+{{ "│" | dim }} {{ "TIME" | pad(8) | dim }} {{ "METHOD" | pad(6) | dim }} {{ "STA" | pad(3) | dim }} {{ "PATH" | dim }}
+{{ "├" | dim }}{{ ("─" * 76) | dim }}{{ "┤" | dim }}
 {%- elif mode == "request" -%}
 {%- set status_color = "green" if status[:1] == "2" else ("red" if status[:1] == "4" else "yellow") -%}
 {%- set method_color = "cyan" if method == "GET" else ("green" if method == "POST" else "yellow") -%}
@@ -28,15 +29,17 @@
 {%- if not is_asset -%}
 {%- set indicator = (icons.info ~ " ") if status[:1] == "2" else ((icons.cross ~ " ") if status[:1] == "4" else "") -%}
 {%- endif -%}
-  {{ timestamp }} │ {{ method | pad(6) | fg(method_color) }} │ {{ status | pad(3) | fg(status_color) }} │ {{ indicator }}{{ path | truncate(60) }}
+{{ "│" | fg(status_color) }} {{ timestamp | dim }} {{ method | pad(6) | fg(method_color) | bold }} {{ status | pad(3) | fg(status_color) }} {{ indicator }}{{ path | truncate(60) }}
 {%- elif mode == "file_change" -%}
-  {{ ("─" * 78) | dim }}
-  {{ timestamp }} │ {{ "📝 File changed:" | yellow }} {{ file_name }}
-  {{ ("─" * 78) | dim }}
+{{ "├" | dim }}{{ ("─" * 76) | dim }}{{ "┤" | dim }}
+{{ "│" | yellow }} {{ timestamp | dim }} {{ "File changed" | yellow | bold }}  {{ file_name }}
+{{ "╰" | dim }}{{ ("─" * 76) | dim }}{{ "╯" | dim }}
 {%- elif mode == "url" -%}
 
-  {{ "➜" | cyan }}  Local: {{ ("http://" ~ host ~ ":" ~ (port | string) ~ "/") | bold }}
+{{ "╭─ Server Ready " | cyan | bold }}{{ ("─" * 61) | dim }}{{ "╮" | dim }}
+{{ "│" | cyan }} {{ "Local" | dim }}  {{ ("http://" ~ host ~ ":" ~ (port | string) ~ "/") | bold }}
+{{ "╰" | dim }}{{ ("─" * 76) | dim }}{{ "╯" | dim }}
 
 {%- elif mode == "separator" -%}
-  {{ ("─" * 78) | dim }}
+{{ "├" | dim }}{{ ("─" * 76) | dim }}{{ "┤" | dim }}
 {%- endif -%}

--- a/bengal/output/templates/upgrade_status.kida
+++ b/bengal/output/templates/upgrade_status.kida
@@ -14,18 +14,21 @@
         up_to_date: Boolean
         dry_run: Boolean (optional)
 -#}
-{% from "components/_defs.kida" import kv_pair, status_line %}
-{{ kv_pair("Current version", current) }}
-{{ kv_pair("Latest version", latest) }}
-{%- if installer | default(none) %}
-{{ kv_pair("Installer", installer.name) }}
-{{ kv_pair("Command", installer.command) }}
-{%- endif %}
+{% from "_bengal.kida" import close_rule, open_rule, rail_line %}
+{% from "components/_defs.kida" import status_line %}
+{{ open_rule("Upgrade Check") }}
+{{ rail_line("Current version" | kv(current, width=40), "info") }}
+{{ rail_line("Latest version" | kv(latest, width=40), "info") }}
+{% if installer | default(none) -%}
+{{ rail_line("Installer" | kv(installer.name, width=40), "info") }}
+{{ rail_line("Command" | kv(installer.command, width=40), "info") }}
+{% endif -%}
+{{ close_rule() }}
 
-{%- if up_to_date %}
+{% if up_to_date -%}
 {{ status_line("success", "Already on latest version (v" ~ current ~ ")") }}
-{%- elif dry_run | default(false) %}
+{% elif dry_run | default(false) -%}
 {{ status_line("info", "Would run: " ~ installer.command) }}
-{%- else %}
+{% else -%}
 {{ status_line("warning", "Update available: " ~ current ~ " → " ~ latest) }}
-{%- endif -%}
+{% endif -%}

--- a/bengal/output/templates/validation_report.kida
+++ b/bengal/output/templates/validation_report.kida
@@ -16,20 +16,39 @@
         issues: List of {level, message, detail?} dicts
         summary: {errors, warnings, passed} counts (optional)
 -#}
-{% from "_bengal.kida" import bengal_header %}
-{% from "components/_defs.kida" import issue_list, status_line %}
-{%- if title | default(false) %}
+{% from "_bengal.kida" import bengal_header, close_rule, open_rule, rail_line, report_metric %}
+{% from "components/_defs.kida" import status_line %}
+{% if title | default(false) -%}
 {{ bengal_header(title) }}
-{%- endif %}
-{{ issue_list(issues) }}
-{%- if summary | default(false) -%}
-{%- if summary.errors %}
+{% endif -%}
+{% if summary | default(false) -%}
+{{ open_rule("Validation Signal") }}
+{{ report_metric("Errors", summary.errors | default(0), "error") }}
+{{ report_metric("Warnings", summary.warnings | default(0), "warning") }}
+{{ report_metric("Passed", summary.passed | default(0), "success") }}
+{{ close_rule() }}
+{% endif -%}
+{% if issues -%}
+
+{{ open_rule("Findings") }}
+{% for issue in issues -%}
+{% set level = issue.level | default("info") -%}
+{% set glyph = icons.cross if level == "error" else (icons.dot if level == "warning" else (icons.check if level == "success" else icons.info)) -%}
+{% set color = "red" if level == "error" else ("yellow" if level == "warning" else ("green" if level == "success" else "cyan")) -%}
+{{ rail_line((glyph ~ " " ~ issue.message) | fg(color) | bold, level) }}
+{% if issue.detail | default(false) -%}
+{{ rail_line(("  " ~ issue.detail) | dim, level) }}
+{% endif -%}
+{% endfor -%}
+{{ close_rule() }}
+{% endif -%}
+{% if summary | default(false) -%}
+
+{% if summary.errors | default(0) -%}
 {{ status_line("error", (summary.errors | string) ~ " error(s) found") }}
-{%- endif -%}
-{%- if summary.warnings %}
+{% elif summary.warnings | default(0) -%}
 {{ status_line("warning", (summary.warnings | string) ~ " warning(s)") }}
-{%- endif -%}
-{%- if summary.passed and not summary.errors %}
+{% elif summary.passed | default(0) -%}
 {{ status_line("success", "Validation passed") }}
-{%- endif -%}
-{%- endif -%}
+{% endif -%}
+{% endif -%}

--- a/changelog.d/cli-output-beautiful.changed.md
+++ b/changelog.d/cli-output-beautiful.changed.md
@@ -1,1 +1,1 @@
-Refresh shared CLI Kida templates with gallery-style frames, signal rails, and cleaner report sections for build, validation, list, detail, and dev-server output.
+Refresh shared CLI Kida templates with gallery-style frames, signal rails, and cleaner report sections for build, validation, list, detail, dev-server, scaffold, upgrade, i18n, graph, diff, progress, and inspect-page output.

--- a/changelog.d/cli-output-beautiful.changed.md
+++ b/changelog.d/cli-output-beautiful.changed.md
@@ -1,0 +1,1 @@
+Refresh shared CLI Kida templates with gallery-style frames, signal rails, and cleaner report sections for build, validation, list, detail, and dev-server output.


### PR DESCRIPTION
## Summary
- add Bengal Kida report primitives for gallery-style frames, signal rails, and compact metrics
- refresh build summary/report, validation report, generic detail/list, and dev-server output templates
- extend the same treatment to scaffold, upgrade, i18n, graph, diff, progress, error, and inspect-page templates
- keep existing CLI render contexts and command contracts unchanged

## Commits
- 73ff4009f cli: refine kida output templates
- 02ead713a cli: extend kida output polish

## Testing
- PASS: render smoke across all touched Kida templates
- PASS: uv run pytest tests/unit/cli/test_output.py tests/unit/utils/test_cli_output.py tests/unit/utils/test_performance_report.py tests/unit/health/test_health_report.py tests/unit/health/linkcheck/test_orchestrator_reporting.py tests/integration/test_cli_output_integration.py -q
- PASS: make changelog-check
- FAIL: make test currently fails in tests/integration/test_autodoc_html_generation.py because generated autodoc HTML is missing for existing .txt outputs (48 HTML vs 773 TXT); not related to this template-only diff.
- FAIL: make ty currently reports the existing ty floor (545 diagnostics) under autodoc/snapshots/server/etc.; this PR changes no Python files.

## Steward Notes
- bengal/output: presentation stays centralized in Kida templates and shared Bengal output primitives.
- bengal/cli: command interfaces and render contexts are unchanged.
- bengal/health, bengal/orchestration, bengal/debug: report semantics stay owned by their domains; only terminal presentation changed.

Reference: Milo CLI output gallery patterns inspired the frame/rail treatment: https://github.com/lbliii/milo-cli/tree/main/examples/outputgallery