### PR TITLE
[codex] docs: upgrade agent steward system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,9 @@ performance, and user-visible correctness.
   rendering-side helpers.
 - `Site` coordinates registries, services, and orchestration. Do not rebuild old
   forwarding layers around it.
-- `bengal/protocols/` and plugin hooks are public contracts. Prefer adapters or
-  internal helpers over widening `SiteLike`, `PageLike`, `SectionLike`, or
-  `Plugin`.
+- `bengal/protocols/`, `bengal/plugins/`, and hook surfaces are public
+  contracts. Prefer adapters or internal helpers over widening `SiteLike`,
+  `PageLike`, `SectionLike`, or `Plugin`.
 
 ## Stakes
 
@@ -49,6 +49,7 @@ performance, and user-visible correctness.
 - Free-threading races make 3.14t look flaky.
 - Plugin contract breaks affect third-party extensions discovered through
   `bengal.plugins`.
+- CLI/config changes break automation, docs snippets, and generated sites.
 - Performance regressions weaken Bengal's "scales with cores" claim.
 
 Bengal is alpha, published on PyPI, and used. Calibrate accordingly.
@@ -57,12 +58,16 @@ Bengal is alpha, published on PyPI, and used. Calibrate accordingly.
 
 Check in before doing any of these:
 
+- Changing public API, plugin protocols, hook signatures, `bengal.plugins`
+  entry points, CLI flags/commands, config keys, release layout, or
+  `BengalError` construction.
+- Adding a runtime dependency, build phase, persistence schema, migration,
+  output format contract, security/auth behavior, or irreversible operation.
+- Touching immutable pipeline records or adding mutation to pipeline stages.
 - Reintroducing core mixins or growing the empty mixin allow-list.
 - Hoisting a deferred import to module level. Run `check-cycles` first.
-- Touching immutable pipeline records or adding a pipeline stage.
-- Changing `Plugin`, any of the 9 hook surfaces, CLI flags/commands,
-  `bengal.plugins` entry points, or `BengalError` construction.
-- Adding a runtime dependency, config option, or build phase.
+- Changing concurrency, lifecycle, watcher, cache invalidation, or free-threaded
+  shared state behavior.
 - Chasing ty diagnostics below the floor around 570.
 - Reorganizing methods on `Site`, `Page`, or `Section` instead of deleting
   vestiges and migrating callers.
@@ -86,61 +91,111 @@ Check in before doing any of these:
 ## Steward System
 
 Read this root file plus the closest scoped `AGENTS.md` before editing a tree.
-The root is the constitution; scoped files are stewards for concrete domains.
+The root is the constitution, routing guide, and swarm protocol. Scoped files
+are domain stewards for concrete trees, public contracts, product surfaces,
+safety boundaries, docs, tests, examples, fixtures, and checks.
 
-Keep root guidance for rules that apply everywhere: north star, safety
-invariants, public escape hatches, extension routing, done criteria, and steward
-consultation. Move directory-specific ownership, refusal patterns, examples,
-docs, and local checks into the nearest scoped steward.
+Every steward uses this operating model:
 
-Each steward should be able to answer:
-
-- **Point of view:** who or what the domain represents.
+- **Point Of View:** who or what the domain represents.
 - **Protect:** invariants, contracts, quality bars, and failure modes.
+- **Contract Checklist:** local surfaces that must agree when the domain changes.
 - **Advocate:** features, fixes, and investments the domain should push for.
-- **Serve peers:** upstream and downstream domains that need clearer contracts,
-  diagnostics, docs, tests, or ergonomics from this domain.
-- **Own:** tests, docs, examples, fixtures, and maintenance chores that keep the
-  domain truthful.
+- **Serve Peers:** upstream and downstream domains that need clearer contracts,
+  diagnostics, docs, tests, or ergonomics.
+- **Do Not:** local anti-patterns and refusal patterns.
+- **Own:** tests, docs, examples, fixtures, maintenance checks, and proof paths.
 
-Stewards may represent product perspectives, such as documentation quality or
-default-theme UX, but they still protect a concrete tree. They do not override
-the implementation steward that owns an affected code boundary.
+Stewards advise from their domain's interests; the implementing agent owns
+synthesis, scope, and final implementation. When work crosses steward areas, add
+`Steward Notes` to the PR description naming each area and how its invariants
+were protected.
 
-When work crosses steward areas, add `Steward Notes` to the PR description:
-name each area and one sentence about how its invariants were protected.
+## Contract Checklist
 
-### When To Consult
+- Identify every surface that should agree: CLI/API, programmatic use,
+  protocols, schema/types, templates/UI, docs, examples, scaffolds, tests,
+  benchmarks, and changelog.
+- Every accepted finding must name required proof and collateral updates, or
+  explicitly say `no collateral: <reason>`.
+- Docs, examples, and scaffolds move in the same PR as user-facing behavior
+  unless synthesis records why they are unaffected.
+- Contract-affecting PRs include a parity matrix when behavior spans multiple
+  entrypoints.
 
-Consult stewards proactively when a change is cross-boundary, public-facing,
-hard to reverse, performance-sensitive, free-threading-sensitive, or likely to
-change docs, tests, fixtures, template context, cache keys, plugin contracts, or
-build outputs.
+## Steward Signal Format
 
-Use the nearest steward for local work. Use multiple stewards when work crosses
-ownership lines, such as core/rendering, build/incremental/cache,
-protocols/tests, or site/default-theme. Parallelize steward consultation only
-when the questions are independent; otherwise start with the steward that owns
-the safety boundary and let its answer shape the next consultation.
+Steward findings should be contract-oriented, evidence-backed, and
+collateral-aware.
 
-Delegate specialist investigation when a steward has a bounded question with a
-clear output, such as "which fixtures prove this invariant?", "which docs become
-wrong?", or "which downstream contract changes?". Keep final synthesis with the
-implementing agent so tradeoffs are resolved in one place.
+- Steward:
+- Area:
+- Severity: P0/P1/P2/P3
+- Invariant:
+- Evidence:
+- User Impact:
+- Required Fix:
+- Required Proof:
+- Collateral:
+- Confidence:
 
-### Ask Stewards
+## Steward Swarms
 
-Trigger phrase: **"ask stewards"**.
+When the user asks for `ask stewards`, `bugbash`, `review swarm`, or
+`steward synthesis`, and delegation is available:
 
-- For implementation work, consult only affected scoped stewards.
-- For backlog, roadmap, or prioritization, consult all scoped stewards and
-  produce a short rollup.
-- Verify the checkout is current, enumerate scoped `AGENTS.md` files, group
-  related stewards, and ask for top priority, evidence, dependencies, risks,
-  confidence, peer-service opportunities, and tempting "not now" work.
-- Synthesize by convergence, blast radius, dependency order, risk reduction,
-  reversibility, public contracts, free-threading, and user-visible correctness.
-- Preserve minority reports when a steward owns a safety boundary.
+- Spawn independent steward agents for affected domains.
+- Each steward reads root plus its closest scoped `AGENTS.md`.
+- Each steward advocates only for that domain's interests.
+- Each steward returns findings in the Steward Signal Format.
+- The implementing agent owns synthesis and final decisions.
+- Keep PR scope bounded to accepted findings and their proof/collateral.
+- Defer unrelated steward suggestions to not-now/follow-up.
+
+For backlog, roadmap, or prioritization work, consult all scoped stewards and
+produce raw steward signals, confidence, dependencies, risks, convergence,
+minority reports, ranked backlog, and not-now items.
+
+## Steward Feedback Loop
+
+- **Steward miss:** when a bug escapes an applicable steward, update the
+  checklist, a regression test, a docs/snippet check, a routing rule, or record
+  why the miss should not become policy.
+- **Steward overreach:** when a steward repeatedly pulls unrelated work into
+  PRs, narrow the checklist, split the steward, or move the concern to
+  follow-up.
+- Repeated high-quality findings should become checklist items.
+- Repeated noisy findings should be pruned or clarified.
+- Steward guidance evolves from escaped bugs, late collateral updates,
+  CI/review misses, and recurring review comments.
+
+## When To Consult
+
+Consult stewards proactively for cross-boundary, public-facing,
+hard-to-reverse, performance-sensitive, concurrency-sensitive,
+security-sensitive, or contract-affecting work. Use the nearest steward for
+local work. Use multiple stewards when ownership lines cross, such as
+core/rendering, build/incremental/cache, protocols/plugins/tests, or
+site/default-theme. Parallelize consultation only when questions are
+independent. Keep final synthesis and implementation accountability with the
+implementing agent.
+
+## Ask Stewards
+
+Trigger phrase: `ask stewards`.
+
+For implementation work, consult affected stewards and return synthesis before
+or during the change. Include accepted/deferred findings, merged duplicates,
+minority reports, required proof, collateral updates, and not-now items.
+
+For multi-surface work, include a parity matrix like:
+
+| Contract | API/CLI | Programmatic | Protocol | Schema/Types | Docs | Examples | Tests |
+|---|---|---|---|---|---|---|---|
+
+For backlog, roadmap, or prioritization, consult all scoped stewards and rank
+work by convergence, blast radius, dependency order, risk reduction,
+reversibility, public contracts, free-threading, and user-visible correctness.
 
 ## Extension Routing
 
@@ -149,6 +204,8 @@ Trigger phrase: **"ask stewards"**.
   in `register_all()`. No auto-discovery.
 - **Content type strategy:** use `bengal new content-type <name>` or register a
   `ContentTypeStrategy` from `bengal/content_types/`.
+- **Plugin hook:** evolve `bengal/protocols/` and `bengal/plugins/` together,
+  with contract tests and migration notes.
 - **CLI command:** add a Milo command under `bengal/cli/milo_commands/` and
   register it with `cli.lazy_command(...)` in `bengal/cli/milo_app.py`. Use
   annotated parameters, dict returns, and CLI render helpers; do not `print()`.
@@ -164,12 +221,15 @@ Trigger phrase: **"ask stewards"**.
 - `ruff format` and `ruff check --fix` are clean.
 - Tests cover the interesting path, including failure paths and malformed input
   where relevant.
-- Free-threading-sensitive changes state what shared mutable state was
-  considered.
+- Docs, examples, scaffolds, and templates are updated for user-facing changes.
+- Free-threading, performance, or security-sensitive changes state what shared
+  state, hot path, or trust boundary was considered.
 - User-facing changes under `bengal/` include a `changelog.d/` fragment.
 - Public API or plugin protocol changes include migration notes.
 - Errors use `BengalError` with useful `code`, `context`, `suggestion`, and
   `debug_payload` where appropriate.
+- Every accepted steward finding has test/docs/example/benchmark proof or an
+  explicit no-impact note.
 - `check-cycles` passes when imports move.
 - PR description explains why. The diff explains what.
 
@@ -179,10 +239,11 @@ Tests passing is not the same as done.
 
 - One concern per PR unless a broad rename is the concern.
 - Commit style: `<scope>: <description>`, using scopes such as `core`,
-  `orchestration`, `rendering`, `cache`, `cli`, `tests`, `docs`, `deps`,
-  or `release`.
-- Flag surprises: weird tests, dead code, unused config, changed allow-lists,
-  stale docs, or anything that looked load-bearing.
+  `orchestration`, `rendering`, `cache`, `cli`, `tests`, `docs`, `deps`, or
+  `release`.
+- Flag surprises: weird tests, unused public names, suppressions, dead code,
+  changed allow-lists, stale docs, benchmark gaps, free-threading assumptions,
+  steward disagreement, or deferred/not-now findings.
 - Do not silently delete dead code you found while doing unrelated work.
 
 ## When This File Is Wrong

--- a/benchmarks/AGENTS.md
+++ b/benchmarks/AGENTS.md
@@ -1,0 +1,62 @@
+# Benchmarks Steward
+
+The `benchmarks/` suite measures Bengal's build, parsing, rendering,
+highlighting, cache, and free-threading claims outside the fast test loop.
+Benchmarks should be reproducible enough to guide engineering decisions without
+blocking ordinary development.
+
+Related docs:
+- root `../AGENTS.md`
+- `README.md`
+- `../tests/performance/README.md`
+- `../site/content/docs/about/benchmarks.md`
+- `../site/content/docs/building/performance/`
+
+## Point Of View
+
+Benchmarks represent Bengal's published performance story. They should measure
+real work at realistic sizes and make environment assumptions explicit.
+
+## Protect
+
+- Scenario generation, site sizes, and benchmark categories.
+- Comparability of saved baselines.
+- Parser/template/highlighter comparisons that still reflect current supported
+  engines.
+- Memory and scaling measurements for 3.14 and 3.14t.
+
+## Contract Checklist
+
+- Benchmark docs and performance docs when numbers, scenarios, or supported
+  engines change.
+- Tests/performance steward when benchmark logic overlaps regression tests.
+- Setup instructions for standalone and b-stack workspace installs.
+- Baseline save/compare notes for claims used in PRs or docs.
+
+## Advocate
+
+- Removing stale comparisons only after preserving the claim they used to test.
+- Scenario fixtures that model docs-heavy, directive-heavy, and large-site
+  workloads.
+- Clear commands for quick vs full measurement.
+
+## Serve Peers
+
+- Give rendering, orchestration, cache, and parser stewards measured evidence.
+- Give planning realistic estimates and regression risk.
+- Give docs performance claims with dated, reproducible context.
+
+## Do Not
+
+- Let stale engine names or deleted backends remain in active benchmark claims.
+- Compare runs without noting Python version, threading mode, and hardware.
+- Treat benchmark-only speedups as valid if correctness work disappeared.
+- Add dependencies just for a benchmark convenience without asking.
+
+## Own
+
+- `benchmarks/`
+- `benchmarks/README.md`
+- Performance docs that cite benchmark results
+- Checks: `uv run pytest benchmarks -q --benchmark-disable` for import/smoke coverage
+- Checks: `uv run pytest benchmarks/ tests/performance/ -v --benchmark-only` for measured runs

--- a/bengal/assets/AGENTS.md
+++ b/bengal/assets/AGENTS.md
@@ -1,0 +1,61 @@
+# Assets Steward
+
+Assets protect the files readers actually download: copied static files,
+fingerprinted theme assets, manifests, CSS/JS bundling, and references embedded
+in rendered pages.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/rendering/assets-pipeline.md`
+- `../../site/content/docs/theming/assets/`
+- `../../bengal/themes/default/assets/css/README.md`
+
+## Point Of View
+
+Assets represent browser correctness and deployment reliability. Every copied,
+fingerprinted, bundled, or referenced file must exist where rendered HTML says
+it exists.
+
+## Protect
+
+- Asset discovery, deduplication, manifest generation, and baseurl handling.
+- Fingerprint stability and invalidation when asset content changes.
+- CSS/JS bundling without adding npm or Node to the build path.
+- Atomic output writes and generated artifact references.
+
+## Contract Checklist
+
+- Tests under `tests/unit/assets/`, theme asset tests, rendering asset URL
+  tests, and integration asset manifest tests.
+- Assets pipeline docs, theming assets docs, and default-theme asset READMEs.
+- Cache/incremental collateral when asset changes affect rebuild decisions.
+- Health/audit collateral for broken asset references.
+- Changelog for user-visible asset output or URL behavior changes.
+
+## Advocate
+
+- Manifest entries that can explain source, output path, hash, and owner.
+- Small fixtures for baseurl, installed theme assets, and duplicate asset names.
+- CSS/JS optimizations that preserve reader behavior and accessibility.
+
+## Serve Peers
+
+- Give rendering and default theme stable asset URLs.
+- Give postprocess, health, and audit complete output artifact data.
+- Give docs truthful theming asset examples.
+
+## Do Not
+
+- Add an npm, Node, or external JS build step.
+- Write assets outside atomic output helpers.
+- Change fingerprint or manifest semantics without invalidation tests.
+- Ignore missing asset references because the page still renders.
+
+## Own
+
+- `bengal/assets/`
+- `site/content/docs/reference/architecture/rendering/assets-pipeline.md`
+- `site/content/docs/theming/assets/`
+- Tests: `tests/unit/assets/`, asset rendering/integration tests
+- Checks: `uv run pytest tests/unit/assets tests/integration/test_assets_manifest.py tests/integration/test_installed_theme_asset_build.py -q`
+- Checks: `uv run ruff check bengal/assets tests/unit/assets`

--- a/bengal/autodoc/AGENTS.md
+++ b/bengal/autodoc/AGENTS.md
@@ -1,0 +1,62 @@
+# Autodoc Steward
+
+Autodoc turns Python, CLI, and OpenAPI sources into virtual documentation pages.
+It must be resilient because it analyzes user projects and should not import or
+execute their code during extraction.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/subsystems/autodoc.md`
+- `../../site/content/docs/content/sources/autodoc.md`
+- `../../plan/epic-openapi-rest-layout-upgrade.md`
+
+## Point Of View
+
+Autodoc represents developers who expect API docs to reflect source truth
+without side effects. Extraction should be static, recoverable, and honest about
+partial failures.
+
+## Protect
+
+- Zero-import Python extraction using AST/static analysis.
+- `DocElement` model serialization and virtual page generation.
+- Configured source discovery, grouping, exclude patterns, and source links.
+- Resilience for syntax errors, malformed annotations, partial OpenAPI specs,
+  and missing docstrings.
+
+## Contract Checklist
+
+- Tests under `tests/unit/autodoc/` and integration autodoc builds.
+- Autodoc docs, template docs, and default-theme API-reference templates.
+- Cache/incremental collateral for extractor caching and virtual pages.
+- Output format/search collateral when generated API pages are indexed.
+- Changelog for user-visible autodoc behavior.
+
+## Advocate
+
+- Static extraction over importing user modules.
+- Edge-case fixtures for nested classes, overloaded methods, aliases, schemas,
+  and malformed inputs.
+- Clear diagnostics that identify source path, object, extractor, and recovery.
+
+## Serve Peers
+
+- Give rendering virtual pages with stable metadata and template context.
+- Give cache/incremental stable content hashes and dependency paths.
+- Give site docs accurate examples for Python, CLI, and OpenAPI sources.
+
+## Do Not
+
+- Import user code to discover docs.
+- Drop malformed elements silently when a warning would preserve trust.
+- Change `DocElement` shape without cache and template collateral.
+- Treat extractor crashes as full-build crashes when partial recovery is safe.
+
+## Own
+
+- `bengal/autodoc/`
+- `site/content/docs/reference/architecture/subsystems/autodoc.md`
+- `site/content/docs/content/sources/autodoc.md`
+- Tests: `tests/unit/autodoc/`, autodoc integration tests
+- Checks: `uv run pytest tests/unit/autodoc tests/integration/test_autodoc_html_generation.py -q`
+- Checks: `uv run ruff check bengal/autodoc tests/unit/autodoc`

--- a/bengal/build/AGENTS.md
+++ b/bengal/build/AGENTS.md
@@ -1,0 +1,58 @@
+# Build Contracts Steward
+
+The `bengal/build/` package holds lower-level build contracts, provenance, and
+detector utilities that other orchestration layers depend on. Its names are
+load-bearing even when orchestration owns the user-visible build flow.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/core/pipeline.md`
+- `../../site/content/docs/reference/architecture/core/cache.md`
+- `../../plan/rfc-provenance-mtime-short-circuit.md`
+
+## Point Of View
+
+Build contracts represent the typed facts that make provenance, detectors, and
+phase handoffs verifiable. They should stay small and stable enough for cache
+and orchestration code to share.
+
+## Protect
+
+- Contract dataclasses, keys, result shapes, and provenance record semantics.
+- Mtime short-circuit correctness and conservative fallback behavior.
+- Compatibility with orchestration build phases and cache persistence.
+- Type stability for tests and downstream internal callers.
+
+## Contract Checklist
+
+- `tests/unit/build/contracts/` and `tests/unit/build/provenance/`.
+- Cache and orchestration tests when keys, inputs, or result shapes change.
+- Architecture docs and RFCs that mention build/provenance package names.
+- Changelog for user-visible rebuild behavior changes.
+
+## Advocate
+
+- Narrow typed contracts instead of sharing raw dicts between phases.
+- Provenance evidence that can explain rebuild decisions.
+- Explicit stale/unknown states over optimistic skips.
+
+## Serve Peers
+
+- Give orchestration clear phase inputs and outputs.
+- Give cache and incremental stewards stable provenance keys.
+- Give tests small contract fixtures independent from full site builds.
+
+## Do Not
+
+- Treat provenance shortcuts as performance-only changes.
+- Change keys or result schemas without migration/fallback tests.
+- Add build orchestration behavior here when `bengal/orchestration/` owns it.
+- Let stale plan references misname this package without a verification note.
+
+## Own
+
+- `bengal/build/contracts/` and `bengal/build/provenance/`
+- Tests: `tests/unit/build/contracts/`, `tests/unit/build/provenance/`
+- Relevant provenance and cache architecture docs/RFCs
+- Checks: `uv run pytest tests/unit/build/contracts tests/unit/build/provenance -q`
+- Checks: `uv run ruff check bengal/build tests/unit/build`

--- a/bengal/cache/AGENTS.md
+++ b/bengal/cache/AGENTS.md
@@ -3,10 +3,10 @@
 Cache code protects rebuild correctness and repeatability. A cache hit is a
 claim that the rendered output is still trustworthy.
 
-Related architecture docs:
-
-- `../../AGENTS.md`
+Related docs:
+- root `../../AGENTS.md`
 - `../../site/content/docs/reference/architecture/core/cache.md`
+- `../../plan/rfc-output-cache-architecture.md`
 
 ## Point Of View
 
@@ -19,6 +19,16 @@ atomic, deterministic, and honest about whether a hit can be trusted.
 - Atomic persistence and crash safety.
 - Explicit migration paths for old cache shapes.
 - Deterministic serialization for free-threaded builds.
+- Distinct behavior for misses, stale entries, corruption, and migration.
+
+## Contract Checklist
+
+- Cache tests under `tests/unit/cache/` plus warm-build and incremental
+  integration tests.
+- Provenance/build-cache docs and migration notes when schemas or keys change.
+- Performance notes when cache behavior changes rebuild speed or storage.
+- Changelog for user-visible cache behavior, invalidation, or diagnostics.
+- Atomic write proof for every persisted file path.
 
 ## Advocate
 
@@ -44,9 +54,9 @@ atomic, deterministic, and honest about whether a hit can be trusted.
 
 ## Own
 
-- Own `site/content/docs/reference/architecture/core/cache.md`.
-- Keep performance docs accurate when cache behavior changes rebuild speed or storage.
-- Update migration notes when cache schema compatibility changes.
-- `uv run pytest tests/unit/cache tests/unit/discovery -q`
-- `uv run pytest tests/integration/test_phase2b_cache_integration.py -q`
-- `uv run ruff check bengal/cache tests/unit/cache`
+- `site/content/docs/reference/architecture/core/cache.md`
+- Cache migration and performance notes
+- Tests: `tests/unit/cache/`, warm-build cache integrations
+- Checks: `uv run pytest tests/unit/cache tests/unit/discovery -q`
+- Checks: `uv run pytest tests/integration/test_phase2b_cache_integration.py -q`
+- Checks: `uv run ruff check bengal/cache tests/unit/cache`

--- a/bengal/cli/AGENTS.md
+++ b/bengal/cli/AGENTS.md
@@ -3,33 +3,58 @@
 The CLI is a user-facing contract. Commands should be fast to import, explicit
 to discover, structured for machines, and helpful for humans.
 
-Related architecture docs:
-
-- `../../AGENTS.md`
+Related docs:
+- root `../../AGENTS.md`
 - `../../site/content/docs/reference/architecture/tooling/cli.md`
+- `../../README.md`
+- `../../CONTRIBUTING.md`
+
+## Point Of View
+
+CLI represents site authors and automation. It should be predictable for
+scripts while giving humans clear next steps when something goes wrong.
 
 ## Protect
 
 - Milo command patterns: annotated parameters, lazy registration, dict returns.
-- Stable command names, flags, and structured output.
+- Stable command names, aliases, flags, structured output, and exit behavior.
 - Clear errors and tips for site authors.
-- Cold-start performance.
+- Cold-start performance and limited import fan-out.
+
+## Contract Checklist
+
+- CLI tests under `tests/unit/cli/` and smoke/integration CLI tests.
+- README, site docs, snippets, and generated help examples.
+- Config, plugin, health, build, and scaffold stewards for commands that route
+  to their domains.
+- Changelog and migration notes for command/flag/output changes.
+- Wheel/install smoke tests for packaging-visible command changes.
+
+## Advocate
+
+- Structured output envelopes for machine-readable commands.
+- Command examples that match actual help output and defaults.
+- Lazy imports and narrow command modules for startup speed.
+
+## Serve Peers
+
+- Give config, build, health, plugins, and scaffolds stable entrypoints.
+- Give docs exact help text and runnable examples.
+- Give tests command-level proof for user-facing workflows.
 
 ## Do Not
 
 - Add Click-style decorators or parser construction shortcuts.
-- `print()` command results instead of returning structured data or using CLI render helpers.
+- `print()` command results instead of returning structured data or using CLI
+  render helpers.
 - Add broad imports at CLI startup.
 - Change public flags without migration notes.
 
-## Documentation Ownership
+## Own
 
-- Own `site/content/docs/reference/architecture/tooling/cli.md`.
-- Keep command examples and help-output docs in sync with Milo command changes.
-- Update migration notes when flags, command names, or structured output changes.
-
-## Local Checks
-
-- `uv run pytest tests/unit/cli tests/integration/test_cli_help.py -q`
-- `uv run ruff check bengal/cli tests/unit/cli`
+- `site/content/docs/reference/architecture/tooling/cli.md`
+- CLI examples in README and site docs
+- Tests: `tests/unit/cli/`, CLI integration smoke tests
+- Checks: `uv run pytest tests/unit/cli tests/integration/test_cli_smoke.py tests/integration/test_cli_output_integration.py -q`
+- Checks: `uv run ruff check bengal/cli tests/unit/cli`
 - Run wheel/install smoke tests for packaging-visible command changes.

--- a/bengal/config/AGENTS.md
+++ b/bengal/config/AGENTS.md
@@ -1,0 +1,61 @@
+# Configuration Steward
+
+Configuration controls how authors shape builds, content behavior, environments,
+profiles, and template-visible params. It is a public contract across CLI,
+programmatic use, docs, scaffolds, and tests.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/tooling/config.md`
+- `../../site/content/docs/building/configuration/`
+- `../../site/config/`
+
+## Point Of View
+
+Configuration represents site authors who need predictable defaults,
+overrides, origins, and validation. It should make behavior explainable without
+requiring readers to inspect Python.
+
+## Protect
+
+- Config file discovery, merge precedence, environment/profile overrides, and
+  origin tracking.
+- Typed/default config behavior that templates and orchestration rely on.
+- Validation errors with concrete suggestions.
+- Backward-compatible key names and migration behavior.
+
+## Contract Checklist
+
+- Tests under `tests/unit/config/` and integration config workflows.
+- CLI docs for `bengal config`, build/serve flags, and environment detection.
+- Scaffolds and site templates that generate config files.
+- Programmatic API examples using `ConfigLoader`.
+- Changelog/migration notes for key, default, or precedence changes.
+
+## Advocate
+
+- Origin-aware diagnostics for confusing merges.
+- Conservative defaults that keep new sites building.
+- Typed accessors or validators before ad hoc dict assumptions spread.
+
+## Serve Peers
+
+- Give orchestration stable build options and environment context.
+- Give rendering/theme dependable params and template-visible values.
+- Give site docs and scaffolds truthful config examples.
+
+## Do Not
+
+- Add config keys without docs, defaults, validation, and tests.
+- Change precedence silently.
+- Treat environment variables as invisible magic; document and test them.
+- Let scaffolds emit config that docs do not explain.
+
+## Own
+
+- `bengal/config/`
+- `site/content/docs/reference/architecture/tooling/config.md`
+- `site/content/docs/building/configuration/`
+- Tests: `tests/unit/config/`, config integration tests
+- Checks: `uv run pytest tests/unit/config tests/integration/test_config_system_integration.py -q`
+- Checks: `uv run ruff check bengal/config tests/unit/config`

--- a/bengal/content_types/AGENTS.md
+++ b/bengal/content_types/AGENTS.md
@@ -1,0 +1,61 @@
+# Content Types Steward
+
+Content types define how authored pages are classified, routed, templated, and
+presented. They are an extension surface because custom strategies can change
+site structure and template selection.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/core/content-types.md`
+- `../../site/content/docs/content/organization/component-model.md`
+- `../../site/content/docs/extending/custom-skeletons.md`
+
+## Point Of View
+
+Content types represent authors who expect frontmatter, scaffold defaults, and
+template selection to produce the right kind of page without surprise.
+
+## Protect
+
+- Built-in content type strategy behavior and custom strategy registration.
+- Template selection, URL behavior, and section/page classification contracts.
+- Compatibility with scaffolds, frontmatter docs, and default theme templates.
+- Clear errors for unknown or malformed content type values.
+
+## Contract Checklist
+
+- Tests under `tests/unit/content_types/` and content-type orchestration tests.
+- Architecture content-type docs, frontmatter docs, scaffold docs, and template
+  docs when strategy behavior changes.
+- CLI collateral for `bengal new content-type <name>` and scaffold generation.
+- Changelog for user-visible classification or template-selection changes.
+
+## Advocate
+
+- Strategy APIs that stay narrow and documented.
+- Test roots that demonstrate custom and built-in type behavior.
+- Diagnostics that distinguish unknown type, missing template, and invalid
+  frontmatter.
+
+## Serve Peers
+
+- Give scaffolds and docs accurate built-in type names and defaults.
+- Give rendering/theme stable template-selection expectations.
+- Give orchestration clear classification before build phases run.
+
+## Do Not
+
+- Add a content type without templates, docs, scaffold implications, and tests.
+- Make classification depend on implicit filesystem guesses without documenting
+  precedence.
+- Widen public strategy contracts for one internal shortcut.
+- Hide malformed frontmatter by silently falling back to a generic type.
+
+## Own
+
+- `bengal/content_types/`
+- `site/content/docs/reference/architecture/core/content-types.md`
+- Content organization and custom skeleton docs when types affect examples
+- Tests: `tests/unit/content_types/`, content-type orchestration tests
+- Checks: `uv run pytest tests/unit/content_types tests/unit/orchestration/test_content_type_detection.py tests/unit/orchestration/test_content_type_urls.py -q`
+- Checks: `uv run ruff check bengal/content_types tests/unit/content_types`

--- a/bengal/core/AGENTS.md
+++ b/bengal/core/AGENTS.md
@@ -1,11 +1,14 @@
 # Core Steward
 
 This directory protects Bengal's passive domain model. Core objects describe
-state, identity, relationships, and cacheable facts. They do not perform I/O,
-log directly, or own rendering behavior.
+state, identity, relationships, and cacheable facts without performing I/O,
+logging directly, or owning rendering behavior.
 
-Start with the root guidance in `../../AGENTS.md`, then use this file for the
-local boundary.
+Related docs:
+- root `../../AGENTS.md`
+- `../../CLAUDE.md`
+- `../../site/content/docs/reference/architecture/core/object-model.md`
+- `../../site/content/docs/reference/architecture/design-principles.md`
 
 ## Point Of View
 
@@ -15,10 +18,26 @@ rendered, logs are emitted, or outputs are written.
 
 ## Protect
 
-- Passive objects: `Site`, `Page`, `Section`, `PageCore`, records, registries.
-- Compatibility shims that preserve existing template/plugin access.
-- Deferred imports where core reaches into rendering only from a shim.
+- Passive objects: `Site`, `Page`, `Section`, `PageCore`, records, registries,
+  and value objects.
+- Compatibility shims that preserve existing template/plugin access while
+  delegating presentation elsewhere.
+- Deferred imports where core reaches into rendering or orchestration only from
+  a compatibility shim.
 - The empty core mixin allow-list in `tests/unit/core/test_no_core_mixins.py`.
+- Import-linter contracts that keep page/section coupled to `SiteContext`
+  instead of concrete `Site`.
+
+## Contract Checklist
+
+- Unit and architecture guards: `tests/unit/core/`, `tests/core/`,
+  `tests/unit/core/test_no_core_mixins.py`, `.importlinter`.
+- Protocol impact: `bengal/protocols/`, `tests/unit/protocols/`, template-facing
+  compatibility properties.
+- Rendering impact: Page/Section shims must have rendering-side proof when
+  derived content, URLs, TOCs, excerpts, or resource views change.
+- Docs: core object-model and design-principle docs under `site/content/docs/`.
+- Changelog: required when user-facing behavior under `bengal/` changes.
 
 ## Advocate
 
@@ -46,9 +65,9 @@ rendered, logs are emitted, or outputs are written.
 
 ## Own
 
-- Keep `site/content/docs/reference/architecture/core/` aligned with core boundaries.
-- Update `site/content/docs/reference/architecture/design-principles.md` when core's role changes.
-- Keep object model docs honest when `Page`, `Section`, `Site`, or records move behavior.
-- `uv run pytest tests/unit/core tests/core -q`
-- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
-- `uv run ruff check bengal/core tests/unit/core tests/core`
+- `site/content/docs/reference/architecture/core/`
+- `site/content/docs/reference/architecture/design-principles.md`
+- `tests/unit/core/`, `tests/core/`, and core import-linter expectations
+- Checks: `uv run pytest tests/unit/core tests/core -q`
+- Checks: `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
+- Checks: `uv run ruff check bengal/core tests/unit/core tests/core`

--- a/bengal/core/page/AGENTS.md
+++ b/bengal/core/page/AGENTS.md
@@ -1,38 +1,69 @@
 # Page Steward
 
 `Page` is a compatibility surface, not a renderer. It may expose stable
-template-facing properties, but the work behind rendered content, URLs, TOC,
-excerpts, shortcode/link extraction, and bundle resource views belongs under
+template-facing properties, but rendered content, URLs, TOC, excerpts,
+shortcode/link extraction, and bundle resource views belong under
 `bengal/rendering/`.
 
-Related architecture docs:
-
-- `../../../AGENTS.md`
+Related docs:
+- root `../../../AGENTS.md`
+- `../../../CLAUDE.md`
 - `../../../site/content/docs/reference/architecture/core/object-model.md`
 - `../../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
+
+## Point Of View
+
+Page represents author content identity and compatibility for existing
+templates/plugins. It should preserve stable access while pushing derived
+presentation work to rendering helpers.
 
 ## Protect
 
 - `PageCore` as the cacheable metadata shape.
-- `Page` properties that older templates and plugins already call.
+- Existing template/plugin property names that are compatibility contracts.
 - Thin deferred shims from `Page` to rendering helpers.
-- Bundle/resource compatibility without putting filesystem or image behavior in core.
+- Bundle/resource compatibility without putting filesystem or image behavior in
+  core.
+
+## Contract Checklist
+
+- Page metadata and compatibility tests in `tests/unit/core/`, `tests/core/`,
+  and `tests/unit/rendering/test_page_*.py`.
+- Template docs for Page properties and rendering content-processing docs.
+- Protocol surfaces: `PageLike`, mocks in `tests/_testing/`, and plugin-facing
+  access.
+- Import boundaries: no module-level parser/rendering imports; rerun
+  `test_no_core_mixins.py` when helper imports move.
+
+## Advocate
+
+- Rendering helper APIs for every new derived template value.
+- Page fixtures that reproduce real frontmatter, bundles, and resource access
+  before changing compatibility behavior.
+- Deleting vestigial forwarding wrappers when callers can use the composed
+  service directly.
+
+## Serve Peers
+
+- Give rendering exact compatibility shims to preserve.
+- Give tests canonical fixtures for page metadata, cacheability, bundles, and
+  URL behavior.
+- Give docs current Page property names and migration notes.
 
 ## Do Not
 
-- Move parser, HTML, excerpt, TOC, shortcode, URL, or resource I/O logic into `Page`.
-- Add broad convenience fields to `PageCore` for values that require parsing/rendering.
-- Recreate deleted `content.py`, `metadata.py`, or relationship mixin modules as behavior sinks.
+- Move parser, HTML, excerpt, TOC, shortcode, URL, or resource I/O logic into
+  `Page`.
+- Add broad convenience fields to `PageCore` for values that require parsing or
+  rendering.
+- Recreate deleted behavior modules as dumping grounds.
 - Add `# type: ignore` to quiet Page protocol friction.
 
-## Documentation Ownership
+## Own
 
-- Own Page sections in `site/content/docs/reference/architecture/core/object-model.md`.
-- Keep `site/content/docs/reference/architecture/rendering/content-processing-api.md` accurate for Page shims.
-- Update `site/content/docs/reference/template-functions/page-properties.md` when template-facing Page access changes.
-
-## Local Checks
-
-- `uv run pytest tests/unit/rendering/test_page_content.py tests/unit/rendering/test_page_operations.py tests/unit/rendering/test_page_urls.py tests/unit/rendering/test_page_resources.py -q`
-- `uv run pytest tests/core/test_page_bundles.py tests/unit/core/test_computed_functions.py -q`
-- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
+- Page sections in `site/content/docs/reference/architecture/core/object-model.md`
+- `site/content/docs/reference/architecture/rendering/content-processing-api.md`
+- `site/content/docs/reference/template-functions/page-properties.md`
+- Checks: `uv run pytest tests/unit/rendering/test_page_content.py tests/unit/rendering/test_page_operations.py tests/unit/rendering/test_page_urls.py tests/unit/rendering/test_page_resources.py -q`
+- Checks: `uv run pytest tests/core/test_page_bundles.py tests/unit/core/test_computed_functions.py -q`
+- Checks: `uv run pytest tests/unit/core/test_no_core_mixins.py -q`

--- a/bengal/core/section/AGENTS.md
+++ b/bengal/core/section/AGENTS.md
@@ -3,18 +3,43 @@
 `Section` protects structural hierarchy, page membership, query/sort behavior,
 and version-aware structural navigation. Presentation belongs in rendering.
 
-Related architecture docs:
-
-- `../../../AGENTS.md`
+Related docs:
+- root `../../../AGENTS.md`
+- `../../../CLAUDE.md`
 - `../../../site/content/docs/reference/architecture/core/object-model.md`
 - `../../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
 
+## Point Of View
+
+Section represents the site's authored hierarchy and membership rules. It
+should answer structural questions without becoming the theme/navigation view
+model.
+
 ## Protect
 
-- Parent/child relationships, section walking, and structural identity.
-- Page retrieval, sorting, and index-page decisions.
-- Version filters that describe content membership.
+- Parent/child relationships, walking, and structural identity.
+- Page retrieval, sorting, index-page decisions, and version filters.
 - Compatibility shims for older imports and template access.
+- Deferred imports for URL and theme ergonomics.
+
+## Contract Checklist
+
+- Structure and sorting tests in `tests/unit/core/` and `tests/unit/test_nav_tree.py`.
+- Rendering-side URL and ergonomics tests.
+- Navigation template-function docs and object-model docs.
+- Protocol impact on `SectionLike` and test mocks.
+
+## Advocate
+
+- Rendering-side section URL and ergonomics helpers.
+- Explicit tests for versioned and index-page edge cases.
+- Clear docs when section membership or navigation behavior changes.
+
+## Serve Peers
+
+- Give rendering stable section structure without asking core to format URLs.
+- Give default theme predictable navigation and hierarchy data.
+- Give tests focused roots for navigation and version behavior.
 
 ## Do Not
 
@@ -24,14 +49,10 @@ Related architecture docs:
 - Hoist rendering imports to module level.
 - Treat theme ergonomics as structural domain logic.
 
-## Documentation Ownership
+## Own
 
-- Own Section sections in `site/content/docs/reference/architecture/core/object-model.md`.
-- Keep `site/content/docs/reference/architecture/rendering/content-processing-api.md` accurate for Section shims.
-- Update `site/content/docs/reference/template-functions/navigation-functions.md` when navigation-facing behavior changes.
-
-## Local Checks
-
-- `uv run pytest tests/unit/rendering/test_section_urls.py tests/unit/rendering/test_section_ergonomics.py -q`
-- `uv run pytest tests/unit/core/test_section_sorting.py tests/unit/core/test_section_versioning.py tests/unit/test_nav_tree.py -q`
-- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
+- Section sections in `site/content/docs/reference/architecture/core/object-model.md`
+- `site/content/docs/reference/template-functions/navigation-functions.md`
+- Checks: `uv run pytest tests/unit/rendering/test_section_urls.py tests/unit/rendering/test_section_ergonomics.py -q`
+- Checks: `uv run pytest tests/unit/core/test_section_sorting.py tests/unit/core/test_section_versioning.py tests/unit/test_nav_tree.py -q`
+- Checks: `uv run pytest tests/unit/core/test_no_core_mixins.py -q`

--- a/bengal/core/site/AGENTS.md
+++ b/bengal/core/site/AGENTS.md
@@ -4,18 +4,45 @@
 orchestration. It is not a place to reacquire forwarding wrappers just because a
 service exists.
 
-Related architecture docs:
-
-- `../../../AGENTS.md`
+Related docs:
+- root `../../../AGENTS.md`
+- `../../../CLAUDE.md`
 - `../../../site/content/docs/reference/architecture/core/object-model.md`
 - `../../../site/content/docs/reference/architecture/core/orchestration.md`
+- `../../../site/content/docs/reference/architecture/core/data-flow.md`
+
+## Point Of View
+
+Site represents the assembled project graph and public compatibility surface.
+It should coordinate durable state while leaving build execution, rendering,
+and presentation to their owning layers.
 
 ## Protect
 
 - Site state, registries, and lookup surfaces used by orchestration/rendering.
 - Stable compatibility behavior expected by themes and plugins.
 - The post-mixin shape of `bengal/core/site/`.
-- Clear handoff to orchestration for build work.
+- Clear handoff to orchestration for build/serve/clean behavior.
+
+## Contract Checklist
+
+- Site lifecycle and registry tests under `tests/unit/core/` and `tests/core/`.
+- Import-linter contracts and `test_no_core_mixins.py`.
+- Programmatic API docs for `Site.from_config()`, build, serve, and graph access.
+- Protocol impact on `SiteLike`, plugin hooks, and test mocks.
+- CLI/docs impact if user-visible lifecycle behavior changes.
+
+## Advocate
+
+- Composed services for real subsystems, not forwarding wrappers.
+- Migration of build and server work into orchestration/server modules.
+- Narrow protocols and adapters when downstream callers need a smaller surface.
+
+## Serve Peers
+
+- Give orchestration a clear graph and service handoff.
+- Give rendering and themes stable lookup surfaces without owning presentation.
+- Give protocols/tests realistic but narrow site contracts.
 
 ## Do Not
 
@@ -24,14 +51,11 @@ Related architecture docs:
 - Expand `SiteLike` as a shortcut for one implementation detail.
 - Reintroduce Site mixins.
 
-## Documentation Ownership
+## Own
 
-- Own Site sections in `site/content/docs/reference/architecture/core/object-model.md`.
-- Keep `site/content/docs/reference/architecture/core/orchestration.md` honest about what Site delegates.
-- Update `site/content/docs/reference/architecture/core/data-flow.md` when Site state handoffs change.
-
-## Local Checks
-
-- `uv run pytest tests/unit/core tests/core -q`
-- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
-- `uv run ruff check bengal/core/site`
+- Site sections in `site/content/docs/reference/architecture/core/object-model.md`
+- `site/content/docs/reference/architecture/core/orchestration.md`
+- `site/content/docs/reference/architecture/core/data-flow.md`
+- Checks: `uv run pytest tests/unit/core tests/core -q`
+- Checks: `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
+- Checks: `uv run ruff check bengal/core/site`

--- a/bengal/errors/AGENTS.md
+++ b/bengal/errors/AGENTS.md
@@ -3,16 +3,42 @@
 Errors are documentation for people under stress. Bengal errors should identify
 what broke, where it broke, and what the author can do next.
 
-Related architecture docs:
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/errors/`
+- `../../site/content/docs/building/troubleshooting/`
 
-- `../../AGENTS.md`
+## Point Of View
+
+Errors represent the author at the moment Bengal failed them. Messages should
+preserve context, avoid blame, and provide a credible next action.
 
 ## Protect
 
 - `BengalError` with `code`, `context`, `suggestion`, and `debug_payload`.
 - Reader-facing messages with concrete next steps.
-- Diagnostics that preserve source path and phase context.
+- Diagnostics that preserve source path, phase, and user input context.
 - Error rendering that does not introduce rendering/core import cycles.
+
+## Contract Checklist
+
+- Error tests under `tests/unit/errors/`, health/report tests, and CLI error
+  display tests.
+- Error reference docs, troubleshooting docs, and examples using error codes.
+- Changelog/migration notes when error codes or structured fields change.
+- Import-cycle checks when display/rendering code moves.
+
+## Advocate
+
+- Error codes and suggestions for recurring author mistakes.
+- Aggregated diagnostics that avoid hiding individual failures.
+- Tests for malformed input, not just happy-path formatting.
+
+## Serve Peers
+
+- Give CLI and health structured errors that render consistently.
+- Give docs stable codes and troubleshooting paths.
+- Give core a diagnostic sink instead of direct logging.
 
 ## Do Not
 
@@ -21,14 +47,11 @@ Related architecture docs:
 - Log directly from `bengal/core/`.
 - Hide malformed user input behind fallback behavior.
 
-## Documentation Ownership
+## Own
 
-- Own `site/content/docs/reference/errors/`.
-- Keep troubleshooting docs, including `site/content/docs/building/troubleshooting/template-errors.md`, aligned with user-facing errors.
-- Update examples when `BengalError` context, codes, or suggestions change.
-
-## Local Checks
-
-- `uv run pytest tests/unit/errors tests/unit/health -q`
-- `uv run ruff check bengal/errors tests/unit/errors`
+- `site/content/docs/reference/errors/`
+- Troubleshooting docs, including template error docs
+- Tests: `tests/unit/errors/`, CLI error tests, health error paths
+- Checks: `uv run pytest tests/unit/errors tests/unit/health tests/unit/cli/test_error_display.py -q`
+- Checks: `uv run ruff check bengal/errors tests/unit/errors`
 - Search for broad exception handling when touching error paths.

--- a/bengal/health/AGENTS.md
+++ b/bengal/health/AGENTS.md
@@ -1,0 +1,63 @@
+# Health Steward
+
+Health checks validate source content and author-facing policy. They should find
+problems early, explain next steps, and stay distinct from generated artifact
+audits.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/subsystems/health.md`
+- `../../site/content/docs/content/validation/validate-and-fix.md`
+- `../../plan/rfc-health-diagnostics-audit.md`
+
+## Point Of View
+
+Health represents authors trying to trust a site before publishing. It should
+surface broken links, policy issues, and quality risks with evidence and
+actionable recommendations.
+
+## Protect
+
+- Source policy checks under `bengal check` and compatibility alias behavior.
+- Validator independence, result envelopes, severity ordering, and diagnostics.
+- Separation from `bengal audit` artifact scanning.
+- Link/reference truth shared with rendering registries without duplicating
+  ownership.
+
+## Contract Checklist
+
+- Tests under `tests/unit/health/` and health validator integration tests.
+- CLI output envelopes, JSON formats, docs, and troubleshooting snippets.
+- Rendering/reference registry collateral for link and anchor validation.
+- Config docs when validator enablement, thresholds, or defaults change.
+- Changelog for user-visible validation behavior.
+
+## Advocate
+
+- Validator messages that name the file/page, why it matters, and the fix.
+- Narrow validators with cheap execution and clear failure boundaries.
+- Regression fixtures for malformed content, broken links, and false positives.
+
+## Serve Peers
+
+- Give rendering precise feedback when generated references are ambiguous.
+- Give CLI structured result envelopes and progressive human output.
+- Give docs and scaffolds checks that keep examples publishable.
+
+## Do Not
+
+- Mix generated artifact audit policy back into source health checks.
+- Swallow validator crashes without a result that names the validator and site
+  context.
+- Treat all link failures as the same class of problem.
+- Add validators that require broad global state or unpredictable network work
+  in normal builds.
+
+## Own
+
+- `bengal/health/`
+- `site/content/docs/reference/architecture/subsystems/health.md`
+- `site/content/docs/content/validation/validate-and-fix.md`
+- Tests: `tests/unit/health/`
+- Checks: `uv run pytest tests/unit/health -q`
+- Checks: `uv run ruff check bengal/health tests/unit/health`

--- a/bengal/orchestration/AGENTS.md
+++ b/bengal/orchestration/AGENTS.md
@@ -4,18 +4,49 @@ Orchestration coordinates discovery, build phases, rendering batches,
 provenance, cache policy, and output writing. It should make sequencing clear
 without absorbing domain or rendering behavior.
 
-Related architecture docs:
-
-- `../../AGENTS.md`
+Related docs:
+- root `../../AGENTS.md`
 - `../../site/content/docs/reference/architecture/core/orchestration.md`
 - `../../site/content/docs/reference/architecture/core/data-flow.md`
+- `../../site/content/docs/reference/architecture/core/pipeline.md`
+
+## Point Of View
+
+Orchestration represents the build lifecycle. It should connect services and
+phase outputs without becoming the owner of content semantics, presentation, or
+extension contracts.
 
 ## Protect
 
-- Build phase clarity and ordering.
+- Build phase clarity, ordering, and user-visible lifecycle behavior.
 - Plugin hook timing and compatibility.
 - Atomic output writes through approved helpers.
 - Boundaries between discovery, rendering, postprocess, and cache/provenance.
+- Incremental/full build parity.
+
+## Contract Checklist
+
+- Unit tests under `tests/unit/orchestration/` and integration build workflows.
+- Build docs, data-flow docs, and extension-point docs when phase handoffs or
+  hook timing change.
+- CLI output/docs when build command behavior, warnings, or artifacts change.
+- Cache/provenance and incremental collateral for rebuild decisions.
+- Changelog for user-visible build behavior.
+
+## Advocate
+
+- Observable phase inputs, outputs, timing, and diagnostics.
+- Plugin hook usage over custom phase additions when extension behavior is
+  needed mid-build.
+- Integration tests for phase changes that affect caches, generated artifacts,
+  command output, or incremental rebuilds.
+
+## Serve Peers
+
+- Give rendering clear batch inputs and do not mix presentation work into phase
+  coordinators.
+- Give cache/incremental precise invalidation and provenance events.
+- Give CLI and site docs stable build output behavior to explain.
 
 ## Do Not
 
@@ -24,14 +55,11 @@ Related architecture docs:
 - Write files non-atomically.
 - Move domain convenience behavior into orchestration just to share it.
 
-## Documentation Ownership
+## Own
 
-- Own `site/content/docs/reference/architecture/core/orchestration.md`.
-- Keep `site/content/docs/reference/architecture/core/data-flow.md` accurate for phase handoffs.
-- Update extension-point docs when orchestration changes plugin hook timing.
-
-## Local Checks
-
-- `uv run pytest tests/unit/orchestration tests/integration -q`
-- `uv run ruff check bengal/orchestration tests/unit/orchestration`
-- `make changelog-check` for behavior-visible changes.
+- `site/content/docs/reference/architecture/core/orchestration.md`
+- `site/content/docs/reference/architecture/core/data-flow.md`
+- Extension-point docs for orchestration hook timing
+- Checks: `uv run pytest tests/unit/orchestration tests/integration -q`
+- Checks: `uv run ruff check bengal/orchestration tests/unit/orchestration`
+- Checks: `make changelog-check` for behavior-visible changes

--- a/bengal/orchestration/build/AGENTS.md
+++ b/bengal/orchestration/build/AGENTS.md
@@ -3,10 +3,10 @@
 The numbered build pipeline is intentionally explicit. Phase changes affect
 cache correctness, plugin hook timing, user output, and incremental rebuilds.
 
-Related architecture docs:
-
-- `../../../AGENTS.md`
+Related docs:
+- root `../../../AGENTS.md`
 - `../../../site/content/docs/reference/architecture/core/orchestration.md`
+- `../../../site/content/docs/reference/architecture/core/pipeline.md`
 
 ## Point Of View
 
@@ -20,6 +20,15 @@ without hiding behavior in phase coordinators.
 - Clear inputs and outputs for each phase.
 - Atomic finalization and output safety.
 - Explicit callbacks for observability instead of hidden side effects.
+
+## Contract Checklist
+
+- Unit tests in `tests/unit/orchestration/build/`.
+- Integration tests for full build, incremental parity, artifact inventory, and
+  finalization.
+- Docs for phase order, pipeline inputs/outputs, and plugin hook timing.
+- Cache/provenance collateral when phases add, remove, or rename artifacts.
+- Changelog for user-visible output or command behavior.
 
 ## Advocate
 
@@ -47,9 +56,9 @@ without hiding behavior in phase coordinators.
 
 ## Own
 
-- Own build-phase descriptions in `site/content/docs/reference/architecture/core/orchestration.md`.
-- Keep `site/content/docs/reference/architecture/core/pipeline.md` aligned with phase inputs/outputs.
-- Update user-facing build docs when phase behavior affects command output or artifacts.
-- `uv run pytest tests/unit/orchestration/build -q`
-- `uv run pytest tests/integration/test_incremental_invariants.py -q`
-- `uv run ruff check bengal/orchestration/build`
+- Build-phase descriptions in `site/content/docs/reference/architecture/core/orchestration.md`
+- `site/content/docs/reference/architecture/core/pipeline.md`
+- User-facing build docs when phases affect command output or artifacts
+- Checks: `uv run pytest tests/unit/orchestration/build -q`
+- Checks: `uv run pytest tests/integration/test_incremental_invariants.py -q`
+- Checks: `uv run ruff check bengal/orchestration/build`

--- a/bengal/orchestration/incremental/AGENTS.md
+++ b/bengal/orchestration/incremental/AGENTS.md
@@ -3,10 +3,11 @@
 Incremental orchestration protects the promise that a rebuild is both fast and
 correct. Stale content is worse than a failed build because authors trust it.
 
-Related architecture docs:
-
-- `../../../AGENTS.md`
+Related docs:
+- root `../../../AGENTS.md`
 - `../../../site/content/docs/reference/architecture/core/cache.md`
+- `../../../site/content/docs/building/performance/template-deps.md`
+- `../../../plan/rfc-incremental-build-observability.md`
 
 ## Point Of View
 
@@ -16,9 +17,18 @@ correct rebuilds. When uncertain, it should rebuild and explain why.
 ## Protect
 
 - Dependency tracking and invalidation correctness.
-- Provenance of content, templates, data, assets, and config.
+- Provenance of content, templates, data, assets, config, and generated pages.
 - Conservative rebuilds when uncertainty exists.
 - Clear diagnostics for why a page did or did not rebuild.
+
+## Contract Checklist
+
+- Tests in `tests/unit/orchestration/incremental/`,
+  `tests/integration/warm_build/`, and incremental invariants.
+- Cache/provenance tests when dependency keys or invalidation reasons change.
+- Performance docs and benchmark notes for warm-build speed claims.
+- Troubleshooting/docs when diagnostics or rebuild explanations change.
+- Changelog for user-visible rebuild behavior.
 
 ## Advocate
 
@@ -43,9 +53,9 @@ correct rebuilds. When uncertain, it should rebuild and explain why.
 
 ## Own
 
-- Own incremental sections in `site/content/docs/reference/architecture/core/cache.md`.
-- Keep `site/content/docs/building/performance/template-deps.md` accurate for dependency behavior.
-- Update troubleshooting docs when invalidation diagnostics change.
-- `uv run pytest tests/unit/orchestration/incremental tests/integration/warm_build -q`
-- `uv run pytest tests/integration/test_incremental_invariants.py -q`
-- `uv run ruff check bengal/orchestration/incremental`
+- Incremental sections in `site/content/docs/reference/architecture/core/cache.md`
+- `site/content/docs/building/performance/template-deps.md`
+- Troubleshooting docs for invalidation diagnostics
+- Checks: `uv run pytest tests/unit/orchestration/incremental tests/integration/warm_build -q`
+- Checks: `uv run pytest tests/integration/test_incremental_invariants.py -q`
+- Checks: `uv run ruff check bengal/orchestration/incremental`

--- a/bengal/plugins/AGENTS.md
+++ b/bengal/plugins/AGENTS.md
@@ -1,0 +1,58 @@
+# Plugins Steward
+
+The plugin package turns protocol promises into discoverable extension behavior.
+It protects entry-point loading, registry freezing, hook wiring, and third-party
+developer trust.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/meta/extension-points.md`
+- `../../site/content/docs/extending/plugins.md`
+- `../../pyproject.toml`
+
+## Point Of View
+
+Plugins represent external authors who extend Bengal without patching core. The
+registry should be predictable, inspectable, and conservative about failures.
+
+## Protect
+
+- `bengal.plugins` entry-point discovery and registry behavior.
+- Hook ordering, freezing, and duplicate/conflict handling.
+- Safe error reporting when a plugin cannot load or validate.
+- Compatibility with protocol definitions and extension docs.
+
+## Contract Checklist
+
+- `pyproject.toml` entry-point group and plugin registry tests.
+- `bengal/protocols/` hook signatures and migration notes.
+- CLI plugin commands, docs, and example plugin snippets when discovery or
+  reporting changes.
+- Integration tests proving a plugin can register behavior and fail usefully.
+
+## Advocate
+
+- A working example plugin and contract tests before advertising new hook paths.
+- Clear diagnostics that name the plugin, hook, entry point, and next step.
+- Registry inspection APIs that support CLI/docs without exposing internals.
+
+## Serve Peers
+
+- Give protocols real usage feedback before widening contracts.
+- Give orchestration/rendering exact hook timing needs.
+- Give docs and CLI truthful extension capability descriptions.
+
+## Do Not
+
+- Document aspirational hooks as shipped behavior.
+- Let plugin import failures disappear into broad exceptions.
+- Add hook surfaces without tests, docs, and migration language.
+- Bypass protocols with ad hoc duck typing in registry code.
+
+## Own
+
+- `bengal/plugins/`
+- Plugin sections in `site/content/docs/extending/` and architecture meta docs
+- Tests: `tests/unit/plugins/`, protocol tests, and plugin CLI tests
+- Checks: `uv run pytest tests/unit/plugins tests/unit/protocols tests/unit/cli/test_plugin_command.py -q`
+- Checks: `uv run ruff check bengal/plugins tests/unit/plugins`

--- a/bengal/postprocess/AGENTS.md
+++ b/bengal/postprocess/AGENTS.md
@@ -1,0 +1,61 @@
+# Postprocess Steward
+
+Postprocess owns site-wide artifacts after rendering: sitemap, feeds, output
+formats, redirects, search indexes, social cards, and AI-readable manifests.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/rendering/postprocess.md`
+- `../../site/content/docs/building/output-formats.md`
+- `../../site/content/docs/building/ai-native-output.md`
+
+## Point Of View
+
+Postprocess represents downstream consumers of the built site: search engines,
+readers, feed clients, AI agents, and deployment platforms. Artifacts should be
+complete, deterministic, and aligned with visibility policy.
+
+## Protect
+
+- Sitemap/RSS/XML correctness and visibility filtering.
+- JSON/TXT/Markdown/LLM output format schemas and incremental skip behavior.
+- Redirect, robots, social card, and search-index artifact paths.
+- Atomic writes and deterministic output ordering.
+
+## Contract Checklist
+
+- Tests under `tests/unit/postprocess/` and integration output-format tests.
+- Output format docs, AI-native output docs, deployment docs, and generated
+  artifact examples.
+- Cache/incremental collateral when artifacts are skipped or regenerated.
+- Schema/types docs and changelog when artifact fields change.
+- Artifact audit/link health collateral for generated URLs.
+
+## Advocate
+
+- Explicit schemas and snapshots for machine-readable outputs.
+- Visibility and content-signal behavior that is easy for authors to predict.
+- Fast incremental paths that never leave stale search or AI indexes.
+
+## Serve Peers
+
+- Give health/audit complete artifact inventories and URL targets.
+- Give docs and default theme stable generated artifact promises.
+- Give cache/incremental deterministic hashes and regeneration reasons.
+
+## Do Not
+
+- Generate artifacts from stale page lists or hidden/draft content.
+- Change JSON fields or URL paths without docs/tests/changelog.
+- Write output files non-atomically.
+- Treat AI-readable outputs as secondary when they are user-facing artifacts.
+
+## Own
+
+- `bengal/postprocess/`
+- `site/content/docs/reference/architecture/rendering/postprocess.md`
+- `site/content/docs/building/output-formats.md`
+- `site/content/docs/building/ai-native-output.md`
+- Tests: `tests/unit/postprocess/`, output-format integration tests
+- Checks: `uv run pytest tests/unit/postprocess tests/integration/test_incremental_output_formats.py -q`
+- Checks: `uv run ruff check bengal/postprocess tests/unit/postprocess`

--- a/bengal/protocols/AGENTS.md
+++ b/bengal/protocols/AGENTS.md
@@ -3,11 +3,11 @@
 Protocols and plugin hook shapes are public contracts. They are read by plugin
 developers and mocked throughout tests, so casual widening is expensive.
 
-Related architecture docs:
-
-- `../../AGENTS.md`
+Related docs:
+- root `../../AGENTS.md`
 - `../../site/content/docs/reference/architecture/meta/protocols.md`
 - `../../site/content/docs/reference/architecture/meta/extension-points.md`
+- `../../site/content/docs/extending/plugins.md`
 
 ## Point Of View
 
@@ -19,8 +19,18 @@ turning private convenience into permanent API.
 
 - The `Plugin` protocol and the 9 supported hook surfaces.
 - Narrow `PageLike`, `SectionLike`, and `SiteLike` contracts.
-- Test-double compatibility.
-- Backward-compatible evolution through adapters where possible.
+- Template, parser, and syntax-highlighting engine protocols.
+- Test-double compatibility and backward-compatible evolution.
+
+## Contract Checklist
+
+- Protocol tests in `tests/unit/protocols/` and type-safety tests in
+  `tests/core/test_type_safety.py`.
+- Plugin docs, extension-point docs, and migration notes for signature changes.
+- Mocks/fakes under `tests/_testing/` and downstream test fixtures.
+- Changelog for public protocol or hook behavior changes.
+- Parity matrix when a contract spans CLI, plugin hook, programmatic API, and
+  docs.
 
 ## Advocate
 
@@ -47,9 +57,9 @@ turning private convenience into permanent API.
 
 ## Own
 
-- Own `site/content/docs/reference/architecture/meta/protocols.md`.
-- Own plugin-contract material in `site/content/docs/reference/architecture/meta/extension-points.md`.
-- Update migration docs/changelog notes for public protocol or hook changes.
-- `uv run pytest tests/unit/protocols tests/core/test_type_safety.py -q`
-- `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
-- `uv run ruff check bengal/protocols tests/unit/protocols`
+- `site/content/docs/reference/architecture/meta/protocols.md`
+- `site/content/docs/reference/architecture/meta/extension-points.md`
+- Public protocol migration notes and changelog collateral
+- Checks: `uv run pytest tests/unit/protocols tests/core/test_type_safety.py -q`
+- Checks: `uv run pytest tests/unit/core/test_no_core_mixins.py -q`
+- Checks: `uv run ruff check bengal/protocols tests/unit/protocols`

--- a/bengal/rendering/AGENTS.md
+++ b/bengal/rendering/AGENTS.md
@@ -4,11 +4,11 @@ Rendering owns the work that turns domain state into presentation: HTML,
 template views, excerpts, TOC structures, URLs, shortcode/link extraction, and
 page/section resource views.
 
-Related architecture docs:
-
-- `../../AGENTS.md`
+Related docs:
+- root `../../AGENTS.md`
 - `../../site/content/docs/reference/architecture/design-principles.md`
-- `../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
+- `../../site/content/docs/reference/architecture/rendering/`
+- `../../site/content/docs/reference/template-functions/`
 
 ## Point Of View
 
@@ -21,7 +21,20 @@ and themes get dependable data.
 - Template compatibility for existing themes and plugins.
 - Clear helper/service boundaries behind core compatibility shims.
 - Deferred imports where rendering and core need to see each other.
-- Rendering behavior that is deterministic under parallel builds.
+- Deterministic rendering under parallel builds.
+- URL, reference, anchor, asset, shortcode, and template context correctness.
+
+## Contract Checklist
+
+- Unit tests under `tests/unit/rendering/`, parser tests under
+  `tests/rendering/`, and integration roots that exercise rendered output.
+- Template-function docs, theming docs, and default-theme templates when context
+  changes.
+- Protocol impact on `PageLike`, `SectionLike`, `TemplateEngine`, and test
+  doubles.
+- Cache/incremental impact when rendering records dependencies, references, or
+  output hashes.
+- Changelog for user-visible rendering changes.
 
 ## Advocate
 
@@ -49,10 +62,10 @@ and themes get dependable data.
 
 ## Own
 
-- Own `site/content/docs/reference/architecture/rendering/`.
-- Keep `site/content/docs/reference/template-functions/` accurate for template-facing behavior.
-- Update theming docs when rendering helpers change what themes can rely on.
-- `uv run pytest tests/unit/rendering -q`
-- `uv run pytest tests/rendering -q`
-- `uv run ruff check bengal/rendering tests/unit/rendering tests/rendering`
+- `site/content/docs/reference/architecture/rendering/`
+- `site/content/docs/reference/template-functions/`
+- Theming docs when rendering helpers change theme contracts
+- Checks: `uv run pytest tests/unit/rendering -q`
+- Checks: `uv run pytest tests/rendering -q`
+- Checks: `uv run ruff check bengal/rendering tests/unit/rendering tests/rendering`
 - Run `check-cycles` before hoisting any deferred import across core/rendering.

--- a/bengal/rendering/pipeline/AGENTS.md
+++ b/bengal/rendering/pipeline/AGENTS.md
@@ -4,11 +4,16 @@ The rendering pipeline protects the phase where pages become output-ready
 content. This is free-threading sensitive: avoid hidden shared state, late
 mutation surprises, and cache writes that depend on task timing.
 
-Related architecture docs:
-
-- `../../../AGENTS.md`
+Related docs:
+- root `../../../AGENTS.md`
 - `../../../site/content/docs/reference/architecture/core/pipeline.md`
 - `../../../site/content/docs/reference/architecture/rendering/rendering.md`
+
+## Point Of View
+
+The pipeline represents the handoff from parsed content to render-ready output.
+It should make inputs, outputs, dependencies, and errors explicit enough for
+parallel execution and incremental reuse.
 
 ## Protect
 
@@ -17,6 +22,27 @@ Related architecture docs:
 - Separation between immutable pipeline records and mutable compatibility pages.
 - Cache/provenance updates that are explicit and testable.
 
+## Contract Checklist
+
+- Pipeline, rendering, orchestration, and incremental tests that prove full and
+  warm build parity.
+- Docs for `SourcePage -> ParsedPage -> RenderedPage` and build pipeline handoff.
+- Cache/provenance collateral when dependency or output-hash behavior changes.
+- Threading notes for shared mutable state, contextvars, task-local caches, and
+  worker exception handling.
+
+## Advocate
+
+- Explicit dependency capture over inferred global state.
+- Early, contextual error reporting for template/parser failures.
+- Tests that compare sequential and parallel outputs for hot paths.
+
+## Serve Peers
+
+- Give incremental/cache stewards trustworthy provenance and output-hash data.
+- Give rendering helpers a deterministic execution context.
+- Give tests small fixtures that prove task ordering does not affect output.
+
 ## Do Not
 
 - Add global mutable caches without locks or a written reason.
@@ -24,14 +50,11 @@ Related architecture docs:
 - Swallow rendering errors without diagnostics and context.
 - Make output writes directly from ad hoc code paths.
 
-## Documentation Ownership
+## Own
 
-- Own pipeline details in `site/content/docs/reference/architecture/core/pipeline.md`.
-- Keep `site/content/docs/reference/architecture/rendering/rendering.md` current.
-- Update cache/provenance docs when pipeline scheduling changes invalidation behavior.
-
-## Local Checks
-
-- `uv run pytest tests/unit/rendering tests/unit/orchestration -q`
-- `uv run pytest tests/integration/test_incremental_invariants.py -q`
-- `uv run ruff check bengal/rendering/pipeline bengal/orchestration/build`
+- `site/content/docs/reference/architecture/core/pipeline.md`
+- `site/content/docs/reference/architecture/rendering/rendering.md`
+- Cache/provenance docs when pipeline scheduling changes invalidation behavior
+- Checks: `uv run pytest tests/unit/rendering tests/unit/orchestration -q`
+- Checks: `uv run pytest tests/integration/test_incremental_invariants.py -q`
+- Checks: `uv run ruff check bengal/rendering/pipeline bengal/orchestration/build`

--- a/bengal/rendering/template_functions/AGENTS.md
+++ b/bengal/rendering/template_functions/AGENTS.md
@@ -3,17 +3,44 @@
 Template functions are the supported ergonomic surface for themes. They should
 be explicit, registered intentionally, and safe for template authors to compose.
 
-Related architecture docs:
-
-- `../../../AGENTS.md`
+Related docs:
+- root `../../../AGENTS.md`
 - `../../../site/content/docs/reference/architecture/rendering/content-processing-api.md`
+- `../../../site/content/docs/reference/template-functions/`
+- `../../../site/content/docs/theming/templating/`
+
+## Point Of View
+
+Template functions represent the public helper language available to themes and
+site authors. Names and behavior are sticky because templates copy them.
 
 ## Protect
 
 - The explicit `register(env, site)` pattern.
-- Stable filter/global names used by bundled and user themes.
+- Stable filter/global/test names used by bundled and user themes.
 - Small helpers that delegate domain-heavy work elsewhere.
 - Clear template-facing behavior and useful errors.
+
+## Contract Checklist
+
+- Tests under `tests/unit/rendering/template_functions/`,
+  `tests/unit/template_functions/`, and engine parity tests when helpers are
+  engine-sensitive.
+- Docs under reference template-functions and theming quick references.
+- Default theme templates and site examples that call helper names.
+- Protocol impact on `TemplateEnvironment` and `TemplateEngine`.
+
+## Advocate
+
+- Helper docs with exact inputs, fallback behavior, and examples.
+- Data coercion and useful diagnostics where YAML/frontmatter types vary.
+- A small public surface that composes rather than a long list of near-duplicates.
+
+## Serve Peers
+
+- Give default theme stable helpers instead of private object reaches.
+- Give docs generated references and realistic snippets.
+- Give rendering/core a place for presentation ergonomics without widening core.
 
 ## Do Not
 
@@ -22,13 +49,10 @@ Related architecture docs:
 - Add helper names casually; template APIs are public enough to preserve.
 - Hide missing data or broken links with silent empty output.
 
-## Documentation Ownership
+## Own
 
-- Own `site/content/docs/reference/template-functions/`.
-- Keep `site/content/docs/theming/templating/` and theming recipes accurate when helper behavior changes.
-- Update generated/reference docs when adding, renaming, or removing filters/globals.
-
-## Local Checks
-
-- `uv run pytest tests/unit/rendering tests/unit/template_functions -q`
-- `uv run ruff check bengal/rendering/template_functions tests/unit/template_functions`
+- `site/content/docs/reference/template-functions/`
+- `site/content/docs/theming/templating/` and theming recipes using helpers
+- Generated/reference docs when adding, renaming, or removing filters/globals
+- Checks: `uv run pytest tests/unit/rendering/template_functions tests/unit/template_functions -q`
+- Checks: `uv run ruff check bengal/rendering/template_functions tests/unit/template_functions`

--- a/bengal/scaffolds/AGENTS.md
+++ b/bengal/scaffolds/AGENTS.md
@@ -1,0 +1,59 @@
+# Scaffolds Steward
+
+Scaffolds create the first files authors trust. They must match current config,
+theme, content, and CLI behavior because copied starter content becomes real
+sites.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../README.md`
+- `../../site/content/docs/get-started/scaffold-your-site.md`
+- `../../site/content/docs/reference/site-templates.md`
+- `../../site/content/docs/extending/custom-skeletons.md`
+
+## Point Of View
+
+Scaffolds represent new site authors. They should create runnable, modern,
+well-documented examples that do not rely on hidden state or stale APIs.
+
+## Protect
+
+- Template names and generated directory layouts.
+- Frontmatter, config, sample content, and asset references that build cleanly.
+- Compatibility with default theme, content types, output formats, and docs.
+- Dry-run/force behavior and skeleton manifest semantics.
+
+## Contract Checklist
+
+- Scaffold tests in `tests/unit/scaffolds/`, CLI skeleton tests, and integration
+  template scaffolding tests.
+- README quickstart, scaffold docs, site-template docs, and custom skeleton docs.
+- Config docs and theme docs when generated files include those surfaces.
+- Changelog for user-visible scaffold/template changes.
+
+## Advocate
+
+- Minimal starter sites that demonstrate the right pattern once.
+- Examples that are useful as regression fixtures.
+- Clear failure messages when a scaffold cannot overwrite or validate files.
+
+## Serve Peers
+
+- Give config/docs/theme stewards examples that match shipped defaults.
+- Give tests small generated-site fixtures for smoke builds.
+- Give CLI a predictable scaffold inventory and structured output.
+
+## Do Not
+
+- Emit config keys, template helpers, or frontmatter fields docs do not cover.
+- Add generated content that fails `bengal build` out of the box.
+- Treat scaffold examples as marketing copy instead of executable examples.
+- Add a runtime dependency for scaffolding.
+
+## Own
+
+- `bengal/scaffolds/`
+- Scaffold and skeleton docs in README and `site/content/docs/`
+- Tests: `tests/unit/scaffolds/`, CLI scaffold tests, template scaffolding integration
+- Checks: `uv run pytest tests/unit/scaffolds tests/unit/cli/test_skeleton.py tests/integration/test_template_scaffolding.py -q`
+- Checks: `uv run ruff check bengal/scaffolds tests/unit/scaffolds`

--- a/bengal/server/AGENTS.md
+++ b/bengal/server/AGENTS.md
@@ -1,0 +1,61 @@
+# Development Server Steward
+
+The server owns local author feedback: watching files, rebuilding safely,
+serving stable output, and reloading browsers without making production build
+semantics fuzzy.
+
+Related docs:
+- root `../../AGENTS.md`
+- `../../site/content/docs/reference/architecture/tooling/server.md`
+- `../../docs/live-reload-pipeline-review.md`
+- `../../plan/reload-tier-architecture.md`
+
+## Point Of View
+
+The dev server represents the editing loop. It should be fast and calm while
+never serving half-written output or hiding rebuild failures.
+
+## Protect
+
+- Watcher scope, debounce behavior, rebuild trigger classification, and CSS hot
+  reload semantics.
+- Double-buffered output and atomic active-directory swaps.
+- SSE reload protocol and browser injection safety.
+- Clean lifecycle behavior for Ctrl+C, stale processes, and port fallback.
+
+## Contract Checklist
+
+- Tests under `tests/unit/server/` and warm-build/dev-server integration tests.
+- Server architecture docs, live-reload docs, and build performance docs.
+- Config/CLI docs for serve flags and watcher settings.
+- Incremental/cache collateral when file changes alter rebuild decisions.
+- Changelog for user-visible server behavior.
+
+## Advocate
+
+- Rebuild explanations that distinguish content, template, asset, config, and
+  theme changes.
+- Small reproducible tests for race conditions and lifecycle bugs.
+- Fast-path improvements that keep full-build fallback correct.
+
+## Serve Peers
+
+- Give orchestration exact rebuild requests and lifecycle boundaries.
+- Give incremental/cache stewards file-change evidence.
+- Give CLI/docs stable serve behavior and troubleshooting language.
+
+## Do Not
+
+- Serve directly from a directory while it is being written.
+- Add browser-side behavior that requires npm or a JS build step.
+- Hide rebuild failures behind reload success.
+- Use sleeps as synchronization without a testable reason.
+
+## Own
+
+- `bengal/server/`
+- `site/content/docs/reference/architecture/tooling/server.md`
+- Live reload and dev-server planning docs
+- Tests: `tests/unit/server/`, warm-build integration tests
+- Checks: `uv run pytest tests/unit/server tests/integration/warm_build -q`
+- Checks: `uv run ruff check bengal/server tests/unit/server`

--- a/bengal/snapshots/AGENTS.md
+++ b/bengal/snapshots/AGENTS.md
@@ -4,10 +4,15 @@ Snapshots protect a stable, render-ready view of a site for scheduling and
 parallel rendering. They should make shared state explicit and immutable where
 possible.
 
-Related architecture docs:
-
-- `../../AGENTS.md`
+Related docs:
+- root `../../AGENTS.md`
 - `../../site/content/docs/reference/architecture/core/pipeline.md`
+- `../../plan/rfc-bengal-snapshot-engine.md`
+
+## Point Of View
+
+Snapshots represent the point where mutable compatibility state is captured for
+parallel work. They should give workers a deterministic view of the site.
 
 ## Protect
 
@@ -16,6 +21,25 @@ Related architecture docs:
 - Deterministic navigation/template/cache snapshots.
 - Thread-safe progress and error handling.
 
+## Contract Checklist
+
+- Snapshot unit tests and warm-build integration tests.
+- Pipeline and cache docs when snapshot reuse or scheduling changes.
+- Free-threading notes for shared state, worker queues, and mutable handoff.
+- Changelog for user-visible build/rebuild behavior.
+
+## Advocate
+
+- Captured values over live object references.
+- Small scheduling APIs with explicit error propagation.
+- Tests that compare sequential and parallel snapshot behavior.
+
+## Serve Peers
+
+- Give rendering workers stable inputs.
+- Give cache/incremental deterministic snapshot hashes or reuse signals.
+- Give tests a clear seam for parallel scheduling proof.
+
 ## Do Not
 
 - Store live mutable objects when a snapshot value should be captured.
@@ -23,14 +47,11 @@ Related architecture docs:
 - Mutate page pipeline records.
 - Hide worker exceptions without page/source context.
 
-## Documentation Ownership
+## Own
 
-- Own snapshot-related explanations in `site/content/docs/reference/architecture/core/pipeline.md`.
-- Keep cache and warm-build docs aligned when snapshot reuse behavior changes.
-- Update architecture docs when mutable Page compatibility and immutable snapshot handoffs move.
-
-## Local Checks
-
-- `uv run pytest tests/unit/snapshots -q`
-- `uv run pytest tests/integration/warm_build -q`
-- `uv run ruff check bengal/snapshots tests/unit/snapshots`
+- Snapshot explanations in `site/content/docs/reference/architecture/core/pipeline.md`
+- Cache and warm-build docs when snapshot reuse behavior changes
+- Tests: `tests/unit/snapshots/`, warm-build integrations
+- Checks: `uv run pytest tests/unit/snapshots -q`
+- Checks: `uv run pytest tests/integration/warm_build -q`
+- Checks: `uv run ruff check bengal/snapshots tests/unit/snapshots`

--- a/bengal/themes/default/AGENTS.md
+++ b/bengal/themes/default/AGENTS.md
@@ -4,26 +4,41 @@ The default theme is Bengal's shipped user experience. It should make real
 documentation readable, navigable, accessible, and fast without adding a Node or
 npm build path.
 
-Related architecture docs:
-
-- `../../../AGENTS.md`
+Related docs:
+- root `../../../AGENTS.md`
 - `README.md`
 - `templates/README.md`
 - `templates/SAFE_PATTERNS.md`
 - `templates/TEMPLATE-CONTEXT.md`
+- `../../../site/content/docs/theming/`
+
+## Point Of View
+
+Default theme represents readers, authors, and theme customizers encountering
+Bengal's built-in UX. It should make documentation feel trustworthy at desktop,
+mobile, keyboard, and code-heavy scales.
 
 ## Protect
 
-- Reader ergonomics for documentation, blogs, release notes, API references,
-  CLI references, search, navigation, and code-heavy pages.
+- Reader ergonomics for docs, blogs, release notes, API references, CLI
+  references, search, navigation, and code-heavy pages.
 - Semantic HTML, keyboard navigation, focus states, contrast, and responsive
   behavior.
-- Pure-Python delivery: no npm, no Node build step, and no theme asset pipeline
-  that depends on external JavaScript tooling.
+- Pure-Python delivery: no npm, no Node build step, and no external JS build
+  pipeline.
 - Stable template contracts and swizzle-friendly template structure.
-- CSS token discipline and component scoping that prevents site-authored
-  content from being accidentally restyled.
+- CSS token discipline and component scoping that avoids restyling authored
+  content accidentally.
 - Asset weight and rendering performance on mobile and low-power devices.
+
+## Contract Checklist
+
+- Theme tests under `tests/unit/themes/`, `tests/themes/`, and representative
+  integration builds.
+- Template context docs, safe patterns, CSS architecture docs, and theming docs.
+- Rendering/template-function collateral when templates need new context.
+- Accessibility/responsive manual inspection for layout-affecting changes.
+- Changelog for user-visible default-theme behavior.
 
 ## Advocate
 
@@ -55,15 +70,12 @@ Related architecture docs:
 
 ## Own
 
-- Own `README.md`, `templates/README.md`, `templates/SAFE_PATTERNS.md`, and
-  `templates/TEMPLATE-CONTEXT.md`.
-- Keep `site/content/docs/theming/`,
-  `site/content/docs/reference/theme-variables.md`, and theme customization
-  docs accurate when default theme behavior changes.
-- Coordinate with the rendering steward when template context or helper
-  behavior changes.
-- `uv run pytest tests/unit/themes tests/themes -q`
-- `uv run bengal build site`
-- Inspect representative pages for docs, release notes, search, tags,
-  autodoc/API reference, and narrow mobile layouts.
-- `rg "^[^@#][^{]*\b(ul|ol|a|pre|code|table)\b" bengal/themes/default`
+- `README.md`, `templates/README.md`, `templates/SAFE_PATTERNS.md`, and
+  `templates/TEMPLATE-CONTEXT.md`
+- `site/content/docs/theming/`,
+  `site/content/docs/reference/theme-variables.md`, and theme customization docs
+- Checks: `uv run pytest tests/unit/themes tests/themes -q`
+- Checks: `uv run bengal build site`
+- Inspect representative docs, release notes, search, tags, autodoc/API, and
+  narrow mobile layouts.
+- Checks: `rg "^[^@#][^{]*\\b(ul|ol|a|pre|code|table)\\b" bengal/themes/default`

--- a/plan/AGENTS.md
+++ b/plan/AGENTS.md
@@ -5,11 +5,17 @@ work that can be executed without rediscovering the same context. This steward
 protects decision quality and archive hygiene; it does not outrank the package
 stewards that own implementation boundaries.
 
-Related architecture docs:
-
-- `../AGENTS.md`
+Related docs:
+- root `../AGENTS.md`
 - `README.md`
 - `ROADMAP.md`
+- `maturity-assessment.md`
+
+## Point Of View
+
+Planning represents the future work queue and decision memory. It should keep
+tradeoffs, dependencies, and stale assumptions visible before code changes
+start.
 
 ## Protect
 
@@ -19,8 +25,17 @@ Related architecture docs:
   measurable performance, and user-visible documentation correctness.
 - Steward notes for cross-boundary work, especially public contracts,
   rendering behavior, incremental correctness, and free-threading safety.
-- Archive status that stays truthful: drafted, evaluated, stale, superseded,
-  or complete.
+- Archive status that stays truthful: drafted, evaluated, stale, superseded, or
+  complete.
+
+## Contract Checklist
+
+- `plan/README.md`, `plan/ROADMAP.md`, and active RFC/epic status lines.
+- Code steward agreement before promoting implementation plans.
+- Docs/tests/examples/changelog collateral listed in acceptance criteria.
+- Verification notes for stale package names, deleted modules, and changed
+  architecture boundaries.
+- Not-now sections for tempting adjacent work.
 
 ## Advocate
 
@@ -44,17 +59,15 @@ Related architecture docs:
   routing through the root escape hatches.
 - Let stale architecture names survive in active plans without a verification
   note.
-- Hide deferred work in vague "later" language; name the tradeoff or move it
-  to a not-now section.
+- Hide deferred work in vague "later" language; name the tradeoff or move it to
+  a not-now section.
 
 ## Own
 
-- Own `plan/README.md` and `plan/ROADMAP.md`.
-- Keep RFC, epic, sprint, stale, superseded, evaluated, and complete buckets
-  consistent with the actual implementation state.
-- Carry steward consultation rollups into follow-up plans or PR descriptions
-  when planning work crosses scoped steward areas.
-- `rg "^\*\*Status\*\*" plan`
-- `rg "bengal/build|dependency_tracker|PageCacheManager|ConfigService" plan`
+- `plan/README.md` and `plan/ROADMAP.md`
+- RFC, epic, sprint, stale, superseded, evaluated, and complete bucket hygiene
+- Steward consultation rollups for planning work
+- Checks: `rg "^\\*\\*Status\\*\\*" plan`
+- Checks: `rg "bengal/build|dependency_tracker|PageCacheManager|ConfigService" plan`
 - Re-read affected scoped `AGENTS.md` files before promoting a plan from draft
   to active work.

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -4,24 +4,37 @@ The `site/` tree is Bengal's dogfood documentation site. It represents the
 reader, site author, plugin developer, and contributor experience before the
 project asks anyone else to trust the tool.
 
-Related architecture docs:
-
-- `../AGENTS.md`
+Related docs:
+- root `../AGENTS.md`
 - `content/docs/about/philosophy.md`
 - `content/docs/get-started/`
 - `content/docs/reference/`
+- `../docs/b-stack-changelog-strategy.md`
+
+## Point Of View
+
+Site docs represent readers trying to complete tasks: install, scaffold, build,
+theme, extend, debug, migrate, and understand architecture.
 
 ## Protect
 
 - Docs that match current CLI behavior, config shape, template context, and
   extension contracts.
-- Reader task completion: install, scaffold, build, theme, extend, debug, and
-  migrate.
-- Runnable examples and snippets that do not depend on unstated local state.
-- Clear audience paths for site authors, plugin developers, theme developers,
+- Reader task completion for site authors, plugin developers, theme developers,
   and contributors.
+- Runnable examples and snippets that do not depend on unstated local state.
 - Release notes and migration guidance that say what changed, who is affected,
   and what to do next.
+
+## Contract Checklist
+
+- Authored docs under `site/content/`, snippets, config, data, and hand-maintained
+  assets.
+- README/CONTRIBUTING parity when quickstarts or contributor flows change.
+- CLI help and command examples for command docs.
+- Package stewards for architecture, protocols, config, rendering, theme, and
+  output claims.
+- `uv run bengal build site` for substantial docs or template changes.
 
 ## Advocate
 
@@ -52,14 +65,10 @@ Related architecture docs:
 
 ## Own
 
-- Own authored content under `site/content/`, `site/config/`, `site/data/`, and
-  hand-maintained site assets.
-- Keep snippets in `site/content/_snippets/` synchronized with installation,
-  configuration, and command examples.
-- Coordinate with package stewards when docs explain architecture, public API,
-  plugin hooks, or theme behavior owned outside `site/`.
-- `uv run bengal build site`
-- `uv run bengal serve site`
-- `rg "TODO|TBD|coming soon|not yet implemented" site/content`
-- For command docs, compare examples with `uv run bengal --help` or the
-  relevant subcommand help.
+- `site/content/`, `site/config/`, `site/data/`, and hand-maintained site assets
+- Snippets in `site/content/_snippets/`
+- Architecture, public API, plugin hook, and theme docs in coordination with
+  package stewards
+- Checks: `uv run bengal build site`
+- Checks: `rg "TODO|TBD|coming soon|not yet implemented" site/content`
+- For command docs, compare examples with `uv run bengal --help` or subcommand help.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -4,9 +4,10 @@ Tests protect behavior, not implementation trivia. They should make regressions
 obvious, keep fixtures understandable, and avoid widening production contracts
 just to satisfy mocks.
 
-Related architecture docs:
-
-- `../AGENTS.md`
+Related docs:
+- root `../AGENTS.md`
+- `README.md`
+- `TEST_COVERAGE.md`
 - `../site/content/docs/reference/architecture/meta/testing.md`
 
 ## Point Of View
@@ -20,7 +21,18 @@ easy to reason about.
 - Focused unit tests for interesting branches.
 - Integration tests for user-visible workflows and build correctness.
 - `tests/roots/` fixtures as intentional, minimal sites.
-- Existing markers and parallel-safety expectations.
+- Existing markers, xdist behavior, and parallel-safety expectations.
+- Canonical mocks and helpers in `tests/_testing/`.
+
+## Contract Checklist
+
+- Unit/integration/performance scope stewards for the affected proof layer.
+- Fixture docs in `tests/roots/README.md` and helper docs in
+  `tests/_testing/README.md`.
+- Public protocol, CLI, config, and docs surfaces when tests expose contract
+  drift.
+- Marker updates when tests spawn workers, use global state, or are slow.
+- Changelog only when tests accompany user-visible package behavior changes.
 
 ## Advocate
 
@@ -47,9 +59,9 @@ easy to reason about.
 
 ## Own
 
-- Own `site/content/docs/reference/architecture/meta/testing.md`.
-- Keep `tests/README.md` and `tests/roots/README.md` accurate when fixture/test patterns change.
-- Update docs when markers, shared mocks, or test-layer expectations change.
-- `uv run pytest tests/unit -q`
-- `uv run pytest tests/integration -q`
-- `uv run ruff check tests`
+- `site/content/docs/reference/architecture/meta/testing.md`
+- `tests/README.md`, `tests/roots/README.md`, and `tests/_testing/README.md`
+- Shared mocks, fixtures, markers, and test helper patterns
+- Checks: `uv run pytest tests/unit -q`
+- Checks: `uv run pytest tests/integration -q`
+- Checks: `uv run ruff check tests`

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -3,12 +3,46 @@
 Integration tests protect workflows: content in, site out, cache behavior
 preserved. They should catch what unit tests cannot see across subsystem seams.
 
+Related docs:
+- root `../../AGENTS.md`
+- `../README.md`
+- `../roots/README.md`
+- `../../site/content/docs/reference/architecture/meta/testing.md`
+
+## Point Of View
+
+Integration tests represent users running Bengal across real directories,
+commands, configs, and generated artifacts. They should prove seams and avoid
+testing pure helpers twice.
+
 ## Protect
 
 - Realistic site builds using focused `tests/roots/` fixtures.
 - Output correctness for pages, assets, indexes, feeds, and incremental rebuilds.
 - Regression tests for user-visible failures.
-- Clear fixture ownership and cleanup.
+- Clear fixture ownership, isolation, and cleanup.
+- CI shard duration hygiene via `.test_durations`.
+
+## Contract Checklist
+
+- A minimal `tests/roots/` fixture or existing root that demonstrates the
+  workflow.
+- Unit proof for local logic before adding large workflow coverage.
+- Output docs/examples when generated artifacts or CLI workflows change.
+- Marker and shard updates for slow, stateful, or parallel-unsafe tests.
+- `.test_durations` refresh when integration timing materially changes.
+
+## Advocate
+
+- Workflow tests that follow real author commands and file layouts.
+- Targeted artifact assertions instead of whole-site snapshots.
+- Warm-build parity proof when caches or invalidation are involved.
+
+## Serve Peers
+
+- Give build/cache/rendering stewards proof across subsystem seams.
+- Give docs stewards runnable examples backed by fixtures.
+- Give CI owners clear marker and shard expectations.
 
 ## Do Not
 
@@ -17,12 +51,11 @@ preserved. They should catch what unit tests cannot see across subsystem seams.
 - Depend on test order or leftover build artifacts.
 - Use integration tests for pure helper behavior.
 
-## Documentation Ownership
+## Own
 
-- Keep integration-test guidance in `site/content/docs/reference/architecture/meta/testing.md` current.
-- Own fixture documentation in `tests/roots/README.md` when roots are added or reshaped.
-
-## Local Checks
-
-- `uv run pytest tests/integration -q`
-- `uv run ruff check tests/integration`
+- Integration-test guidance in `site/content/docs/reference/architecture/meta/testing.md`
+- Fixture documentation in `tests/roots/README.md`
+- Tests under `tests/integration/`
+- Checks: `uv run pytest tests/integration -q`
+- Checks: `uv run ruff check tests/integration`
+- Refresh durations with `poe test-integration-durations` after material shard impact.

--- a/tests/performance/AGENTS.md
+++ b/tests/performance/AGENTS.md
@@ -3,6 +3,18 @@
 Performance tests protect Bengal's claim that pure Python can scale with cores.
 Treat regressions as product risk, not benchmark trivia.
 
+Related docs:
+- root `../../AGENTS.md`
+- `README.md`
+- `../../benchmarks/README.md`
+- `../../site/content/docs/building/performance/`
+- `../../site/content/docs/about/benchmarks.md`
+
+## Point Of View
+
+Performance tests represent Bengal's public speed, memory, and free-threading
+claims. They should distinguish measured regressions from noisy environments.
+
 ## Protect
 
 - Stable benchmark setup and repeatable fixture sizes.
@@ -10,20 +22,41 @@ Treat regressions as product risk, not benchmark trivia.
 - Incremental rebuild and parallel rendering hot paths.
 - Notes when a benchmark result is noisy or environment-sensitive.
 
+## Contract Checklist
+
+- Performance tests under `tests/performance/` and benchmark suite overlap under
+  `benchmarks/`.
+- Docs that publish speed, scaling, memory, or incremental claims.
+- Changelog/performance notes for hot-path behavior changes.
+- Free-threading notes for parallelism or shared mutable state changes.
+- Baselines/results when thresholds or fixture sizes change.
+
+## Advocate
+
+- Benchmarks that measure complete required work, not skipped paths.
+- Separate setup from measured loops.
+- Confidence intervals, saved baselines, and environment notes for comparisons.
+
+## Serve Peers
+
+- Give orchestration/rendering/cache evidence for hot-path changes.
+- Give docs honest benchmark claims and caveats.
+- Give planning credible performance risk signals.
+
 ## Do Not
 
-- Mix correctness assertions with expensive benchmark loops when setup can be separated.
+- Mix correctness assertions with expensive benchmark loops when setup can be
+  separated.
 - Add broad sleeps or machine-specific thresholds.
 - Delete historical fixtures without explaining what claim changed.
 - Treat a faster result as good if it skips required work.
 
-## Documentation Ownership
+## Own
 
-- Own performance testing guidance in `site/content/docs/reference/architecture/meta/testing.md`.
-- Keep `site/content/docs/building/performance/` honest when benchmark claims or hot paths change.
-
-## Local Checks
-
-- `uv run pytest tests/performance -q`
-- Relevant benchmark scripts under `tests/performance/`
-- `make test-cov` only when coverage impact matters.
+- `site/content/docs/reference/architecture/meta/testing.md`
+- `site/content/docs/building/performance/`
+- `site/content/docs/about/benchmarks.md`
+- Tests under `tests/performance/`
+- Checks: `uv run pytest tests/performance -q`
+- Checks: relevant benchmark scripts under `tests/performance/`
+- Checks: `make test-cov` only when coverage impact matters

--- a/tests/unit/AGENTS.md
+++ b/tests/unit/AGENTS.md
@@ -3,6 +3,16 @@
 Unit tests should pin small contracts and architectural boundaries. They are
 the fast feedback loop contributors should trust while editing.
 
+Related docs:
+- root `../../AGENTS.md`
+- `../README.md`
+- `../../site/content/docs/reference/architecture/meta/testing.md`
+
+## Point Of View
+
+Unit tests represent local behavioral contracts. They should prove the branch,
+boundary, and failure mode with the smallest useful setup.
+
 ## Protect
 
 - Tests that name the behavior and the boundary being guarded.
@@ -10,19 +20,39 @@ the fast feedback loop contributors should trust while editing.
 - Architectural guards for core/rendering/protocol drift.
 - Deterministic assertions that run well in parallel.
 
+## Contract Checklist
+
+- The package steward for the code under test.
+- Shared mock/helper updates when public contracts change.
+- Marker safety for tests that create threads/processes or mutate globals.
+- Docs/testing guidance when new patterns become standard.
+- Regression tests for failure paths and malformed input when relevant.
+
+## Advocate
+
+- Direct helper tests before full site setup.
+- Property tests for parsers, serializers, URL normalization, and other broad
+  input spaces.
+- Named fixtures that express contract intent.
+
+## Serve Peers
+
+- Give implementation stewards fast targeted proof.
+- Give protocols feedback when fakes need unrealistic attributes.
+- Give integration tests confidence about which seam still needs workflow proof.
+
 ## Do Not
 
 - Spin up full sites when a direct helper test would prove the behavior.
-- Overfit assertions to private implementation details unless guarding architecture.
+- Overfit assertions to private implementation details unless guarding
+  architecture.
 - Add sleeps or timing assumptions.
 - Use private mutation in tests when a public constructor/API exists.
 
-## Documentation Ownership
+## Own
 
-- Keep unit-test guidance in `site/content/docs/reference/architecture/meta/testing.md` current.
-- Update shared-mock guidance when `tests/_testing` patterns change.
-
-## Local Checks
-
-- `uv run pytest tests/unit -q`
-- `uv run ruff check tests/unit`
+- Unit-test guidance in `site/content/docs/reference/architecture/meta/testing.md`
+- Shared-mock guidance when `tests/_testing` patterns change
+- Tests under `tests/unit/`
+- Checks: `uv run pytest tests/unit -q`
+- Checks: `uv run ruff check tests/unit`


### PR DESCRIPTION
## Summary

Upgrades Bengal's AGENTS.md steward system so future agents have a compact root constitution, consistent scoped steward operating model, and concrete routing/checklist guidance for cross-boundary work.

## Changes

- Expanded the root `AGENTS.md` with steward signal format, swarm protocol, feedback loop, parity matrix guidance, extension routing, and done criteria.
- Upgraded existing scoped stewards for core, rendering, protocols, cache, orchestration, CLI, errors, snapshots, default theme, site docs, planning, and tests.
- Added concrete scoped stewards for benchmarks, assets, autodoc, build contracts, config, content types, health, plugins, postprocess, scaffolds, and server.

## Steward Notes

- Root constitution: kept repo-wide safety rules compact while adding contract and swarm protocol guidance.
- Package domains: scoped stewards now name local invariants, contract checklists, peer-service expectations, and owned proof paths.
- Docs/tests/performance: added ownership for dogfood docs, planning artifacts, test layers, and benchmark/performance claims.

## Validation

- Required-section audit across authored `AGENTS.md` files passed.
- Trailing whitespace scan passed.
- `git diff --check` passed.
- `uv run ruff format --check .` passed.
- Commit hooks passed. The dependency-layer hook reported six existing warning-level violations while still exiting successfully; this PR only changes Markdown steward docs.

No changelog fragment: agent guidance/docs-only change, no user-facing Bengal package behavior.
