### PR TITLE
[codex] Add Chirp UI theme asset contracts

### DIFF
--- a/bengal/orchestration/content.py
+++ b/bengal/orchestration/content.py
@@ -807,6 +807,18 @@ class ContentOrchestrator:
             for asset in discovery.discover():
                 if asset.output_path:
                     asset.output_path = Path(prefix) / asset.output_path
+                    asset.logical_path = asset.output_path
+                # Some libraries expose CSS and Kida templates from the same package
+                # root; only browser-downloadable assets should enter the manifest.
+                if asset.source_path.suffix.lower() == ".html":
+                    continue
+                # Provider CSS files such as chirpui.css are standalone static files,
+                # not modules imported by a site/theme style.css entry point.
+                if (
+                    asset.source_path.suffix.lower() == ".css"
+                    and asset.source_path.name != "style.css"
+                ):
+                    asset.asset_type = "other"
                 self.site.assets.append(asset)
 
     def _setup_page_references(self) -> None:

--- a/bengal/parsing/backends/patitas/directives/builtins/cards.py
+++ b/bengal/parsing/backends/patitas/directives/builtins/cards.py
@@ -93,6 +93,12 @@ VALID_COLORS = frozenset(
     ]
 )
 
+GAP_TO_CHIRPUI = {
+    "small": "sm",
+    "medium": "md",
+    "large": "lg",
+}
+
 
 # =============================================================================
 # Utility functions
@@ -337,13 +343,12 @@ class CardsDirective:
         sb: StringBuilder,
     ) -> None:
         """Render cards grid container to HTML."""
-        opts = node.options  # Direct typed access!
-
-        columns = opts.columns
-        gap = opts.gap
-        style = opts.style
-        variant = opts.variant
-        layout = opts.layout
+        ctx = self.get_template_context(node, rendered_children)
+        columns = ctx["columns"]
+        gap = ctx["gap"]
+        style = ctx["style"]
+        variant = ctx["variant"]
+        layout = ctx["layout"]
 
         sb.append(
             f'<div class="card-grid" '
@@ -355,6 +360,25 @@ class CardsDirective:
         )
         sb.append(rendered_children)
         sb.append("</div>\n")
+
+    def get_template_context(
+        self,
+        node: Directive[CardsOptions],
+        rendered_children: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Return template context for theme-overridable cards grid rendering."""
+        opts = node.options
+        return {
+            "columns": opts.columns,
+            "gap": opts.gap,
+            "chirpui_gap": GAP_TO_CHIRPUI.get(opts.gap, "md"),
+            "style": opts.style,
+            "variant": opts.variant,
+            "layout": opts.layout,
+            "extra_class": opts.class_,
+            "children": rendered_children,
+        }
 
 
 # =============================================================================
@@ -433,31 +457,21 @@ class CardDirective:
             xref_index: Optional cross-reference index for link resolution
             current_page_dir: Content-relative directory for resolving ./ and ../
         """
-        opts = node.options  # Direct typed access!
-
-        # Title comes from node.title (directive title)
-        title = node.title or ""
-        icon = opts.icon
-        link = opts.link
-        description = opts.description
-        badge = opts.badge
-        color = opts.color
-        image = opts.image
-        footer = opts.footer
-        layout = opts.layout
-        pull_fields = [f.strip() for f in opts.pull.split(",") if f.strip()]
-
-        # Resolve link and pull data from linked page if xref_index is available
-        resolved_link = link
-        linked_page = None
-        if link and xref_index:
-            resolved_link, linked_page = _resolve_link(link, xref_index, current_page_dir)
-
-        # Pull data from linked page
-        if linked_page and pull_fields:
-            title, description, icon = _pull_from_page(
-                linked_page, pull_fields, title, description, icon
-            )
+        ctx = self.get_template_context(
+            node,
+            rendered_children,
+            xref_index=xref_index,
+            current_page_dir=current_page_dir,
+        )
+        title = ctx["title"]
+        icon = ctx["icon"]
+        resolved_link = ctx["href"]
+        description = ctx["description"]
+        badge = ctx["badge"]
+        color = ctx["color"]
+        image = ctx["image"]
+        footer = ctx["footer"]
+        layout = ctx["layout"]
 
         # Card wrapper (link or div)
         if resolved_link:
@@ -518,6 +532,49 @@ class CardDirective:
             sb.append("  </div>\n")
 
         sb.append(f"</{card_tag}>\n")
+
+    def get_template_context(
+        self,
+        node: Directive[CardOptions],
+        rendered_children: str,
+        *,
+        xref_index: dict[str, Any] | None = None,
+        current_page_dir: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Return template context for theme-overridable card rendering."""
+        opts = node.options
+
+        title = node.title or ""
+        icon = opts.icon
+        link = opts.link
+        description = opts.description
+        pull_fields = [f.strip() for f in opts.pull.split(",") if f.strip()]
+
+        resolved_link = link
+        linked_page = None
+        if link and xref_index:
+            resolved_link, linked_page = _resolve_link(link, xref_index, current_page_dir)
+
+        if linked_page and pull_fields:
+            title, description, icon = _pull_from_page(
+                linked_page, pull_fields, title, description, icon
+            )
+
+        return {
+            "title": title,
+            "icon": icon,
+            "icon_html": _render_icon(icon, card_title=title) if icon else "",
+            "href": resolved_link,
+            "description": description,
+            "badge": opts.badge,
+            "color": opts.color,
+            "image": opts.image,
+            "footer": opts.footer,
+            "layout": opts.layout,
+            "extra_class": opts.class_,
+            "children": rendered_children,
+        }
 
 
 # =============================================================================
@@ -656,3 +713,76 @@ class ChildCardsDirective:
             sb.append(card_html)
 
         sb.append("</div>\n")
+
+    def get_template_context(
+        self,
+        node: Directive[ChildCardsOptions],
+        rendered_children: str,
+        *,
+        page_context: Any | None = None,
+        xref_index: dict[str, Any] | None = None,
+        current_page_dir: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Return template context for theme-overridable child-card rendering."""
+        from bengal.parsing.backends.patitas.directives.builtins.cards_utils import (
+            _render_description_html,
+            collect_children,
+        )
+
+        opts = node.options
+        fields = [f.strip() for f in opts.fields.split(",") if f.strip()]
+        context: dict[str, Any] = {
+            "columns": opts.columns,
+            "gap": opts.gap,
+            "chirpui_gap": GAP_TO_CHIRPUI.get(opts.gap, "md"),
+            "style": opts.style,
+            "variant": "navigation",
+            "layout": opts.layout,
+            "include": opts.include,
+            "fields": fields,
+            "cards": [],
+            "empty_message": "",
+            "children": rendered_children,
+        }
+
+        if not page_context:
+            context["empty_message"] = "No page context available"
+            return context
+
+        section = getattr(page_context, "_section", None)
+        if not section:
+            context["empty_message"] = "Page has no section"
+            return context
+
+        children_items = collect_children(
+            section, page_context, opts.include, xref_index, current_page_dir
+        )
+        if not children_items:
+            context["empty_message"] = "No child content found"
+            return context
+
+        cards: list[dict[str, Any]] = []
+        for child in children_items:
+            child_type = child.get("type", "page")
+            icon = child.get("icon", "") if "icon" in fields else ""
+            if not icon and "icon" in fields:
+                icon = "folder" if child_type == "section" else "file"
+            title = child.get("title", "") if "title" in fields else ""
+            description = child.get("description", "") if "description" in fields else ""
+            cards.append(
+                {
+                    "title": title,
+                    "description": description,
+                    "description_html": _render_description_html(description)
+                    if description
+                    else "",
+                    "icon": icon,
+                    "icon_html": _render_icon(icon, card_title=title) if icon else "",
+                    "href": child.get("url", ""),
+                    "type": child_type,
+                    "layout": opts.layout,
+                }
+            )
+        context["cards"] = cards
+        return context

--- a/bengal/rendering/assets.py
+++ b/bengal/rendering/assets.py
@@ -113,6 +113,7 @@ __all__ = [
     "clear_manifest_cache",
     "drain_asset_fallback_aggregator",
     "get_asset_manifest",
+    "get_asset_manifest_revision",
     # Observability exports (Phase 2)
     "get_resolution_stats",
     "reset_asset_manifest",
@@ -239,6 +240,41 @@ def asset_manifest_context(ctx: AssetManifestContext):
         The context that was set (same as input).
     """
     return _asset_manifest(ctx)
+
+
+def get_asset_manifest_revision(site: AssetSiteLike | None = None) -> str | None:
+    """Return the current asset manifest revision for cache key namespacing.
+
+    Fragment caches can outlive a single page render. If a cached fragment
+    contains ``asset_url()``, its output depends on the active asset manifest.
+    Namespacing fragment keys by this revision prevents a cache hit from
+    replaying URLs from an older manifest.
+    """
+    ctx = get_asset_manifest()
+    if ctx is not None:
+        if ctx.mtime is not None:
+            return f"context-mtime:{ctx.mtime}"
+        if ctx.entries:
+            import hashlib
+
+            digest = hashlib.sha256()
+            for logical_path, output_path in sorted(ctx.entries.items()):
+                digest.update(logical_path.encode("utf-8", "surrogateescape"))
+                digest.update(b"\0")
+                digest.update(output_path.encode("utf-8", "surrogateescape"))
+                digest.update(b"\0")
+            return f"context-entries:{digest.hexdigest()[:16]}"
+        return "context-empty"
+
+    if site is None or getattr(site, "dev_mode", False):
+        return None
+
+    manifest_path = site.output_dir / "asset-manifest.json"
+    try:
+        stat = manifest_path.stat()
+    except OSError:
+        return None
+    return f"file:{stat.st_mtime_ns}:{stat.st_size}"
 
 
 # =============================================================================

--- a/bengal/rendering/engines/kida.py
+++ b/bengal/rendering/engines/kida.py
@@ -456,6 +456,12 @@ class KidaTemplateEngine:
             pure_filters=_PURE_FILTERS,
             **env_kwargs,
         )
+        from bengal.rendering.fragment_cache import AssetManifestFragmentCache
+
+        self._env._fragment_cache = AssetManifestFragmentCache(
+            self._env._fragment_cache,
+            self.site,
+        )
 
         # Register Bengal-specific globals and filters
         # Uses register_all() which works because Kida has same interface as Jinja2

--- a/bengal/rendering/fragment_cache.py
+++ b/bengal/rendering/fragment_cache.py
@@ -1,0 +1,66 @@
+"""Bengal-aware wrappers for template fragment caches."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bengal.rendering.assets import AssetSiteLike
+
+
+class AssetManifestFragmentCache:
+    """Namespace Kida fragment cache keys by the active asset manifest revision."""
+
+    __slots__ = ("_cache", "_site")
+
+    def __init__(self, cache: Any, site: AssetSiteLike) -> None:
+        self._cache = cache
+        self._site = site
+
+    def _key(self, key: str) -> str:
+        from bengal.rendering.assets import get_asset_manifest_revision
+
+        revision = get_asset_manifest_revision(self._site)
+        if revision is None:
+            return key
+        return f"asset-manifest:{revision}:{key}"
+
+    def get(self, key: str) -> str | None:
+        return self._cache.get(self._key(key))
+
+    def get_or_set(
+        self,
+        key: str,
+        factory: Callable[[], str] | Callable[[str], str],
+        *,
+        pass_key: bool = False,
+        ttl: float | None = None,
+    ) -> str:
+        namespaced_key = self._key(key)
+        if pass_key:
+            key_factory = cast("Callable[[str], str]", factory)
+            return self._cache.get_or_set(
+                namespaced_key,
+                lambda _namespaced_key: key_factory(key),
+                pass_key=True,
+                ttl=ttl,
+            )
+        return self._cache.get_or_set(
+            namespaced_key,
+            factory,
+            ttl=ttl,
+        )
+
+    def set(self, key: str, value: str, *, ttl: float | None = None) -> None:
+        self._cache.set(self._key(key), value, ttl=ttl)
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    def stats(self) -> dict[str, Any]:
+        return self._cache.stats()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cache, name)

--- a/bengal/themes/chirpui/README.md
+++ b/bengal/themes/chirpui/README.md
@@ -1,0 +1,33 @@
+# Bengal Chirp UI Theme
+
+Experimental bundled theme that renders Bengal sites with Chirp UI 0.7
+components.
+
+This theme is separate from `default` and does not inherit its assets. It uses
+the Bengal theme-library provider contract in `theme.toml`:
+
+```toml
+name = "chirpui"
+libraries = ["chirp_ui"]
+```
+
+Install `chirp-ui` in the build environment before selecting this theme:
+
+```bash
+uv add chirp-ui
+```
+
+Then set:
+
+```toml
+[site]
+theme = "chirpui"
+```
+
+The first version is intentionally static and server-rendered. It uses Chirp UI
+0.7 macros for the site shell, navbar, drawer-backed mobile docs menu, document
+headers, detail headers, profile headers, rendered markdown content, docs side
+panels, nav trees, resource indexes, index cards, post cards, timelines, badges,
+metrics, and search headers. A small Bengal bridge stylesheet handles the docs
+grid, grouped search filtering surface, skip link, and footer spacing. It does
+not load the default theme CSS or JavaScript.

--- a/bengal/themes/chirpui/assets/css/style.css
+++ b/bengal/themes/chirpui/assets/css/style.css
@@ -1,0 +1,276 @@
+body {
+    margin: 0;
+    min-height: 100vh;
+    color: var(--chirpui-text);
+    background: var(--chirpui-bg);
+    font-family: var(--chirpui-prose-font-family);
+}
+
+.chirpui-bengal-skip {
+    position: fixed;
+    inset-block-start: var(--chirpui-spacing-sm);
+    inset-inline-start: var(--chirpui-spacing-sm);
+    z-index: 100;
+    transform: translateY(-150%);
+}
+
+.chirpui-bengal-skip:focus {
+    transform: translateY(0);
+}
+
+.chirpui-bengal-main {
+    padding-block: var(--chirpui-spacing-xl);
+}
+
+.chirpui-bengal-topbar-actions {
+    align-items: center;
+}
+
+.chirpui-bengal-icon-btn {
+    inline-size: 2rem;
+    min-inline-size: 2rem;
+    padding-inline: 0;
+}
+
+.chirpui-bengal-shell {
+    min-height: 100vh;
+}
+
+.chirpui-bengal-home-metrics {
+    align-items: stretch;
+}
+
+.chirpui-bengal-docs {
+    display: grid;
+    grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr) minmax(12rem, 16rem);
+    gap: var(--chirpui-spacing-lg);
+    align-items: start;
+}
+
+.chirpui-bengal-docs__mobile-nav {
+    display: none;
+    margin-block-end: var(--chirpui-spacing-md);
+}
+
+.chirpui-bengal-docs__nav,
+.chirpui-bengal-docs__toc {
+    position: sticky;
+    inset-block-start: calc(var(--chirpui-spacing-lg) + 4rem);
+    max-height: calc(100vh - 6rem);
+    overflow: auto;
+}
+
+.chirpui-bengal-docs__article {
+    min-width: 0;
+}
+
+.chirpui-bengal-doc-header {
+    padding-block-end: var(--chirpui-spacing-sm);
+    border-block-end: 1px solid var(--chirpui-border);
+}
+
+.chirpui-bengal-doc-header .chirpui-document-header__details {
+    margin-block-start: var(--chirpui-spacing-xs);
+}
+
+.chirpui-bengal-article-surface {
+    min-width: 0;
+}
+
+.chirpui-bengal-rendered {
+    max-width: 72ch;
+}
+
+.chirpui-bengal-docs__article .chirpui-bengal-rendered {
+    max-width: 76ch;
+}
+
+.chirpui-bengal-content-card .chirpui-bengal-rendered {
+    max-width: none;
+}
+
+.chirpui-bengal-docs__nav .chirpui-nav-tree__header {
+    padding-inline: var(--chirpui-spacing-sm);
+    padding-block-end: var(--chirpui-spacing-xs);
+}
+
+.chirpui-bengal-docs__nav .chirpui-nav-tree__list {
+    margin: 0;
+    padding-inline-start: 0;
+}
+
+.chirpui-bengal-docs__nav .chirpui-nav-tree__list--nested {
+    margin-block-start: var(--chirpui-spacing-xs);
+    margin-inline-start: var(--chirpui-spacing-sm);
+    padding-inline-start: var(--chirpui-spacing-sm);
+    border-inline-start: 1px solid var(--chirpui-border);
+}
+
+.chirpui-bengal-docs__nav .chirpui-nav-tree__item + .chirpui-nav-tree__item {
+    margin-block-start: 0.125rem;
+}
+
+.chirpui-bengal-docs__nav .chirpui-nav-tree__link {
+    border-radius: var(--chirpui-radius-sm);
+}
+
+.chirpui-bengal-docs__nav .chirpui-nav-tree__link--active {
+    font-weight: 650;
+}
+
+.chirpui-bengal-docs-drawer .chirpui-nav-tree__header {
+    display: none;
+}
+
+.chirpui-bengal-toc-panel .chirpui-panel__body {
+    padding: var(--chirpui-spacing-sm);
+}
+
+.chirpui-bengal-toc :where(ul, ol) {
+    list-style: none;
+    padding-inline-start: 0;
+    margin-block: 0;
+}
+
+.chirpui-bengal-toc :where(ul ul, ol ol) {
+    padding-inline-start: var(--chirpui-spacing-md);
+    margin-block-start: var(--chirpui-spacing-xs);
+}
+
+.chirpui-bengal-toc li + li {
+    margin-block-start: var(--chirpui-spacing-xs);
+}
+
+.chirpui-bengal-toc a {
+    display: block;
+    padding-block: 0.125rem;
+    color: var(--chirpui-text-muted);
+    font-size: 0.875rem;
+    line-height: 1.4;
+    text-decoration: none;
+}
+
+.chirpui-bengal-toc a:hover {
+    color: var(--chirpui-text);
+}
+
+.chirpui-bengal-page-nav {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--chirpui-spacing-md);
+    margin-block-start: var(--chirpui-spacing-xl);
+}
+
+.chirpui-bengal-post-feed {
+    display: grid;
+    gap: var(--chirpui-spacing-md);
+}
+
+.chirpui-bengal-post-card p {
+    margin-block: 0;
+}
+
+.chirpui-bengal-search-count {
+    margin: calc(var(--chirpui-spacing-md) * -1) 0 0;
+}
+
+.chirpui-bengal-search-results,
+.chirpui-bengal-search-group__items {
+    display: grid;
+    gap: var(--chirpui-spacing-md);
+}
+
+.chirpui-bengal-search-group {
+    display: grid;
+    gap: var(--chirpui-spacing-sm);
+}
+
+.chirpui-bengal-search-group__header,
+.chirpui-bengal-search-result__meta {
+    display: flex;
+    align-items: center;
+    gap: var(--chirpui-spacing-xs);
+}
+
+.chirpui-bengal-search-group__header {
+    justify-content: space-between;
+    padding-block-end: var(--chirpui-spacing-xs);
+    border-block-end: 1px solid var(--chirpui-border);
+}
+
+.chirpui-bengal-search-group__header h2 {
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+.chirpui-bengal-search-result {
+    display: grid;
+    gap: var(--chirpui-spacing-xs);
+    padding-block: var(--chirpui-spacing-sm);
+    border-block-end: 1px solid var(--chirpui-border);
+}
+
+.chirpui-bengal-search-result__meta {
+    color: var(--chirpui-text-muted);
+    font-size: 0.8rem;
+}
+
+.chirpui-bengal-search-result__title {
+    color: var(--chirpui-text);
+    font-weight: 650;
+    text-decoration: none;
+}
+
+.chirpui-bengal-search-result__title:hover {
+    color: var(--chirpui-primary);
+}
+
+.chirpui-bengal-search-result p {
+    margin: 0;
+    color: var(--chirpui-text-muted);
+}
+
+.chirpui-bengal-release-timeline p {
+    margin-block-start: 0;
+}
+
+.chirpui-bengal-change-list {
+    margin-block: 0;
+    padding-inline-start: 1.1rem;
+}
+
+.chirpui-bengal-footer {
+    border-block-start: 1px solid var(--chirpui-border);
+    padding-block: var(--chirpui-spacing-lg);
+    color: var(--chirpui-text-muted);
+}
+
+.chirpui-bengal-search-box {
+    width: 100%;
+    padding: var(--chirpui-spacing-sm) var(--chirpui-spacing-md);
+    border: 1px solid var(--chirpui-border);
+    border-radius: var(--chirpui-radius-md);
+    background: var(--chirpui-surface);
+    color: var(--chirpui-text);
+    font: inherit;
+}
+
+@media (max-width: 62rem) {
+    .chirpui-bengal-docs {
+        grid-template-columns: 1fr;
+    }
+
+    .chirpui-bengal-docs__toc {
+        position: static;
+        max-height: none;
+    }
+
+    .chirpui-bengal-docs__nav {
+        display: none;
+    }
+
+    .chirpui-bengal-docs__mobile-nav {
+        display: block;
+    }
+}

--- a/bengal/themes/chirpui/assets/js/chirpui-bengal.js
+++ b/bengal/themes/chirpui/assets/js/chirpui-bengal.js
@@ -1,0 +1,135 @@
+(function () {
+    "use strict";
+
+    var themeOrder = ["system", "light", "dark"];
+    var themeIcons = { system: "◐", light: "○", dark: "●" };
+
+    function setAttr(name, value) {
+        document.documentElement.setAttribute(name, value);
+    }
+
+    function stored(name, fallback) {
+        try {
+            return localStorage.getItem(name) || fallback;
+        } catch (error) {
+            return fallback;
+        }
+    }
+
+    function persist(name, value) {
+        try {
+            localStorage.setItem(name, value);
+        } catch (error) {
+            return;
+        }
+    }
+
+    function cycle(current, order) {
+        var index = order.indexOf(current);
+        return order[(index + 1) % order.length] || order[0];
+    }
+
+    function syncControls() {
+        var theme = stored("chirpui-theme", "system");
+
+        setAttr("data-theme", theme);
+
+        document.querySelectorAll("[data-chirpui-theme-icon]").forEach(function (icon) {
+            icon.textContent = themeIcons[theme] || themeIcons.system;
+        });
+    }
+
+    function setupThemeControls() {
+        document.querySelectorAll("[data-chirpui-theme-cycle]").forEach(function (button) {
+            button.addEventListener("click", function () {
+                var next = cycle(stored("chirpui-theme", "system"), themeOrder);
+                persist("chirpui-theme", next);
+                syncControls();
+            });
+        });
+
+        syncControls();
+    }
+
+    function setupSearch() {
+        var input = document.getElementById("q");
+        var results = Array.prototype.slice.call(document.querySelectorAll("[data-chirpui-search-item]"));
+        var groups = Array.prototype.slice.call(document.querySelectorAll("[data-chirpui-search-group]"));
+        var empty = document.getElementById("chirpui-bengal-search-empty");
+        var count = document.getElementById("chirpui-bengal-search-count");
+
+        if (!input || results.length === 0) {
+            return;
+        }
+
+        var params = new URLSearchParams(window.location.search);
+        if (params.has(input.name)) {
+            input.value = params.get(input.name) || "";
+        }
+
+        function apply() {
+            var query = input.value.trim().toLowerCase();
+            var visible = 0;
+
+            results.forEach(function (item) {
+                var text = (item.getAttribute("data-search-text") || "").toLowerCase();
+                var match = !query || text.indexOf(query) !== -1;
+                item.hidden = !match;
+                if (match) {
+                    visible += 1;
+                }
+            });
+
+            groups.forEach(function (group) {
+                var groupVisible = Array.prototype.some.call(
+                    group.querySelectorAll("[data-chirpui-search-item]"),
+                    function (item) {
+                        return !item.hidden;
+                    }
+                );
+                group.hidden = !groupVisible;
+            });
+
+            if (count) {
+                count.textContent = visible + (visible === 1 ? " result" : " results");
+            }
+
+            if (empty) {
+                empty.hidden = visible !== 0;
+            }
+        }
+
+        input.addEventListener("input", apply);
+        var form = input.closest("form");
+        if (form) {
+            form.addEventListener("submit", function (event) {
+                event.preventDefault();
+                apply();
+            });
+        }
+        apply();
+    }
+
+    function setupDrawers() {
+        document.querySelectorAll("[data-chirpui-drawer-open]").forEach(function (button) {
+            button.addEventListener("click", function () {
+                var id = button.getAttribute("data-chirpui-drawer-open");
+                var drawer = id ? document.getElementById(id) : null;
+                if (!drawer) {
+                    return;
+                }
+                if (typeof drawer.showModal === "function") {
+                    drawer.showModal();
+                    return;
+                }
+                drawer.setAttribute("open", "");
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        setupThemeControls();
+        setupSearch();
+        setupDrawers();
+    });
+})();

--- a/bengal/themes/chirpui/templates/404.html
+++ b/bengal/themes/chirpui/templates/404.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container %}
+{% from "chirpui/empty.html" import empty_state %}
+
+{% block content %}
+{% call container(max_width="48rem") %}
+    {% call empty_state(title="Page not found", action_label="Go Home", action_href="/" | absolute_url) %}
+        <p>The page may have moved, or the link may be out of date.</p>
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/archive-year.html
+++ b/bengal/themes/chirpui/templates/archive-year.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container %}
+{% from "chirpui/resource_index.html" import resource_index %}
+{% from "chirpui/metric_grid.html" import metric_grid, metric_card %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import searchable_post_feed %}
+
+{% block content %}
+{% let year = params?.year ?? page?.title ?? "Archive" %}
+{% let year_posts = posts ?? section?.regular_pages ?? section?.pages ?? site.listable_pages ?? [] %}
+
+{% call container(max_width="76rem") %}
+    {% call resource_index(year ~ " Archive", page?.href ?? page?._path ?? "/archive/", subtitle=page?.description ?? "Content published during this year.", search_placeholder="Filter this year...", button_icon="search", results_title="Entries", results_subtitle=(year_posts | length) ~ " entries", has_results=year_posts | length > 0, empty_title="No content for this year yet", cls="chirpui-bengal-resource-index") %}
+        <p class="chirpui-text-muted chirpui-bengal-search-count" id="chirpui-bengal-search-count" aria-live="polite">{{ year_posts | length }} results</p>
+        {% if content %}
+        {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+        {% end %}
+        {% call metric_grid(cols=2, gap="md") %}
+            {{ metric_card(value=year_posts | length, label="Entries") }}
+            {{ metric_card(value=year, label="Year") }}
+        {% end %}
+        {{ searchable_post_feed(year_posts, "No content for this year yet.") }}
+        <div id="chirpui-bengal-search-empty" class="chirpui-bengal-search-empty" hidden>
+            <p class="chirpui-text-muted">No matching entries.</p>
+        </div>
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/archive.html
+++ b/bengal/themes/chirpui/templates/archive.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container %}
+{% from "chirpui/resource_index.html" import resource_index %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import searchable_post_feed %}
+
+{% block content %}
+{% let title = page?.title ?? section?.title ?? "Archive" %}
+{% let description = page?.description ?? section?.description ?? "Browse published content." %}
+{% let archive_posts = posts ?? section?.regular_pages ?? section?.pages ?? site.listable_pages ?? [] %}
+
+{% call container(max_width="76rem") %}
+    {% call resource_index(title, page?.href ?? page?._path ?? "/archive/", subtitle=description, search_placeholder="Filter archive...", button_icon="search", results_title="Archive", results_subtitle=(archive_posts | length) ~ " entries", has_results=archive_posts | length > 0, empty_title="No archived content yet", cls="chirpui-bengal-resource-index") %}
+        <p class="chirpui-text-muted chirpui-bengal-search-count" id="chirpui-bengal-search-count" aria-live="polite">{{ archive_posts | length }} results</p>
+        {% if content %}
+        {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+        {% end %}
+        {{ searchable_post_feed(archive_posts, "No archived content yet.") }}
+        <div id="chirpui-bengal-search-empty" class="chirpui-bengal-search-empty" hidden>
+            <p class="chirpui-text-muted">No matching archive entries.</p>
+        </div>
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/author.html
+++ b/bengal/themes/chirpui/templates/author.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack %}
+{% from "chirpui/profile_header.html" import profile_header %}
+{% from "chirpui/metric_grid.html" import metric_grid, metric_card %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import post_feed %}
+
+{% block content %}
+{% let author_name = params?.author_name ?? page?.title ?? "Author" %}
+{% let author_bio = params?.bio ?? page?.description ?? none %}
+{% let author_posts = posts ?? section?.regular_pages ?? section?.pages ?? site.listable_pages ?? [] %}
+
+{% call container(max_width="76rem") %}
+    {% call stack(gap="lg") %}
+        {% call profile_header(name=author_name, use_slots=true, cls="chirpui-bengal-author-header") %}
+            {% slot bio %}
+            {% if author_bio %}<p>{{ author_bio }}</p>{% end %}
+            {% end %}
+            {% slot stats %}
+            <span>{{ author_posts | length }} published</span>
+            {% end %}
+        {% end %}
+        {% if content %}
+            {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+        {% end %}
+        {% call metric_grid(cols=2, gap="md") %}
+            {{ metric_card(value=author_posts | length, label="Published Pages") }}
+            {{ metric_card(value=author_name, label="Author") }}
+        {% end %}
+        {{ post_feed(author_posts, "No author content yet.") }}
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/base.html
+++ b/bengal/themes/chirpui/templates/base.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+{% from "chirpui/navbar.html" import navbar, navbar_link, navbar_dropdown %}
+{% from "chirpui/button.html" import btn %}
+{% from "chirpui/layout.html" import cluster %}
+{% from "chirpui/nav_progress.html" import nav_progress %}
+{% from "chirpui/site_shell.html" import site_shell %}
+{% from "chirpui/site_footer.html" import site_footer, footer_column, footer_link %}
+
+{% let _current_lang = current_lang() %}
+{% let _direction = direction() %}
+{% let _site_title = site.title %}
+{% let _page_title = page?.title ?? _site_title %}
+{% let _page_url = page?._path ?? page?.href ?? "/" %}
+{% let _main_menu = get_menu_lang("main", _current_lang) %}
+{% let _auto_nav = get_auto_nav() if _main_menu | length == 0 else [] %}
+
+<html lang="{{ _current_lang }}" dir="{{ _direction }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ _page_title }}{% if _page_title != _site_title %} - {{ _site_title }}{% end %}</title>
+    <meta name="description" content="{{ meta_desc ?? site.description }}">
+    {% if site.baseurl %}
+    <link rel="canonical" href="{{ canonical_url(_page_url) }}">
+    {% end %}
+    <link rel="stylesheet" href="{{ asset_url('chirp_ui/chirpui.css') }}">
+    <link rel="stylesheet" href="{{ asset_url('chirp_ui/chirpui-transitions.css') }}">
+    <link rel="stylesheet" href="{{ asset_url('css/style.css') }}">
+    <script src="{{ asset_url('chirp_ui/chirpui.js') }}"></script>
+    {% block extra_head %}{% end %}
+</head>
+<body data-type="{{ page?.type ?? '' }}">
+    {% call site_shell(cls="chirpui-bengal-shell") %}
+    {% slot header %}
+        {% if "accessibility.skip_link" in (theme.features ?? []) %}
+        <a class="chirpui-btn chirpui-btn--primary chirpui-bengal-skip" href="#main">Skip to main content</a>
+        {% end %}
+        {{ nav_progress() }}
+
+        {% call navbar(brand=_site_title, brand_url="/" | absolute_url, cls="chirpui-navbar--sticky", use_slots=true, current_path=_page_url) %}
+            {% for item in _main_menu %}
+                {% let item_href = item?.href ?? item?.url ?? "#" %}
+                {% let item_name = item?.name ?? item?.title ?? "Untitled" %}
+                {% set active_children = [] %}
+                {% for child in item?.children ?? [] %}
+                    {% let child_href = child?.href ?? child?.url ?? "#" %}
+                    {% if child_href != "#" and (_page_url == child_href or (child_href != "/" and _page_url.startswith(child_href))) %}
+                        {% set _ = active_children.append(true) %}
+                    {% end %}
+                {% end %}
+                {% let item_active = (item?.active ?? false) or (_page_url == item_href) or (item_href != "/" and item_href != "#" and _page_url.startswith(item_href)) or (active_children | length > 0) %}
+                {% if item?.children ?? [] %}
+                    {% call navbar_dropdown(item_name, active=item_active) %}
+                        {% for child in item.children %}
+                        {% let child_href = child?.href ?? child?.url ?? "#" %}
+                        {% let child_active = child_href != "#" and (_page_url == child_href or (child_href != "/" and child_href != "#" and _page_url.startswith(child_href))) %}
+                        <a class="chirpui-dropdown__item{% if child_active %} chirpui-dropdown__item--active{% end %}" href="{{ child_href | absolute_url }}"{% if child_active %} aria-current="page"{% end %}>{{ child?.name ?? child?.title ?? "Untitled" }}</a>
+                        {% end %}
+                    {% end %}
+                {% else %}
+                    {{ navbar_link(item_href | absolute_url, item_name, active=item_active) }}
+                {% end %}
+            {% end %}
+            {% for item in _auto_nav %}
+                {% let item_href = item?.href ?? item?.url ?? "#" %}
+                {% let item_name = item?.name ?? item?.title ?? "Untitled" %}
+                {% let item_active = (_page_url == item_href) or (item_href != "/" and item_href != "#" and _page_url.startswith(item_href)) %}
+                {{ navbar_link(item_href | absolute_url, item_name, active=item_active) }}
+            {% end %}
+            {% slot end %}
+            {% call cluster(gap="xs", cls="chirpui-bengal-topbar-actions") %}
+                {{ btn("Search", href="/search/" | absolute_url, variant="ghost", size="sm", icon="search") }}
+                <button type="button" class="chirpui-btn chirpui-btn--ghost chirpui-btn--sm chirpui-bengal-icon-btn" data-chirpui-theme-cycle aria-label="Cycle color theme" title="Theme">
+                    <span aria-hidden="true" data-chirpui-theme-icon>◐</span>
+                </button>
+            {% end %}
+            {% end %}
+        {% end %}
+    {% end %}
+
+        <main id="main" class="chirpui-bengal-main">
+            {% block content %}{% end %}
+        </main>
+
+    {% slot footer %}
+        {% block site_footer %}
+        {% call site_footer(layout="simple", cls="chirpui-bengal-footer") %}
+            {% slot brand %}
+            <a href="{{ "/" | absolute_url }}">{{ _site_title }}</a>
+            {% end %}
+            {% call footer_column() %}
+                {{ footer_link("/search/" | absolute_url, "Search") }}
+                {{ footer_link("https://github.com/lbliii/bengal", "Bengal", external=true) }}
+            {% end %}
+            {% slot colophon %}&copy; {{ site.build_time | dateformat("%Y") }} {{ _site_title }}{% end %}
+        {% end %}
+        {% end %}
+    {% end %}
+    {% end %}
+    <script defer src="{{ asset_url('js/chirpui-bengal.js') }}"></script>
+    {% block extra_js %}{% end %}
+</body>
+</html>

--- a/bengal/themes/chirpui/templates/blog/home.html
+++ b/bengal/themes/chirpui/templates/blog/home.html
@@ -1,0 +1,1 @@
+{% extends "home.html" %}

--- a/bengal/themes/chirpui/templates/blog/list.html
+++ b/bengal/themes/chirpui/templates/blog/list.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container %}
+{% from "chirpui/resource_index.html" import resource_index %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import searchable_post_feed %}
+
+{% block content %}
+{% let title = page?.title ?? section?.title ?? "Blog" %}
+{% let description = page?.description ?? section?.description ?? "Latest posts and updates." %}
+{% let posts = section?.regular_pages ?? section?.pages ?? page?.children ?? [] %}
+
+{% call container(max_width="76rem") %}
+    {% call resource_index(title, page?.href ?? section?.href ?? "/blog/", subtitle=description, search_placeholder="Filter posts...", button_icon="search", results_title="Posts", results_subtitle=(posts | length) ~ " published", has_results=posts | length > 0, empty_title="No posts yet", cls="chirpui-bengal-resource-index") %}
+        <p class="chirpui-text-muted chirpui-bengal-search-count" id="chirpui-bengal-search-count" aria-live="polite">{{ posts | length }} results</p>
+        {% if content %}
+        {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+        {% end %}
+        {{ searchable_post_feed(posts, "No posts yet.") }}
+        <div id="chirpui-bengal-search-empty" class="chirpui-bengal-search-empty" hidden>
+            <p class="chirpui-text-muted">No matching posts.</p>
+        </div>
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/blog/single.html
+++ b/bengal/themes/chirpui/templates/blog/single.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack %}
+{% from "chirpui/detail_header.html" import detail_header %}
+{% from "chirpui/card.html" import card %}
+{% from "chirpui/breadcrumbs.html" import breadcrumbs %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import tag_badges %}
+
+{% block content %}
+{% let title = page?.title ?? "Post" %}
+{% let description = page?.description ?? params?.description ?? none %}
+{% let page_date = page?.date ?? none %}
+
+{% call container(max_width="72rem") %}
+    {% call stack(gap="lg") %}
+        {{ breadcrumbs([{"label": "Home", "href": "/" | absolute_url}, {"label": "Blog", "href": "/blog/" | absolute_url}, {"label": title}]) }}
+        {% call detail_header(title, summary=description, eyebrow="Blog Post", cls="chirpui-bengal-detail-header") %}
+            {% slot meta %}
+            {% if page_date %}<span class="chirpui-text-muted">{{ page_date | dateformat("%B %d, %Y") }}</span>{% end %}
+            {% end %}
+            {% slot badges %}
+            {{ tag_badges(page?.tags ?? []) }}
+            {% end %}
+        {% end %}
+
+        {% call card(cls="chirpui-bengal-content-card") %}
+            {% call rendered_content(cls="chirpui-bengal-rendered") %}
+                {{ content | safe }}
+            {% end %}
+        {% end %}
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/changelog/list.html
+++ b/bengal/themes/chirpui/templates/changelog/list.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack %}
+{% from "chirpui/hero.html" import page_hero %}
+{% from "chirpui/timeline.html" import timeline, timeline_item %}
+{% from "chirpui/button.html" import btn %}
+{% from "chirpui/empty.html" import empty_state %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+
+{% block content %}
+{% let title = page?.title ?? section?.title ?? "Changelog" %}
+{% let description = page?.description ?? section?.description ?? "Release notes and project changes." %}
+{% let releases = pages ?? section?.regular_pages ?? section?.pages ?? page?.children ?? [] %}
+
+{% call container(max_width="76rem") %}
+    {% call stack(gap="lg") %}
+        {% call page_hero(title=title, subtitle=description, variant="minimal", background="muted") %}
+            {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+        {% end %}
+
+        {% if releases %}
+        {% call timeline(cls="chirpui-bengal-release-timeline") %}
+            {% for release in releases %}
+            {% let release_date = release.date ?? none %}
+            {% let release_date_text = "" %}
+            {% if release_date %}{% let release_date_text = release_date | dateformat("%B %d, %Y") %}{% end %}
+            {% call timeline_item(release.title, release_date_text) %}
+                {% slot content %}
+                {% if release.description ?? release.summary ?? none %}
+                <p>{{ release.description ?? release.summary }}</p>
+                {% end %}
+                {{ btn("Read notes", href=release.href, variant="ghost", size="sm") }}
+                {% end %}
+            {% end %}
+            {% end %}
+        {% end %}
+        {% else %}
+        {{ empty_state(title="No releases yet") }}
+        {% end %}
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/changelog/single.html
+++ b/bengal/themes/chirpui/templates/changelog/single.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack, grid, block %}
+{% from "chirpui/detail_header.html" import detail_header %}
+{% from "chirpui/card.html" import card %}
+{% from "chirpui/callout.html" import callout %}
+{% from "chirpui/status.html" import status_indicator %}
+{% from "chirpui/breadcrumbs.html" import breadcrumbs %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+
+{% def change_group(title, items, variant="neutral") %}
+{% if items %}
+{% call block() %}
+    {% call callout(title=title, variant=variant) %}
+        <ul class="chirpui-bengal-change-list">
+            {% for item in items %}
+            <li>{{ item }}</li>
+            {% end %}
+        </ul>
+    {% end %}
+{% end %}
+{% end %}
+{% end %}
+
+{% block content %}
+{% let title = page?.title ?? "Release" %}
+{% let description = page?.description ?? params?.summary ?? params?.description ?? none %}
+{% let status = params?.status ?? "released" %}
+{% let release_date = page?.date ?? none %}
+
+{% call container(max_width="76rem") %}
+    {% call stack(gap="lg") %}
+        {{ breadcrumbs([{"label": "Home", "href": "/" | absolute_url}, {"label": "Changelog", "href": "/changelog/" | absolute_url}, {"label": title}]) }}
+        {% call detail_header(title, summary=description, eyebrow="Release", cls="chirpui-bengal-detail-header") %}
+            {% slot badges %}
+            {{ status_indicator(status, variant="success") }}
+            {% end %}
+            {% slot meta %}
+            {% if release_date %}<span class="chirpui-text-muted">{{ release_date | dateformat("%B %d, %Y") }}</span>{% end %}
+            {% end %}
+        {% end %}
+
+        {% call grid(cols=2, gap="md") %}
+            {{ change_group("Added", params?.added ?? [], "success") }}
+            {{ change_group("Changed", params?.changed ?? [], "info") }}
+            {{ change_group("Fixed", params?.fixed ?? [], "neutral") }}
+            {{ change_group("Breaking", params?.breaking ?? [], "warning") }}
+        {% end %}
+
+        {% call card(cls="chirpui-bengal-content-card") %}
+            {% call rendered_content(cls="chirpui-bengal-rendered") %}
+                {{ content | safe }}
+            {% end %}
+        {% end %}
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/doc/list.html
+++ b/bengal/themes/chirpui/templates/doc/list.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack %}
+{% from "chirpui/document_header.html" import document_header %}
+{% from "chirpui/panel.html" import panel %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import page_grid, tag_badges %}
+{% from "partials/navigation.html" import docs_mobile_nav, docs_sidebar %}
+
+{% block content %}
+{% let page_title = page?.title ?? section?.title ?? "Documentation" %}
+{% let page_description = page?.description ?? section?.description ?? none %}
+{% let section_pages = posts ?? section?.regular_pages ?? section?.pages ?? page?.children ?? [] %}
+{% let subsections = subsections ?? section?.subsections ?? [] %}
+{% let doc_breadcrumbs = [{"label": "Home", "href": "/" | absolute_url}, {"label": "Docs", "href": "/docs/" | absolute_url}, {"label": page_title}] %}
+
+{% call container(max_width="96rem") %}
+{{ docs_mobile_nav(page) }}
+<div class="chirpui-bengal-docs">
+    {{ docs_sidebar(page) }}
+
+    <article class="chirpui-bengal-docs__article">
+        {% call stack(gap="lg") %}
+            {% call document_header(page_title, subtitle=page_description, breadcrumb_items=doc_breadcrumbs, status="section", cls="chirpui-bengal-doc-header") %}
+                {% slot actions %}
+                {{ tag_badges(page?.tags ?? []) }}
+                {% end %}
+            {% end %}
+
+            <section class="chirpui-bengal-article-surface">
+                {% call rendered_content(cls="chirpui-bengal-rendered") %}
+                    {{ content | safe }}
+                {% end %}
+            </section>
+
+            {{ page_grid(subsections, "No subsections yet.") }}
+            {{ page_grid(section_pages, "No pages yet.") }}
+        {% end %}
+    </article>
+
+    {% if toc %}
+    <aside class="chirpui-bengal-docs__toc">
+        {% call panel(title="On This Page", surface_variant="muted", scroll_body=true, cls="chirpui-bengal-toc-panel") %}
+            <nav class="chirpui-bengal-toc" aria-label="Table of contents">
+                {{ toc | safe }}
+            </nav>
+        {% end %}
+    </aside>
+    {% end %}
+</div>
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/doc/single.html
+++ b/bengal/themes/chirpui/templates/doc/single.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack %}
+{% from "chirpui/document_header.html" import document_header %}
+{% from "chirpui/panel.html" import panel %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "chirpui/button.html" import btn %}
+{% from "partials/cards.html" import tag_badges %}
+{% from "partials/navigation.html" import docs_mobile_nav, docs_sidebar %}
+
+{% block content %}
+{% let page_title = page?.title ?? "Documentation" %}
+{% let page_description = page?.description ?? params?.description ?? none %}
+{% let page_tags = page?.tags ?? [] %}
+{% let doc_breadcrumbs = [{"label": "Home", "href": "/" | absolute_url}, {"label": "Docs", "href": "/docs/" | absolute_url}, {"label": page_title}] %}
+
+{% call container(max_width="96rem") %}
+{{ docs_mobile_nav(page) }}
+<div class="chirpui-bengal-docs">
+    {{ docs_sidebar(page) }}
+
+    <article class="chirpui-bengal-docs__article">
+        {% call stack(gap="lg") %}
+            {% call document_header(page_title, subtitle=page_description, breadcrumb_items=doc_breadcrumbs, status=page?.type ?? "doc", cls="chirpui-bengal-doc-header") %}
+                {% slot actions %}
+                {{ tag_badges(page_tags) }}
+                {% end %}
+            {% end %}
+
+            <section class="chirpui-bengal-article-surface">
+                {% call rendered_content(cls="chirpui-bengal-rendered") %}
+                    {{ content | safe }}
+                {% end %}
+            </section>
+
+            {% if page?.next_page ?? none or page?.prev_page ?? none %}
+            <nav class="chirpui-bengal-page-nav" aria-label="Page navigation">
+                {% if page?.prev_page ?? none %}
+                {{ btn("Previous", href=page.prev_page.href, variant="ghost") }}
+                {% else %}<span></span>{% end %}
+                {% if page?.next_page ?? none %}
+                {{ btn("Next", href=page.next_page.href, variant="primary", icon="arrow") }}
+                {% end %}
+            </nav>
+            {% end %}
+        {% end %}
+    </article>
+
+    {% if toc %}
+    <aside class="chirpui-bengal-docs__toc">
+        {% call panel(title="On This Page", surface_variant="muted", scroll_body=true, cls="chirpui-bengal-toc-panel") %}
+            <nav class="chirpui-bengal-toc" aria-label="Table of contents">
+                {{ toc | safe }}
+            </nav>
+        {% end %}
+    </aside>
+    {% end %}
+</div>
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/home.html
+++ b/bengal/themes/chirpui/templates/home.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack %}
+{% from "chirpui/hero.html" import hero %}
+{% from "chirpui/metric_grid.html" import metric_grid, metric_card %}
+{% from "chirpui/button.html" import btn %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import page_grid %}
+
+{% block content %}
+{% let title = page?.title ?? site.title %}
+{% let subtitle = page?.description ?? site.description %}
+{% let pages = (site.listable_pages ?? [])[:6] %}
+{% let page_count = site.pages | length %}
+{% let listable_count = site.listable_pages | length %}
+
+{% call container(max_width="76rem") %}
+    {% call stack(gap="xl") %}
+        {% call hero(title=title, subtitle=subtitle, background="muted") %}
+            {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+            {% slot action %}
+            {{ btn("Read Docs", href="/docs/" | absolute_url, variant="primary", icon="arrow") }}
+            {{ btn("Search", href="/search/" | absolute_url, variant="ghost", icon="search") }}
+            {% end %}
+        {% end %}
+
+        {% call metric_grid(cols=3, gap="md", cls="chirpui-bengal-home-metrics") %}
+            {{ metric_card(value=page_count, label="Pages", href="/search/" | absolute_url) }}
+            {{ metric_card(value=listable_count, label="Browsable", href="/search/" | absolute_url) }}
+            {{ metric_card(value=_current_lang, label="Language") }}
+        {% end %}
+
+        {{ page_grid(pages, "No pages yet.", page.href) }}
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/index.html
+++ b/bengal/themes/chirpui/templates/index.html
@@ -1,0 +1,1 @@
+{% extends "home.html" %}

--- a/bengal/themes/chirpui/templates/list.html
+++ b/bengal/themes/chirpui/templates/list.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container %}
+{% from "chirpui/resource_index.html" import resource_index %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import searchable_page_grid %}
+
+{% block content %}
+{% let page_title = page?.title ?? section?.title ?? "Index" %}
+{% let page_description = page?.description ?? section?.description ?? none %}
+{% let section_pages = section?.regular_pages ?? section?.pages ?? page?.children ?? [] %}
+
+{% call container(max_width="76rem") %}
+    {% call resource_index(page_title, page?.href ?? page?._path ?? "/", subtitle=page_description, search_placeholder="Filter entries...", button_icon="search", results_title="Entries", results_subtitle=(section_pages | length) ~ " available", has_results=section_pages | length > 0, empty_title="No entries yet", cls="chirpui-bengal-resource-index") %}
+        <p class="chirpui-text-muted chirpui-bengal-search-count" id="chirpui-bengal-search-count" aria-live="polite">{{ section_pages | length }} results</p>
+        {% if content %}
+        {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+        {% end %}
+        {{ searchable_page_grid(section_pages, "No entries yet.") }}
+        <div id="chirpui-bengal-search-empty" class="chirpui-bengal-search-empty" hidden>
+            <p class="chirpui-text-muted">No matching entries.</p>
+        </div>
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/page.html
+++ b/bengal/themes/chirpui/templates/page.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack %}
+{% from "chirpui/document_header.html" import document_header %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "chirpui/button.html" import btn %}
+{% from "partials/cards.html" import tag_badges %}
+
+{% block content %}
+{% let page_title = page?.title ?? "Page" %}
+{% let page_description = page?.description ?? params?.description ?? none %}
+{% let page_tags = page?.tags ?? [] %}
+{% let page_breadcrumbs = [{"label": "Home", "href": "/" | absolute_url}, {"label": page_title}] %}
+
+{% call container(max_width="72rem") %}
+    {% call stack(gap="lg") %}
+        {% call document_header(page_title, subtitle=page_description, breadcrumb_items=page_breadcrumbs, status=page?.type ?? none, cls="chirpui-bengal-doc-header") %}
+            {% slot actions %}
+            {{ tag_badges(page_tags) }}
+            {% end %}
+        {% end %}
+
+        <section class="chirpui-bengal-article-surface">
+            {% call rendered_content(cls="chirpui-bengal-rendered") %}
+                {{ content | safe }}
+            {% end %}
+        </section>
+
+        {% if page?.next_page ?? none or page?.prev_page ?? none %}
+        <nav class="chirpui-bengal-page-nav" aria-label="Page navigation">
+            {% if page?.prev_page ?? none %}
+            {{ btn("Previous", href=page.prev_page.href, variant="ghost") }}
+            {% else %}<span></span>{% end %}
+            {% if page?.next_page ?? none %}
+            {{ btn("Next", href=page.next_page.href, variant="primary", icon="arrow") }}
+            {% end %}
+        </nav>
+        {% end %}
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/partials/cards.html
+++ b/bengal/themes/chirpui/templates/partials/cards.html
@@ -1,0 +1,94 @@
+{% from "chirpui/layout.html" import grid, block, cluster %}
+{% from "chirpui/index_card.html" import index_card %}
+{% from "chirpui/post_card.html" import post_card %}
+{% from "chirpui/badge.html" import badge %}
+
+{% def tag_badges(tags) %}
+{% if tags %}
+{% call cluster(gap="xs") %}
+    {% for tag in tags %}
+    {{ badge(tag, variant="muted") }}
+{% end %}
+{% end %}
+{% end %}
+{% end %}
+
+{% def post_feed(posts, empty_message="No posts yet.") %}
+{% if posts %}
+<div class="chirpui-bengal-post-feed">
+    {% for item in posts %}
+    {% call post_card(name=item.title, handle=item.type ?? "post", href=item.href, cls="chirpui-bengal-post-card") %}
+        <p>{{ item.description ?? item.summary ?? "" }}</p>
+        {% slot actions %}
+        {{ tag_badges(item.tags ?? []) }}
+        {% end %}
+    {% end %}
+    {% end %}
+</div>
+{% else %}
+<p class="chirpui-text-muted">{{ empty_message }}</p>
+{% end %}
+{% end %}
+
+{% def searchable_post_feed(posts, empty_message="No posts yet.") %}
+{% if posts %}
+<div class="chirpui-bengal-post-feed">
+    {% for item in posts %}
+    <div data-chirpui-search-item data-search-text="{{ item.title }} {{ item.description ?? item.summary ?? '' }} {{ item.type ?? item.kind ?? '' }} {{ item.tags | join(' ') if item.tags else '' }}">
+        {% call post_card(name=item.title, handle=item.type ?? "post", href=item.href, cls="chirpui-bengal-post-card") %}
+            <p>{{ item.description ?? item.summary ?? "" }}</p>
+            {% slot actions %}
+            {{ tag_badges(item.tags ?? []) }}
+            {% end %}
+        {% end %}
+    </div>
+    {% end %}
+</div>
+{% else %}
+<p class="chirpui-text-muted">{{ empty_message }}</p>
+{% end %}
+{% end %}
+
+{% def page_grid(pages, empty_message="No pages yet.", exclude_href=none) %}
+{% if pages %}
+{% call grid(cols=3, gap="md") %}
+    {% for item in pages %}
+    {% if not exclude_href or item.href != exclude_href %}
+    {% call block() %}
+        {{ index_card(
+            href=item.href,
+            title=item.title,
+            description=item.description ?? item.summary ?? none,
+            badge=item.type ?? item.kind ?? none
+        ) }}
+    {% end %}
+    {% end %}
+    {% end %}
+{% end %}
+{% else %}
+<p class="chirpui-text-muted">{{ empty_message }}</p>
+{% end %}
+{% end %}
+
+{% def searchable_page_grid(pages, empty_message="No pages yet.", exclude_href=none) %}
+{% if pages %}
+{% call grid(cols=3, gap="md", cls="chirpui-bengal-browse-grid") %}
+    {% for item in pages %}
+    {% if not exclude_href or item.href != exclude_href %}
+    {% call block(cls="chirpui-bengal-browse-grid__item") %}
+        <div data-chirpui-search-item data-search-text="{{ item.title }} {{ item.description ?? item.summary ?? '' }} {{ item.type ?? item.kind ?? '' }} {{ item.tags | join(' ') if item.tags else '' }}">
+            {{ index_card(
+                href=item.href,
+                title=item.title,
+                description=item.description ?? item.summary ?? none,
+                badge=item.type ?? item.kind ?? none
+            ) }}
+        </div>
+    {% end %}
+    {% end %}
+    {% end %}
+{% end %}
+{% else %}
+<p class="chirpui-text-muted">{{ empty_message }}</p>
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/partials/navigation.html
+++ b/bengal/themes/chirpui/templates/partials/navigation.html
@@ -1,0 +1,50 @@
+{% from "chirpui/button.html" import btn %}
+{% from "chirpui/drawer.html" import drawer %}
+{% from "chirpui/nav_tree.html" import nav_tree %}
+
+{% def collect_nav_items(nodes, target) %}
+{% for node in nodes %}
+{% let children = node?.children ?? [] %}
+{% let has_children = children | length > 0 %}
+{% let href = node?.href ?? "#" %}
+{% let title = node?.title ?? node?.name ?? "Untitled" %}
+{% let active = node?.is_current ?? node?.active ?? false %}
+{% let open = active or (node?.is_in_trail ?? false) or (node?.is_expanded ?? false) %}
+{% let child_items = [] %}
+{% if has_children %}
+{{ collect_nav_items(children, child_items) }}
+{% end %}
+{% set _ = target.append({
+    "title": title,
+    "href": href,
+    "active": active,
+    "open": open,
+    "children": child_items
+}) %}
+{% end %}
+{% end %}
+
+{% def docs_nav_tree(page, cls="") %}
+{% let root_section = page?._section?.root ?? none %}
+{% let nav_nodes = get_nav_tree(page, root_section=root_section) if page else [] %}
+{% let nav_items = [] %}
+{{ collect_nav_items(nav_nodes, nav_items) }}
+{% call nav_tree(items=nav_items, branch_mode="linked", cls=cls) %}
+    {% slot header %}
+    <span class="chirpui-sidebar__section-title">Documentation</span>
+    {% end %}
+{% end %}
+{% end %}
+
+{% def docs_sidebar(page) %}
+{{ docs_nav_tree(page, cls="chirpui-bengal-docs__nav") }}
+{% end %}
+
+{% def docs_mobile_nav(page) %}
+<div class="chirpui-bengal-docs__mobile-nav">
+    {{ btn("Docs menu", type="button", variant="secondary", size="sm", icon="list", attrs_map={"data-chirpui-drawer-open": "chirpui-docs-nav-drawer", "aria-controls": "chirpui-docs-nav-drawer"}) }}
+</div>
+{% call drawer("chirpui-docs-nav-drawer", title="Documentation", side="left", cls="chirpui-bengal-docs-drawer") %}
+    {{ docs_nav_tree(page, cls="chirpui-bengal-docs__drawer-nav") }}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/post.html
+++ b/bengal/themes/chirpui/templates/post.html
@@ -1,0 +1,1 @@
+{% extends "page.html" %}

--- a/bengal/themes/chirpui/templates/search.html
+++ b/bengal/themes/chirpui/templates/search.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container %}
+{% from "chirpui/resource_index.html" import resource_index %}
+{% from "chirpui/badge.html" import badge %}
+{% from "chirpui/empty.html" import empty_state %}
+
+{% block content %}
+{% let pages = site.listable_pages ?? [] %}
+{% let query = query ?? "" %}
+{% set result_types = [] %}
+{% for item in pages %}
+    {% let item_type = item.type if item.type else "page" %}
+    {% if item_type not in result_types %}
+        {% set _ = result_types.append(item_type) %}
+    {% end %}
+{% end %}
+
+{% call container(max_width="76rem") %}
+    {% call resource_index(
+        page?.title ?? "Search",
+        "/search/" | absolute_url,
+        query=query,
+        subtitle=(pages | length) ~ " pages indexed",
+        search_placeholder="Search documentation...",
+        button_icon="search",
+        results_title="Results",
+        results_subtitle="Grouped by content type",
+        results_layout="stack",
+        has_results=pages | length > 0,
+        empty_title="No pages indexed",
+        empty_icon="search",
+        cls="chirpui-bengal-resource-index"
+    ) %}
+            <p class="chirpui-text-muted chirpui-bengal-search-count" id="chirpui-bengal-search-count" aria-live="polite">{{ pages | length }} results</p>
+            <div id="chirpui-bengal-search-results" class="chirpui-bengal-search-results" aria-live="polite">
+                {% for result_type in result_types %}
+                <section class="chirpui-bengal-search-group" data-chirpui-search-group data-search-group="{{ result_type }}">
+                    <header class="chirpui-bengal-search-group__header">
+                        <h2>{{ result_type | title }}</h2>
+                        {{ badge(result_type, variant="muted") }}
+                    </header>
+                    <div class="chirpui-bengal-search-group__items">
+                    {% for item in pages %}
+                    {% let item_type = item.type if item.type else "page" %}
+                    {% if item_type == result_type %}
+                    <article class="chirpui-bengal-search-result" data-chirpui-search-item data-search-type="{{ item_type }}" data-search-text="{{ item.title }} {{ item.description ?? item.summary ?? '' }} {{ item.type ?? '' }} {{ item.tags | join(' ') if item.tags else '' }}">
+                        <div class="chirpui-bengal-search-result__meta">
+                            {{ badge(item_type, variant="muted") }}
+                            {% if item._section?.title ?? none %}<span>{{ item._section.title }}</span>{% end %}
+                        </div>
+                        <a href="{{ item.href }}" class="chirpui-bengal-search-result__title">{{ item.title }}</a>
+                        {% if item.description ?? item.summary ?? none %}
+                        <p>{{ item.description ?? item.summary }}</p>
+                        {% end %}
+                    </article>
+                    {% end %}
+                    {% end %}
+                    </div>
+                </section>
+                {% end %}
+            </div>
+            <div id="chirpui-bengal-search-empty" class="chirpui-bengal-search-empty" hidden>
+                {{ empty_state(title="No results found", icon="search", search_hint="Try a page title, section name, tag, or content type.") }}
+            </div>
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/tag.html
+++ b/bengal/themes/chirpui/templates/tag.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container %}
+{% from "chirpui/resource_index.html" import resource_index %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+{% from "partials/cards.html" import searchable_page_grid %}
+
+{% block content %}
+{% let current_tag = tag ?? page?.title ?? "Tag" %}
+{% let tagged_pages = posts ?? [] %}
+
+{% call container(max_width="76rem") %}
+    {% call resource_index(current_tag, page?.href ?? page?._path ?? "/tags/", subtitle="Content filed under this tag.", search_placeholder="Filter tagged pages...", button_icon="search", results_title="Tagged pages", results_subtitle=(tagged_pages | length) ~ " entries", has_results=tagged_pages | length > 0, empty_title="No tagged pages yet", cls="chirpui-bengal-resource-index") %}
+        <p class="chirpui-text-muted chirpui-bengal-search-count" id="chirpui-bengal-search-count" aria-live="polite">{{ tagged_pages | length }} results</p>
+        {% if content %}
+        {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+        {% end %}
+        {{ searchable_page_grid(tagged_pages, "No tagged pages yet.") }}
+        <div id="chirpui-bengal-search-empty" class="chirpui-bengal-search-empty" hidden>
+            <p class="chirpui-text-muted">No matching tagged pages.</p>
+        </div>
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/tags.html
+++ b/bengal/themes/chirpui/templates/tags.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% from "chirpui/layout.html" import container, stack, cluster %}
+{% from "chirpui/hero.html" import page_hero %}
+{% from "chirpui/badge.html" import badge %}
+{% from "chirpui/rendered_content.html" import rendered_content %}
+
+{% block content %}
+{% let title = page?.title ?? "Tags" %}
+{% let all_tags = tags ?? [] %}
+
+{% call container(max_width="72rem") %}
+    {% call stack(gap="lg") %}
+        {% call page_hero(title=title, subtitle="Browse content by tag.", variant="minimal", background="muted") %}
+            {% call rendered_content(compact=true, cls="chirpui-bengal-rendered") %}{{ content | safe }}{% end %}
+        {% end %}
+        {% call cluster(gap="sm") %}
+            {% for tag in all_tags %}
+            {% let tag_name = tag?.name ?? tag %}
+            <a href="{{ (tag?.href ?? tag_url(tag_name)) | absolute_url }}">{{ badge(tag_name, variant="primary") }}</a>
+            {% end %}
+        {% end %}
+    {% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/chirpui/templates/tutorial/list.html
+++ b/bengal/themes/chirpui/templates/tutorial/list.html
@@ -1,0 +1,1 @@
+{% extends "list.html" %}

--- a/bengal/themes/chirpui/templates/tutorial/single.html
+++ b/bengal/themes/chirpui/templates/tutorial/single.html
@@ -1,0 +1,1 @@
+{% extends "doc/single.html" %}

--- a/bengal/themes/chirpui/theme.toml
+++ b/bengal/themes/chirpui/theme.toml
@@ -1,0 +1,3 @@
+name = "chirpui"
+version = "0.1.0"
+libraries = ["chirp_ui"]

--- a/bengal/themes/chirpui/theme.yaml
+++ b/bengal/themes/chirpui/theme.yaml
@@ -1,0 +1,29 @@
+name: chirpui
+version: 0.1.0
+parent: null
+
+features:
+  navigation:
+    breadcrumbs: true
+    toc: true
+    prev_next: true
+  content:
+    code.copy: false
+    lightbox: false
+    reading_time: true
+    excerpts: true
+    children: true
+  search:
+    suggest: false
+    highlight: false
+  accessibility:
+    skip_link: true
+
+appearance:
+  default_mode: system
+  default_palette: ""
+
+header:
+  nav_position: left
+  sticky: true
+  autohide: false

--- a/changelog.d/chirpui-theme.added.md
+++ b/changelog.d/chirpui-theme.added.md
@@ -1,0 +1,1 @@
+Added a separate bundled `chirpui` theme that renders Bengal pages with Chirp UI macros and assets without modifying the existing `default` theme.

--- a/changelog.d/rendering-asset-fragment-cache.fixed.md
+++ b/changelog.d/rendering-asset-fragment-cache.fixed.md
@@ -1,0 +1,1 @@
+Fixed Kida fragment cache entries that include `asset_url()` so asset fingerprint changes cannot replay stale CSS or JavaScript URLs.

--- a/plan/README.md
+++ b/plan/README.md
@@ -24,6 +24,8 @@ Quick reference for RFC status. Run `rg "^\*\*Status\*\*" plan/rfc-*.md` to refr
 | rfc-bengal-v2-architecture | Draft | Large; protocol-first, composition |
 | rfc-remaining-coupling-fixes | Draft | Depends on module-coupling-reduction (unverified) |
 | rfc-health-diagnostics-audit | Active implementation | Splits health policy, rendering registries, artifact audit, and Kida output |
+| rfc-theme-library-assets | Draft | First-class package/library assets for themes |
+| rfc-template-view-model-contracts | Draft | Engine-neutral view data for Kida and BYO templates |
 
 ## Implemented
 

--- a/plan/rfc-template-view-model-contracts.md
+++ b/plan/rfc-template-view-model-contracts.md
@@ -1,0 +1,159 @@
+# Template View Model Contracts
+
+**Status**: Draft
+**Created**: 2026-05-06
+**Scope**: Rendering, Kida, themes, directives, shortcodes, content types
+
+## Problem
+
+Bengal has enough Kida and rendering infrastructure to support richer themes,
+but too many surfaces still depend on theme-local HTML expectations instead of
+clear data contracts. Directives, shortcodes, autodocs, indexes, notebooks,
+tutorial flows, tracks, and reference hubs can leak presentation choices into
+the parser, renderer, or theme.
+
+That makes the default theme harder to migrate, makes Chirp UI adoption feel
+like wrapping old Bengal markup, and keeps bring-your-own template engines from
+having a universal contract to consume.
+
+## Direction
+
+Bengal should normalize content into engine-neutral view data before templates
+render it:
+
+```text
+source syntax -> parsed semantic node -> template view model -> template engine
+```
+
+Kida is the first-class engine Bengal ships, but the contract should be plain
+Python data: dictionaries, lists, strings, numbers, booleans, URLs, and explicit
+safe-HTML fields when HTML is the actual value. Template engines should not need
+to understand parser internals, shortcode implementation details, or Bengal's
+default theme layout dialect.
+
+Content type templates own information architecture. Theme systems such as
+Chirp UI own interface grammar. Bengal's job is to hand either one a stable data
+shape.
+
+## Goals
+
+- Define reusable template view models for directives, shortcodes, content
+  types, resource indexes, REST autodocs, notebooks, tutorials, tracks, and
+  reference hubs.
+- Keep those view models presentation-neutral enough for Kida, Jinja, or a
+  future template engine adapter.
+- Make risky template data explicit: safe HTML, raw source, URLs, headings,
+  asset references, diagnostics, and provenance should be named fields.
+- Let the default theme keep working through compatibility shims while new
+  surfaces migrate to view models.
+- Add generated manifests and documentation checks so view contracts do not
+  drift from implementation.
+
+## Non-Goals
+
+- Do not remove the default theme's existing HTML paths in the first wave.
+- Do not change public plugin protocols, config keys, CLI commands, or template
+  helper names without the constitution's stop-and-ask step.
+- Do not move rendering behavior back into `bengal/core/`.
+- Do not make Kida-specific syntax the contract. Kida consumes the contract; it
+  is not the contract.
+
+## Proposed Contract Shape
+
+Each renderable concept should have a small descriptor and a serializable view
+shape. A descriptor names the concept, its maturity, fields, allowed variants,
+required assets, safe-HTML fields, and diagnostics.
+
+Illustrative shape:
+
+```python
+{
+    "kind": "directive.admonition",
+    "schema": "bengal-template-view@1",
+    "variant": "warning",
+    "title": "Watch the cache key",
+    "body_html": "<p>...</p>",
+    "body_text": "Watch the cache key ...",
+    "attrs": {"collapsible": False},
+    "provenance": {"source_path": "docs/cache.md", "line": 42},
+    "assets": [],
+}
+```
+
+Field conventions:
+
+- `*_html` fields are already rendered HTML and must be explicitly marked safe
+  at the template boundary.
+- `*_text` fields are plain text fallbacks for search, previews, and summaries.
+- `assets` lists local CSS, JS, image, or library asset requirements.
+- `provenance` carries enough source context for diagnostics without exposing
+  mutable pipeline records.
+- `variant`, `size`, `role`, and `state` fields use documented enum values.
+
+## Chirp UI Lessons To Borrow
+
+Chirp UI keeps contracts honest with deterministic generated artifacts:
+
+- component descriptors in code;
+- generated manifests checked in CI;
+- generated API docs inside stable marker blocks;
+- explicit runtime requirements;
+- quality and debt scorecards that catch unclassified or under-described
+  components.
+
+Bengal should apply the same pattern to template view contracts. A generated
+manifest can describe every known view model, field, allowed variant, safe-HTML
+field, required asset, and template entrypoint. A `--check` mode should fail
+when docs or manifests drift from descriptors.
+
+## Milestones
+
+1. **Manifest foundation**: add internal descriptors and a generated template
+   view manifest for existing high-value render shapes. This is read-only
+   documentation at first.
+2. **Directive and shortcode pilot**: migrate a narrow set such as admonitions,
+   cards, and tabs to descriptor-backed view data while preserving current
+   output.
+3. **Content type views**: define views for landing pages, tutorial pages,
+   notebooks, list pages, tracks, and reference hubs.
+4. **Autodoc and resource views**: normalize REST autodocs, API indexes, and
+   resource listings so templates do not inspect parser-specific structures.
+5. **Theme parity pass**: update the default theme and Chirp UI theme to consume
+   the same view models for migrated surfaces.
+6. **BYO engine proof**: render a representative fixture through a second
+   template adapter using only the view manifest and plain data.
+
+## Acceptance Criteria
+
+- Representative directive, shortcode, and content type fixtures expose stable
+  view data before template rendering.
+- Default theme output remains unchanged except for intentional, reviewed
+  template migrations.
+- Chirp UI theme templates consume view models instead of Bengal-specific layout
+  dialects for migrated surfaces.
+- Manifest generation is deterministic and has a `--check` mode.
+- Docs include generated contract sections guarded by marker comments.
+- Tests cover safe-HTML handling, missing context diagnostics, malformed input,
+  and at least one non-Kida adapter proof once the adapter exists.
+
+## Compatibility And Risk
+
+This direction should not break the default theme if the migration is additive:
+old template-facing properties and render helpers can remain as shims while new
+view models are introduced. The risk is contract sprawl. The mitigation is to
+start with a small pilot, generate the manifest from descriptors, and avoid
+promoting field names to public contracts until they are exercised by both the
+default theme and the Chirp UI theme.
+
+## Steward Notes
+
+- **Rendering**: owns template view construction, safe-HTML boundaries, URLs,
+  excerpts, TOCs, shortcode views, and content type render data.
+- **Core**: immutable pipeline records stay unchanged; view models are derived
+  rendering artifacts.
+- **Themes**: default and Chirp UI themes should converge on the same data
+  shapes while keeping different interface grammar.
+- **Tests**: every accepted view contract needs fixtures, malformed input
+  coverage, and parity proof when multiple entrypoints consume it.
+- **Docs**: generated manifest/docs sections should move with any user-facing
+  contract.

--- a/plan/rfc-theme-library-assets.md
+++ b/plan/rfc-theme-library-assets.md
@@ -1,0 +1,178 @@
+# Theme Library Assets
+
+**Status**: Draft
+**Created**: 2026-05-06
+**Scope**: Rendering assets, themes, dev server, static builds, diagnostics
+
+## Problem
+
+Bengal has a usable theme asset pipeline and Chirp UI has real package assets,
+but the bridge between them is too implicit. A Chirp UI-powered theme currently
+needs to know where provider CSS lives, which files Bengal fingerprints, which
+paths live reload serves, and whether imported provider CSS is copied as a
+logical asset.
+
+That gap produced a live/dev/static parity failure: the browser requested local
+CSS URLs that static output did not actually emit. The short-term fix is to make
+the theme stylesheet the single entrypoint and import Chirp UI there. The
+long-term fix is for Bengal to understand library assets as first-class inputs.
+
+## Direction
+
+Themes should be composition layers. A theme should declare that it uses a UI
+library, then write templates, macros, tokens, and theme-specific polish. Bengal
+should discover provider assets, serve them in development, copy and fingerprint
+them in static builds, rewrite references, expose macros and filters, and fail
+loudly when templates link assets Bengal did not emit.
+
+## Goals
+
+- Add a first-class library asset model that can represent package-provided CSS,
+  JS, macros, filters, runtime requirements, and optional bundle behavior.
+- Keep dev server URLs and static build URLs part of the same contract.
+- Make missing emitted assets a build diagnostic before a browser sees a 404.
+- Let provider metadata come from the library package when possible.
+- Let themes override tokens and compose patterns without copying framework CSS
+  or hand-linking package internals.
+
+## Non-Goals
+
+- Do not add npm, Node, or a JavaScript build phase.
+- Do not commit to a public config shape without the constitution's stop-and-ask
+  step.
+- Do not require Chirp UI specifically; the model should work for any Python
+  package that can expose static assets and optional template helpers.
+- Do not replace the current theme asset pipeline in the first wave.
+
+## Illustrative Declaration
+
+This is a planning sketch, not an accepted config contract:
+
+```toml
+[libraries.chirp_ui]
+package = "chirp_ui"
+css = ["chirpui.css", "chirpui-transitions.css"]
+js = ["chirpui.js"]
+macros = true
+mode = "bundle" # or "link"
+runtime = ["alpine"]
+```
+
+Equivalent data may come from theme metadata, a Python registration hook, or a
+library package manifest. The final shape needs explicit approval because it
+would affect theme configuration and output behavior.
+
+## Library Metadata
+
+A provider such as Chirp UI can expose clean package metadata:
+
+- static asset root, such as `chirp_ui.static_path()`;
+- CSS and JS entrypoints;
+- optional macro namespace and loader;
+- optional filters or template helper registration;
+- runtime requirements such as Alpine or HTMX;
+- token and component manifest metadata;
+- bundle/link capability and whether entries are safe to concatenate.
+
+Bengal consumes that metadata declaratively. Theme templates should not hardcode
+package-internal paths.
+
+## Pipeline Contract
+
+The asset pipeline should converge on this flow:
+
+```text
+library declaration
+  -> provider metadata discovery
+  -> logical asset records
+  -> development stable URLs
+  -> static copied/fingerprinted outputs
+  -> asset manifest
+  -> HTML reference audit
+```
+
+Development and static builds should agree on logical asset identity. Static
+builds may fingerprint physical output paths, but templates should resolve
+through the same logical asset records.
+
+## Helper Surface
+
+The exact helper names are open. Two candidate directions:
+
+- `library_asset_url("chirp_ui", "chirpui.css")`
+- `asset_url("chirp_ui/chirpui.css")` where library assets live in the same
+  logical asset namespace as theme assets
+
+The second option keeps templates simpler if Bengal can provide diagnostics
+that distinguish project, theme, and library sources behind the scenes.
+
+## Diagnostics
+
+Missing or unsafe asset usage should produce structured diagnostics with:
+
+- source page or template path when known;
+- logical asset requested;
+- known emitted assets in the same namespace;
+- provider or theme responsible for declaration;
+- suggestion, such as "declare this library asset" or "use asset_url()";
+- dev/static mode and active manifest revision when relevant.
+
+The same audit should catch local CSS and JS references in rendered HTML that
+are not serveable in the current mode.
+
+## Milestones
+
+1. **Declarative contract draft**: define internal `LibraryAsset` and
+   `ThemeLibrary` shapes without exposing new public config.
+2. **Provider discovery pilot**: consume Chirp UI metadata from a small adapter
+   or package manifest and map it into logical asset records.
+3. **Dev/static parity**: serve library assets at stable dev URLs, copy and
+   fingerprint them in static builds, and verify every rendered local CSS/JS URL
+   is serveable.
+4. **Diagnostics**: add missing-emitted-asset diagnostics with source context
+   and actionable suggestions.
+5. **Composition modes**: support link mode first; evaluate bundle mode only
+   after defining pure-Python concatenation, source maps or provenance, and
+   duplicate asset semantics.
+6. **Theme cleanup**: remove Chirp UI asset plumbing from theme templates and
+   keep theme CSS focused on token overrides and Bengal-specific composition.
+7. **Generated manifest checks**: borrow Chirp UI's generated-manifest pattern
+   for provider metadata, docs drift, and runtime requirement coverage.
+
+## Acceptance Criteria
+
+- A representative Chirp UI theme can declare library usage without hardcoding
+  provider asset paths in templates.
+- Dev server serves declared library assets at stable logical URLs.
+- Static builds copy, fingerprint, and rewrite declared library assets.
+- Route smoke tests verify all local CSS and JS references are serveable in
+  development and static output.
+- Missing undeclared or unemitted assets produce Bengal diagnostics with a
+  suggestion and source context.
+- Default theme behavior is unchanged unless it opts into the same library asset
+  model.
+- User-facing changes include docs, examples or theme scaffolds as applicable,
+  tests, and a changelog fragment.
+
+## Compatibility And Risk
+
+This can stay additive if library assets enter the pipeline as another asset
+source. Existing theme assets keep their current behavior, and the default theme
+does not need to use library assets immediately.
+
+The high-risk decisions are public config shape, helper names, bundle behavior,
+and output manifest semantics. Those require an explicit stop-and-ask checkpoint
+before implementation.
+
+## Steward Notes
+
+- **Assets/rendering**: own logical asset records, manifest revisioning,
+  `asset_url()` behavior, and HTML reference audits.
+- **Dev server**: must serve the same logical asset namespace that static builds
+  emit.
+- **Themes**: remain composition layers; custom CSS should shrink toward token
+  overrides and Bengal documentation patterns.
+- **Config/public contracts**: any accepted declaration syntax needs docs,
+  scaffolds, tests, and migration notes.
+- **Tests**: live/dev/static parity gets route smoke tests that exercise CSS and
+  JS URLs, not just rendered HTML strings.

--- a/site/content/docs/theming/templating/kida/caching/fragments.md
+++ b/site/content/docs/theming/templating/kida/caching/fragments.md
@@ -149,6 +149,12 @@ Fragment cache uses a global TTL configured at the environment level. All cached
 
 ## Cache Invalidation
 
+### Asset URLs
+
+Bengal namespaces fragment cache entries by the active asset manifest revision.
+That means a cached fragment that calls `asset_url()` will re-render after asset
+fingerprints change instead of replaying stale CSS or JavaScript URLs.
+
 ### Version-Based
 
 ```kida

--- a/site/content/docs/theming/themes/_index.md
+++ b/site/content/docs/theming/themes/_index.md
@@ -57,6 +57,13 @@ Full control. Start from scratch or fork existing.
 :::
 :::{/cards}
 
+## Bundled Themes
+
+| Theme | Use when |
+|-------|----------|
+| `default` | You want Bengal's built-in documentation theme with no extra packages. |
+| `chirpui` | You want a site rendered with Chirp UI components and can install `chirp-ui` in the build environment. |
+
 ## Quick Reference
 
 :::{tab-set}

--- a/site/content/docs/theming/themes/chirpui.md
+++ b/site/content/docs/theming/themes/chirpui.md
@@ -1,0 +1,57 @@
+---
+title: Chirp UI Theme
+description: Build a Bengal site with the optional Chirp UI component library
+weight: 20
+category: guide
+icon: palette
+card_color: green
+---
+# Chirp UI Theme
+
+Bengal includes an optional `chirpui` theme that renders the site shell, pages,
+docs, lists, search, tags, and blog templates with Chirp UI Kida components.
+It lives beside `default`; switching to it does not modify the default theme.
+
+Install Chirp UI 0.7 or newer in the environment that builds the site:
+
+```bash
+uv add chirp-ui
+```
+
+Then select the theme:
+
+```toml
+[build]
+theme = "chirpui"
+```
+
+The theme loads Chirp UI through `theme.toml` provider libraries and fingerprints
+`chirp_ui/chirpui.css` through Bengal's normal asset manifest. Bengal does not
+bundle `chirp-ui` as a hard dependency, so builds that use this theme should
+fail fast if the package is missing.
+
+## Scope
+
+- Uses Chirp UI component macros for the site shell, navigation, docs drawer,
+  heroes, document headers, detail headers, profile headers, rendered content,
+  panels, nav trees, resource indexes, index cards, badges, breadcrumbs, empty
+  states, buttons, metrics, post cards, timelines, and search headers.
+- Adds local browser behavior for theme toggles, static page filtering, and the
+  mobile docs drawer trigger.
+- Groups search results by content type, makes browse/index pages filterable,
+  and keeps nested docs navigation open on the active branch.
+- Keeps a small Bengal bridge stylesheet for documentation layout, search
+  results, skip links, and footer spacing.
+- Avoids default theme templates, classes, CSS, and JavaScript.
+
+## Current Limitations
+
+The bundled theme is ready for preview and fixture coverage, but sites with
+custom taxonomies, unusual menus, or heavily customized default-theme partials
+should verify their pages before switching production builds.
+
+## Preview Coverage
+
+The integration fixture exercises nested documentation, blog posts, changelog
+releases, archives, author pages, tags, search, and generated 404 output. It is
+intended to grow into the visual regression fixture for future theme work.

--- a/tests/integration/test_chirpui_theme_build.py
+++ b/tests/integration/test_chirpui_theme_build.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from textwrap import dedent
+from urllib.parse import urlparse
+
+from bengal.assets.manifest import AssetManifest
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCAL_CSS_JS_RE = re.compile(r"""(?:href|src)=["']([^"']+\.(?:css|js)(?:\?[^"']*)?)["']""")
+
+
+def _write_text(path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(content).lstrip(), encoding="utf-8")
+
+
+def _write_fake_chirp_ui(package_root) -> None:
+    pkg = package_root / "chirp_ui"
+    templates = pkg / "templates"
+    components = templates / "chirpui"
+
+    _write_text(
+        pkg / "__init__.py",
+        """
+        from pathlib import Path
+        from kida import PackageLoader
+
+        def static_path():
+            return Path(__file__).parent / "templates"
+
+        def get_loader():
+            return PackageLoader("chirp_ui", "templates")
+
+        def register_filters(app):
+            return None
+        """,
+    )
+    _write_text(templates / "chirpui.css", ".chirpui-navbar{}.chirpui-rendered-content{}")
+    _write_text(templates / "chirpui-transitions.css", ".chirpui-transition{}")
+    _write_text(templates / "chirpui.js", "window.__chirpui_test__=true;")
+    _write_text(
+        components / "navbar.html",
+        """
+        {% def navbar(brand=none, brand_url="/", cls="", use_slots=false, brand_slot=false, current_path="") %}
+        <nav class="chirpui-navbar {{ cls }}"><a class="chirpui-navbar__brand" href="{{ brand_url }}">{{ brand }}</a><div class="chirpui-navbar__links">{% slot %}</div><div class="chirpui-navbar__links chirpui-navbar__links--end">{% slot end %}</div></nav>
+        {% end %}
+        {% def navbar_link(href, label, active=false, match="", cls="") %}<a class="chirpui-navbar__link{{ ' chirpui-navbar__link--active' if active else '' }}" href="{{ href }}">{{ label }}</a>{% end %}
+        {% def navbar_dropdown(label, active=false, match="", href="", cls="") %}<details class="chirpui-navbar-dropdown"><summary>{{ label }}</summary>{% slot %}</details>{% end %}
+    """,
+    )
+    _write_text(
+        components / "button.html",
+        """
+        {% def btn(label, variant="", size=none, loading=false, type="submit", href=none, icon=none, cls="", attrs="", attrs_map=none, disabled=false, data_action=none, aria_label=none) %}
+        {% if href %}<a class="chirpui-btn chirpui-btn--{{ variant }} chirpui-btn--{{ size }}" href="{{ href }}">{% if icon %}<span class="chirpui-btn__icon">{{ icon }}</span>{% end %}<span class="chirpui-btn__label">{{ label }}</span></a>{% else %}<button class="chirpui-btn" type="{{ type }}"{% if attrs_map %}{% if attrs_map.get("data-chirpui-drawer-open") %} data-chirpui-drawer-open="{{ attrs_map.get("data-chirpui-drawer-open") }}"{% end %}{% if attrs_map.get("aria-controls") %} aria-controls="{{ attrs_map.get("aria-controls") }}"{% end %}{% end %}>{% if icon %}<span class="chirpui-btn__icon">{{ icon }}</span>{% end %}<span class="chirpui-btn__label">{{ label }}</span></button>{% end %}
+        {% end %}
+    """,
+    )
+    _write_text(
+        components / "layout.html",
+        """
+        {% def container(max_width="72rem", padding=true, cls="") %}<div class="chirpui-container {{ cls }}" style="--chirpui-container-max: {{ max_width }}">{% slot %}</div>{% end %}
+        {% def grid(cols=none, gap=none, cls="") %}<div class="chirpui-grid chirpui-grid--cols-{{ cols }} chirpui-grid--gap-{{ gap }} {{ cls }}">{% slot %}</div>{% end %}
+        {% def stack(gap=none, cls="") %}<div class="chirpui-stack chirpui-stack--{{ gap }} {{ cls }}">{% slot %}</div>{% end %}
+        {% def cluster(gap=none, cls="") %}<div class="chirpui-cluster chirpui-cluster--{{ gap }} {{ cls }}">{% slot %}</div>{% end %}
+        {% def block(span=1, cls="") %}<div class="chirpui-block {{ cls }}">{% slot %}</div>{% end %}
+    """,
+    )
+    _write_text(
+        components / "hero.html",
+        """
+        {% def hero(title=none, subtitle=none, background="solid", cls="") %}<section class="chirpui-hero chirpui-hero--{{ background }}"><h1 class="chirpui-hero__title">{{ title }}</h1>{% if subtitle %}<p class="chirpui-hero__subtitle">{{ subtitle }}</p>{% end %}<div class="chirpui-hero__content">{% slot %}</div><div class="chirpui-hero__action">{% slot action %}</div></section>{% end %}
+        {% def page_hero(title=none, subtitle=none, variant="editorial", background="solid", cls="") %}<section class="chirpui-hero chirpui-hero--page chirpui-hero--page-{{ variant }} chirpui-hero--{{ background }}"><div class="chirpui-hero__eyebrow">{% slot eyebrow %}</div><h1 class="chirpui-hero__title">{{ title }}</h1>{% if subtitle %}<p class="chirpui-hero__subtitle">{{ subtitle }}</p>{% end %}<div class="chirpui-hero__metadata">{% slot metadata %}</div><div class="chirpui-hero__content">{% slot %}</div><div class="chirpui-hero__actions">{% slot actions %}</div><div class="chirpui-hero__footer">{% slot footer %}</div></section>{% end %}
+    """,
+    )
+    _write_text(
+        components / "card.html",
+        """
+        {% def card(title=none, subtitle=none, footer=none, collapsible=false, open=false, variant="", icon=none, border_variant="", header_variant="", cls="") %}<article class="chirpui-card {{ cls }}">{% if title %}<header class="chirpui-card__header"><span class="chirpui-card__title">{{ title }}</span></header>{% end %}<div class="chirpui-card__body"><div class="chirpui-card__body-content">{% slot %}</div></div></article>{% end %}
+    """,
+    )
+    _write_text(
+        components / "document_header.html",
+        """
+        {% def document_header(title, subtitle=none, meta=none, breadcrumb_items=none, eyebrow=none, path=none, provenance=none, status=none, meta_items=none, cls="") %}<section class="chirpui-document-header {{ cls }}">{% if breadcrumb_items %}<nav class="chirpui-breadcrumbs"><ol>{% for item in breadcrumb_items %}<li>{% if item.get("href") %}<a href="{{ item.href }}">{{ item.label }}</a>{% else %}<span>{{ item.label }}</span>{% end %}</li>{% end %}</ol></nav>{% end %}<h1>{{ title }}</h1>{% if subtitle %}<p>{{ subtitle }}</p>{% end %}{% if status %}<span class="chirpui-document-header__status">{{ status }}</span>{% end %}<div class="chirpui-document-header__actions">{% slot actions %}</div></section>{% end %}
+    """,
+    )
+    _write_text(
+        components / "detail_header.html",
+        """
+        {% def detail_header(title, summary=none, eyebrow=none, cls="") %}<header class="chirpui-detail-header {{ cls }}">{% if eyebrow %}<p class="chirpui-detail-header__eyebrow">{{ eyebrow }}</p>{% end %}<h1 class="chirpui-detail-header__title">{{ title }}</h1>{% if summary %}<p class="chirpui-detail-header__summary">{{ summary }}</p>{% end %}<div class="chirpui-detail-header__badges">{% slot badges %}</div><div class="chirpui-detail-header__meta">{% slot meta %}</div></header>{% end %}
+    """,
+    )
+    _write_text(
+        components / "profile_header.html",
+        """
+        {% def profile_header(name=none, cover_url=none, href=none, cls="", use_slots=false) %}<header class="chirpui-profile-header {{ cls }}">{% if name %}<h1 class="chirpui-profile-header__name">{{ name }}</h1>{% end %}<div class="chirpui-profile-header__bio">{% slot bio %}</div><div class="chirpui-profile-header__stats">{% slot stats %}</div><div class="chirpui-profile-header__action">{% slot actions %}</div>{% slot %}</header>{% end %}
+    """,
+    )
+    _write_text(
+        components / "panel.html",
+        """
+        {% def panel(title=none, subtitle=none, surface_variant="muted", scroll_body=false, cls="") %}<section class="chirpui-surface chirpui-panel {{ cls }}">{% if title %}<header class="chirpui-panel__header"><h2 class="chirpui-panel__title">{{ title }}</h2></header>{% end %}<div class="chirpui-panel__body">{% slot %}</div><footer class="chirpui-panel__footer">{% slot footer %}</footer></section>{% end %}
+    """,
+    )
+    _write_text(
+        components / "index_card.html",
+        """
+        {% def index_card(href, title, description=none, badge=none, cls="") %}<a href="{{ href }}" class="chirpui-index-card {{ cls }}">{% if badge %}<span class="chirpui-index-card__badge">{{ badge }}</span>{% end %}<span class="chirpui-index-card__title">{{ title }}</span>{% if description %}<p class="chirpui-index-card__description">{{ description }}</p>{% end %}</a>{% end %}
+    """,
+    )
+    _write_text(
+        components / "badge.html",
+        """
+        {% def badge(text, variant="primary", icon=none, cls="") %}<span class="chirpui-badge chirpui-badge--{{ variant }}"><span class="chirpui-badge__text">{{ text }}</span></span>{% end %}
+    """,
+    )
+    _write_text(
+        components / "breadcrumbs.html",
+        """
+        {% def breadcrumbs(items, cls="") %}<nav class="chirpui-breadcrumbs"><ol>{% for item in items %}<li>{% if item.get("href") %}<a href="{{ item.href }}">{{ item.label }}</a>{% else %}<span>{{ item.label }}</span>{% end %}</li>{% end %}</ol></nav>{% end %}
+    """,
+    )
+    _write_text(
+        components / "sidebar.html",
+        """
+        {% def sidebar(cls="") %}<nav class="chirpui-sidebar {{ cls }}"><div class="chirpui-sidebar__header">{% slot header %}</div><div class="chirpui-sidebar__nav">{% slot %}</div></nav>{% end %}
+        {% def sidebar_section(title="", collapsible=false, cls="") %}<div class="chirpui-sidebar__section"><div class="chirpui-sidebar__section-links">{% slot %}</div></div>{% end %}
+        {% def sidebar_link(href, label, icon="", active=false, boost=true, cls="") %}<a class="chirpui-sidebar__link{{ ' chirpui-sidebar__link--active' if active else '' }}" href="{{ href }}"><span class="chirpui-sidebar__label">{{ label }}</span></a>{% end %}
+    """,
+    )
+    _write_text(
+        components / "empty.html",
+        """
+        {% def empty_state(icon=none, title="No items", illustration=none, action_label=none, action_href=none, code=none, suggestions=none, search_hint=none, cls="") %}<div class="chirpui-empty-state"><h2>{{ title }}</h2>{% slot %}{% if action_label and action_href %}<a href="{{ action_href }}">{{ action_label }}</a>{% end %}</div>{% end %}
+    """,
+    )
+    _write_text(
+        components / "rendered_content.html",
+        """
+        {% def rendered_content(compact=false, cls="") %}<div class="chirpui-rendered-content {{ cls }}">{% slot %}</div>{% end %}
+    """,
+    )
+    _write_text(
+        components / "nav_progress.html",
+        """
+        {% def nav_progress(cls="") %}<div class="chirpui-nav-progress {{ cls }}" aria-hidden="true"></div>{% end %}
+    """,
+    )
+    _write_text(
+        components / "site_shell.html",
+        """
+        {% def site_shell(ambient=false, cls="") %}<div class="chirpui-site-shell {{ cls }}"><div class="chirpui-site-shell__header">{% slot header %}</div><div class="chirpui-site-shell__main">{% slot %}</div><div class="chirpui-site-shell__footer">{% slot footer %}</div></div>{% end %}
+    """,
+    )
+    _write_text(
+        components / "nav_tree.html",
+        """
+        {% def nav_tree(items, show_icons=false, branch_mode="disclosure", cls="") %}
+        <nav class="chirpui-nav-tree{% if branch_mode == "linked" %} chirpui-nav-tree--linked-branches{% end %} {{ cls }}" aria-label="Navigation"><div class="chirpui-nav-tree__header">{% slot header %}</div><ul class="chirpui-nav-tree__list">{% for item in items %}<li class="chirpui-nav-tree__item{% if item.get("active") %} chirpui-nav-tree__item--active{% end %}{% if item.get("open") %} chirpui-nav-tree__item--open{% end %}">{% if item.get("href") %}<a href="{{ item.href }}" class="chirpui-nav-tree__link{% if item.get("children") | length == 0 %} chirpui-nav-tree__link--leaf{% end %}{% if item.get("active") %} chirpui-nav-tree__link--active{% end %}"{% if item.get("active") %} aria-current="page"{% end %}><span class="chirpui-nav-tree__title">{{ item.title }}</span></a>{% else %}<span class="chirpui-nav-tree__text">{{ item.title }}</span>{% end %}{% if item.get("open") and item.get("children") %}{{ nav_tree_items(item.children) }}{% end %}</li>{% end %}</ul></nav>
+        {% end %}
+        {% def nav_tree_items(items) %}<ul class="chirpui-nav-tree__list chirpui-nav-tree__list--nested">{% for item in items %}<li class="chirpui-nav-tree__item chirpui-nav-tree__item--child{% if item.get("active") %} chirpui-nav-tree__item--active{% end %}{% if item.get("open") %} chirpui-nav-tree__item--open{% end %}"><a href="{{ item.href }}" class="chirpui-nav-tree__link chirpui-nav-tree__link--leaf{% if item.get("active") %} chirpui-nav-tree__link--active{% end %}"{% if item.get("active") %} aria-current="page"{% end %}><span class="chirpui-nav-tree__title">{{ item.title }}</span></a>{% if item.get("open") and item.get("children") %}{{ nav_tree_items(item.children) }}{% end %}</li>{% end %}</ul>{% end %}
+    """,
+    )
+    _write_text(
+        components / "drawer.html",
+        """
+        {% def drawer(id, title=none, side="right", cls="") %}<dialog id="{{ id }}" class="chirpui-drawer chirpui-drawer--{{ side }} {{ cls }}"><div class="chirpui-drawer__panel">{% if title %}<header class="chirpui-drawer__header"><h2 class="chirpui-drawer__title">{{ title }}</h2><form method="dialog"><button class="chirpui-drawer__close" aria-label="Close">&times;</button></form></header>{% end %}<div class="chirpui-drawer__body">{% slot %}</div></div></dialog>{% end %}
+    """,
+    )
+    _write_text(
+        components / "site_footer.html",
+        """
+        {% def site_footer(layout="columns", cls="") %}<footer class="chirpui-site-footer chirpui-site-footer--{{ layout }} {{ cls }}"><div class="chirpui-site-footer__brand">{% slot brand %}</div>{% slot %}<div class="chirpui-site-footer__colophon">{% slot colophon %}</div></footer>{% end %}
+        {% def footer_column(title="", cls="") %}<div class="chirpui-site-footer__column {{ cls }}">{% if title %}<h3>{{ title }}</h3>{% end %}<ul>{% slot %}</ul></div>{% end %}
+        {% def footer_link(href, label, glyph="", external=false, cls="") %}<li><a class="chirpui-site-footer__link {{ cls }}" href="{{ href }}">{{ label }}</a></li>{% end %}
+    """,
+    )
+    _write_text(
+        components / "metric_grid.html",
+        """
+        {% def metric_grid(cols=3, gap="md", cls="") %}<div class="chirpui-metric-grid {{ cls }}">{% slot %}</div>{% end %}
+        {% def metric_card(value, label, icon=none, trend=none, hint=none, href=none, cls="") %}{% if href %}<a href="{{ href }}" class="chirpui-card chirpui-metric-card {{ cls }}"><span class="chirpui-stat__value">{{ value }}</span><span class="chirpui-stat__label">{{ label }}</span></a>{% else %}<div class="chirpui-card chirpui-metric-card {{ cls }}"><span class="chirpui-stat__value">{{ value }}</span><span class="chirpui-stat__label">{{ label }}</span></div>{% end %}{% end %}
+    """,
+    )
+    _write_text(
+        components / "post_card.html",
+        """
+        {% def post_card(name=none, handle=none, time=none, href=none, cls="") %}<article class="chirpui-post-card {{ cls }}">{% if href %}<a class="chirpui-post-card__name" href="{{ href }}">{{ name }}</a>{% else %}<span class="chirpui-post-card__name">{{ name }}</span>{% end %}<div class="chirpui-post-card__body">{% slot %}</div><footer class="chirpui-post-card__actions">{% slot actions %}</footer></article>{% end %}
+    """,
+    )
+    _write_text(
+        components / "search_header.html",
+        """
+        {% def search_header(title, form_action, query="", search_name="q", subtitle=none, meta=none, breadcrumb_items=none, form_method="get", form_attrs="", form_attrs_map=none, search_placeholder="Search...", button_label="Search", button_icon="search", surface_variant="muted", density="md", wrap="wrap", sticky=false, cls="") %}<div class="chirpui-search-header {{ cls }}"><h1>{{ title }}</h1>{% if subtitle %}<p>{{ subtitle }}</p>{% end %}<form action="{{ form_action }}" method="{{ form_method }}"><input id="{{ search_name }}" name="{{ search_name }}" type="search" value="{{ query }}" placeholder="{{ search_placeholder }}"><button type="submit">{{ button_label }}</button></form>{% slot %}</div>{% end %}
+    """,
+    )
+    _write_text(
+        components / "resource_index.html",
+        """
+        {% from "chirpui/search_header.html" import search_header %}
+        {% from "chirpui/empty.html" import empty_state %}
+        {% def resource_index(title, search_action, query="", subtitle=none, search_name="q", search_placeholder="Search...", button_label="Search", button_icon="search", search_method="get", filter_action=none, filter_method="get", filter_surface_variant="default", filter_density="sm", filter_label=none, filter_state_name=none, filter_state_value=none, selected_count=0, selected_label="filters selected", selected_aria_label=none, results_title=none, results_subtitle=none, results_layout="stack", results_cols=2, results_gap="md", has_results=true, empty_title="No results found", empty_icon="search", empty_hint=none, empty_message=none, mutation_result_id=none, cls="") %}
+        <section class="chirpui-resource-index {{ cls }}">{{ search_header(title, search_action, query=query, search_name=search_name, subtitle=subtitle, search_placeholder=search_placeholder, button_label=button_label, button_icon=button_icon) }}{% if results_title %}<h2>{{ results_title }}</h2>{% end %}{% if has_results %}<div class="chirpui-resource-index__results">{% slot %}</div>{% else %}{{ empty_state(title=empty_title, icon=empty_icon) }}{% end %}</section>
+        {% end %}
+    """,
+    )
+    _write_text(
+        components / "timeline.html",
+        """
+        {% def timeline(items=none, cls="") %}<div class="chirpui-timeline {{ cls }}">{% slot %}</div>{% end %}
+        {% def timeline_item(title, date, content=none, cls="") %}<div class="chirpui-timeline__item {{ cls }}"><span class="chirpui-timeline__title">{{ title }}</span><span class="chirpui-timeline__date">{{ date }}</span><div class="chirpui-timeline__body">{% slot content %}</div></div>{% end %}
+    """,
+    )
+    _write_text(
+        components / "callout.html",
+        """
+        {% def callout(variant="info", title=none, icon=none, cls="") %}<aside class="chirpui-callout chirpui-callout--{{ variant }} {{ cls }}">{% if title %}<h3>{{ title }}</h3>{% end %}<div class="chirpui-callout__body">{% slot %}</div></aside>{% end %}
+    """,
+    )
+    _write_text(
+        components / "status.html",
+        """
+        {% def status_indicator(label, variant="default", icon=none, pulse=false, cls="") %}<span class="chirpui-status-indicator chirpui-status-indicator--{{ variant }} {{ cls }}">{{ label }}</span>{% end %}
+    """,
+    )
+
+
+def _local_css_js_asset_paths(html: str, baseurl: str) -> set[str]:
+    paths: set[str] = set()
+    base_prefix = f"{baseurl.rstrip('/')}/" if baseurl else "/"
+    for raw_url in LOCAL_CSS_JS_RE.findall(html):
+        parsed = urlparse(raw_url)
+        if parsed.scheme or parsed.netloc:
+            continue
+        path = parsed.path
+        if not path.startswith("/"):
+            path = f"/{path}"
+        if base_prefix != "/" and path.startswith(base_prefix):
+            path = "/" + path[len(base_prefix) :]
+        if path.startswith("/assets/"):
+            paths.add(path.lstrip("/"))
+    return paths
+
+
+def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> None:
+    """The bundled chirpui theme renders without default assets when chirp_ui is present."""
+    package_root = tmp_path / "pkg"
+    _write_fake_chirp_ui(package_root)
+    monkeypatch.syspath_prepend(str(package_root))
+
+    site_root = tmp_path / "site"
+    shutil.copytree(ROOT / "roots" / "test-chirpui-theme", site_root)
+
+    site = Site.from_config(site_root)
+    site.build(BuildOptions(incremental=False, quiet=True))
+
+    index_html = (site.output_dir / "index.html").read_text(encoding="utf-8")
+    docs_index_html = (site.output_dir / "docs" / "index.html").read_text(encoding="utf-8")
+    getting_started_html = (site.output_dir / "docs" / "getting-started" / "index.html").read_text(
+        encoding="utf-8"
+    )
+    guide_html = (site.output_dir / "docs" / "guide" / "index.html").read_text(encoding="utf-8")
+    quickstart_html = (
+        site.output_dir / "docs" / "getting-started" / "quickstart" / "index.html"
+    ).read_text(encoding="utf-8")
+    author_html = (site.output_dir / "authors" / "jane" / "index.html").read_text(encoding="utf-8")
+    blog_index_html = (site.output_dir / "blog" / "index.html").read_text(encoding="utf-8")
+    blog_html = (site.output_dir / "blog" / "launch" / "index.html").read_text(encoding="utf-8")
+    archive_html = (site.output_dir / "history" / "index.html").read_text(encoding="utf-8")
+    search_html = (site.output_dir / "search" / "index.html").read_text(encoding="utf-8")
+    changelog_html = (site.output_dir / "changelog" / "index.html").read_text(encoding="utf-8")
+    release_html = (site.output_dir / "changelog" / "v0-1" / "index.html").read_text(
+        encoding="utf-8"
+    )
+    manifest = AssetManifest.load(site.output_dir / "asset-manifest.json")
+    representative_html = {
+        "index.html": index_html,
+        "docs/index.html": docs_index_html,
+        "docs/getting-started/index.html": getting_started_html,
+        "docs/guide/index.html": guide_html,
+        "blog/index.html": blog_index_html,
+        "search/index.html": search_html,
+    }
+
+    for html_path in site.output_dir.rglob("*.html"):
+        html = html_path.read_text(encoding="utf-8")
+        assert "Build Error" not in html, html_path
+        assert "header-appshell" not in html, html_path
+        assert "bengal-enhance" not in html, html_path
+        assert "data-chirpui-style-cycle" not in html, html_path
+
+    assert "Build Error" not in index_html
+    assert "chirpui-site-shell" in index_html
+    assert "chirpui-navbar" in index_html
+    assert "chirpui-hero" in index_html
+    assert "chirpui-metric-card" in index_html
+    assert "chirpui-rendered-content" in index_html
+
+    assert "chirpui-bengal-docs" in guide_html
+    assert "chirpui-document-header" in guide_html
+    assert "chirpui-rendered-content" in guide_html
+    assert "chirpui-panel" in guide_html
+    assert "chirpui-document-header" in getting_started_html
+    assert "chirpui-rendered-content" in getting_started_html
+    assert "chirpui-rendered-content" in docs_index_html
+    assert "chirpui-rendered-content" in quickstart_html
+    assert "chirpui-nav-tree chirpui-nav-tree--linked-branches" in guide_html
+    assert "chirpui-drawer chirpui-drawer--left" in guide_html
+    assert 'data-chirpui-drawer-open="chirpui-docs-nav-drawer"' in guide_html
+    assert "chirpui-nav-tree__link--active" in guide_html
+    assert 'href="/preview/docs/getting-started/quickstart/"' in quickstart_html
+    assert "chirpui-nav-tree__list--nested" in quickstart_html
+    assert "chirpui-dropdown__item--active" in quickstart_html
+    assert 'href="/preview/docs/"' in index_html
+    assert "/preview/assets/chirp_ui/chirpui." in guide_html
+    assert "/preview/assets/chirp_ui/chirpui." in index_html
+    assert "/preview/assets/chirp_ui/chirpui-" in index_html
+    assert re.search(r"/preview/assets/chirp_ui/chirpui\.[0-9a-f]+\.js", index_html)
+    assert "/preview/assets/js/chirpui-bengal." in guide_html
+    assert "chirpui-rendered-content" in blog_html
+    assert "chirpui-prose" not in blog_html
+    assert "chirpui-detail-header" in blog_html
+    assert "chirpui-post-card" in blog_index_html
+    assert "chirpui-resource-index" in blog_index_html
+    assert "chirpui-rendered-content" in blog_index_html
+    assert "data-chirpui-search-item" in blog_index_html
+    assert "chirpui-profile-header" in author_html
+    assert "chirpui-resource-index" in archive_html
+    assert "chirpui-search-header" in search_html
+    assert "chirpui-resource-index" in search_html
+    assert "data-chirpui-search-item" in search_html
+    assert "data-chirpui-search-group" in search_html
+    assert 'data-search-type="doc"' in search_html
+    assert 'data-search-group="page"' in search_html
+    assert 'data-search-group=""' not in search_html
+    assert "chirpui-timeline" in changelog_html
+    assert "chirpui-rendered-content" in changelog_html
+    assert "chirpui-callout" in release_html
+    assert "chirpui-detail-header" in release_html
+    assert "chirpui-rendered-content" in release_html
+
+    assert manifest is not None
+    css_entry = manifest.get("chirp_ui/chirpui.css")
+    assert css_entry is not None
+    assert (site.output_dir / css_entry.output_path).exists()
+    assert manifest.get("chirp_ui/chirpui/navbar.html") is None
+
+    asset_paths = {
+        path
+        for html in representative_html.values()
+        for path in _local_css_js_asset_paths(html, site.baseurl)
+    }
+    assert asset_paths, "Representative Chirp UI pages should reference local CSS/JS assets"
+    missing_assets = sorted(path for path in asset_paths if not (site.output_dir / path).exists())
+    assert not missing_assets, f"Local CSS/JS asset URLs should be serveable: {missing_assets}"

--- a/tests/roots/README.md
+++ b/tests/roots/README.md
@@ -69,6 +69,18 @@ def test_asset_copying(site, build_site):
     assert (site.output_dir / "assets/images/test.png").exists()
 ```
 
+### test-chirpui-theme
+**Purpose**: Tests the optional Chirp UI theme integration  
+**Structure**: Home, nested docs, blog, changelog, archive, author, tags, and search with `baseurl="/preview"`  
+**Use for**: Provider templates/assets, baseurl-safe asset links, template alias coverage, and theme isolation from `default`
+
+```python
+def test_chirpui_theme_builds_with_provider_assets(site):
+    site.build(BuildOptions(incremental=False, quiet=True))
+    html = (site.output_dir / "docs/guide/index.html").read_text()
+    assert "/preview/assets/chirp_ui/chirpui." in html
+```
+
 ## Design Principles
 
 1. **Minimal**: Each root has ≤5 files (keep focused)

--- a/tests/roots/test-chirpui-theme/bengal.toml
+++ b/tests/roots/test-chirpui-theme/bengal.toml
@@ -1,0 +1,12 @@
+[site]
+title = "Chirp UI Test"
+description = "A fixture for the bundled Chirp UI theme."
+baseurl = "/preview"
+
+[build]
+content_dir = "content"
+output_dir = "public"
+theme = "chirpui"
+
+[markdown]
+parser = "patitas"

--- a/tests/roots/test-chirpui-theme/content/_index.md
+++ b/tests/roots/test-chirpui-theme/content/_index.md
@@ -1,0 +1,8 @@
+---
+title: Home
+description: Welcome to the Chirp UI fixture.
+---
+
+# Intro
+
+Home content.

--- a/tests/roots/test-chirpui-theme/content/authors/jane.md
+++ b/tests/roots/test-chirpui-theme/content/authors/jane.md
@@ -1,0 +1,9 @@
+---
+title: Jane Writer
+description: A fixture author page.
+template: author.html
+author_name: Jane Writer
+bio: Writes careful Bengal release notes.
+---
+
+Jane writes documentation and changelog entries.

--- a/tests/roots/test-chirpui-theme/content/blog/_index.md
+++ b/tests/roots/test-chirpui-theme/content/blog/_index.md
@@ -1,0 +1,7 @@
+---
+title: Blog
+description: Release notes and updates.
+template: blog/list.html
+---
+
+Blog index.

--- a/tests/roots/test-chirpui-theme/content/blog/launch.md
+++ b/tests/roots/test-chirpui-theme/content/blog/launch.md
@@ -1,0 +1,11 @@
+---
+title: Launch Notes
+description: What changed in this release.
+template: blog/single.html
+tags: [alpha, release]
+date: 2026-05-05
+---
+
+## Highlights
+
+The Chirp UI theme renders blog content without inheriting the default theme shell.

--- a/tests/roots/test-chirpui-theme/content/changelog/_index.md
+++ b/tests/roots/test-chirpui-theme/content/changelog/_index.md
@@ -1,0 +1,7 @@
+---
+title: Changelog
+description: Release notes for the preview fixture.
+template: changelog/list.html
+---
+
+Fixture releases are rendered with the Chirp UI timeline component.

--- a/tests/roots/test-chirpui-theme/content/changelog/v0-1.md
+++ b/tests/roots/test-chirpui-theme/content/changelog/v0-1.md
@@ -1,0 +1,20 @@
+---
+title: Version 0.1
+description: First Chirp UI fixture release.
+template: changelog/single.html
+type: changelog
+status: preview
+date: 2026-05-05
+added:
+  - Added a Chirp UI docs shell.
+  - Added static search filtering.
+changed:
+  - Replaced generic list pages with component layouts.
+fixed:
+  - Prevented provider templates from entering the asset manifest.
+---
+
+## Notes
+
+This release proves the bundled theme can render changelog content without
+falling back to the default theme.

--- a/tests/roots/test-chirpui-theme/content/docs/_index.md
+++ b/tests/roots/test-chirpui-theme/content/docs/_index.md
@@ -1,0 +1,8 @@
+---
+title: Docs
+description: Product documentation.
+type: doc
+template: doc/list.html
+---
+
+Docs index.

--- a/tests/roots/test-chirpui-theme/content/docs/getting-started/_index.md
+++ b/tests/roots/test-chirpui-theme/content/docs/getting-started/_index.md
@@ -1,0 +1,8 @@
+---
+title: Getting Started
+description: A nested documentation section.
+type: doc
+template: doc/list.html
+---
+
+Start here when evaluating the Chirp UI theme.

--- a/tests/roots/test-chirpui-theme/content/docs/getting-started/quickstart.md
+++ b/tests/roots/test-chirpui-theme/content/docs/getting-started/quickstart.md
@@ -1,0 +1,15 @@
+---
+title: Quickstart
+description: A deeper documentation page.
+type: doc
+template: doc/single.html
+tags: [alpha, docs]
+---
+
+## Install
+
+Install Bengal and choose the Chirp UI theme.
+
+## Build
+
+Run a full build and inspect the generated pages.

--- a/tests/roots/test-chirpui-theme/content/docs/guide.md
+++ b/tests/roots/test-chirpui-theme/content/docs/guide.md
@@ -1,0 +1,11 @@
+---
+title: Guide
+description: A documentation page rendered through Chirp UI.
+type: doc
+template: doc/single.html
+tags: [alpha]
+---
+
+## Step One
+
+Guide content.

--- a/tests/roots/test-chirpui-theme/content/history-2026.md
+++ b/tests/roots/test-chirpui-theme/content/history-2026.md
@@ -1,0 +1,8 @@
+---
+title: "2026"
+description: A fixture page that renders the yearly archive template.
+template: archive-year.html
+year: "2026"
+---
+
+Year archive overview content.

--- a/tests/roots/test-chirpui-theme/content/history.md
+++ b/tests/roots/test-chirpui-theme/content/history.md
@@ -1,0 +1,7 @@
+---
+title: Archive
+description: A fixture page that renders the archive template.
+template: archive.html
+---
+
+Archive overview content.

--- a/tests/unit/rendering/directives/test_directive_templates.py
+++ b/tests/unit/rendering/directives/test_directive_templates.py
@@ -19,6 +19,12 @@ import pytest
 from bengal.parsing.backends.patitas.directives.builtins.admonition import (
     AdmonitionDirective,
 )
+from bengal.parsing.backends.patitas.directives.builtins.cards import (
+    CardDirective,
+    CardOptions,
+    CardsDirective,
+    CardsOptions,
+)
 
 
 class TestAdmonitionTemplateContext:
@@ -91,6 +97,36 @@ class TestAdmonitionTemplateContext:
         node = self._make_node()
         ctx = handler.get_template_context(node, "<p>x</p>", page_context="fake", site="fake")
         assert ctx["children"] == "<p>x</p>"
+
+
+class TestCardTemplateContext:
+    """Tests for card directive template contexts."""
+
+    def test_cards_context_exposes_chirpui_gap(self):
+        handler = CardsDirective()
+        node = MagicMock()
+        node.options = CardsOptions(columns="2", gap="large", variant="navigation")
+
+        ctx = handler.get_template_context(node, "<p>cards</p>")
+
+        assert ctx["columns"] == "2"
+        assert ctx["gap"] == "large"
+        assert ctx["chirpui_gap"] == "lg"
+        assert ctx["children"] == "<p>cards</p>"
+
+    def test_card_context_preserves_resolved_shape(self):
+        handler = CardDirective()
+        node = MagicMock()
+        node.title = "Docs"
+        node.options = CardOptions(icon="book", link="/docs/", description="Read docs")
+
+        ctx = handler.get_template_context(node, "<p>body</p>")
+
+        assert ctx["title"] == "Docs"
+        assert ctx["icon"] == "book"
+        assert ctx["href"] == "/docs/"
+        assert ctx["description"] == "Read docs"
+        assert ctx["children"] == "<p>body</p>"
 
 
 class TestDirectiveTemplateRendering:

--- a/tests/unit/rendering/test_kida_asset_url.py
+++ b/tests/unit/rendering/test_kida_asset_url.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from bengal.core.site import Site
 from bengal.rendering.assets import resolve_asset_url
 
 if TYPE_CHECKING:
@@ -192,3 +193,39 @@ class TestManifestCaching:
         site = MockSite(output_dir=tmp_path)  # No manifest file
         result = resolve_asset_url("css/style.css", site)
         assert result == "/assets/css/style.css"  # Fallback
+
+    def test_fragment_cache_keys_include_asset_manifest_revision(self, tmp_path: Path) -> None:
+        """Cached fragments containing asset_url() must not replay stale fingerprints."""
+        from bengal.rendering.assets import AssetManifestContext, asset_manifest_context
+        from bengal.rendering.engines.kida import KidaTemplateEngine
+
+        site_root = tmp_path / "site"
+        site_root.mkdir()
+        (site_root / "content").mkdir()
+        (site_root / "content" / "_index.md").write_text("# Home", encoding="utf-8")
+        (site_root / "bengal.toml").write_text(
+            '[site]\ntitle = "Fragment Cache Test"\n',
+            encoding="utf-8",
+        )
+        site = Site.from_config(site_root)
+        site.output_dir.mkdir(parents=True, exist_ok=True)
+
+        engine = KidaTemplateEngine(site)
+        template = "{% cache 'asset-fragment' %}{{ asset_url('css/style.css') }}{% end %}"
+
+        first_ctx = AssetManifestContext(
+            entries={"css/style.css": "assets/css/style.11111111.css"},
+            mtime=1.0,
+        )
+        second_ctx = AssetManifestContext(
+            entries={"css/style.css": "assets/css/style.22222222.css"},
+            mtime=2.0,
+        )
+
+        with asset_manifest_context(first_ctx):
+            first = engine.render_string(template, {})
+        with asset_manifest_context(second_ctx):
+            second = engine.render_string(template, {})
+
+        assert first == "/assets/css/style.11111111.css"
+        assert second == "/assets/css/style.22222222.css"

--- a/tests/unit/rendering/test_kida_asset_url.py
+++ b/tests/unit/rendering/test_kida_asset_url.py
@@ -204,7 +204,7 @@ class TestManifestCaching:
         (site_root / "content").mkdir()
         (site_root / "content" / "_index.md").write_text("# Home", encoding="utf-8")
         (site_root / "bengal.toml").write_text(
-            '[site]\ntitle = "Fragment Cache Test"\n',
+            '[site]\ntitle = "Fragment Cache Test"\nbaseurl = ""\n',
             encoding="utf-8",
         )
         site = Site.from_config(site_root)

--- a/tests/unit/rendering/test_page_dependent_directive_caching.py
+++ b/tests/unit/rendering/test_page_dependent_directive_caching.py
@@ -17,6 +17,7 @@ on the current page's position in the site tree.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
 
@@ -172,14 +173,12 @@ class TestChildCardsNotCachedAcrossPages:
 """
 
         # Render page A (site needs root_path for child-cards current_page_dir resolution)
-        site_a = Mock()
-        site_a.root_path = "/tmp/site"
+        site_a = SimpleNamespace(root_path="/tmp/site")
         context_a = {"page": page_a, "site": site_a}
         result_a = patitas.parse_with_context(content, {}, context_a)
 
         # Render page B (if caching is broken, this would show page A's content)
-        site_b = Mock()
-        site_b.root_path = "/tmp/site"
+        site_b = SimpleNamespace(root_path="/tmp/site")
         context_b = {"page": page_b, "site": site_b}
         result_b = patitas.parse_with_context(content, {}, context_b)
 
@@ -206,8 +205,7 @@ class TestChildCardsNotCachedAcrossPages:
         page = create_mock_page(title="Index", source_path="test/_index.md")
         page._section = section
 
-        site = Mock()
-        site.root_path = "/tmp/site"
+        site = SimpleNamespace(root_path="/tmp/site")
         context = {"page": page, "site": site}
         content = ":::{child-cards}\n:::"
 


### PR DESCRIPTION
## What changed

- Added a bundled `chirpui` theme that renders Bengal content through Chirp UI provider macros, assets, and theme-specific composition.
- Added provider asset handling so library templates are not copied into the browser asset manifest, while standalone provider CSS/JS remains serveable and fingerprinted.
- Exposed card directive template contexts needed by theme overrides.
- Namespaced Kida fragment cache keys by the active asset manifest revision so cached fragments that call `asset_url()` cannot replay stale fingerprinted URLs.
- Added Chirp UI fixture coverage and docs for using the bundled theme.

## Why

Chirp UI is the first customer for a vendored Bengal theme. The theme needs to rely on Chirp UI primitives while Bengal protects generated asset contracts, especially around manifest-sensitive `asset_url()` output and cached Kida fragments.

## Steward Notes

- Rendering/template functions: kept presentation behavior under rendering/theme surfaces and added a regression for cached `asset_url()` fragment output.
- Assets: provider HTML templates are excluded from the manifest, standalone provider CSS/JS stays browser-downloadable, and route smoke coverage verifies local CSS/JS references exist in output.
- Tests: added a focused `test-chirpui-theme` root and integration assertions instead of broad snapshots.
- Docs: added Chirp UI theme docs and documented asset-manifest namespacing for fragment cache invalidation.

## Validation

- `uv run pytest tests/unit/rendering/test_kida_asset_url.py tests/unit/rendering/test_asset_manifest_contextvar.py tests/integration/test_chirpui_theme_build.py -q`
- `uv run ruff check bengal/rendering/assets.py bengal/rendering/fragment_cache.py bengal/rendering/engines/kida.py tests/unit/rendering/test_kida_asset_url.py tests/integration/test_chirpui_theme_build.py`
- `uv run ruff format --check bengal/rendering/assets.py bengal/rendering/fragment_cache.py bengal/rendering/engines/kida.py tests/unit/rendering/test_kida_asset_url.py tests/integration/test_chirpui_theme_build.py`
- Commit hook: `ruff`, `ruff format`, `ty`, template CSS class check, thread/concurrency guards, `check-cycles`, and dependency-layer warning check ran during commit.
