### PR TITLE
[codex] close Milo CLI migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Every layer — markdown parsing, syntax highlighting, templates, dev server —
 
 ```bash
 pip install bengal
-bengal new site mysite && cd mysite && bengal serve
+bengal new site --name mysite && cd mysite && bengal serve
 ```
 
 ---
@@ -45,11 +45,11 @@ Bengal is a static site generator where the entire stack is Python you can read,
 |---------|-------------|
 | `bengal build` | Production build |
 | `bengal serve` | Dev server with live reload |
-| `bengal validate` | Health checks and validation |
+| `bengal check` | Health checks and validation |
 | `bengal fix` | Auto-fix common issues |
-| `bengal graph report` | Site structure analysis |
+| `bengal inspect graph` | Site structure analysis |
 
-Aliases: `b` (build), `s` (serve), `v` (validate)
+Aliases: `b` (build), `s` (serve), `v` (check)
 
 ---
 
@@ -87,9 +87,9 @@ Each preset creates a complete site with appropriate sections, sample content, a
 Create sites non-interactively with `--template`:
 
 ```bash
-bengal new site my-docs --template docs
-bengal new site my-blog --template blog
-bengal new site portfolio --template portfolio
+bengal new site --name my-docs --template docs
+bengal new site --name my-blog --template blog
+bengal new site --name portfolio --template portfolio
 ```
 
 **Available templates:**
@@ -108,110 +108,39 @@ bengal new site portfolio --template portfolio
 </details>
 
 <details>
-<summary><strong>Add Sections to Existing Sites</strong> — Expand without recreating</summary>
+<summary><strong>Add Pages and Templates</strong> — Expand without recreating</summary>
 
-Add new content sections to an existing Bengal site:
+Add content and template files to an existing Bengal site:
 
 ```bash
-# Add multiple sections
-bengal init --sections docs --sections tutorials
+# Add a page under a section
+bengal new page --name getting-started --section docs
 
-# Add sections with sample content
-bengal init --sections blog --with-content --pages-per-section 5
+# Add template files
+bengal new layout --name docs-page
+bengal new partial --name docs-sidebar
 
-# Preview without creating files
-bengal init --sections api --dry-run
+# Add a content type strategy scaffold
+bengal new content-type --name tutorial
 ```
 
-**Section type inference:**
-
-| Name Pattern | Inferred Type | Behavior |
-|--------------|---------------|----------|
-| blog, posts, articles, news | `blog` | Date-sorted, post-style |
-| docs, documentation, guides, tutorials | `doc` | Weight-sorted, doc-style |
-| projects, portfolio | `section` | Standard section |
-| about, contact | `section` | Standard section |
+Use frontmatter, content type strategies, and section index pages to shape how
+new content is grouped and rendered.
 
 </details>
 
 <details>
-<summary><strong>Custom Skeleton Manifests</strong> — YAML-defined site structures</summary>
+<summary><strong>Content Type Scaffolds</strong> — Python-defined content behavior</summary>
 
-For complex or repeatable scaffolding, define structures in YAML manifests:
+Generate a starter `ContentTypeStrategy` when a section needs custom matching,
+template selection, summaries, or pagination behavior:
 
 ```bash
-# Preview what would be created
-bengal project skeleton apply my-structure.yaml --dry-run
-
-# Apply the skeleton
-bengal project skeleton apply my-structure.yaml
-
-# Overwrite existing files
-bengal project skeleton apply my-structure.yaml --force
+bengal new content-type --name changelog
 ```
 
-**Example manifest** (`docs-skeleton.yaml`):
-
-```yaml
-name: Documentation Site
-description: Technical docs with navigation sections
-version: "1.0"
-
-cascade:
-  type: doc  # Applied to all pages
-
-structure:
-  - path: _index.md
-    props:
-      title: Documentation
-      description: Project documentation
-      weight: 100
-    content: |
-      # Documentation
-      Welcome! Start with our [Quick Start](getting-started/quickstart/).
-
-  - path: getting-started/_index.md
-    props:
-      title: Getting Started
-      weight: 10
-    cascade:
-      type: doc
-    pages:
-      - path: installation.md
-        props:
-          title: Installation
-          weight: 20
-        content: |
-          # Installation
-          ```bash
-          pip install your-package
-          ```
-
-      - path: quickstart.md
-        props:
-          title: Quick Start
-          weight: 30
-        content: |
-          # Quick Start
-          Your first project in 5 minutes.
-
-  - path: api/_index.md
-    props:
-      title: API Reference
-      weight: 30
-    content: |
-      # API Reference
-      Complete API documentation.
-```
-
-**Component Model:**
-- `path` — File or directory path
-- `type` — Component identity (blog, doc, landing)
-- `variant` — Visual style variant
-- `props` — Frontmatter data (title, weight, etc.)
-- `content` — Markdown body content
-- `pages` — Child components (makes this a section)
-- `cascade` — Values inherited by all descendants
+The generated file contains TODO markers for matching, template selection,
+excerpt generation, and pagination so custom content behavior stays in Python.
 
 </details>
 
@@ -266,7 +195,7 @@ config/
 ```
 
 ```bash
-bengal build -e production    # Production environment
+bengal build --environment production    # Production environment
 bengal build --profile dev    # Development profile
 ```
 

--- a/bengal/cli/__init__.py
+++ b/bengal/cli/__init__.py
@@ -5,12 +5,11 @@ The CLI is powered by milo-cli with kida template rendering.
 
 Entry points:
     bengal      → bengal.cli.milo_app:run
-    bengal-next → bengal.cli.milo_app:run  (alias during migration, will be removed)
 
 Surface area (12 groups, 4 tiers):
 
     Tier 1 — Core workflow (daily use):
-        build, serve, clean, check, fix, new
+        build, serve, clean, check, audit, fix, new
 
     Tier 2 — Feature groups (weekly use):
         config, theme, content, version, i18n
@@ -19,7 +18,7 @@ Surface area (12 groups, 4 tiers):
         inspect, debug
 
     Tier 4 — Infrastructure (rare):
-        cache, codemod, upgrade, provenance
+        cache, codemod, upgrade
 
 Related:
 - bengal/cli/milo_app.py: CLI definition and entry point

--- a/bengal/cli/milo_app.py
+++ b/bengal/cli/milo_app.py
@@ -1,9 +1,9 @@
 """
 Bengal CLI — powered by milo-cli.
 
-This module defines the new CLI surface area using milo's type-annotated
-command framework. It replaces the Click-based CLI with a cleaner 4-tier
-hierarchy and gains MCP server, structured output, and llms.txt for free.
+This module defines Bengal's CLI surface area using milo's type-annotated
+command framework. Milo owns command registration, structured output,
+MCP server mode, completions, and llms.txt generation.
 
 Surface area (12 groups, 4 tiers):
 
@@ -17,7 +17,7 @@ Surface area (12 groups, 4 tiers):
         inspect, debug
 
     Tier 4 — Infrastructure (rare):
-        cache, codemod, upgrade, provenance
+        cache, codemod, upgrade
 """
 
 from __future__ import annotations
@@ -895,7 +895,7 @@ cli.lazy_command(
 
 
 def run() -> None:
-    """Entry point for bengal-next console script."""
+    """Entry point for the bengal console script."""
     try:
         cli.run()
     except KeyboardInterrupt:

--- a/changelog.d/milo-cli-closure.changed.md
+++ b/changelog.d/milo-cli-closure.changed.md
@@ -1,0 +1,1 @@
+Documented the Milo CLI as Bengal's settled command entry point and removed stale migration alias references.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,9 +203,8 @@ ignore = [
     "S110",  # try-except-pass is fine in test setup/teardown
     "S112",  # try-except-continue is fine in test iteration
 ]
-# CLI layer — print() is the primary output mechanism, callbacks have fixed signatures
-"bengal/cli/**/*.py" = ["T201", "ARG"]
-"bengal/__main__.py" = ["T201"]
+# CLI layer — callbacks have fixed signatures; terminal output routes through CLIOutput/Milo.
+"bengal/cli/**/*.py" = ["ARG"]
 # Dev server / build output — print for output, callbacks have fixed signatures
 "bengal/server/**/*.py" = ["T201", "S108", "S603", "S607", "ARG"]
 "bengal/build/**/*.py" = ["T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ classifiers = [
     "Topic :: Software Development :: Documentation",
 ]
 dependencies = [
-    "click>=8.1.7",
-    "milo-cli>=0.3.0",                         # B-stack CLI framework (replaces Click — migration in progress)
+    "click>=8.1.7",                            # Autodoc compatibility for documenting Click apps
+    "milo-cli>=0.3.0",                         # B-stack CLI framework for Bengal commands
 
     "rosettes>=0.2.0",
     "kida-templates>=0.7.0",                   # Kida template engine (AST-native, free-threading ready)

--- a/site/content/docs/reference/architecture/tooling/cli.md
+++ b/site/content/docs/reference/architecture/tooling/cli.md
@@ -119,7 +119,7 @@ bengal serve --port 8080
 bengal serve --no-watch
 
 # Open browser automatically (default)
-bengal serve --open
+bengal serve --open-browser
 
 # ASCII-safe server lifecycle output for CI or log capture
 bengal serve --style ci
@@ -128,63 +128,32 @@ bengal serve --style ci
 bengal serve --verbose
 ```
 
-**Graph Analysis Commands**:
+**Inspection Commands**:
 ```bash
-# Top-level graph command group
-bengal graph
+# Explain how a page is built
+bengal inspect page --page-path index
 
-# Unified site analysis report
-bengal graph report
-bengal graph report --brief          # CI-friendly compact output
-bengal graph report --format json    # Export as JSON
+# Check internal and external links
+bengal inspect links
+bengal inspect links --internal-only
+bengal inspect links --external-only
 
-# CI integration with thresholds
-bengal graph report --ci --threshold-isolated 5
+# Analyze site structure and link graph
+bengal inspect graph
 
-# Connectivity analysis by level
-bengal graph orphans                 # Show isolated pages (score < 0.25)
-bengal graph orphans --level lightly # Show lightly-linked pages
-bengal graph orphans --level all     # Show all under-linked pages
-bengal graph orphans --format json   # Export with detailed metrics
-
-# Analyze site structure and connectivity
-bengal graph analyze
-bengal graph analyze --tree          # Show site structure as tree
-bengal graph analyze --output public/graph.html  # Interactive viz
-
-# Compute PageRank scores
-bengal graph pagerank --top 20
-
-# Detect topical communities
-bengal graph communities --min-size 3
-
-# Find bridge pages (navigation bottlenecks)
-bengal graph bridges --top 10
-
-# Get link suggestions
-bengal graph suggest --min-score 0.5
-
-# Short aliases
-bengal g report                      # g → graph
-bengal analyze                       # Top-level alias for graph analyze
+# Visualize dependency relationships
+bengal debug deps
 ```
 
-:::{example-label} bengal graph report Output
+:::{example-label} bengal inspect graph Output
 :::
 
 ```text
-📊 Site Analysis Report
-================================================================================
-📈 Overview
-   Total pages:        124
-   Avg conn. score:    1.46
+ᓚᘏᗢ Site Graph
 
-🔗 Connectivity Distribution
-   🟢 Well-Connected:      39 pages (31.5%)
-   🟡 Adequately:          38 pages (30.6%)
-   🟠 Lightly Linked:      26 pages (21.0%)
-   🔴 Isolated:            21 pages (16.9%) ⚠️
-================================================================================
+Pages: 124
+Links: 428
+Orphans: 3
 ```
 
 Refer to [Graph Analysis](../../../content/analysis/graph.md) for details and [Analyze site connectivity](../../../../tutorials/operations/analyze-site-connectivity/) for a guided walkthrough.
@@ -192,16 +161,16 @@ Refer to [Graph Analysis](../../../content/analysis/graph.md) for details and [A
 **Performance Commands**:
 ```bash
 # Show recent build performance metrics
-bengal perf
+bengal inspect perf
 
 # Show last N builds
-bengal perf --last 20
+bengal inspect perf --last 20
 
 # Compare last two builds
-bengal perf --compare
+bengal inspect perf --compare
 
 # Export as JSON
-bengal perf --format json
+bengal inspect perf --output-format json
 ```
 
 **Utility Commands**:
@@ -234,10 +203,10 @@ bengal clean
 bengal clean --cache
 
 # Create new site
-bengal new site mysite
+bengal new site --name mysite
 
 # Create new page
-bengal new page content/blog/post.md
+bengal new page --name post --section blog
 
 # Show version
 bengal --version
@@ -307,6 +276,80 @@ new.lazy_command(
     display_result=False,
 )
 ```
+
+## Command Inventory
+
+The public command inventory is generated from the Milo registry and guarded by
+unit tests against this documentation, `--llms-txt`, README command snippets,
+and runtime smoke coverage.
+
+```text cli-command-inventory
+build
+serve
+clean
+check
+audit
+health
+fix
+upgrade
+codemod
+new.site
+new.theme
+new.page
+new.layout
+new.partial
+new.content-type
+config.show
+config.doctor
+config.diff
+config.init
+config.inspect
+theme.list
+theme.info
+theme.discover
+theme.swizzle
+theme.install
+theme.validate
+theme.new
+theme.debug
+theme.directives
+theme.test
+theme.assets
+content.sources
+content.fetch
+content.collections
+content.schemas
+version.list
+version.info
+version.create
+version.diff
+i18n.init
+i18n.extract
+i18n.compile
+i18n.sync
+i18n.status
+plugin.list
+plugin.info
+plugin.validate
+inspect.page
+inspect.links
+inspect.graph
+inspect.perf
+debug.incremental
+debug.delta
+debug.deps
+debug.migrate
+debug.sandbox
+cache.inputs
+cache.hash
+```
+
+Root aliases are part of the contract: `b` for `build`, `s` and `dev` for
+`serve`, `c` for `clean`, and `v` for `check`. Group aliases are `n` for `new`
+and `plugins` for `plugin`.
+
+`health` remains a top-level legacy alias for `check`. It is kept for existing
+automation, but new docs and examples should use `check`.
 
 ## Themed Help
 

--- a/tests/integration/test_wheel_install.py
+++ b/tests/integration/test_wheel_install.py
@@ -141,6 +141,67 @@ def test_wheel_bengal_help_succeeds(installed_venv: Path) -> None:
     assert "bengal" in result.stdout.lower()
 
 
+def test_wheel_bengal_llms_txt_succeeds(installed_venv: Path) -> None:
+    """``bengal --llms-txt`` must expose the installed Milo command tree."""
+    bengal = _bengal_bin(installed_venv)
+    result = subprocess.run(
+        [str(bengal), "--llms-txt"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"bengal --llms-txt failed with code {result.returncode}\n"
+        f"stdout={result.stdout[-1000:]!r}\nstderr={result.stderr[-1000:]!r}"
+    )
+    assert "# bengal" in result.stdout
+    assert "**build**" in result.stdout
+    assert "**cache**" not in result.stderr
+
+
+def test_wheel_python_m_bengal_cli_routes_to_milo(installed_venv: Path) -> None:
+    """``python -m bengal.cli`` should match the installed console script route."""
+    py = installed_venv / ("Scripts" if os.name == "nt" else "bin") / "python"
+    result = subprocess.run(
+        [str(py), "-m", "bengal.cli", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"python -m bengal.cli --help failed with code {result.returncode}\n"
+        f"stderr={result.stderr[-1000:]!r}"
+    )
+    assert "Core workflow" in result.stdout
+    assert "--llms-txt" in result.stdout
+
+
+def test_wheel_does_not_install_bengal_next(installed_venv: Path) -> None:
+    """The closed migration should install only the ``bengal`` console script."""
+    script_dir = installed_venv / ("Scripts" if os.name == "nt" else "bin")
+    assert not (script_dir / "bengal-next").exists()
+    assert not (script_dir / "bengal-next.exe").exists()
+
+    py = script_dir / "python"
+    result = subprocess.run(
+        [
+            str(py),
+            "-c",
+            (
+                "from importlib.metadata import entry_points; "
+                "print('\\n'.join(sorted("
+                "ep.name for ep in entry_points(group='console_scripts') "
+                "if ep.value.startswith('bengal.cli.'))))"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines() == ["bengal"]
+
+
 def test_wheel_cache_hash_help_succeeds(installed_venv: Path) -> None:
     """``bengal cache hash --help`` — the specific command that crashed in v0.3.1.
 

--- a/tests/unit/cli/test_cli_contract_inventory.py
+++ b/tests/unit/cli/test_cli_contract_inventory.py
@@ -1,0 +1,117 @@
+"""CLI command inventory guards for public discovery surfaces."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+CLI_DOCS = ROOT / "site" / "content" / "docs" / "reference" / "architecture" / "tooling" / "cli.md"
+README = ROOT / "README.md"
+
+
+def _registered_command_keys() -> set[str]:
+    from bengal.cli.milo_app import cli
+
+    return {path for path, _command in cli.walk_commands()}
+
+
+def _registered_invocation_keys() -> set[str]:
+    from bengal.cli.milo_app import cli
+
+    return _registered_command_keys() | set(cli._groups)
+
+
+def _case_command_key(args: tuple[str, ...], registered: set[str]) -> str | None:
+    parts: list[str] = []
+    match: str | None = None
+    for arg in args:
+        if arg.startswith("-"):
+            break
+        parts.append(arg)
+        candidate = ".".join(parts)
+        if candidate in registered:
+            match = candidate
+    return match
+
+
+def _docs_inventory() -> set[str]:
+    text = CLI_DOCS.read_text(encoding="utf-8")
+    match = re.search(r"```text cli-command-inventory\n(?P<body>.*?)\n```", text, re.S)
+    assert match, "CLI docs must include a cli-command-inventory fenced block"
+    return {line.strip() for line in match.group("body").splitlines() if line.strip()}
+
+
+def _markdown_command_args(path: Path) -> list[tuple[str, ...]]:
+    commands: list[tuple[str, ...]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "bengal " not in line:
+            continue
+        line = line.split("#", 1)[0]
+        for match in re.finditer(r"bengal\s+([^`|&]+)", line):
+            command = "bengal " + match.group(1).strip()
+            try:
+                tokens = shlex.split(command)
+            except ValueError:
+                continue
+            if len(tokens) > 1:
+                args = tuple(tokens[1:])
+                if args[0][:1].isdigit():
+                    continue
+                commands.append(args)
+    return commands
+
+
+def test_cli_docs_inventory_matches_milo_registry():
+    """Architecture docs should list the same leaf commands as the Milo registry."""
+    assert _docs_inventory() == _registered_command_keys()
+
+
+def test_llms_txt_advertises_registered_command_inventory():
+    """Agent-facing discovery should expose every registered command leaf."""
+    from bengal.cli.milo_app import cli
+
+    output = cli.invoke(["--llms-txt"]).output
+
+    for command in sorted(_registered_command_keys()):
+        leaf = command.rsplit(".", 1)[-1]
+        assert f"**{leaf}**" in output, command
+
+
+def test_readme_bengal_command_snippets_resolve_to_registered_commands():
+    """README command examples should name commands that exist in the public CLI."""
+    registered = _registered_invocation_keys()
+    commands = _markdown_command_args(README)
+
+    assert commands, "README should include Bengal command snippets"
+    assert {args for args in commands if _case_command_key(args, registered) is None} == set()
+
+
+def test_cli_docs_bengal_command_snippets_resolve_to_registered_commands():
+    """Architecture doc command examples should name commands that exist."""
+    registered = _registered_invocation_keys()
+    commands = [args for args in _markdown_command_args(CLI_DOCS) if not args[0].startswith("-")]
+
+    assert commands, "CLI architecture docs should include Bengal command snippets"
+    assert {args for args in commands if _case_command_key(args, registered) is None} == set()
+
+
+def test_alias_inventory_matches_documented_contract():
+    """Documented aliases should resolve to the canonical command help."""
+    from bengal.cli.milo_app import cli
+
+    aliases = {
+        ("b",): "bengal build",
+        ("s",): "bengal serve",
+        ("dev",): "bengal serve",
+        ("c",): "bengal clean",
+        ("v",): "bengal check",
+        ("n", "site"): "bengal new site",
+        ("plugins", "list"): "bengal plugin list",
+    }
+
+    for argv, canonical in aliases.items():
+        result = cli.invoke([*argv, "--help"])
+        assert result.exit_code == 0, argv
+        assert result.output.startswith(f"ᓚᘏᗢ {canonical}"), argv

--- a/tests/unit/cli/test_command_output_templates.py
+++ b/tests/unit/cli/test_command_output_templates.py
@@ -199,6 +199,21 @@ def test_command_output_matrix_covers_priority_commands():
         "config diff missing config": "command_empty.kida",
         "unknown command": "command_error.kida",
         "unknown group command": "command_error.kida",
+        "serve option conflicts": "message_line.kida",
+        "fix no-op": "message_line.kida",
+        "upgrade status": "upgrade_status.kida",
+        "theme install validation": "message_line.kida",
+        "theme new": "scaffold_result.kida",
+        "theme test": "kv_detail.kida / validation_report.kida / json_output.kida",
+        "theme assets": "command_list.kida / message_line.kida",
+        "inspect links": "validation_report.kida / json_output.kida",
+        "inspect graph": "json_output.kida / message_line.kida debug report",
+        "inspect perf": "message_line.kida performance report",
+        "debug incremental": "json_output.kida / message_line.kida debug report",
+        "debug delta": "json_output.kida / message_line.kida debug report",
+        "debug deps": "item_list.kida / message_line.kida debug report",
+        "debug migrate": "message_line.kida debug report",
+        "debug sandbox": "item_list.kida / kv_detail.kida / validation_report.kida",
     }
 
     assert len(matrix) >= 12
@@ -225,3 +240,121 @@ def test_build_ci_style_applies_to_memory_incremental_warning(monkeypatch, capsy
     output = capsys.readouterr().out
     assert "! --memory-optimized with --incremental may not fully utilize cache" in output
     assert "▲" not in output
+
+
+def test_serve_conflict_uses_cli_output_not_argparse(capsys):
+    """Serve preflight conflicts should render through CLIOutput before site loading."""
+    from bengal.cli.milo_commands.serve import serve
+    from bengal.output import reset_cli_output
+
+    reset_cli_output()
+    with pytest.raises(SystemExit) as exc:
+        serve(verbose=True, debug=True)
+    reset_cli_output()
+
+    assert exc.value.code == 2
+    output = capsys.readouterr().out
+    assert "--verbose and --debug cannot be used together" in output
+    assert "Pick one" in output
+    assert "usage:" not in output
+
+
+def test_fix_noop_branch_uses_cli_output(monkeypatch, tmp_path, capsys):
+    """Fix should report no-op states through Bengal output helpers."""
+    from bengal.cli.milo_commands.fix import fix
+    from bengal.output import reset_cli_output
+
+    class FakeSite:
+        root_path = tmp_path
+
+        def discover_content(self):
+            return None
+
+        def discover_assets(self):
+            return None
+
+    class FakeHealthCheck:
+        def __init__(self, site):
+            self.site = site
+
+        def run(self, profile):
+            return SimpleNamespace()
+
+    class FakeAutoFixer:
+        def __init__(self, report, site_root):
+            self.report = report
+            self.site_root = site_root
+
+        def suggest_fixes(self):
+            return []
+
+    reset_cli_output()
+    monkeypatch.setattr("bengal.cli.utils.load_site_from_cli", lambda **kwargs: FakeSite())
+    monkeypatch.setattr("bengal.health.HealthCheck", FakeHealthCheck)
+    monkeypatch.setattr("bengal.health.remediation.AutoFixer", FakeAutoFixer)
+
+    result = fix(dry_run=True)
+    reset_cli_output()
+
+    output = capsys.readouterr().out
+    assert result["status"] == "ok"
+    assert "Auto-Fix" in output
+    assert "No fixes available" in output
+    assert "usage:" not in output
+
+
+def test_upgrade_dry_run_uses_status_template(monkeypatch, capsys):
+    """Upgrade dry runs should render the dedicated status template."""
+    from bengal.cli.milo_commands.upgrade import upgrade
+    from bengal.output import reset_cli_output
+
+    installer = SimpleNamespace(
+        name="pipx",
+        display_command="pipx upgrade bengal",
+        command=["pipx", "upgrade", "bengal"],
+    )
+
+    reset_cli_output()
+    monkeypatch.setattr("bengal.cli.helpers.upgrade_check.fetch_latest_version", lambda: "9.9.9")
+    monkeypatch.setattr("bengal.cli.helpers.upgrade_installers.detect_installer", lambda: installer)
+
+    result = upgrade(dry_run=True)
+    reset_cli_output()
+
+    output = capsys.readouterr().out
+    assert result["dry_run"] is True
+    assert "9.9.9" in output
+    assert "pipx upgrade bengal" in output
+    assert "usage:" not in output
+
+
+def test_theme_install_invalid_name_uses_actionable_error(capsys):
+    """Theme install validation should fail before invoking installers."""
+    from bengal.cli.milo_commands.theme import theme_install
+    from bengal.output import reset_cli_output
+
+    reset_cli_output()
+    with pytest.raises(SystemExit):
+        theme_install("../not-safe")
+    reset_cli_output()
+
+    output = capsys.readouterr().out
+    assert "doesn't match safe pattern" in output
+    assert "Use --force to override" in output
+    assert "usage:" not in output
+
+
+def test_debug_sandbox_empty_state_is_actionable(capsys):
+    """Debug sandbox empty input should give a bounded usage hint."""
+    from bengal.cli.milo_commands.debug import debug_sandbox
+    from bengal.output import reset_cli_output
+
+    reset_cli_output()
+    result = debug_sandbox()
+    reset_cli_output()
+
+    output = capsys.readouterr().out
+    assert result["status"] == "skipped"
+    assert "No content provided" in output
+    assert "bengal debug sandbox" in output
+    assert "usage:" not in output

--- a/tests/unit/cli/test_terminal_output_boundaries.py
+++ b/tests/unit/cli/test_terminal_output_boundaries.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -53,3 +54,12 @@ def test_cli_facing_packages_do_not_write_directly_to_terminal():
                     violations.append(f"{rel}:{node.lineno} uses {call_name}()")
 
     assert not violations, "\n".join(violations)
+
+
+def test_cli_ruff_config_does_not_allow_print_suppression():
+    """Ruff should agree with the AST guard: CLI code may not suppress print calls."""
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    ignores = pyproject["tool"]["ruff"]["lint"]["per-file-ignores"]
+
+    assert "T201" not in ignores.get("bengal/cli/**/*.py", [])
+    assert "T201" not in ignores.get("bengal/__main__.py", [])


### PR DESCRIPTION
## Summary

Closes the Milo CLI migration as the settled Bengal command contract.

- removes stale migration language and `bengal-next` references
- adds live command inventory guards for docs, README snippets, aliases, `--llms-txt`, and smoke coverage
- expands output parity tests across high-risk Milo command paths
- tightens CLI terminal-output policy by removing broad `T201` suppression
- strengthens installed-wheel smoke for `--llms-txt`, `python -m bengal.cli`, and absence of `bengal-next`

## Validation

- `uv run pytest tests/unit/cli tests/integration/test_cli_smoke.py tests/integration/test_cli_output_integration.py -q`
- `uv run ruff check bengal/cli tests/unit/cli tests/integration/test_wheel_install.py`
- `make ty` (passes with existing 538 diagnostics)
- `uv run pytest tests/integration/test_wheel_install.py -q -m slow -n0`
- `uv run bengal build --source site` completed, with existing site health/parsing issues unrelated to this PR

## Steward Notes

- CLI: Milo is now documented and tested as the public command registry; stale transitional aliases were removed from tracked docs/comments.
- Site docs: README and CLI architecture examples now resolve against the live command tree.
- Tests: Added focused unit/integration guards for command contract drift and installed-wheel behavior.
