### PR TITLE
[codex] Add theme library asset contracts

### DIFF
--- a/bengal/assets/manifest.py
+++ b/bengal/assets/manifest.py
@@ -27,7 +27,13 @@ The manifest is stored as JSON with the following structure::
                 "output_path": "assets/css/style.abc123.css",
                 "fingerprint": "abc123def456",
                 "size_bytes": 4096,
-                "updated_at": "2025-01-15T10:30:00Z"
+                "updated_at": "2025-01-15T10:30:00Z",
+                "provenance": {
+                    "kind": "theme_library",
+                    "package": "vendor_ui",
+                    "mode": "bundle",
+                    "sources": ["vendor.css", "transitions.css"]
+                }
             }
         }
     }
@@ -46,16 +52,16 @@ Related:
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bengal.utils.io.atomic_write import atomic_write_text
 from bengal.utils.observability.logger import get_logger
 from bengal.utils.paths.normalize import to_posix
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from pathlib import Path
 
 logger = get_logger(__name__)
@@ -81,6 +87,13 @@ def _isoformat(timestamp: float | None) -> str | None:
     return datetime.fromtimestamp(timestamp, tz=UTC).isoformat().replace("+00:00", "Z")
 
 
+def _normalize_provenance(raw: object) -> dict[str, Any] | None:
+    """Return JSON object provenance with string keys, ignoring malformed values."""
+    if not isinstance(raw, Mapping):
+        return None
+    return {key: value for key, value in raw.items() if isinstance(key, str)}
+
+
 @dataclass(frozen=True, slots=True)
 class AssetManifestEntry:
     """
@@ -97,6 +110,7 @@ class AssetManifestEntry:
         fingerprint: Content hash used for cache-busting, or None if disabled.
         size_bytes: File size in bytes for visibility and debugging.
         updated_at: ISO-8601 timestamp of the last file write.
+        provenance: Optional owner/source metadata for generated assets.
 
     Example:
             >>> entry = AssetManifestEntry(
@@ -116,8 +130,9 @@ class AssetManifestEntry:
     fingerprint: str | None = None
     size_bytes: int | None = None
     updated_at: str | None = None
+    provenance: dict[str, Any] | None = None
 
-    def to_dict(self) -> dict[str, str | int]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Serialize entry to a JSON-friendly dictionary.
 
@@ -126,7 +141,7 @@ class AssetManifestEntry:
         Returns:
             Dictionary with 'output_path' and any present optional fields.
         """
-        data: dict[str, str | int] = {
+        data: dict[str, Any] = {
             "output_path": self.output_path,
         }
         if self.fingerprint:
@@ -135,6 +150,8 @@ class AssetManifestEntry:
             data["size_bytes"] = self.size_bytes
         if self.updated_at:
             data["updated_at"] = self.updated_at
+        if self.provenance:
+            data["provenance"] = self.provenance
         return data
 
     @classmethod
@@ -150,6 +167,7 @@ class AssetManifestEntry:
             Populated AssetManifestEntry with normalized paths.
         """
         size_bytes_val = data.get("size_bytes")
+        provenance = data.get("provenance")
         return cls(
             logical_path=to_posix(logical_path),
             output_path=to_posix(str(data.get("output_path", ""))),
@@ -158,6 +176,7 @@ class AssetManifestEntry:
             if size_bytes_val is not None and isinstance(size_bytes_val, (int, str))
             else None,
             updated_at=str(data["updated_at"]) if data.get("updated_at") else None,
+            provenance=_normalize_provenance(provenance),
         )
 
 
@@ -207,6 +226,7 @@ class AssetManifest:
         fingerprint: str | None,
         size_bytes: int | None,
         updated_at: float | None,
+        provenance: dict[str, Any] | None = None,
     ) -> None:
         """
         Add or replace a manifest entry for a logical asset.
@@ -225,6 +245,7 @@ class AssetManifest:
             fingerprint=fingerprint,
             size_bytes=size_bytes,
             updated_at=_isoformat(updated_at),
+            provenance=provenance,
         )
 
     def get(self, logical_path: str) -> AssetManifestEntry | None:

--- a/bengal/core/asset/asset_core.py
+++ b/bengal/core/asset/asset_core.py
@@ -85,6 +85,7 @@ class Asset:
     optimized: bool = False
     bundled: bool = False
     logical_path: Path | None = None
+    manifest_provenance: dict[str, Any] | None = None
 
     # Processing state (set during asset processing)
     _bundled_content: str | None = None  # CSS content after @import resolution

--- a/bengal/core/asset/asset_core.py
+++ b/bengal/core/asset/asset_core.py
@@ -85,6 +85,7 @@ class Asset:
     optimized: bool = False
     bundled: bool = False
     logical_path: Path | None = None
+    standalone: bool = False
     manifest_provenance: dict[str, Any] | None = None
 
     # Processing state (set during asset processing)
@@ -155,7 +156,7 @@ class Asset:
         Returns:
             True if this is a CSS module (e.g., components/buttons.css)
         """
-        return self.asset_type == "css" and not self.is_css_entry_point()
+        return self.asset_type == "css" and not self.is_css_entry_point() and not self.standalone
 
     def is_js_entry_point(self) -> bool:
         """

--- a/bengal/core/theme/__init__.py
+++ b/bengal/core/theme/__init__.py
@@ -55,8 +55,10 @@ from bengal.core.theme.compatibility import (
 )
 from bengal.core.theme.config import Theme
 from bengal.core.theme.providers import (
+    LibraryAsset,
     ThemeLibraryProvider,
     get_provider_asset_dirs,
+    get_provider_assets,
     resolve_theme_providers,
 )
 from bengal.core.theme.registry import (
@@ -74,6 +76,7 @@ from bengal.core.theme.resolution import (
 
 __all__ = [
     "FEATURE_SUPPORT",
+    "LibraryAsset",
     "Theme",
     "ThemeLibraryProvider",
     "ThemePackage",
@@ -85,6 +88,7 @@ __all__ = [
     "get_installed_themes",
     "get_minimum_engine_level",
     "get_provider_asset_dirs",
+    "get_provider_assets",
     "get_theme_package",
     "iter_theme_asset_dirs",
     "resolve_theme_chain",

--- a/bengal/core/theme/providers.py
+++ b/bengal/core/theme/providers.py
@@ -389,10 +389,20 @@ def _contract_assets(
                 ),
             )
 
-        source_path = Path(path_raw)
+        source_path = _normalize_contract_path(
+            package_name,
+            path_raw,
+            field_name="path",
+            allow_absolute=True,
+        )
         if not source_path.is_absolute():
             source_path = asset_root / source_path
-        output_path = Path(str(output_raw))
+        output_path = _normalize_contract_path(
+            package_name,
+            output_raw,
+            field_name="output",
+            allow_absolute=False,
+        )
         logical_path = Path(asset_prefix) / output_path
         if not asset_type:
             asset_type = _asset_type_from_path(source_path)
@@ -405,6 +415,91 @@ def _contract_assets(
             )
         )
     return tuple(assets)
+
+
+def _normalize_contract_path(
+    package_name: str,
+    raw_path: Any,
+    *,
+    field_name: str,
+    allow_absolute: bool,
+) -> Path:
+    """Normalize a path-like contract field and reject ambiguous output paths."""
+    from bengal.errors import ErrorCode
+    from bengal.errors.exceptions import BengalConfigError
+
+    if isinstance(raw_path, str) and not raw_path.strip():
+        raw_path = None
+    if raw_path is None:
+        raise BengalConfigError(
+            f"Theme library '{package_name}' has a library asset without a {field_name}",
+            code=ErrorCode.C003,
+            suggestion=f"Give each library asset a non-empty {field_name}.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+                returned_type=type(raw_path).__name__,
+            ),
+        )
+
+    try:
+        path = Path(raw_path)
+    except TypeError as e:
+        raise BengalConfigError(
+            f"Theme library '{package_name}' asset {field_name} must be path-like, "
+            f"got {type(raw_path).__name__}",
+            code=ErrorCode.C003,
+            suggestion=f"Use a string or pathlib.Path for asset {field_name}.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+                returned_type=type(raw_path).__name__,
+            ),
+        ) from e
+    except ValueError as e:
+        raise BengalConfigError(
+            f"Theme library '{package_name}' asset {field_name} must be path-like, "
+            f"got {type(raw_path).__name__}",
+            code=ErrorCode.C003,
+            suggestion=f"Use a string or pathlib.Path for asset {field_name}.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+                returned_type=type(raw_path).__name__,
+            ),
+        ) from e
+
+    if path == Path("."):
+        raise BengalConfigError(
+            f"Theme library '{package_name}' has an empty asset {field_name}",
+            code=ErrorCode.C003,
+            suggestion=f"Give each library asset a non-empty {field_name}.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+            ),
+        )
+    if not allow_absolute and path.is_absolute():
+        raise BengalConfigError(
+            f"Theme library '{package_name}' asset {field_name} must be relative: {path}",
+            code=ErrorCode.C003,
+            suggestion="Use a relative output path so Bengal can namespace emitted assets.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+            ),
+        )
+    if ".." in path.parts:
+        raise BengalConfigError(
+            f"Theme library '{package_name}' asset {field_name} must not contain '..': {path}",
+            code=ErrorCode.C003,
+            suggestion="Use a path inside the library asset namespace.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+            ),
+        )
+    return path
 
 
 def _iter_contract_asset_entries(contract: Mapping[str, Any]) -> Sequence[Any]:
@@ -441,7 +536,7 @@ def _contract_runtime(package_name: str, runtime_raw: Any) -> tuple[str, ...]:
         return ()
     if isinstance(runtime_raw, str):
         return (runtime_raw,)
-    if not isinstance(runtime_raw, Sequence):
+    if isinstance(runtime_raw, bytes) or not isinstance(runtime_raw, Sequence):
         raise BengalConfigError(
             f"Theme library '{package_name}': runtime must be a string or list of strings",
             code=ErrorCode.C003,
@@ -452,7 +547,22 @@ def _contract_runtime(package_name: str, runtime_raw: Any) -> tuple[str, ...]:
                 returned_type=type(runtime_raw).__name__,
             ),
         )
-    return tuple(str(item) for item in runtime_raw if item)
+    runtime: list[str] = []
+    for item in runtime_raw:
+        if not isinstance(item, str):
+            raise BengalConfigError(
+                f"Theme library '{package_name}': runtime entries must be strings",
+                code=ErrorCode.C003,
+                suggestion="Use runtime = ['alpine'] style metadata in the library contract.",
+                debug_payload=_theme_library_debug_payload(
+                    package_name,
+                    hook_name="get_library_contract",
+                    returned_type=type(item).__name__,
+                ),
+            )
+        if item:
+            runtime.append(item)
+    return tuple(runtime)
 
 
 def _asset_type_from_path(path: Path) -> str:

--- a/bengal/core/theme/providers.py
+++ b/bengal/core/theme/providers.py
@@ -76,6 +76,8 @@ class LibraryAsset:
     logical_path: Path
     asset_type: str
     mode: str
+    package: str = ""
+    contract_path: Path | None = None
     tag_attrs: tuple[tuple[str, str | bool], ...] = field(default_factory=tuple)
 
 
@@ -400,6 +402,9 @@ def _contract_assets(
         )
         if not source_path.is_absolute():
             source_path = asset_root / source_path
+            contract_path = Path(path_raw)
+        else:
+            contract_path = Path(source_path.name)
         output_path = _normalize_contract_path(
             package_name,
             output_raw,
@@ -415,6 +420,8 @@ def _contract_assets(
                 logical_path=logical_path,
                 asset_type=asset_type,
                 mode=mode,
+                package=package_name,
+                contract_path=contract_path,
                 tag_attrs=tag_attrs,
             )
         )

--- a/bengal/core/theme/providers.py
+++ b/bengal/core/theme/providers.py
@@ -26,16 +26,19 @@ Related Modules:
 from __future__ import annotations
 
 import importlib
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 logger = get_logger(__name__)
+
+_ASSET_MODES = frozenset({"bundle", "link", "none"})
 
 
 def _theme_library_debug_payload(
@@ -66,6 +69,16 @@ def _theme_library_debug_payload(
 
 
 @dataclass(frozen=True, slots=True)
+class LibraryAsset:
+    """A browser-downloadable asset declared by a theme library contract."""
+
+    source_path: Path
+    logical_path: Path
+    asset_type: str
+    mode: str
+
+
+@dataclass(frozen=True, slots=True)
 class ThemeLibraryProvider:
     """Normalized provider record for an external Kida UI library.
 
@@ -79,13 +92,16 @@ class ThemeLibraryProvider:
     asset_root: Path | None
     asset_prefix: str
     register_env: Callable[[Any], None] | None
+    assets: tuple[LibraryAsset, ...] = field(default_factory=tuple)
+    runtime: tuple[str, ...] = field(default_factory=tuple)
 
 
 def resolve_provider(package_name: str) -> ThemeLibraryProvider:
     """Import a library package and normalize its convention hooks.
 
-    Probes the package module for get_loader(), static_path(), and
-    register_filters(). Missing hooks produce None fields, not errors.
+    Probes the package module for get_library_contract(), get_loader(),
+    static_path(), and register_filters(). Missing hooks produce None fields,
+    not errors.
     Import failure or hook invocation errors raise BengalConfigError.
 
     Args:
@@ -129,32 +145,21 @@ def resolve_provider(package_name: str) -> ThemeLibraryProvider:
             debug_payload=_theme_library_debug_payload(package_name),
         ) from e
 
-    loader = _probe_hook(package_name, module, "get_loader")
-    asset_root_raw = _probe_hook(package_name, module, "static_path")
-    asset_root: Path | None = None
-    if asset_root_raw is not None:
-        from pathlib import Path as _Path
+    contract_raw = _probe_hook(package_name, module, "get_library_contract")
+    contract = _normalize_contract(package_name, contract_raw)
 
-        try:
-            asset_root = _Path(asset_root_raw)
-        except TypeError as e:
-            msg = (
-                f"Theme library '{package_name}': static_path() returned "
-                f"{type(asset_root_raw).__name__}, expected a path-like object"
-            )
-            raise BengalConfigError(
-                msg,
-                code=ErrorCode.C003,
-                suggestion=(
-                    f"Change '{package_name}.static_path()' to return a str or Path, "
-                    "or remove the hook if the library has no static assets."
-                ),
-                debug_payload=_theme_library_debug_payload(
-                    package_name,
-                    hook_name="static_path",
-                    returned_type=type(asset_root_raw).__name__,
-                ),
-            ) from e
+    loader = contract.get("loader") or contract.get("template_loader")
+    if loader is None:
+        loader = _probe_hook(package_name, module, "get_loader")
+
+    asset_root = _normalize_asset_root(
+        package_name,
+        contract.get("asset_root") or contract.get("static_path"),
+    )
+    if asset_root is None:
+        asset_root_raw = _probe_hook(package_name, module, "static_path")
+        asset_root = _normalize_asset_root(package_name, asset_root_raw, hook_name="static_path")
+
     register_filters_fn = getattr(module, "register_filters", None)
 
     register_env: Callable[[Any], None] | None = None
@@ -162,6 +167,8 @@ def resolve_provider(package_name: str) -> ThemeLibraryProvider:
         register_env = register_filters_fn
 
     asset_prefix = package_name.replace("-", "_").replace(".", "_")
+    assets = _contract_assets(package_name, asset_prefix, asset_root, contract)
+    runtime = _contract_runtime(package_name, contract.get("runtime"))
 
     logger.debug(
         "theme_library_provider_resolved",
@@ -169,6 +176,8 @@ def resolve_provider(package_name: str) -> ThemeLibraryProvider:
         has_loader=loader is not None,
         has_asset_root=asset_root is not None,
         has_register_env=register_env is not None,
+        contract_assets=len(assets),
+        runtime=list(runtime),
     )
 
     return ThemeLibraryProvider(
@@ -177,6 +186,8 @@ def resolve_provider(package_name: str) -> ThemeLibraryProvider:
         asset_root=asset_root,
         asset_prefix=asset_prefix,
         register_env=register_env,
+        assets=assets,
+        runtime=runtime,
     )
 
 
@@ -233,8 +244,228 @@ def get_provider_asset_dirs(
     return [
         (p.asset_prefix, p.asset_root)
         for p in providers
-        if p.asset_root is not None and p.asset_root.exists()
+        if p.asset_root is not None and p.asset_root.exists() and not p.assets
     ]
+
+
+def get_provider_assets(
+    providers: tuple[ThemeLibraryProvider, ...],
+) -> tuple[LibraryAsset, ...]:
+    """Return explicit library assets declared by provider contracts."""
+    return tuple(asset for provider in providers for asset in provider.assets)
+
+
+def _normalize_contract(package_name: str, contract_raw: Any) -> dict[str, Any]:
+    """Normalize get_library_contract() output into a plain dict."""
+    from bengal.errors import ErrorCode
+    from bengal.errors.exceptions import BengalConfigError
+
+    if contract_raw is None:
+        return {}
+    if not isinstance(contract_raw, Mapping):
+        raise BengalConfigError(
+            f"Theme library '{package_name}': get_library_contract() returned "
+            f"{type(contract_raw).__name__}, expected a mapping",
+            code=ErrorCode.C003,
+            suggestion=(
+                f"Change '{package_name}.get_library_contract()' to return a dict-like "
+                "contract with optional assets, runtime, loader, and asset_root fields."
+            ),
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+                returned_type=type(contract_raw).__name__,
+            ),
+        )
+    return dict(contract_raw)
+
+
+def _normalize_asset_root(
+    package_name: str,
+    raw_root: Any,
+    *,
+    hook_name: str = "get_library_contract",
+) -> Path | None:
+    """Normalize a provider asset root to Path, preserving absent roots."""
+    from pathlib import Path as _Path
+
+    from bengal.errors import ErrorCode
+    from bengal.errors.exceptions import BengalConfigError
+
+    if raw_root is None:
+        return None
+    try:
+        return _Path(raw_root)
+    except TypeError as e:
+        msg = (
+            f"Theme library '{package_name}': {hook_name} returned "
+            f"{type(raw_root).__name__} for asset root, expected a path-like object"
+        )
+        raise BengalConfigError(
+            msg,
+            code=ErrorCode.C003,
+            suggestion=(
+                f"Change '{package_name}.{hook_name}()' to provide a str or Path asset root, "
+                "or omit the asset root if the library has no static assets."
+            ),
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name=hook_name,
+                returned_type=type(raw_root).__name__,
+            ),
+        ) from e
+
+
+def _contract_assets(
+    package_name: str,
+    asset_prefix: str,
+    asset_root: Path | None,
+    contract: Mapping[str, Any],
+) -> tuple[LibraryAsset, ...]:
+    """Normalize explicit provider asset declarations."""
+    from bengal.errors import ErrorCode
+    from bengal.errors.exceptions import BengalConfigError
+
+    default_mode = str(contract.get("mode") or "link")
+    if default_mode not in _ASSET_MODES:
+        raise BengalConfigError(
+            f"Theme library '{package_name}': asset mode '{default_mode}' is invalid",
+            code=ErrorCode.C003,
+            suggestion="Use one of: bundle, link, none.",
+            debug_payload=_theme_library_debug_payload(
+                package_name, hook_name="get_library_contract"
+            ),
+        )
+
+    raw_assets = list(_iter_contract_asset_entries(contract))
+    if not raw_assets:
+        return ()
+    if asset_root is None:
+        raise BengalConfigError(
+            f"Theme library '{package_name}' declares assets but has no asset root",
+            code=ErrorCode.C003,
+            suggestion=(
+                f"Return 'asset_root' from '{package_name}.get_library_contract()' or "
+                "provide a static_path() hook."
+            ),
+            debug_payload=_theme_library_debug_payload(
+                package_name, hook_name="get_library_contract"
+            ),
+        )
+
+    assets: list[LibraryAsset] = []
+    for entry in raw_assets:
+        path_raw: Any
+        output_raw: Any
+        mode = default_mode
+        asset_type = ""
+        if isinstance(entry, Mapping):
+            path_raw = entry.get("path") or entry.get("src") or entry.get("source")
+            output_raw = entry.get("output") or entry.get("logical_path") or path_raw
+            mode = str(entry.get("mode") or mode)
+            asset_type = str(entry.get("type") or entry.get("kind") or "")
+        else:
+            path_raw = entry
+            output_raw = entry
+
+        if not path_raw:
+            raise BengalConfigError(
+                f"Theme library '{package_name}' has a library asset without a path",
+                code=ErrorCode.C003,
+                suggestion="Give each library asset a non-empty path.",
+                debug_payload=_theme_library_debug_payload(
+                    package_name,
+                    hook_name="get_library_contract",
+                ),
+            )
+        if mode not in _ASSET_MODES:
+            raise BengalConfigError(
+                f"Theme library '{package_name}': asset mode '{mode}' is invalid",
+                code=ErrorCode.C003,
+                suggestion="Use one of: bundle, link, none.",
+                debug_payload=_theme_library_debug_payload(
+                    package_name,
+                    hook_name="get_library_contract",
+                ),
+            )
+
+        source_path = Path(path_raw)
+        if not source_path.is_absolute():
+            source_path = asset_root / source_path
+        output_path = Path(str(output_raw))
+        logical_path = Path(asset_prefix) / output_path
+        if not asset_type:
+            asset_type = _asset_type_from_path(source_path)
+        assets.append(
+            LibraryAsset(
+                source_path=source_path,
+                logical_path=logical_path,
+                asset_type=asset_type,
+                mode=mode,
+            )
+        )
+    return tuple(assets)
+
+
+def _iter_contract_asset_entries(contract: Mapping[str, Any]) -> Sequence[Any]:
+    """Yield explicit asset declarations from compact or grouped contract fields."""
+    assets = contract.get("assets")
+    if assets is not None:
+        if isinstance(assets, Sequence) and not isinstance(assets, (str, bytes)):
+            return assets
+        return [assets]
+
+    grouped: list[dict[str, Any]] = []
+    for kind, field_name in (("css", "css"), ("javascript", "js")):
+        values = contract.get(field_name)
+        if values is None:
+            continue
+        if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+            values = [values]
+        for value in values:
+            if isinstance(value, Mapping):
+                item = dict(value)
+                item.setdefault("type", kind)
+                grouped.append(item)
+            else:
+                grouped.append({"path": value, "type": kind})
+    return grouped
+
+
+def _contract_runtime(package_name: str, runtime_raw: Any) -> tuple[str, ...]:
+    """Normalize optional runtime metadata from a provider contract."""
+    from bengal.errors import ErrorCode
+    from bengal.errors.exceptions import BengalConfigError
+
+    if runtime_raw is None:
+        return ()
+    if isinstance(runtime_raw, str):
+        return (runtime_raw,)
+    if not isinstance(runtime_raw, Sequence):
+        raise BengalConfigError(
+            f"Theme library '{package_name}': runtime must be a string or list of strings",
+            code=ErrorCode.C003,
+            suggestion="Use runtime = ['alpine'] style metadata in the library contract.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+                returned_type=type(runtime_raw).__name__,
+            ),
+        )
+    return tuple(str(item) for item in runtime_raw if item)
+
+
+def _asset_type_from_path(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext == ".css":
+        return "css"
+    if ext == ".js":
+        return "javascript"
+    if ext in {".woff", ".woff2", ".ttf", ".otf", ".eot"}:
+        return "font"
+    if ext in {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".avif"}:
+        return "image"
+    return "other"
 
 
 def _probe_hook(package_name: str, module: Any, hook_name: str) -> Any | None:

--- a/bengal/core/theme/providers.py
+++ b/bengal/core/theme/providers.py
@@ -357,6 +357,7 @@ def _contract_assets(
         )
 
     assets: list[LibraryAsset] = []
+    seen_logical: dict[Path, tuple[str, str]] = {}
     for entry in raw_assets:
         path_raw: Any
         output_raw: Any
@@ -414,6 +415,25 @@ def _contract_assets(
         logical_path = Path(asset_prefix) / output_path
         if not asset_type:
             asset_type = _asset_type_from_path(source_path)
+        previous = seen_logical.get(logical_path)
+        if previous is not None:
+            previous_mode, previous_type = previous
+            if mode != "bundle" or previous_mode != "bundle" or asset_type != previous_type:
+                raise BengalConfigError(
+                    f"Theme library '{package_name}' declares duplicate asset output "
+                    f"'{logical_path.as_posix()}'",
+                    code=ErrorCode.C003,
+                    suggestion=(
+                        "Use unique output paths, or use bundle mode for every asset "
+                        "that should concatenate into the same output file."
+                    ),
+                    debug_payload=_theme_library_debug_payload(
+                        package_name,
+                        hook_name="get_library_contract",
+                    ),
+                )
+        else:
+            seen_logical[logical_path] = (mode, asset_type)
         assets.append(
             LibraryAsset(
                 source_path=source_path,

--- a/bengal/core/theme/providers.py
+++ b/bengal/core/theme/providers.py
@@ -76,6 +76,7 @@ class LibraryAsset:
     logical_path: Path
     asset_type: str
     mode: str
+    tag_attrs: tuple[tuple[str, str | bool], ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True, slots=True)
@@ -364,9 +365,11 @@ def _contract_assets(
             output_raw = entry.get("output") or entry.get("logical_path") or path_raw
             mode = str(entry.get("mode") or mode)
             asset_type = str(entry.get("type") or entry.get("kind") or "")
+            tag_attrs = _contract_tag_attrs(package_name, entry)
         else:
             path_raw = entry
             output_raw = entry
+            tag_attrs = ()
 
         if not path_raw:
             raise BengalConfigError(
@@ -412,6 +415,7 @@ def _contract_assets(
                 logical_path=logical_path,
                 asset_type=asset_type,
                 mode=mode,
+                tag_attrs=tag_attrs,
             )
         )
     return tuple(assets)
@@ -500,6 +504,106 @@ def _normalize_contract_path(
             ),
         )
     return path
+
+
+def _contract_tag_attrs(
+    package_name: str,
+    entry: Mapping[str, Any],
+) -> tuple[tuple[str, str | bool], ...]:
+    """Normalize optional HTML attributes for provider-rendered asset tags."""
+    from bengal.errors import ErrorCode
+    from bengal.errors.exceptions import BengalConfigError
+
+    raw_attrs = entry.get("attributes", entry.get("attrs"))
+    attrs: dict[str, str | bool] = {}
+    if raw_attrs is not None:
+        if not isinstance(raw_attrs, Mapping):
+            raise BengalConfigError(
+                f"Theme library '{package_name}' asset attributes must be a mapping",
+                code=ErrorCode.C003,
+                suggestion="Use attributes = {'defer': True, 'crossorigin': 'anonymous'}.",
+                debug_payload=_theme_library_debug_payload(
+                    package_name,
+                    hook_name="get_library_contract",
+                    returned_type=type(raw_attrs).__name__,
+                ),
+            )
+        for raw_name, raw_value in raw_attrs.items():
+            attrs[_normalize_attribute_name(package_name, raw_name)] = _normalize_attribute_value(
+                package_name, raw_value
+            )
+
+    for bool_attr in ("async", "defer", "nomodule"):
+        if bool_attr in entry and bool(entry[bool_attr]):
+            attrs[bool_attr] = True
+    if entry.get("module"):
+        attrs["type"] = "module"
+    if media := entry.get("media"):
+        attrs["media"] = _normalize_attribute_value(package_name, media)
+
+    for reserved in ("href", "src"):
+        if reserved in attrs:
+            raise BengalConfigError(
+                f"Theme library '{package_name}' asset attributes must not set '{reserved}'",
+                code=ErrorCode.C003,
+                suggestion=(
+                    "Use path/output for asset locations; Bengal owns href/src so "
+                    "fingerprinted URLs stay correct."
+                ),
+                debug_payload=_theme_library_debug_payload(
+                    package_name,
+                    hook_name="get_library_contract",
+                ),
+            )
+    return tuple(attrs.items())
+
+
+def _normalize_attribute_name(package_name: str, raw_name: Any) -> str:
+    from bengal.errors import ErrorCode
+    from bengal.errors.exceptions import BengalConfigError
+
+    if not isinstance(raw_name, str) or not raw_name:
+        raise BengalConfigError(
+            f"Theme library '{package_name}' asset attribute names must be non-empty strings",
+            code=ErrorCode.C003,
+            suggestion="Use HTML attribute names such as defer, media, integrity, or data-*.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+                returned_type=type(raw_name).__name__,
+            ),
+        )
+    if not all(ch.isalnum() or ch in "-_:." for ch in raw_name):
+        raise BengalConfigError(
+            f"Theme library '{package_name}' asset attribute name is invalid: {raw_name}",
+            code=ErrorCode.C003,
+            suggestion="Use plain HTML attribute names without whitespace or quotes.",
+            debug_payload=_theme_library_debug_payload(
+                package_name,
+                hook_name="get_library_contract",
+            ),
+        )
+    return raw_name
+
+
+def _normalize_attribute_value(package_name: str, raw_value: Any) -> str | bool:
+    from bengal.errors import ErrorCode
+    from bengal.errors.exceptions import BengalConfigError
+
+    if isinstance(raw_value, bool):
+        return raw_value
+    if isinstance(raw_value, str):
+        return raw_value
+    raise BengalConfigError(
+        f"Theme library '{package_name}' asset attribute values must be strings or booleans",
+        code=ErrorCode.C003,
+        suggestion="Use True for boolean HTML attributes or a string for valued attributes.",
+        debug_payload=_theme_library_debug_payload(
+            package_name,
+            hook_name="get_library_contract",
+            returned_type=type(raw_value).__name__,
+        ),
+    )
 
 
 def _iter_contract_asset_entries(contract: Mapping[str, Any]) -> Sequence[Any]:

--- a/bengal/orchestration/asset.py
+++ b/bengal/orchestration/asset.py
@@ -241,10 +241,12 @@ class AssetOrchestrator:
         else:
             self.site._asset_manifest_previous = prev_manifest
 
-        # Separate CSS entry points, CSS modules, and other assets
+        # Separate CSS entry points, CSS modules, and other assets. Standalone
+        # provider CSS remains CSS so minification still applies, but is not
+        # treated as an import-only module.
         css_entries = [a for a in assets if a.is_css_entry_point()]
         css_modules = [a for a in assets if a.is_css_module()]
-        other_assets = [a for a in assets if a.asset_type != "css"]
+        other_assets = [a for a in assets if not a.is_css_entry_point() and not a.is_css_module()]
 
         # Check if JS bundling is enabled
         assets_cfg = self.site.config_service.assets_config

--- a/bengal/orchestration/asset.py
+++ b/bengal/orchestration/asset.py
@@ -839,6 +839,7 @@ class AssetOrchestrator:
                 fingerprint=asset.fingerprint,
                 size_bytes=stat.st_size,
                 updated_at=stat.st_mtime,
+                provenance=asset.manifest_provenance,
             )
 
         manifest_path = self.site.output_dir / "asset-manifest.json"

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -322,6 +322,12 @@ class BuildOrchestrator:
 
         reset_fast_write_tracker()
 
+        # Reset asset fallback diagnostics so strict-mode failures are scoped to
+        # the current build, not earlier tests or dev-server rebuilds.
+        from bengal.rendering.assets import drain_asset_fallback_aggregator
+
+        drain_asset_fallback_aggregator()
+
         # Create fresh BuildState for this build
         build_state = BuildState(
             build_time=self.site.build_time,

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -81,6 +81,45 @@ def phase_postprocess(
                 hint="ContextVar not set in some paths - check asset_manifest_context() coverage",
             )
 
+        from bengal.rendering.asset_audit import find_missing_local_asset_references
+
+        missing_refs = find_missing_local_asset_references(
+            orchestrator.site.output_dir,
+            baseurl=getattr(orchestrator.site, "baseurl", "") or "",
+        )
+        if missing_refs:
+            samples = [
+                {
+                    "html": str(ref.html_path.relative_to(orchestrator.site.output_dir)),
+                    "url": ref.url,
+                    "expected": str(ref.expected_path),
+                }
+                for ref in missing_refs[:5]
+            ]
+            strict = getattr(ctx, "strict", False) or getattr(
+                orchestrator.stats, "strict_mode", False
+            )
+            if strict:
+                from bengal.errors import BengalAssetError, ErrorCode
+
+                first = missing_refs[0]
+                raise BengalAssetError(
+                    f"Build emitted {len(missing_refs)} local CSS/JS reference(s) "
+                    "without matching output files.",
+                    code=ErrorCode.X001,
+                    suggestion=(
+                        "Declare the asset through the theme library contract, use asset_url(), "
+                        "or remove the stale HTML reference."
+                    ),
+                    file_path=first.html_path,
+                )
+            orchestrator.logger.warning(
+                "rendered_asset_reference_missing",
+                count=len(missing_refs),
+                samples=samples,
+                hint="Declare missing assets or route references through asset_url().",
+            )
+
         # Show phase completion
         cli.phase("Post-process", duration_ms=orchestrator.stats.postprocess_time_ms)
 

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -92,7 +92,10 @@ def phase_postprocess(
                 {
                     "html": str(ref.html_path.relative_to(orchestrator.site.output_dir)),
                     "url": ref.url,
-                    "expected": str(ref.expected_path),
+                    "expected": _relative_output_path(
+                        ref.expected_path,
+                        orchestrator.site.output_dir,
+                    ),
                 }
                 for ref in missing_refs[:5]
             ]
@@ -125,6 +128,13 @@ def phase_postprocess(
         cli.phase("Post-process", duration_ms=orchestrator.stats.postprocess_time_ms)
 
         orchestrator.logger.info("postprocessing_complete")
+
+
+def _relative_output_path(path: Any, output_dir: Any) -> str:
+    try:
+        return str(path.relative_to(output_dir))
+    except ValueError:
+        return str(path)
 
 
 def phase_cache_save(

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -105,7 +105,7 @@ def phase_postprocess(
                 first = missing_refs[0]
                 raise BengalAssetError(
                     f"Build emitted {len(missing_refs)} local CSS/JS reference(s) "
-                    "without matching output files.",
+                    f"without matching output files. First missing reference: {first.url}",
                     code=ErrorCode.X001,
                     suggestion=(
                         "Declare the asset through the theme library contract, use asset_url(), "
@@ -116,6 +116,7 @@ def phase_postprocess(
             orchestrator.logger.warning(
                 "rendered_asset_reference_missing",
                 count=len(missing_refs),
+                url=missing_refs[0].url,
                 samples=samples,
                 hint="Declare missing assets or route references through asset_url().",
             )

--- a/bengal/orchestration/content.py
+++ b/bengal/orchestration/content.py
@@ -790,8 +790,16 @@ class ContentOrchestrator:
 
     def _discover_provider_assets(self) -> None:
         """Discover assets from theme library providers, namespaced by prefix."""
+        from collections import defaultdict
+
         from bengal.content.discovery.asset_discovery import AssetDiscovery
-        from bengal.core.theme.providers import get_provider_asset_dirs, resolve_theme_providers
+        from bengal.core.asset import Asset
+        from bengal.core.theme.providers import (
+            LibraryAsset,
+            get_provider_asset_dirs,
+            get_provider_assets,
+            resolve_theme_providers,
+        )
         from bengal.core.theme.resolution import resolve_theme_chain
 
         if not self.site.theme:
@@ -801,6 +809,67 @@ class ContentOrchestrator:
         providers = resolve_theme_providers(self.site.root_path, theme_chain)
         if not providers:
             return
+
+        bundle_groups: dict[tuple[Path, str], list[LibraryAsset]] = defaultdict(list)
+
+        for library_asset in get_provider_assets(providers):
+            if library_asset.mode == "none":
+                continue
+            if not library_asset.source_path.exists():
+                from bengal.errors import BengalAssetError, ErrorCode
+
+                raise BengalAssetError(
+                    f"Theme library asset not found: {library_asset.source_path}",
+                    code=ErrorCode.X001,
+                    suggestion=(
+                        "Check the provider get_library_contract() asset path or remove "
+                        "the asset from the contract."
+                    ),
+                    file_path=library_asset.source_path,
+                )
+            if library_asset.mode == "bundle":
+                bundle_groups[(library_asset.logical_path, library_asset.asset_type)].append(
+                    library_asset
+                )
+                continue
+            output_path = library_asset.logical_path
+            asset_type = library_asset.asset_type
+            # Provider CSS is a standalone browser asset unless a later bundle
+            # phase explicitly opts into concatenation semantics.
+            if asset_type == "css":
+                asset_type = "other"
+            self.site.assets.append(
+                Asset(
+                    source_path=library_asset.source_path,
+                    output_path=output_path,
+                    asset_type=asset_type,
+                    logical_path=output_path,
+                )
+            )
+
+        for (logical_path, asset_type), assets in bundle_groups.items():
+            if asset_type not in {"css", "javascript"}:
+                from bengal.errors import BengalAssetError, ErrorCode
+
+                raise BengalAssetError(
+                    f"Theme library bundle target '{logical_path.as_posix()}' has "
+                    f"unsupported asset type '{asset_type}'.",
+                    code=ErrorCode.X003,
+                    suggestion="Use bundle mode only for CSS or JavaScript provider assets.",
+                )
+
+            bundle_dir = self.site.root_path / ".bengal" / "cache" / "library-assets"
+            bundle_path = bundle_dir / logical_path
+            self._write_library_asset_bundle(bundle_path, assets, asset_type)
+            output_asset_type = "other" if asset_type == "css" else "javascript"
+            self.site.assets.append(
+                Asset(
+                    source_path=bundle_path,
+                    output_path=logical_path,
+                    asset_type=output_asset_type,
+                    logical_path=logical_path,
+                )
+            )
 
         for prefix, asset_root in get_provider_asset_dirs(providers):
             discovery = AssetDiscovery(asset_root)
@@ -820,6 +889,25 @@ class ContentOrchestrator:
                 ):
                     asset.asset_type = "other"
                 self.site.assets.append(asset)
+
+    def _write_library_asset_bundle(
+        self,
+        bundle_path: Path,
+        assets: list[Any],
+        asset_type: str,
+    ) -> None:
+        """Concatenate declared library assets into a generated bundle source."""
+        from bengal.utils.io.atomic_write import atomic_write_text
+
+        comment_open, comment_close = ("/*", "*/") if asset_type == "css" else ("//", "")
+        chunks: list[str] = []
+        for asset in assets:
+            content = asset.source_path.read_text(encoding="utf-8")
+            if comment_close:
+                chunks.append(f"{comment_open} {asset.source_path.name} {comment_close}\n{content}")
+            else:
+                chunks.append(f"{comment_open} {asset.source_path.name}\n{content}")
+        atomic_write_text(bundle_path, "\n\n".join(chunks), encoding="utf-8")
 
     def _setup_page_references(self) -> None:
         """

--- a/bengal/orchestration/content.py
+++ b/bengal/orchestration/content.py
@@ -860,16 +860,13 @@ class ContentOrchestrator:
                 continue
             output_path = library_asset.logical_path
             asset_type = library_asset.asset_type
-            # Provider CSS is a standalone browser asset unless a later bundle
-            # phase explicitly opts into concatenation semantics.
-            if asset_type == "css":
-                asset_type = "other"
             self.site.assets.append(
                 Asset(
                     source_path=library_asset.source_path,
                     output_path=output_path,
                     asset_type=asset_type,
                     logical_path=output_path,
+                    standalone=asset_type == "css",
                     manifest_provenance=_library_asset_manifest_provenance(
                         library_asset,
                         sources=(library_asset,),
@@ -891,13 +888,13 @@ class ContentOrchestrator:
             bundle_dir = self.site.root_path / ".bengal" / "cache" / "library-assets"
             bundle_path = bundle_dir / logical_path
             self._write_library_asset_bundle(bundle_path, assets, asset_type)
-            output_asset_type = "other" if asset_type == "css" else "javascript"
             self.site.assets.append(
                 Asset(
                     source_path=bundle_path,
                     output_path=logical_path,
-                    asset_type=output_asset_type,
+                    asset_type=asset_type,
                     logical_path=logical_path,
+                    standalone=asset_type == "css",
                     manifest_provenance=_library_asset_manifest_provenance(
                         assets[0],
                         sources=tuple(assets),
@@ -921,7 +918,7 @@ class ContentOrchestrator:
                     asset.source_path.suffix.lower() == ".css"
                     and asset.source_path.name != "style.css"
                 ):
-                    asset.asset_type = "other"
+                    asset.standalone = True
                 self.site.assets.append(asset)
 
     def _write_library_asset_bundle(
@@ -941,7 +938,8 @@ class ContentOrchestrator:
                 chunks.append(f"{comment_open} {asset.source_path.name} {comment_close}\n{content}")
             else:
                 chunks.append(f"{comment_open} {asset.source_path.name}\n{content}")
-        atomic_write_text(bundle_path, "\n\n".join(chunks), encoding="utf-8")
+        separator = "\n\n" if asset_type == "css" else "\n;\n"
+        atomic_write_text(bundle_path, separator.join(chunks), encoding="utf-8")
 
     def _setup_page_references(self) -> None:
         """

--- a/bengal/orchestration/content.py
+++ b/bengal/orchestration/content.py
@@ -61,6 +61,32 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _library_asset_manifest_provenance(
+    library_asset: Any,
+    *,
+    sources: tuple[Any, ...],
+) -> dict[str, Any]:
+    """Return sanitized manifest provenance for a theme-library asset."""
+    package = str(getattr(library_asset, "package", "") or "")
+    mode = str(getattr(library_asset, "mode", "") or "")
+    source_paths: list[str] = []
+    for source in sources:
+        contract_path = getattr(source, "contract_path", None)
+        if isinstance(contract_path, Path) and contract_path != Path("."):
+            source_paths.append(contract_path.as_posix())
+        else:
+            source_paths.append(Path(source.source_path).name)
+
+    provenance: dict[str, Any] = {"kind": "theme_library"}
+    if package:
+        provenance["package"] = package
+    if mode:
+        provenance["mode"] = mode
+    if source_paths:
+        provenance["sources"] = source_paths
+    return provenance
+
+
 class ContentOrchestrator:
     """
     Handles content and asset discovery.
@@ -844,6 +870,10 @@ class ContentOrchestrator:
                     output_path=output_path,
                     asset_type=asset_type,
                     logical_path=output_path,
+                    manifest_provenance=_library_asset_manifest_provenance(
+                        library_asset,
+                        sources=(library_asset,),
+                    ),
                 )
             )
 
@@ -868,6 +898,10 @@ class ContentOrchestrator:
                     output_path=logical_path,
                     asset_type=output_asset_type,
                     logical_path=logical_path,
+                    manifest_provenance=_library_asset_manifest_provenance(
+                        assets[0],
+                        sources=tuple(assets),
+                    ),
                 )
             )
 

--- a/bengal/rendering/asset_audit.py
+++ b/bengal/rendering/asset_audit.py
@@ -29,7 +29,7 @@ def find_missing_local_asset_references(
         return []
 
     missing: list[MissingAssetReference] = []
-    base_prefix = f"{baseurl.rstrip('/')}/" if baseurl else "/"
+    base_prefix = _normalized_base_prefix(baseurl)
     for html_path in output_dir.rglob("*.html"):
         try:
             html = html_path.read_text(encoding="utf-8")
@@ -55,6 +55,20 @@ def find_missing_local_asset_references(
                     )
                 )
     return missing
+
+
+def _normalized_base_prefix(baseurl: str) -> str:
+    base = baseurl.strip()
+    if not base:
+        return "/"
+    parsed = urlparse(base)
+    if parsed.scheme or parsed.netloc:
+        base = parsed.path
+    if not base:
+        return "/"
+    if not base.startswith("/"):
+        base = f"/{base}"
+    return f"{base.rstrip('/')}/"
 
 
 def _resolve_asset_path(path: str, html_rel: Path) -> str:

--- a/bengal/rendering/asset_audit.py
+++ b/bengal/rendering/asset_audit.py
@@ -58,6 +58,8 @@ def find_missing_local_asset_references(
 
 
 def _normalized_base_prefix(baseurl: str) -> str:
+    if not isinstance(baseurl, str):
+        return "/"
     base = baseurl.strip()
     if not base:
         return "/"

--- a/bengal/rendering/asset_audit.py
+++ b/bengal/rendering/asset_audit.py
@@ -1,0 +1,66 @@
+"""Audit rendered HTML for local CSS/JS references that are not serveable."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+LOCAL_CSS_JS_RE = re.compile(r"""(?:href|src)=["']([^"']+\.(?:css|js)(?:\?[^"']*)?)["']""")
+
+
+@dataclass(frozen=True, slots=True)
+class MissingAssetReference:
+    html_path: Path
+    url: str
+    expected_path: Path
+
+
+def find_missing_local_asset_references(
+    output_dir: Path, baseurl: str = ""
+) -> list[MissingAssetReference]:
+    """Find local CSS/JS URLs in rendered HTML that do not exist on disk."""
+    if not output_dir.exists():
+        return []
+
+    missing: list[MissingAssetReference] = []
+    base_prefix = f"{baseurl.rstrip('/')}/" if baseurl else "/"
+    for html_path in output_dir.rglob("*.html"):
+        try:
+            html = html_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        html_rel = html_path.relative_to(output_dir)
+        for raw_url in LOCAL_CSS_JS_RE.findall(html):
+            parsed = urlparse(raw_url)
+            if parsed.scheme or parsed.netloc or parsed.path.startswith("//"):
+                continue
+            resolved = _resolve_asset_path(parsed.path, html_rel)
+            if base_prefix != "/" and resolved.startswith(base_prefix):
+                resolved = "/" + resolved[len(base_prefix) :]
+            if not resolved.endswith((".css", ".js")):
+                continue
+            expected = output_dir / resolved.lstrip("/")
+            if not expected.exists():
+                missing.append(
+                    MissingAssetReference(
+                        html_path=html_path,
+                        url=raw_url,
+                        expected_path=expected,
+                    )
+                )
+    return missing
+
+
+def _resolve_asset_path(path: str, html_rel: Path) -> str:
+    if path.startswith("/"):
+        return posixpath.normpath(path)
+    html_parent = html_rel.parent.as_posix()
+    if html_parent == ".":
+        html_parent = ""
+    return posixpath.normpath(f"/{html_parent}/{path}")

--- a/bengal/rendering/engines/kida.py
+++ b/bengal/rendering/engines/kida.py
@@ -602,9 +602,23 @@ class KidaTemplateEngine:
         self._env.globals["get_menu"] = self._get_menu
         self._env.globals["get_menu_lang"] = self._get_menu_lang
         self._env.globals["url_for"] = self._url_for
+        self._env.globals["library_asset_tags"] = self._library_asset_tags
+        self._env.globals["library_runtime"] = self._library_runtime
 
         # === Step 4: Theme library provider filters/globals ===
         self._register_provider_extensions()
+
+    def _library_asset_tags(self):
+        """Render tags for assets declared by active theme libraries."""
+        from bengal.rendering.library_assets import render_library_asset_tags
+
+        return render_library_asset_tags(self._providers, self.site)
+
+    def _library_runtime(self) -> tuple[str, ...]:
+        """Return runtime metadata declared by active theme libraries."""
+        from bengal.rendering.library_assets import library_runtime_metadata
+
+        return library_runtime_metadata(self._providers)
 
     def _register_provider_extensions(self) -> None:
         """Register filters/globals from theme library providers.

--- a/bengal/rendering/library_assets.py
+++ b/bengal/rendering/library_assets.py
@@ -34,11 +34,27 @@ def render_library_asset_tags(
                 continue
             seen.add(logical)
             url = escape(resolve_asset_url(logical, site), quote=True)
+            attrs = _render_tag_attrs(asset.tag_attrs)
             if asset.asset_type == "css":
-                lines.append(f'<link rel="stylesheet" href="{url}">')
+                lines.append(f'<link rel="stylesheet" href="{url}"{attrs}>')
             elif asset.asset_type == "javascript":
-                lines.append(f'<script src="{url}"></script>')
+                lines.append(f'<script src="{url}"{attrs}></script>')
     return Markup("\n".join(lines))
+
+
+def _render_tag_attrs(attrs: tuple[tuple[str, str | bool], ...]) -> str:
+    """Render normalized HTML attributes with escaping."""
+    parts: list[str] = []
+    for name, value in attrs:
+        escaped_name = escape(name, quote=True)
+        if value is True:
+            parts.append(f" {escaped_name}")
+        elif value is False:
+            continue
+        else:
+            escaped_value = escape(value, quote=True)
+            parts.append(f' {escaped_name}="{escaped_value}"')
+    return "".join(parts)
 
 
 def library_runtime_metadata(providers: tuple[ThemeLibraryProvider, ...]) -> tuple[str, ...]:

--- a/bengal/rendering/library_assets.py
+++ b/bengal/rendering/library_assets.py
@@ -1,0 +1,53 @@
+"""Template helpers for theme library assets."""
+
+from __future__ import annotations
+
+from html import escape
+from typing import TYPE_CHECKING
+
+from kida import Markup
+
+from bengal.rendering.assets import resolve_asset_url
+
+if TYPE_CHECKING:
+    from bengal.core.theme.providers import ThemeLibraryProvider
+    from bengal.protocols import SiteLike
+
+
+def render_library_asset_tags(
+    providers: tuple[ThemeLibraryProvider, ...],
+    site: SiteLike,
+) -> Markup:
+    """Render stylesheet/script tags for declared provider assets.
+
+    Library contracts decide which browser assets are Bengal-managed. Assets in
+    ``none`` mode are metadata-only and intentionally produce no tags.
+    """
+    lines: list[str] = []
+    seen: set[str] = set()
+    for provider in providers:
+        for asset in provider.assets:
+            if asset.mode == "none":
+                continue
+            logical = asset.logical_path.as_posix()
+            if logical in seen:
+                continue
+            seen.add(logical)
+            url = escape(resolve_asset_url(logical, site), quote=True)
+            if asset.asset_type == "css":
+                lines.append(f'<link rel="stylesheet" href="{url}">')
+            elif asset.asset_type == "javascript":
+                lines.append(f'<script src="{url}"></script>')
+    return Markup("\n".join(lines))
+
+
+def library_runtime_metadata(providers: tuple[ThemeLibraryProvider, ...]) -> tuple[str, ...]:
+    """Return deduplicated runtime requirements declared by theme libraries."""
+    seen: set[str] = set()
+    runtime: list[str] = []
+    for provider in providers:
+        for item in provider.runtime:
+            if item not in seen:
+                seen.add(item)
+                runtime.append(item)
+    return tuple(runtime)

--- a/bengal/themes/chirpui/templates/base.html
+++ b/bengal/themes/chirpui/templates/base.html
@@ -23,10 +23,8 @@
     {% if site.baseurl %}
     <link rel="canonical" href="{{ canonical_url(_page_url) }}">
     {% end %}
-    <link rel="stylesheet" href="{{ asset_url('chirp_ui/chirpui.css') }}">
-    <link rel="stylesheet" href="{{ asset_url('chirp_ui/chirpui-transitions.css') }}">
+    {{ library_asset_tags() }}
     <link rel="stylesheet" href="{{ asset_url('css/style.css') }}">
-    <script src="{{ asset_url('chirp_ui/chirpui.js') }}"></script>
     {% block extra_head %}{% end %}
 </head>
 <body data-type="{{ page?.type ?? '' }}">

--- a/bengal/utils/observability/logger.py
+++ b/bengal/utils/observability/logger.py
@@ -213,6 +213,9 @@ class LogEvent:
             "icon_not_found_summary": "{count} missing icon{plural}: {icons}",
             "unknown_config_summary": "{count} unknown config entr{plural}: {entries}",
             "found_broken_links": "{total_broken} broken internal link(s) across {pages_affected} page(s)",
+            "rendered_asset_reference_missing": (
+                "{count} rendered local CSS/JS asset reference(s) are not serveable: {url}"
+            ),
             "url_collision": "URL collision: {url}",
             "url_collision_detected": "URL collision: {url}",
             "url_collision_summary": "{count} URL collision(s): {urls}",

--- a/changelog.d/theme-library-assets.added.md
+++ b/changelog.d/theme-library-assets.added.md
@@ -1,0 +1,1 @@
+Add theme library asset contracts with provider-managed CSS/JS emission and missing rendered-asset diagnostics.

--- a/changelog.d/theme-library-assets.added.md
+++ b/changelog.d/theme-library-assets.added.md
@@ -1,1 +1,1 @@
-Add theme library asset contracts with provider-managed CSS/JS emission, tag attributes, runtime metadata, strict missing-asset diagnostics, and vendor-facing documentation.
+Add theme library asset contracts with provider-managed CSS/JS emission, tag attributes, runtime metadata, strict missing-asset diagnostics, manifest provenance, and vendor-facing documentation.

--- a/changelog.d/theme-library-assets.added.md
+++ b/changelog.d/theme-library-assets.added.md
@@ -1,1 +1,1 @@
-Add theme library asset contracts with provider-managed CSS/JS emission and missing rendered-asset diagnostics.
+Add theme library asset contracts with provider-managed CSS/JS emission, tag attributes, runtime metadata, strict missing-asset diagnostics, and vendor-facing documentation.

--- a/site/content/docs/theming/themes/_index.md
+++ b/site/content/docs/theming/themes/_index.md
@@ -64,6 +64,11 @@ Full control. Start from scratch or fork existing.
 | `default` | You want Bengal's built-in documentation theme with no extra packages. |
 | `chirpui` | You want a site rendered with Chirp UI components and can install `chirp-ui` in the build environment. |
 
+Theme authors can package reusable component systems with [theme library asset
+contracts](./library-assets/). Bengal will load the package templates, emit the
+declared CSS/JS in both dev and static builds, and warn or fail when rendered
+HTML references missing local assets.
+
 ## Quick Reference
 
 :::{tab-set}

--- a/site/content/docs/theming/themes/chirpui.md
+++ b/site/content/docs/theming/themes/chirpui.md
@@ -25,10 +25,12 @@ Then select the theme:
 theme = "chirpui"
 ```
 
-The theme loads Chirp UI through `theme.toml` provider libraries and fingerprints
-`chirp_ui/chirpui.css` through Bengal's normal asset manifest. Bengal does not
-bundle `chirp-ui` as a hard dependency, so builds that use this theme should
-fail fast if the package is missing.
+The theme loads Chirp UI through `theme.toml` provider libraries. When the
+package exposes `get_library_contract()`, Bengal uses that contract to emit
+declared CSS and JavaScript under `chirp_ui/`, fingerprint them through the
+normal asset manifest, and render the provider tags from the theme library
+metadata. Bengal does not bundle `chirp-ui` as a hard dependency, so builds
+that use this theme should fail fast if the package is missing.
 
 ## Scope
 

--- a/site/content/docs/theming/themes/chirpui.md
+++ b/site/content/docs/theming/themes/chirpui.md
@@ -29,8 +29,10 @@ The theme loads Chirp UI through `theme.toml` provider libraries. When the
 package exposes `get_library_contract()`, Bengal uses that contract to emit
 declared CSS and JavaScript under `chirp_ui/`, fingerprint them through the
 normal asset manifest, and render the provider tags from the theme library
-metadata. Bengal does not bundle `chirp-ui` as a hard dependency, so builds
-that use this theme should fail fast if the package is missing.
+metadata. See [Theme Library Assets](./library-assets/) for the provider
+contract shape, asset modes, tag attributes, runtime metadata, and strict build
+diagnostics. Bengal does not bundle `chirp-ui` as a hard dependency, so builds
+that use this theme fail fast if the package is missing.
 
 ## Scope
 

--- a/site/content/docs/theming/themes/library-assets.md
+++ b/site/content/docs/theming/themes/library-assets.md
@@ -1,0 +1,154 @@
+---
+title: Theme Library Assets
+description: Package reusable Kida components with CSS and JavaScript for Bengal themes
+weight: 25
+category: guide
+icon: package
+card_color: green
+---
+# Theme Library Assets
+
+Theme libraries let a Python package provide Kida templates, CSS, JavaScript,
+and runtime metadata to any Bengal theme. A theme opts in with `libraries` in
+`theme.toml`; the package exposes a small Python contract; Bengal handles
+fingerprinting, dev URLs, static output, and missing asset diagnostics.
+
+Use this for component libraries such as `chirp_ui`, not for one-off site
+styles. Site and theme-owned files should still use `asset_url()`.
+
+## Theme Setup
+
+Declare the package in the theme manifest:
+
+```toml
+name = "vendor-theme"
+libraries = ["vendor_ui"]
+```
+
+Then render provider-owned tags from the base template:
+
+```html
+{{ library_asset_tags() }}
+<link rel="stylesheet" href="{{ asset_url('css/style.css') }}">
+```
+
+`library_asset_tags()` renders only assets declared by the package contract.
+Your theme can still include its own bridge stylesheet or script with
+`asset_url()`.
+
+## Package Contract
+
+In the library package, expose `get_library_contract()`:
+
+```python
+from pathlib import Path
+
+from kida import PackageLoader
+
+
+def static_path() -> Path:
+    return Path(__file__).parent / "static"
+
+
+def get_loader():
+    return PackageLoader("vendor_ui", "templates")
+
+
+def get_library_contract():
+    return {
+        "asset_root": static_path(),
+        "assets": [
+            {"path": "vendor.css", "mode": "bundle", "type": "css"},
+            {
+                "path": "transitions.css",
+                "mode": "bundle",
+                "type": "css",
+                "output": "vendor.css",
+            },
+            {
+                "path": "vendor.js",
+                "mode": "link",
+                "type": "javascript",
+                "defer": True,
+                "module": True,
+            },
+            {"path": "tokens.css", "mode": "none", "type": "css"},
+        ],
+        "runtime": ["vendor-ui"],
+    }
+```
+
+The contract is intentionally plain Python. Paths are relative to `asset_root`
+unless you return an absolute source path. Output paths must be relative and
+cannot contain `..`; Bengal namespaces them under the package name, such as
+`/assets/vendor_ui/vendor.css`.
+
+## Asset Modes
+
+| Mode | Build behavior | Tag behavior | Use when |
+|------|----------------|--------------|----------|
+| `link` | Emits the file through the normal asset pipeline. | Renders one tag for the emitted asset. | The file should stay separate. |
+| `bundle` | Concatenates assets with the same `output`, then fingerprints the bundle. | Renders one tag for the bundle. | A package splits CSS/JS internally but themes should load one file. |
+| `none` | Does not emit the file. | Renders no tag. | The asset is metadata-only or consumed by another package process. |
+
+CSS and JavaScript emitted through `link` or `bundle` use the normal Bengal
+asset manifest. In development, URLs stay stable. In static builds, URLs are
+fingerprinted.
+
+## Tag Attributes
+
+Use `attributes` or the common shorthands to control the generated HTML tag:
+
+```python
+{
+    "path": "vendor.js",
+    "type": "javascript",
+    "mode": "link",
+    "defer": True,
+    "attributes": {"crossorigin": "anonymous"},
+}
+```
+
+Boolean attributes render without a value. String attributes are escaped.
+Bengal owns `href` and `src`; declaring either as an attribute is rejected so
+fingerprinted URLs cannot drift.
+
+## Runtime Metadata
+
+`runtime` is a string or list of strings:
+
+```python
+{"runtime": ["vendor-ui", "alpine"]}
+```
+
+Templates can read the deduplicated runtime list with:
+
+```html
+{% if "vendor-ui" in library_runtime() %}
+  ...
+{% end %}
+```
+
+Use this for conditional template behavior. Do not use it to bypass asset
+declarations.
+
+## Diagnostics
+
+Bengal validates the contract while resolving the theme library:
+
+- `assets` entries need a non-empty path.
+- `mode` must be `bundle`, `link`, or `none`.
+- Runtime entries must be strings.
+- Output paths must be relative and stay inside the library namespace.
+- Tag attributes must be strings or booleans and cannot set `href` or `src`.
+
+During build, Bengal also checks rendered HTML for local CSS/JS references that
+were not emitted. In normal builds this is a warning with the first missing URL.
+In strict builds it is a `BengalAssetError`.
+
+```bash
+bengal build --strict
+```
+
+Run strict builds in CI for vendor themes. A browser console 404 should not be
+the first signal that a theme library asset is missing.

--- a/site/content/docs/theming/themes/library-assets.md
+++ b/site/content/docs/theming/themes/library-assets.md
@@ -95,6 +95,31 @@ CSS and JavaScript emitted through `link` or `bundle` use the normal Bengal
 asset manifest. In development, URLs stay stable. In static builds, URLs are
 fingerprinted.
 
+## Manifest Provenance
+
+Provider-managed assets add optional provenance to `asset-manifest.json`:
+
+```json
+{
+  "assets": {
+    "vendor_ui/vendor.css": {
+      "output_path": "assets/vendor_ui/vendor.350f9b04.css",
+      "fingerprint": "350f9b04",
+      "size_bytes": 12345,
+      "provenance": {
+        "kind": "theme_library",
+        "package": "vendor_ui",
+        "mode": "bundle",
+        "sources": ["vendor.css", "transitions.css"]
+      }
+    }
+  }
+}
+```
+
+`sources` contains contract-relative paths only. Bengal does not write absolute
+local filesystem paths into the manifest.
+
 ## Tag Attributes
 
 Use `attributes` or the common shorthands to control the generated HTML tag:

--- a/tests/integration/test_asset_reference_diagnostics.py
+++ b/tests/integration/test_asset_reference_diagnostics.py
@@ -51,8 +51,11 @@ def test_missing_rendered_asset_reference_warns_without_strict(tmp_path, capsys)
 
 
 def test_missing_rendered_asset_reference_fails_in_strict_mode(tmp_path) -> None:
+    from bengal.rendering.assets import resolve_asset_url
+
     _write_site_with_missing_asset_reference(tmp_path)
     site = Site.from_config(tmp_path)
+    resolve_asset_url("stale/previous-build.css", site)
 
     with pytest.raises(BengalAssetError, match=r"vendor/missing\.css"):
         site.build(BuildOptions(incremental=False, quiet=True, strict=True))

--- a/tests/integration/test_asset_reference_diagnostics.py
+++ b/tests/integration/test_asset_reference_diagnostics.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from bengal.core.site import Site
+from bengal.errors import BengalAssetError
+from bengal.orchestration.build.options import BuildOptions
+
+
+def _write_site_with_missing_asset_reference(site_root) -> None:
+    (site_root / "content").mkdir(parents=True)
+    (site_root / "templates").mkdir()
+    (site_root / "content" / "missing.md").write_text(
+        "---\ntitle: Missing Asset\n---\n\nBody",
+        encoding="utf-8",
+    )
+    (site_root / "templates" / "page.html").write_text(
+        """
+<!doctype html>
+<html>
+<head>
+  <link rel="stylesheet" href="/assets/vendor/missing.css">
+</head>
+<body>{{ content }}</body>
+</html>
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (site_root / "bengal.toml").write_text(
+        """
+[site]
+title = "Missing Asset Fixture"
+
+[build]
+content_dir = "content"
+output_dir = "public"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_missing_rendered_asset_reference_warns_without_strict(tmp_path, capsys) -> None:
+    _write_site_with_missing_asset_reference(tmp_path)
+    site = Site.from_config(tmp_path)
+
+    site.build(BuildOptions(incremental=False, quiet=True, strict=False))
+
+    captured = capsys.readouterr()
+    assert "rendered local CSS/JS asset reference" in captured.out
+    assert "vendor/missing.css" in captured.out
+
+
+def test_missing_rendered_asset_reference_fails_in_strict_mode(tmp_path) -> None:
+    _write_site_with_missing_asset_reference(tmp_path)
+    site = Site.from_config(tmp_path)
+
+    with pytest.raises(BengalAssetError, match=r"vendor/missing\.css"):
+        site.build(BuildOptions(incremental=False, quiet=True, strict=True))

--- a/tests/integration/test_chirpui_theme_build.py
+++ b/tests/integration/test_chirpui_theme_build.py
@@ -301,6 +301,21 @@ async def _asgi_get(app, path: str) -> tuple[int, bytes]:
     return status, b"".join(body_parts)
 
 
+def test_chirpui_theme_delegates_library_assets_to_contract() -> None:
+    """The bundled theme should not hard-code Chirp UI browser asset paths."""
+    theme_dir = ROOT.parent / "bengal" / "themes" / "chirpui"
+    template_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in (theme_dir / "templates").rglob("*.html")
+    )
+    bridge_css = (theme_dir / "assets" / "css" / "style.css").read_text(encoding="utf-8")
+
+    assert template_text.count("library_asset_tags()") == 1
+    assert "chirpui.css" not in template_text
+    assert "chirpui-transitions.css" not in template_text
+    assert "chirpui.js" not in template_text
+    assert "@import" not in bridge_css
+
+
 def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> None:
     """The bundled chirpui theme renders without default assets when chirp_ui is present."""
     package_root = tmp_path / "pkg"

--- a/tests/integration/test_chirpui_theme_build.py
+++ b/tests/integration/test_chirpui_theme_build.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import re
 import shutil
+import sys
 from pathlib import Path
 from textwrap import dedent
 from urllib.parse import urlparse
@@ -9,6 +11,7 @@ from urllib.parse import urlparse
 from bengal.assets.manifest import AssetManifest
 from bengal.core.site import Site
 from bengal.orchestration.build.options import BuildOptions
+from bengal.server.asgi_app import create_bengal_dev_app
 
 ROOT = Path(__file__).resolve().parents[1]
 LOCAL_CSS_JS_RE = re.compile(r"""(?:href|src)=["']([^"']+\.(?:css|js)(?:\?[^"']*)?)["']""")
@@ -33,6 +36,24 @@ def _write_fake_chirp_ui(package_root) -> None:
         def static_path():
             return Path(__file__).parent / "templates"
 
+        def get_library_contract():
+            root = static_path()
+            return {
+                "asset_root": root,
+                "assets": [
+                    {"path": "chirpui.css", "mode": "bundle", "type": "css"},
+                    {
+                        "path": "chirpui-transitions.css",
+                        "mode": "bundle",
+                        "type": "css",
+                        "output": "chirpui.css",
+                    },
+                    {"path": "chirpui.js", "mode": "link", "type": "javascript"},
+                    {"path": "unused.css", "mode": "none", "type": "css"},
+                ],
+                "runtime": ["chirpui"],
+            }
+
         def get_loader():
             return PackageLoader("chirp_ui", "templates")
 
@@ -43,6 +64,7 @@ def _write_fake_chirp_ui(package_root) -> None:
     _write_text(templates / "chirpui.css", ".chirpui-navbar{}.chirpui-rendered-content{}")
     _write_text(templates / "chirpui-transitions.css", ".chirpui-transition{}")
     _write_text(templates / "chirpui.js", "window.__chirpui_test__=true;")
+    _write_text(templates / "unused.css", ".unused{}")
     _write_text(
         components / "navbar.html",
         """
@@ -248,10 +270,35 @@ def _local_css_js_asset_paths(html: str, baseurl: str) -> set[str]:
     return paths
 
 
+async def _asgi_get(app, path: str) -> tuple[int, bytes]:
+    messages = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        messages.append(message)
+
+    await app(
+        {"type": "http", "method": "GET", "path": path, "headers": []},
+        receive,
+        send,
+    )
+    status = 0
+    body_parts: list[bytes] = []
+    for message in messages:
+        if message["type"] == "http.response.start":
+            status = message["status"]
+        elif message["type"] == "http.response.body":
+            body_parts.append(message.get("body", b""))
+    return status, b"".join(body_parts)
+
+
 def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> None:
     """The bundled chirpui theme renders without default assets when chirp_ui is present."""
     package_root = tmp_path / "pkg"
     _write_fake_chirp_ui(package_root)
+    sys.modules.pop("chirp_ui", None)
     monkeypatch.syspath_prepend(str(package_root))
 
     site_root = tmp_path / "site"
@@ -320,7 +367,6 @@ def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> Non
     assert 'href="/preview/docs/"' in index_html
     assert "/preview/assets/chirp_ui/chirpui." in guide_html
     assert "/preview/assets/chirp_ui/chirpui." in index_html
-    assert "/preview/assets/chirp_ui/chirpui-" in index_html
     assert re.search(r"/preview/assets/chirp_ui/chirpui\.[0-9a-f]+\.js", index_html)
     assert "/preview/assets/js/chirpui-bengal." in guide_html
     assert "chirpui-rendered-content" in blog_html
@@ -348,7 +394,11 @@ def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> Non
     assert manifest is not None
     css_entry = manifest.get("chirp_ui/chirpui.css")
     assert css_entry is not None
-    assert (site.output_dir / css_entry.output_path).exists()
+    css_output = site.output_dir / css_entry.output_path
+    assert css_output.exists()
+    assert "chirpui-transition" in css_output.read_text(encoding="utf-8")
+    assert manifest.get("chirp_ui/chirpui-transitions.css") is None
+    assert manifest.get("chirp_ui/unused.css") is None
     assert manifest.get("chirp_ui/chirpui/navbar.html") is None
 
     asset_paths = {
@@ -359,3 +409,34 @@ def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> Non
     assert asset_paths, "Representative Chirp UI pages should reference local CSS/JS assets"
     missing_assets = sorted(path for path in asset_paths if not (site.output_dir / path).exists())
     assert not missing_assets, f"Local CSS/JS asset URLs should be serveable: {missing_assets}"
+
+
+def test_chirpui_provider_assets_are_serveable_at_dev_urls(tmp_path, monkeypatch) -> None:
+    """Declared library assets resolve to stable dev URLs and server routes."""
+    package_root = tmp_path / "pkg"
+    _write_fake_chirp_ui(package_root)
+    sys.modules.pop("chirp_ui", None)
+    monkeypatch.syspath_prepend(str(package_root))
+
+    site_root = tmp_path / "site"
+    shutil.copytree(ROOT / "roots" / "test-chirpui-theme", site_root)
+
+    site = Site.from_config(site_root)
+    site.config["baseurl"] = ""
+    site.config.setdefault("site", {})["baseurl"] = ""
+    site.config["fingerprint_assets"] = False
+    site.config["minify_assets"] = False
+    site.dev_mode = True
+    site.build(BuildOptions(incremental=False, quiet=True))
+
+    index_html = (site.output_dir / "index.html").read_text(encoding="utf-8")
+    assert 'href="/assets/chirp_ui/chirpui.css"' in index_html
+    assert 'src="/assets/chirp_ui/chirpui.js"' in index_html
+
+    app = create_bengal_dev_app(
+        output_dir=site.output_dir,
+        build_in_progress=lambda: False,
+    )
+    status, body = asyncio.run(_asgi_get(app, "/assets/chirp_ui/chirpui.css"))
+    assert status == 200
+    assert b"chirpui-navbar" in body

--- a/tests/integration/test_chirpui_theme_build.py
+++ b/tests/integration/test_chirpui_theme_build.py
@@ -410,6 +410,7 @@ def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> Non
     css_output = site.output_dir / css_entry.output_path
     assert css_output.exists()
     assert "chirpui-transition" in css_output.read_text(encoding="utf-8")
+    assert "/* chirpui.css */" not in css_output.read_text(encoding="utf-8")
     assert css_entry.provenance == {
         "kind": "theme_library",
         "package": "chirp_ui",

--- a/tests/integration/test_chirpui_theme_build.py
+++ b/tests/integration/test_chirpui_theme_build.py
@@ -270,6 +270,13 @@ def _local_css_js_asset_paths(html: str, baseurl: str) -> set[str]:
     return paths
 
 
+def _local_css_js_asset_paths_for_output(output_dir: Path, baseurl: str) -> set[str]:
+    paths: set[str] = set()
+    for html_path in output_dir.rglob("*.html"):
+        paths.update(_local_css_js_asset_paths(html_path.read_text(encoding="utf-8"), baseurl))
+    return paths
+
+
 async def _asgi_get(app, path: str) -> tuple[int, bytes]:
     messages = []
 
@@ -326,15 +333,6 @@ def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> Non
         encoding="utf-8"
     )
     manifest = AssetManifest.load(site.output_dir / "asset-manifest.json")
-    representative_html = {
-        "index.html": index_html,
-        "docs/index.html": docs_index_html,
-        "docs/getting-started/index.html": getting_started_html,
-        "docs/guide/index.html": guide_html,
-        "blog/index.html": blog_index_html,
-        "search/index.html": search_html,
-    }
-
     for html_path in site.output_dir.rglob("*.html"):
         html = html_path.read_text(encoding="utf-8")
         assert "Build Error" not in html, html_path
@@ -401,12 +399,8 @@ def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> Non
     assert manifest.get("chirp_ui/unused.css") is None
     assert manifest.get("chirp_ui/chirpui/navbar.html") is None
 
-    asset_paths = {
-        path
-        for html in representative_html.values()
-        for path in _local_css_js_asset_paths(html, site.baseurl)
-    }
-    assert asset_paths, "Representative Chirp UI pages should reference local CSS/JS assets"
+    asset_paths = _local_css_js_asset_paths_for_output(site.output_dir, site.baseurl)
+    assert asset_paths, "Chirp UI pages should reference local CSS/JS assets"
     missing_assets = sorted(path for path in asset_paths if not (site.output_dir / path).exists())
     assert not missing_assets, f"Local CSS/JS asset URLs should be serveable: {missing_assets}"
 
@@ -433,10 +427,15 @@ def test_chirpui_provider_assets_are_serveable_at_dev_urls(tmp_path, monkeypatch
     assert 'href="/assets/chirp_ui/chirpui.css"' in index_html
     assert 'src="/assets/chirp_ui/chirpui.js"' in index_html
 
+    asset_paths = _local_css_js_asset_paths_for_output(site.output_dir, site.baseurl)
+    assert "assets/chirp_ui/chirpui.css" in asset_paths
+    assert "assets/chirp_ui/chirpui.js" in asset_paths
+
     app = create_bengal_dev_app(
         output_dir=site.output_dir,
         build_in_progress=lambda: False,
     )
-    status, body = asyncio.run(_asgi_get(app, "/assets/chirp_ui/chirpui.css"))
-    assert status == 200
-    assert b"chirpui-navbar" in body
+    for path in sorted(asset_paths):
+        status, body = asyncio.run(_asgi_get(app, f"/{path}"))
+        assert status == 200, path
+        assert body, path

--- a/tests/integration/test_chirpui_theme_build.py
+++ b/tests/integration/test_chirpui_theme_build.py
@@ -410,6 +410,20 @@ def test_chirpui_theme_builds_with_provider_assets(tmp_path, monkeypatch) -> Non
     css_output = site.output_dir / css_entry.output_path
     assert css_output.exists()
     assert "chirpui-transition" in css_output.read_text(encoding="utf-8")
+    assert css_entry.provenance == {
+        "kind": "theme_library",
+        "package": "chirp_ui",
+        "mode": "bundle",
+        "sources": ["chirpui.css", "chirpui-transitions.css"],
+    }
+    js_entry = manifest.get("chirp_ui/chirpui.js")
+    assert js_entry is not None
+    assert js_entry.provenance == {
+        "kind": "theme_library",
+        "package": "chirp_ui",
+        "mode": "link",
+        "sources": ["chirpui.js"],
+    }
     assert manifest.get("chirp_ui/chirpui-transitions.css") is None
     assert manifest.get("chirp_ui/unused.css") is None
     assert manifest.get("chirp_ui/chirpui/navbar.html") is None

--- a/tests/unit/assets/test_manifest.py
+++ b/tests/unit/assets/test_manifest.py
@@ -17,6 +17,12 @@ def test_manifest_roundtrip(tmp_path: Path) -> None:
         fingerprint="12345678",
         size_bytes=1024,
         updated_at=1_700_000_000.0,
+        provenance={
+            "kind": "theme_library",
+            "package": "chirp_ui",
+            "mode": "bundle",
+            "sources": ["chirpui.css", "chirpui-transitions.css"],
+        },
     )
 
     manifest_path = tmp_path / "asset-manifest.json"
@@ -30,6 +36,38 @@ def test_manifest_roundtrip(tmp_path: Path) -> None:
     assert entry.fingerprint == "12345678"
     assert entry.size_bytes == 1024
     assert entry.updated_at.endswith("Z")
+    assert entry.provenance == {
+        "kind": "theme_library",
+        "package": "chirp_ui",
+        "mode": "bundle",
+        "sources": ["chirpui.css", "chirpui-transitions.css"],
+    }
+
+
+def test_manifest_loads_entries_without_provenance(tmp_path: Path) -> None:
+    """Older manifests without provenance should remain readable."""
+    manifest_path = tmp_path / "asset-manifest.json"
+    manifest_path.write_text(
+        """
+{
+  "version": 1,
+  "generated_at": "2025-01-15T10:30:00Z",
+  "assets": {
+    "css/style.css": {
+      "output_path": "assets/css/style.12345678.css",
+      "fingerprint": "12345678"
+    }
+  }
+}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    loaded = AssetManifest.load(manifest_path)
+    assert loaded is not None
+    entry = loaded.get("css/style.css")
+    assert entry is not None
+    assert entry.provenance is None
 
 
 def test_inspect_asset_outputs_detects_missing_manifest_output(tmp_path: Path) -> None:

--- a/tests/unit/core/theme/test_providers.py
+++ b/tests/unit/core/theme/test_providers.py
@@ -189,6 +189,92 @@ class TestResolveProvider:
         ):
             resolve_provider("fake_ui")
 
+    def test_library_contract_rejects_absolute_output_path(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [{"path": "ui.css", "output": "/tmp/ui.css"}],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="output must be relative"),
+        ):
+            resolve_provider("fake_ui")
+
+    def test_library_contract_rejects_output_traversal(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [{"path": "ui.css", "output": "../ui.css"}],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match=r"output must not contain '\.\.'"),
+        ):
+            resolve_provider("fake_ui")
+
+    def test_library_contract_rejects_source_traversal(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [{"path": "../ui.css"}],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match=r"path must not contain '\.\.'"),
+        ):
+            resolve_provider("fake_ui")
+
+    def test_library_contract_rejects_non_path_asset_value(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [object()],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="path must be path-like"),
+        ):
+            resolve_provider("fake_ui")
+
+    def test_library_contract_rejects_non_string_runtime_entries(self):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(library_contract={"runtime": ["loader", 3]})
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="runtime entries must be strings"),
+        ):
+            resolve_provider("fake_ui")
+
+    def test_library_contract_rejects_bytes_runtime(self):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(library_contract={"runtime": b"loader"})
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="runtime must be a string"),
+        ):
+            resolve_provider("fake_ui")
+
 
 class TestResolveThemeProviders:
     """Tests for resolve_theme_providers() chain accumulation."""

--- a/tests/unit/core/theme/test_providers.py
+++ b/tests/unit/core/theme/test_providers.py
@@ -331,6 +331,25 @@ class TestResolveProvider:
         ):
             resolve_provider("fake_ui")
 
+    def test_library_contract_rejects_duplicate_non_bundle_outputs(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [
+                    {"path": "ui.css", "output": "vendor.css", "mode": "link"},
+                    {"path": "theme.css", "output": "vendor.css", "mode": "link"},
+                ],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="duplicate asset output"),
+        ):
+            resolve_provider("fake_ui")
+
 
 class TestResolveThemeProviders:
     """Tests for resolve_theme_providers() chain accumulation."""

--- a/tests/unit/core/theme/test_providers.py
+++ b/tests/unit/core/theme/test_providers.py
@@ -154,6 +154,9 @@ class TestResolveProvider:
                         "mode": "bundle",
                         "type": "javascript",
                         "output": "bundle.js",
+                        "defer": True,
+                        "module": True,
+                        "attributes": {"crossorigin": "anonymous"},
                     },
                     {"path": "tokens.css", "mode": "none", "type": "css"},
                 ],
@@ -172,6 +175,11 @@ class TestResolveProvider:
             "fake_ui/bundle.js",
             "fake_ui/tokens.css",
         ]
+        assert dict(provider.assets[1].tag_attrs) == {
+            "crossorigin": "anonymous",
+            "defer": True,
+            "type": "module",
+        }
 
     def test_invalid_library_contract_mode_raises_config_error(self, tmp_path):
         from bengal.errors.exceptions import BengalConfigError
@@ -272,6 +280,54 @@ class TestResolveProvider:
         with (
             patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
             pytest.raises(BengalConfigError, match="runtime must be a string"),
+        ):
+            resolve_provider("fake_ui")
+
+    def test_library_contract_rejects_non_mapping_asset_attributes(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [{"path": "ui.js", "attributes": ["defer"]}],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="attributes must be a mapping"),
+        ):
+            resolve_provider("fake_ui")
+
+    def test_library_contract_rejects_reserved_asset_attribute(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [{"path": "ui.js", "attributes": {"src": "/bad.js"}}],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="must not set 'src'"),
+        ):
+            resolve_provider("fake_ui")
+
+    def test_library_contract_rejects_invalid_asset_attribute_value(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [{"path": "ui.css", "attributes": {"media": ["print"]}}],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="values must be strings or booleans"),
         ):
             resolve_provider("fake_ui")
 

--- a/tests/unit/core/theme/test_providers.py
+++ b/tests/unit/core/theme/test_providers.py
@@ -31,6 +31,7 @@ def _make_library_module(
     has_register_filters: bool = False,
     loader_value: object = None,
     static_path_value: Path | None = None,
+    library_contract: dict | None = None,
 ) -> types.ModuleType:
     """Create a fake library module with configurable convention hooks."""
     mod = types.ModuleType("fake_lib")
@@ -40,6 +41,8 @@ def _make_library_module(
         mod.static_path = lambda: static_path_value  # type: ignore[attr-defined]
     if has_register_filters:
         mod.register_filters = lambda app: None  # type: ignore[attr-defined]
+    if library_contract is not None:
+        mod.get_library_contract = lambda: library_contract  # type: ignore[attr-defined]
     return mod
 
 
@@ -134,6 +137,57 @@ class TestResolveProvider:
             provider = resolve_provider("my-ui-kit")
 
         assert provider.asset_prefix == "my_ui_kit"
+
+    def test_consumes_library_contract_assets(self, tmp_path):
+        static = tmp_path / "static"
+        static.mkdir()
+        (static / "ui.css").write_text(".ui{}", encoding="utf-8")
+        (static / "ui.js").write_text("window.ui=true", encoding="utf-8")
+        (static / "tokens.css").write_text(":root{}", encoding="utf-8")
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": static,
+                "assets": [
+                    {"path": "ui.css", "mode": "link", "type": "css"},
+                    {
+                        "path": "ui.js",
+                        "mode": "bundle",
+                        "type": "javascript",
+                        "output": "bundle.js",
+                    },
+                    {"path": "tokens.css", "mode": "none", "type": "css"},
+                ],
+                "runtime": ["ui-runtime"],
+            }
+        )
+
+        with patch("bengal.core.theme.providers.importlib.import_module", return_value=mod):
+            provider = resolve_provider("fake_ui")
+
+        assert provider.asset_root == static
+        assert provider.runtime == ("ui-runtime",)
+        assert [asset.mode for asset in provider.assets] == ["link", "bundle", "none"]
+        assert [asset.logical_path.as_posix() for asset in provider.assets] == [
+            "fake_ui/ui.css",
+            "fake_ui/bundle.js",
+            "fake_ui/tokens.css",
+        ]
+
+    def test_invalid_library_contract_mode_raises_config_error(self, tmp_path):
+        from bengal.errors.exceptions import BengalConfigError
+
+        mod = _make_library_module(
+            library_contract={
+                "asset_root": tmp_path,
+                "assets": [{"path": "ui.css", "mode": "copy"}],
+            }
+        )
+
+        with (
+            patch("bengal.core.theme.providers.importlib.import_module", return_value=mod),
+            pytest.raises(BengalConfigError, match="asset mode 'copy' is invalid"),
+        ):
+            resolve_provider("fake_ui")
 
 
 class TestResolveThemeProviders:

--- a/tests/unit/orchestration/test_library_asset_bundles.py
+++ b/tests/unit/orchestration/test_library_asset_bundles.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bengal.orchestration.content import ContentOrchestrator
+
+
+def test_library_javascript_bundle_inserts_statement_boundary(tmp_path) -> None:
+    first = tmp_path / "first.js"
+    second = tmp_path / "second.js"
+    bundle = tmp_path / "bundle.js"
+    first.write_text("window.first = true", encoding="utf-8")
+    second.write_text("(function () { window.second = true })();", encoding="utf-8")
+
+    orchestrator = ContentOrchestrator.__new__(ContentOrchestrator)
+    orchestrator._write_library_asset_bundle(
+        bundle,
+        [
+            SimpleNamespace(source_path=first),
+            SimpleNamespace(source_path=second),
+        ],
+        "javascript",
+    )
+
+    output = bundle.read_text(encoding="utf-8")
+    assert "\n;\n// second.js" in output

--- a/tests/unit/rendering/test_asset_audit.py
+++ b/tests/unit/rendering/test_asset_audit.py
@@ -52,3 +52,17 @@ def test_accepts_path_only_baseurl_without_false_missing_assets(tmp_path) -> Non
     missing = find_missing_local_asset_references(output, baseurl="preview")
 
     assert missing == []
+
+
+def test_ignores_non_string_baseurl_from_loose_test_doubles(tmp_path) -> None:
+    output = tmp_path / "public"
+    (output / "assets").mkdir(parents=True)
+    (output / "assets" / "app.css").write_text(".app{}", encoding="utf-8")
+    (output / "index.html").write_text(
+        '<link rel="stylesheet" href="/assets/app.css">',
+        encoding="utf-8",
+    )
+
+    missing = find_missing_local_asset_references(output, baseurl=object())
+
+    assert missing == []

--- a/tests/unit/rendering/test_asset_audit.py
+++ b/tests/unit/rendering/test_asset_audit.py
@@ -38,3 +38,17 @@ def test_accepts_existing_baseurl_and_relative_asset_references(tmp_path) -> Non
     missing = find_missing_local_asset_references(output, baseurl="/preview")
 
     assert missing == []
+
+
+def test_accepts_path_only_baseurl_without_false_missing_assets(tmp_path) -> None:
+    output = tmp_path / "public"
+    (output / "assets").mkdir(parents=True)
+    (output / "assets" / "app.css").write_text(".app{}", encoding="utf-8")
+    (output / "index.html").write_text(
+        '<link rel="stylesheet" href="/preview/assets/app.css">',
+        encoding="utf-8",
+    )
+
+    missing = find_missing_local_asset_references(output, baseurl="preview")
+
+    assert missing == []

--- a/tests/unit/rendering/test_asset_audit.py
+++ b/tests/unit/rendering/test_asset_audit.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from bengal.rendering.asset_audit import find_missing_local_asset_references
+
+
+def test_finds_missing_local_css_reference(tmp_path) -> None:
+    output = tmp_path / "public"
+    (output / "docs").mkdir(parents=True)
+    (output / "docs" / "index.html").write_text(
+        '<link rel="stylesheet" href="/assets/missing.css">',
+        encoding="utf-8",
+    )
+
+    missing = find_missing_local_asset_references(output)
+
+    assert len(missing) == 1
+    assert missing[0].url == "/assets/missing.css"
+    assert missing[0].expected_path == output / "assets" / "missing.css"
+
+
+def test_accepts_existing_baseurl_and_relative_asset_references(tmp_path) -> None:
+    output = tmp_path / "public"
+    (output / "assets").mkdir(parents=True)
+    (output / "docs").mkdir(parents=True)
+    (output / "assets" / "app.css").write_text(".app{}", encoding="utf-8")
+    (output / "docs" / "local.js").write_text("window.local=true", encoding="utf-8")
+    (output / "docs" / "index.html").write_text(
+        "\n".join(
+            [
+                '<link rel="stylesheet" href="/preview/assets/app.css">',
+                '<script src="local.js"></script>',
+                '<script src="https://cdn.example.com/app.js"></script>',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    missing = find_missing_local_asset_references(output, baseurl="/preview")
+
+    assert missing == []

--- a/tests/unit/rendering/test_library_assets.py
+++ b/tests/unit/rendering/test_library_assets.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from bengal.core.theme.providers import LibraryAsset, ThemeLibraryProvider
+from bengal.rendering.library_assets import render_library_asset_tags
+
+
+class MockSite:
+    def __init__(self, output_dir: Path):
+        self.output_dir = output_dir
+        self.config: dict[str, Any] = {}
+        self.dev_mode = True
+
+    @property
+    def baseurl(self) -> str:
+        return ""
+
+
+def test_render_library_asset_tags_includes_declared_attributes(tmp_path: Path) -> None:
+    provider = ThemeLibraryProvider(
+        package="fake_ui",
+        loader=None,
+        asset_root=tmp_path,
+        asset_prefix="fake_ui",
+        register_env=None,
+        assets=(
+            LibraryAsset(
+                source_path=tmp_path / "ui.css",
+                logical_path=Path("fake_ui/ui.css"),
+                asset_type="css",
+                mode="link",
+                tag_attrs=(("media", "screen & (min-width: 40rem)"),),
+            ),
+            LibraryAsset(
+                source_path=tmp_path / "ui.js",
+                logical_path=Path("fake_ui/ui.js"),
+                asset_type="javascript",
+                mode="link",
+                tag_attrs=(("defer", True), ("type", "module"), ("async", False)),
+            ),
+        ),
+    )
+
+    html = str(render_library_asset_tags((provider,), MockSite(tmp_path)))
+
+    assert (
+        '<link rel="stylesheet" href="/assets/fake_ui/ui.css" '
+        'media="screen &amp; (min-width: 40rem)">'
+    ) in html
+    assert '<script src="/assets/fake_ui/ui.js" defer type="module"></script>' in html
+    assert "async" not in html
+
+
+def test_render_library_asset_tags_skips_none_mode_and_duplicates(tmp_path: Path) -> None:
+    provider = ThemeLibraryProvider(
+        package="fake_ui",
+        loader=None,
+        asset_root=tmp_path,
+        asset_prefix="fake_ui",
+        register_env=None,
+        assets=(
+            LibraryAsset(
+                source_path=tmp_path / "ui.css",
+                logical_path=Path("fake_ui/ui.css"),
+                asset_type="css",
+                mode="none",
+            ),
+            LibraryAsset(
+                source_path=tmp_path / "ui.js",
+                logical_path=Path("fake_ui/ui.js"),
+                asset_type="javascript",
+                mode="link",
+            ),
+            LibraryAsset(
+                source_path=tmp_path / "ui-again.js",
+                logical_path=Path("fake_ui/ui.js"),
+                asset_type="javascript",
+                mode="link",
+            ),
+        ),
+    )
+
+    html = str(render_library_asset_tags((provider,), MockSite(tmp_path)))
+
+    assert "ui.css" not in html
+    assert html.count("fake_ui/ui.js") == 1


### PR DESCRIPTION
## Summary

- Add Bengal theme-library asset contracts with explicit `bundle`, `link`, and `none` modes.
- Wire provider assets into build discovery, Kida `library_asset_tags()` / `library_runtime()`, static fingerprinted output, and dev-serving parity.
- Add build-time diagnostics for rendered local CSS/JS references that were not emitted.
- Harden malformed provider contracts, support safe tag attributes, and record optional sanitized manifest provenance for theme-library assets.
- Move Chirp UI theme asset loading onto the library contract and document the vendor-facing workflow.

## Why

Vendor themers should be able to ship reusable Kida component packages with browser assets without asking every theme to hand-write temporary CSS/JS paths. Bengal now owns the library asset contract so missing provider CSS is caught during build instead of first appearing as a browser 404.

## Steward Notes

- **Core:** Provider resolution remains a boundary adapter. Core records normalize contract shape without moving rendering or file-output behavior onto Page/Site records.
- **Rendering:** HTML tag generation, escaping, runtime metadata, and rendered-asset diagnostics stay in rendering/finalization helpers.
- **Assets:** Manifest entries now include optional provenance only for provider-managed assets. Provenance is sanitized and uses contract-relative source paths, not absolute filesystem paths.
- **Orchestration/Build:** Provider assets are discovered during existing content/asset discovery and emitted through the existing asset pipeline. No new build phase was added.
- **Tests:** Added unit and integration coverage for contract validation, tag rendering, dev/static parity, missing-asset diagnostics, Chirp UI cleanup, and manifest provenance.
- **Docs:** Added vendor-facing theme library asset docs and updated Chirp UI theme docs/changelog.

## Validation

- `uv run pytest tests/unit/assets/test_manifest.py tests/unit/core/theme/test_providers.py tests/integration/test_chirpui_theme_build.py -q`
- `uv run pytest tests/unit/assets tests/integration/test_assets_manifest.py tests/integration/test_installed_theme_asset_build.py -q`
- `uv run pytest tests/integration/test_asset_reference_diagnostics.py tests/unit/rendering/test_asset_audit.py -q`
- focused `uv run ruff check ...` for touched code/tests
- `make ty` exits 0 with the existing 543-diagnostic baseline
- `uv run bengal build --source site --no-incremental --quiet` exits 0

## Known Existing Noise

- `check-deps` still reports the existing 5 dependency layer warnings.
- Site docs build still reports existing health warnings: i18n URL collision, unknown directive docs errors, broken links, missing icons, and existing generated-site asset warning.
