### PR TITLE
[codex] Fix cache hash wheel release path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,12 +41,10 @@ jobs:
         env:
           PYTHON_GIL: "0"
 
-      # Use bengal cache hash for accurate cache invalidation
-      # This includes all build inputs: content, config, autodoc sources, templates, etc.
-      - name: Get cache hash
-        id: cache
-        working-directory: site
-        run: echo "hash=$(uv run bengal cache hash)" >> $GITHUB_OUTPUT
+      # Use Bengal's own input discovery so CI cache invalidation matches build semantics.
+      - name: Get Bengal cache hash
+        id: bengal-cache
+        run: echo "hash=$(uv run bengal cache hash --source site)" >> $GITHUB_OUTPUT
         env:
           PYTHON_GIL: "0"
 
@@ -54,12 +52,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: site/.bengal
-          key: bengal-${{ runner.os }}-${{ steps.cache.outputs.hash }}
+          key: bengal-${{ runner.os }}-${{ steps.bengal-cache.outputs.hash }}
           # No restore-keys - we want exact match for correctness
 
       - name: Build site
-        working-directory: site
-        run: uv run bengal build --environment production --clean-output
+        run: uv run bengal build --source site --environment production --clean-output
         env:
           PYTHON_GIL: "0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bengal"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python static site generator built on free-threading — every layer pure Python, scales with your cores, zero npm"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "bengal"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "bengal-pounce" },


### PR DESCRIPTION
## Summary

Fix the installed-wheel release path for Bengal's cache hashing CLI and keep the Pages workflow on the intended Bengal-owned cache-key contract.

## What changed

- Keep `bengal cache hash` as the GitHub Pages cache key source, but invoke it from the repo root with `--source site`.
- Build the docs site from the repo root with `bengal build --source site` so CI does not depend on `working-directory: site` behavior.
- Bump the package version to `0.3.3` so the fix can be published as a new wheel instead of trying to replace the broken `0.3.2` artifact.
- Strengthen installed-wheel smoke coverage and CLI output contract coverage already on this branch.

## Root cause

The published `0.3.2` wheel can run into a runtime failure because `bengal cache hash` imports cache input discovery from `bengal.cache.ci`, but that helper was not present in the published artifact. The checkout works because later branch commits restore that module. Since PyPI artifacts are immutable, the durable fix is a new `0.3.3` release with the helper included and wheel smoke tests proving the command executes.

## Validation

- `uv run bengal cache hash --source site`
- `uv build --wheel --out-dir /private/tmp/bengal-wheel-check-033`
- Confirmed the built `bengal-0.3.3` wheel contains `bengal/cache/ci.py`
- `uv run pytest tests/unit/cache/test_ci_inputs.py tests/integration/test_cli_smoke.py -k 'cache_hash or cache_inputs' -q`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/pages.yml').read_text()); print('yaml ok')"`
- `uv run bengal build --source site --environment production --dry-run --quiet`

## Notes

The dry-run still reports pre-existing site warnings for the `/docs/content/i18n/` URL collision, the unknown `important` directive, and the `analytics` feature warning. Those are not changed in this PR.
