### PR TITLE
[codex] upgrade milo-cli to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ uv sync --group dev
 pytest
 ```
 
-**Multi-repo workspace:** With bengal, patitas, rosettes, etc. as siblings, copy `workspace-root.example/pyproject.toml` to the parent directory and run `uv sync` from there. The workspace root overrides sources so all packages use local versions. CI and end users (no workspace root) use PyPI.
+Bengal is a standalone uv project. Run `uv sync` and `uv run ...` from this checkout; sibling repositories are not required for normal development.
 
 ---
 

--- a/changelog.d/milo-cli-0-3.changed.md
+++ b/changelog.d/milo-cli-0-3.changed.md
@@ -1,0 +1,1 @@
+Upgrade Bengal's `milo-cli` requirement and pinned source to 0.3.0, and make Bengal resolve as its own uv workspace root for local development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.7",
-    "milo-cli>=0.2.2",                         # B-stack CLI framework (replaces Click — migration in progress)
+    "milo-cli>=0.3.0",                         # B-stack CLI framework (replaces Click — migration in progress)
 
     "rosettes>=0.2.0",
     "kida-templates>=0.7.0",                   # Kida template engine (AST-native, free-threading ready)
@@ -91,7 +91,10 @@ Repository = "https://github.com/lbliii/bengal"
 "Bug Tracker" = "https://github.com/lbliii/bengal/issues"
 
 [tool.uv.sources]
-milo-cli = { git = "https://github.com/lbliii/milo-cli.git", rev = "db0426e823abec0f853804ec7490e60847560bb9" }
+milo-cli = { git = "https://github.com/lbliii/milo-cli.git", rev = "36d64cf03c96186e3cf3da77fde4ea59e92f19a6" }
+
+[tool.uv.workspace]
+members = ["."]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -296,7 +299,7 @@ invalid-method-override = "warn"        # Liskov violations - review later
 unresolved-reference = "warn"           # Missing imports - fix incrementally
 unknown-argument = "warn"               # Wrong kwargs - needs investigation
 
-# Workspace overrides (kida, patitas, pounce, rosettes) live in b-stack/pyproject.toml.
+# Bengal is its own uv workspace root. Local development uses the pinned lockfile here;
 # CI and standalone installs use PyPI per dependencies above.
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -213,7 +213,7 @@ requires-dist = [
     { name = "jsmin", specifier = ">=3.0.1" },
     { name = "kida-templates", specifier = ">=0.7.0" },
     { name = "lunr", marker = "extra == 'search'", specifier = ">=0.7.0" },
-    { name = "milo-cli", git = "https://github.com/lbliii/milo-cli.git?rev=db0426e823abec0f853804ec7490e60847560bb9" },
+    { name = "milo-cli", git = "https://github.com/lbliii/milo-cli.git?rev=36d64cf03c96186e3cf3da77fde4ea59e92f19a6" },
     { name = "packaging", specifier = ">=23.0" },
     { name = "patitas", specifier = ">=0.3.5" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -679,8 +679,8 @@ wheels = [
 
 [[package]]
 name = "milo-cli"
-version = "0.2.2"
-source = { git = "https://github.com/lbliii/milo-cli.git?rev=db0426e823abec0f853804ec7490e60847560bb9#db0426e823abec0f853804ec7490e60847560bb9" }
+version = "0.3.0"
+source = { git = "https://github.com/lbliii/milo-cli.git?rev=36d64cf03c96186e3cf3da77fde4ea59e92f19a6#36d64cf03c96186e3cf3da77fde4ea59e92f19a6" }
 dependencies = [
     { name = "kida-templates" },
 ]


### PR DESCRIPTION
## Summary

- Upgrade Bengal's shipped `milo-cli` dependency floor to `>=0.3.0`.
- Upgrade Bengal's pinned `milo-cli` Git source to `36d64cf03c96186e3cf3da77fde4ea59e92f19a6`, which resolves as `milo-cli` 0.3.0.
- Regenerate `uv.lock` for the updated Milo source.
- Make Bengal an explicit standalone uv workspace root so local `uv run ...` commands do not resolve through an old parent multi-repo workspace.
- Add a changelog fragment for the dependency/setup change.

## Validation

- `uv lock --check` from a standalone Bengal copy
- `uv run bengal c --cache` from the Bengal checkout reaches Bengal's confirmation prompt instead of failing dependency resolution
- `uv run bengal --version` from the Bengal checkout
- `uv run pytest tests/unit/cli/test_milo_parser_construction.py tests/integration/test_cli_help.py` from the Bengal checkout: 13 passed
- Commit hooks on amend: passed; existing warning-only `check-deps` layer violations were reported

## Notes

`uv run bengal c --cache` was not auto-confirmed because it deletes output/cache state; the command now gets past dependency resolution and waits for the expected Bengal confirmation prompt.

PyPI currently publishes `milo-cli` 0.2.2 as the latest release, so this PR should remain draft until `milo-cli` 0.3.0 is published. The `>=0.3.0` metadata floor is intentional: it prevents publishing a Bengal wheel whose install-time Milo version differs from the validated lock/source revision.

## Steward Notes

- CLI: parser construction and help smoke tests cover the Milo compatibility surface.
- Release/dependencies: `uv.lock` was regenerated, Bengal now owns its uv workspace root, and a `changelog.d` fragment was included.
