### PR TITLE
[codex] Bengal priority batch

### DIFF
--- a/bengal/autodoc/README.md
+++ b/bengal/autodoc/README.md
@@ -238,6 +238,7 @@ Autodoc integrates with Bengal's incremental build system for fast dev server re
 **File Watching**: The dev server automatically watches autodoc source directories:
 - Python `source_dirs` configured in `autodoc.python.source_dirs`
 - OpenAPI spec files configured in `autodoc.openapi.spec_file`
+- Local OpenAPI `$ref` files resolved from those specs
 
 **Selective Rebuilds**: When a Python/OpenAPI source file changes:
 - Only the autodoc pages generated from that file are rebuilt

--- a/bengal/autodoc/extractors/openapi.py
+++ b/bengal/autodoc/extractors/openapi.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlparse
 
 import yaml
 
@@ -45,8 +46,140 @@ class OpenAPIExtractor(Extractor):
     def __init__(self) -> None:
         """Initialize the extractor."""
         self._spec: dict[str, Any] = {}
+        self._documents: dict[Path, dict[str, Any]] = {}
+        self._source: Path | None = None
+        self.resolved_files: set[Path] = set()
 
-    def _resolve_ref(self, ref_or_obj: dict[str, Any]) -> dict[str, Any]:
+    def _parse_document(self, path: Path) -> dict[str, Any]:
+        """Parse an OpenAPI document from YAML or JSON."""
+        content = path.read_text(encoding="utf-8")
+        if path.suffix in (".yaml", ".yml"):
+            parsed = yaml.safe_load(content)
+        else:
+            parsed = json.loads(content)
+        return parsed if isinstance(parsed, dict) else {}
+
+    def _load_document(self, path: Path) -> dict[str, Any] | None:
+        """Load and cache a local OpenAPI reference document."""
+        document_path = path.resolve()
+        if document_path in self._documents:
+            return self._documents[document_path]
+
+        if not document_path.exists():
+            logger.warning("openapi_ref_file_missing", path=str(document_path))
+            return None
+
+        try:
+            document = self._parse_document(document_path)
+        except yaml.YAMLError as exc:
+            logger.warning(
+                "openapi_ref_yaml_parse_failed",
+                path=str(document_path),
+                error=str(exc),
+            )
+            return None
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "openapi_ref_json_parse_failed",
+                path=str(document_path),
+                error=str(exc),
+            )
+            return None
+        except OSError as exc:
+            logger.warning(
+                "openapi_ref_file_read_failed",
+                path=str(document_path),
+                error=str(exc),
+            )
+            return None
+
+        self._documents[document_path] = document
+        self.resolved_files.add(document_path)
+        return document
+
+    def _resolve_ref_document(
+        self, ref_path: str, current_document: Path
+    ) -> tuple[Path, str] | None:
+        """Return local document path and JSON pointer for a ref."""
+        file_part, _, pointer = ref_path.partition("#")
+        pointer = pointer or ""
+
+        parsed = urlparse(file_part)
+        if parsed.scheme and parsed.scheme != "file":
+            logger.warning(
+                "openapi_external_ref_unsupported",
+                ref=ref_path,
+                reason="Only local file references are supported",
+            )
+            return None
+
+        if parsed.scheme == "file":
+            document_path = Path(unquote(parsed.path))
+        elif file_part:
+            document_path = Path(file_part)
+            if not document_path.is_absolute():
+                document_path = current_document.parent / document_path
+        else:
+            document_path = current_document
+
+        return document_path.resolve(), pointer
+
+    def _resolve_json_pointer(
+        self,
+        document: dict[str, Any],
+        pointer: str,
+        ref_path: str,
+    ) -> Any:
+        """Resolve a JSON pointer inside a loaded document."""
+        if pointer in ("", "#"):
+            return document
+
+        if not pointer.startswith("/"):
+            logger.warning(
+                "openapi_ref_pointer_invalid",
+                ref=ref_path,
+                pointer=pointer,
+            )
+            return None
+
+        result: Any = document
+        for raw_part in pointer.lstrip("/").split("/"):
+            part = raw_part.replace("~1", "/").replace("~0", "~")
+            if isinstance(result, dict) and part in result:
+                result = result[part]
+            else:
+                logger.warning("openapi_ref_pointer_missing", ref=ref_path, part=part)
+                return None
+
+        return result
+
+    def _resolve_refs_in_obj(
+        self,
+        obj: Any,
+        current_document: Path,
+        stack: tuple[tuple[Path, str], ...],
+    ) -> Any:
+        """Resolve local $ref entries recursively inside an object."""
+        if isinstance(obj, list):
+            return [self._resolve_refs_in_obj(item, current_document, stack) for item in obj]
+
+        if not isinstance(obj, dict):
+            return obj
+
+        if "$ref" in obj:
+            return self._resolve_ref(obj, current_document, stack)
+
+        return {
+            key: self._resolve_refs_in_obj(value, current_document, stack)
+            for key, value in obj.items()
+        }
+
+    def _resolve_ref(
+        self,
+        ref_or_obj: dict[str, Any],
+        current_document: Path | None = None,
+        stack: tuple[tuple[Path, str], ...] = (),
+    ) -> dict[str, Any]:
         """
         Resolve a $ref reference to its actual definition.
 
@@ -63,22 +196,35 @@ class OpenAPIExtractor(Extractor):
             return ref_or_obj
 
         ref_path = ref_or_obj["$ref"]
-        if not ref_path.startswith("#/"):
-            # External references not supported
-            logger.warning(f"External $ref not supported: {ref_path}")
+        document_path = current_document or self._source
+        if document_path is None:
+            logger.warning("openapi_ref_no_source", ref=ref_path)
             return ref_or_obj
 
-        # Parse the JSON pointer (e.g., "#/components/parameters/UserId")
-        parts = ref_path[2:].split("/")  # Remove "#/" and split
-        result = self._spec
-        for part in parts:
-            if isinstance(result, dict) and part in result:
-                result = result[part]
-            else:
-                logger.warning(f"Could not resolve $ref: {ref_path}")
-                return ref_or_obj
+        target = self._resolve_ref_document(ref_path, document_path)
+        if target is None:
+            return ref_or_obj
 
-        return result if isinstance(result, dict) else ref_or_obj
+        target_document_path, pointer = target
+        key = (target_document_path, pointer)
+        if key in stack:
+            logger.warning(
+                "openapi_ref_cycle",
+                ref=ref_path,
+                document=str(target_document_path),
+            )
+            return ref_or_obj
+
+        document = self._load_document(target_document_path)
+        if document is None:
+            return ref_or_obj
+
+        result = self._resolve_json_pointer(document, pointer, ref_path)
+        if result is None:
+            return ref_or_obj
+
+        resolved = self._resolve_refs_in_obj(result, target_document_path, (*stack, key))
+        return resolved if isinstance(resolved, dict) else ref_or_obj
 
     def extract(self, source: Path) -> list[DocElement]:
         """
@@ -101,11 +247,7 @@ class OpenAPIExtractor(Extractor):
             )
 
         try:
-            content = source.read_text(encoding="utf-8")
-            if source.suffix in (".yaml", ".yml"):
-                spec = yaml.safe_load(content)
-            else:
-                spec = json.loads(content)
+            spec = self._parse_document(source)
         except yaml.YAMLError as e:
             from bengal.errors import BengalContentError, ErrorCode
 
@@ -126,7 +268,10 @@ class OpenAPIExtractor(Extractor):
             ) from e
 
         # Store spec for $ref resolution
+        self._source = source.resolve()
         self._spec = spec
+        self._documents[self._source] = spec
+        self.resolved_files = {self._source}
 
         elements: list[DocElement] = []
 
@@ -143,7 +288,14 @@ class OpenAPIExtractor(Extractor):
         schemas = self._extract_schemas(spec)
         elements.extend(schemas)
 
+        self._attach_source_dependencies(elements)
         return elements
+
+    def _attach_source_dependencies(self, elements: list[DocElement]) -> None:
+        """Attach OpenAPI source dependency files to extracted elements."""
+        dependencies = tuple(str(path) for path in sorted(self.resolved_files))
+        for element in elements:
+            element.metadata["source_dependencies"] = dependencies
 
     def get_output_path(self, element: DocElement) -> Path | None:
         """
@@ -218,7 +370,10 @@ class OpenAPIExtractor(Extractor):
 
         for path, path_item in paths.items():
             # Handle common parameters at path level (resolve $refs)
-            path_params = [self._resolve_ref(p) for p in path_item.get("parameters", [])]
+            path_params = [
+                self._resolve_refs_in_obj(p, self._source or Path(), ())
+                for p in path_item.get("parameters", [])
+            ]
 
             for method in ["get", "post", "put", "delete", "patch", "head", "options"]:
                 if method not in path_item:
@@ -227,7 +382,10 @@ class OpenAPIExtractor(Extractor):
                 operation = path_item[method]
 
                 # Merge path-level parameters with operation-level parameters (resolve $refs)
-                op_params = [self._resolve_ref(p) for p in operation.get("parameters", [])]
+                op_params = [
+                    self._resolve_refs_in_obj(p, self._source or Path(), ())
+                    for p in operation.get("parameters", [])
+                ]
                 all_params = path_params + op_params
 
                 # Construct name like "GET /users"
@@ -249,10 +407,16 @@ class OpenAPIExtractor(Extractor):
                 typed_request_body = None
                 req_body = operation.get("requestBody")
                 if req_body:
-                    req_body = self._resolve_ref(req_body)
+                    raw_req_body = req_body
+                    req_body = self._resolve_refs_in_obj(req_body, self._source or Path(), ())
                     content = req_body.get("content", {})
                     content_type = next(iter(content.keys()), "application/json")
-                    schema_ref = content.get(content_type, {}).get("schema", {}).get("$ref")
+                    schema_ref = (
+                        raw_req_body.get("content", {})
+                        .get(content_type, {})
+                        .get("schema", {})
+                        .get("$ref")
+                    )
                     typed_request_body = OpenAPIRequestBodyMetadata(
                         content_type=content_type,
                         schema_ref=schema_ref,
@@ -263,7 +427,8 @@ class OpenAPIExtractor(Extractor):
                 # Build typed responses (resolve $refs)
                 raw_responses = operation.get("responses") or {}
                 resolved_responses = {
-                    status: self._resolve_ref(resp) for status, resp in raw_responses.items()
+                    status: self._resolve_refs_in_obj(resp, self._source or Path(), ())
+                    for status, resp in raw_responses.items()
                 }
                 typed_responses = tuple(
                     OpenAPIResponseMetadata(
@@ -273,11 +438,18 @@ class OpenAPIExtractor(Extractor):
                         if isinstance(resp, dict)
                         else None,
                         schema_ref=(
-                            resp.get("content", {})
-                            .get(next(iter(resp.get("content", {}).keys()), ""), {})
+                            raw_responses.get(status, {})
+                            .get("content", {})
+                            .get(
+                                next(
+                                    iter(raw_responses.get(status, {}).get("content", {}).keys()),
+                                    "",
+                                ),
+                                {},
+                            )
                             .get("schema", {})
                             .get("$ref")
-                            if isinstance(resp, dict)
+                            if isinstance(raw_responses.get(status), dict)
                             else None
                         ),
                     )
@@ -305,6 +477,7 @@ class OpenAPIExtractor(Extractor):
                     qualified_name=f"openapi.paths.{path}.{method}",
                     description=operation.get("description") or operation.get("summary", ""),
                     element_type="openapi_endpoint",
+                    source_file=self._source,
                     metadata={
                         "method": method,
                         "path": path,
@@ -332,6 +505,7 @@ class OpenAPIExtractor(Extractor):
         schemas = components.get("schemas", {})
 
         for name, schema in schemas.items():
+            schema = self._resolve_refs_in_obj(schema, self._source or Path(), ())
             # Build typed metadata
             typed_meta = OpenAPISchemaMetadata(
                 schema_type=schema.get("type"),
@@ -346,6 +520,7 @@ class OpenAPIExtractor(Extractor):
                 qualified_name=f"openapi.components.schemas.{name}",
                 description=schema.get("description", ""),
                 element_type="openapi_schema",
+                source_file=self._source,
                 metadata={
                     "type": schema.get("type"),
                     "properties": schema.get("properties", {}),

--- a/bengal/autodoc/orchestration/page_builders.py
+++ b/bengal/autodoc/orchestration/page_builders.py
@@ -351,6 +351,15 @@ def create_pages(
             page._raw_metadata["doc_content_hash"] = doc_hash
             result.add_dependency(str(source_file_for_tracking), source_id, content_hash=doc_hash)
 
+            source_dependencies = element.metadata.get("source_dependencies", ())
+            if isinstance(source_dependencies, (list, tuple)):
+                for dependency in source_dependencies:
+                    if not isinstance(dependency, str):
+                        continue
+                    if dependency == str(source_file_for_tracking):
+                        continue
+                    result.add_dependency(dependency, source_id, content_hash=doc_hash)
+
     # Note: HTML rendering is now DEFERRED to the rendering phase
     # This ensures menus and full template context are available.
     # See: RenderingPipeline._process_virtual_page() and _render_autodoc_page()

--- a/bengal/config/feature_mappings.py
+++ b/bengal/config/feature_mappings.py
@@ -10,6 +10,7 @@ configuration is used by the build system.
 
 Supported Features:
 - ``rss``: RSS feed generation
+- ``atom``: Atom feed generation
 - ``sitemap``: XML sitemap generation
 - ``search``: Site search functionality
 - ``json``: Per-page JSON output
@@ -56,6 +57,9 @@ FEATURE_MAPPINGS: dict[str, dict[str, Any]] = {
     "rss": {
         "generate_rss": True,
         "output_formats.site_wide": ["rss"],
+    },
+    "atom": {
+        "generate_atom": True,
     },
     "sitemap": {
         "generate_sitemap": True,

--- a/bengal/config/types.py
+++ b/bengal/config/types.py
@@ -196,6 +196,7 @@ class FeaturesConfig(TypedDict, total=False):
     """Feature toggles for output generation."""
 
     rss: bool
+    atom: bool
     sitemap: bool
     search: bool
     json: bool

--- a/bengal/config/types.py
+++ b/bengal/config/types.py
@@ -242,6 +242,42 @@ class I18nConfig(TypedDict, total=False):
 
 
 # =============================================================================
+# Versioning
+# =============================================================================
+
+
+VersionStatus = Literal["current", "legacy", "deprecated", "preview", "eol"]
+
+
+class VersionEntryConfig(TypedDict, total=False):
+    """Single configured documentation version."""
+
+    id: str
+    source: str
+    label: str
+    latest: bool
+    status: VersionStatus
+    deprecated: bool
+    release_date: str
+    end_of_life: str
+    banner: str | dict[str, str | bool]
+
+
+class VersioningConfig(TypedDict, total=False):
+    """Versioned documentation configuration."""
+
+    enabled: bool
+    mode: Literal["folder", "git"]
+    versions: list[str | VersionEntryConfig]
+    aliases: dict[str, str]
+    sections: list[str]
+    shared: list[str]
+    emit_versions_json: bool
+    default_redirect: bool
+    default_redirect_target: str
+
+
+# =============================================================================
 # Output Formats
 # =============================================================================
 
@@ -518,6 +554,7 @@ class SiteConfig(TypedDict, total=False):
     features: FeaturesConfig
     graph: GraphConfig | bool
     i18n: I18nConfig
+    versioning: VersioningConfig
     output_formats: OutputFormatsConfig | bool
     markdown: MarkdownConfig
     link_previews: LinkPreviewsConfig | bool

--- a/bengal/config/types.py
+++ b/bengal/config/types.py
@@ -128,7 +128,9 @@ class SearchConfig(TypedDict, total=False):
     """Search configuration."""
 
     enabled: bool
+    backend: Literal["lunr"]
     lunr: LunrConfig
+    backends: dict[str, dict[str, object]]
     ui: SearchUIConfig
     analytics: SearchAnalyticsConfig
 

--- a/bengal/core/__init__.py
+++ b/bengal/core/__init__.py
@@ -66,6 +66,7 @@ from bengal.core.version import (
     GitVersionConfig,
     Version,
     VersionConfig,
+    VersionStatus,
 )
 
 __all__ = [
@@ -93,4 +94,5 @@ __all__ = [
     "URLRegistry",
     "Version",
     "VersionConfig",
+    "VersionStatus",
 ]

--- a/bengal/core/version.py
+++ b/bengal/core/version.py
@@ -62,7 +62,32 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict, cast
+
+VersionStatus = Literal["current", "legacy", "deprecated", "preview", "eol"]
+VERSION_STATUSES: frozenset[str] = frozenset({"current", "legacy", "deprecated", "preview", "eol"})
+DEPRECATED_VERSION_STATUSES: frozenset[str] = frozenset({"deprecated", "eol"})
+
+
+def normalize_version_status(
+    status: str | None,
+    *,
+    deprecated: bool,
+    latest: bool,
+) -> VersionStatus:
+    """Normalize version status while preserving deprecated as a legacy alias."""
+    if status is not None:
+        normalized = status.strip().lower()
+        if normalized not in VERSION_STATUSES:
+            expected = ", ".join(sorted(VERSION_STATUSES))
+            raise ValueError(f"Unsupported version status {status!r}. Expected one of: {expected}.")
+        return cast("VersionStatus", normalized)
+
+    if deprecated:
+        return "deprecated"
+    if latest:
+        return "current"
+    return "legacy"
 
 
 @dataclass
@@ -164,6 +189,7 @@ class VersionDict(TypedDict):
     id: str
     label: str
     latest: bool
+    status: VersionStatus
     deprecated: bool
     url_prefix: str
     release_date: str | None
@@ -181,6 +207,9 @@ class Version:
         label: Display label (e.g., '3.0', '2.0 LTS')
         latest: Whether this is the latest/default version
         banner: Optional banner configuration for this version
+        status: Version lifecycle status exposed to templates and docs tooling.
+            When omitted, Bengal derives it from latest/deprecated for backward
+            compatibility. Explicit status wins over deprecated.
         deprecated: Whether this version is deprecated
         release_date: Optional release date for this version
         end_of_life: Optional end-of-life date
@@ -198,12 +227,22 @@ class Version:
     label: str = ""
     latest: bool = False
     banner: VersionBanner | None = None
+    status: str | None = None
     deprecated: bool = False
     release_date: str | None = None
     end_of_life: str | None = None
+    _status_explicit: bool = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         """Initialize defaults."""
+        self._status_explicit = self.status is not None
+        self.status = normalize_version_status(
+            self.status,
+            deprecated=self.deprecated,
+            latest=self.latest,
+        )
+        self.deprecated = self.status in DEPRECATED_VERSION_STATUSES
+
         # Default label to id if not provided
         if not self.label:
             self.label = self.id
@@ -216,6 +255,18 @@ class Version:
             else:
                 # Older versions use _versions/<id>
                 self.source = f"_versions/{self.id}"
+
+    def refresh_derived_status(self) -> None:
+        """Refresh status after inferred latest values change."""
+        if self._status_explicit:
+            return
+
+        self.status = normalize_version_status(
+            None,
+            deprecated=self.deprecated,
+            latest=self.latest,
+        )
+        self.deprecated = self.status in DEPRECATED_VERSION_STATUSES
 
     @property
     def url_prefix(self) -> str:
@@ -242,6 +293,7 @@ class Version:
             "id": self.id,
             "label": self.label,
             "latest": self.latest,
+            "status": cast("VersionStatus", self.status),
             "deprecated": self.deprecated,
             "url_prefix": self.url_prefix,
             "release_date": self.release_date,
@@ -312,6 +364,7 @@ class VersionConfig:
         # Ensure at least one version is marked as latest
         if self.versions and not any(v.latest for v in self.versions):
             self.versions[0].latest = True
+            self.versions[0].refresh_derived_status()
             self._version_map[self.versions[0].id] = self.versions[0]
 
         # Auto-add 'latest' alias if not present
@@ -525,6 +578,7 @@ class VersionConfig:
                         label=v.get("label", ""),
                         latest=v.get("latest", i == 0),
                         banner=banner,
+                        status=v.get("status"),
                         deprecated=v.get("deprecated", False),
                         release_date=v.get("release_date"),
                         end_of_life=v.get("end_of_life"),

--- a/bengal/health/validators/rendering.py
+++ b/bengal/health/validators/rendering.py
@@ -12,6 +12,8 @@ cause immediate template errors during build.
 
 from __future__ import annotations
 
+import json
+from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any, override
 
 from bengal.health.base import BaseValidator
@@ -26,6 +28,34 @@ logger = get_logger(__name__)
 if TYPE_CHECKING:
     from bengal.orchestration.build_context import BuildContext
     from bengal.protocols import SiteLike
+
+
+class _JsonLdExtractor(HTMLParser):
+    """Extract application/ld+json script bodies from rendered HTML."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.blocks: list[str] = []
+        self._capturing = False
+        self._current: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "script":
+            return
+        attr_map = {name.lower(): value for name, value in attrs if value is not None}
+        if attr_map.get("type", "").lower() == "application/ld+json":
+            self._capturing = True
+            self._current = []
+
+    def handle_data(self, data: str) -> None:
+        if self._capturing:
+            self._current.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._capturing and tag.lower() == "script":
+            self.blocks.append("".join(self._current))
+            self._capturing = False
+            self._current = []
 
 
 class RenderingValidator(BaseValidator):
@@ -64,6 +94,12 @@ class RenderingValidator(BaseValidator):
 
         # Check 3: SEO metadata (catches missing titles/descriptions)
         results.extend(self._check_seo_metadata(site))
+
+        # Check 4: Social metadata (catches incomplete share cards)
+        results.extend(self._check_social_metadata(site))
+
+        # Check 5: JSON-LD validity (catches malformed structured data)
+        results.extend(self._check_json_ld(site))
 
         success_count = sum(1 for result in results if result.status.value == "success")
         return compact_successes(
@@ -113,6 +149,95 @@ class RenderingValidator(BaseValidator):
                 CheckResult.success(
                     f"HTML structure validated (sampled {len(pages_to_check)} pages)"
                 )
+            )
+
+        return results
+
+    def _check_social_metadata(self, site: SiteLike) -> list[CheckResult]:
+        """Check for social sharing metadata in rendered pages."""
+        results = []
+        issues = []
+        pages_to_check = sample_pages(site, count=10, exclude_generated=True)
+
+        for page in pages_to_check:
+            content = read_output_content(page)
+            if content is None:
+                continue
+
+            missing_elements = []
+            if 'property="og:title"' not in content:
+                missing_elements.append("og:title")
+            if 'property="og:url"' not in content:
+                missing_elements.append("og:url")
+            if 'name="twitter:card"' not in content:
+                missing_elements.append("twitter:card")
+
+            if missing_elements:
+                issues.append(f"{page.output_path.name}: missing {', '.join(missing_elements)}")
+
+        if issues:
+            results.append(
+                CheckResult.warning(
+                    f"{len(issues)} page(s) missing social sharing metadata",
+                    code="H034",
+                    recommendation="Add Open Graph and Twitter card metadata to the base template.",
+                    details=issues[:5],
+                )
+            )
+        else:
+            results.append(
+                CheckResult.success(
+                    f"Social metadata validated (sampled {len(pages_to_check)} pages)"
+                )
+            )
+
+        return results
+
+    def _check_json_ld(self, site: SiteLike) -> list[CheckResult]:
+        """Check JSON-LD script blocks for valid JSON syntax."""
+        results = []
+        issues = []
+        pages_to_check = sample_pages(site, count=10, exclude_generated=True)
+
+        for page in pages_to_check:
+            content = read_output_content(page)
+            if content is None or "application/ld+json" not in content:
+                continue
+
+            extractor = _JsonLdExtractor()
+            try:
+                extractor.feed(content)
+            except Exception as e:
+                logger.debug(
+                    "rendering_validator_json_ld_parse_failed",
+                    page=str(page.output_path),
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    action="skipping_json_ld_check",
+                )
+                continue
+
+            for index, raw_json in enumerate(extractor.blocks, start=1):
+                try:
+                    json.loads(raw_json)
+                except json.JSONDecodeError as e:
+                    issues.append(
+                        f"{page.output_path.name}: JSON-LD block {index} is invalid JSON "
+                        f"({e.msg} at line {e.lineno}, column {e.colno})"
+                    )
+
+        if issues:
+            results.append(
+                CheckResult.warning(
+                    f"{len(issues)} JSON-LD block(s) are invalid",
+                    code="H035",
+                    recommendation="Fix JSON-LD template output so each application/ld+json script contains valid JSON.",
+                    details=issues[:5],
+                )
+            )
+        else:
+            results.append(
+                CheckResult.success(f"JSON-LD validated (sampled {len(pages_to_check)} pages)")
             )
 
         return results

--- a/bengal/orchestration/build/artifact_inventory.py
+++ b/bengal/orchestration/build/artifact_inventory.py
@@ -78,6 +78,9 @@ def populate_artifact_inventory(site: Any, build_context: Any | None) -> None:
     for path in _rss_output_paths(site):
         _record_existing(collector, site, path, OutputType.XML, "postprocess", seen)
 
+    for path in _feed_output_paths(site, "atom", "generate_atom", default_enabled=False):
+        _record_existing(collector, site, path, OutputType.XML, "postprocess", seen)
+
 
 def _record_output_format_artifacts(
     site: Any,
@@ -140,8 +143,19 @@ def _output_type_for_filename(filename: str) -> OutputType:
 
 def _rss_output_paths(site: Any) -> list[Path]:
     """Return possible RSS output paths for the site's i18n configuration."""
+    return _feed_output_paths(site, "rss", "generate_rss", default_enabled=True)
+
+
+def _feed_output_paths(
+    site: Any,
+    filename_prefix: str,
+    config_key: str,
+    *,
+    default_enabled: bool,
+) -> list[Path]:
+    """Return possible feed output paths for the site's i18n configuration."""
     config = getattr(site, "config", {})
-    if not config.get("generate_rss", True):
+    if not config.get(config_key, default_enabled):
         return []
 
     output_dir = site.output_dir
@@ -157,11 +171,11 @@ def _rss_output_paths(site: Any) -> list[Path]:
         if not code:
             continue
         if strategy == "prefix" and (default_in_subdir or code != default_lang):
-            paths.append(output_dir / code / "rss.xml")
+            paths.append(output_dir / code / f"{filename_prefix}.xml")
         elif code == default_lang:
-            paths.append(output_dir / "rss.xml")
+            paths.append(output_dir / f"{filename_prefix}.xml")
         else:
-            paths.append(output_dir / code / "rss.xml")
+            paths.append(output_dir / code / f"{filename_prefix}.xml")
     return paths
 
 

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 from bengal.postprocess.output_formats import OutputFormatsGenerator
 from bengal.postprocess.redirects import RedirectGenerator
 from bengal.postprocess.robots_txt import RobotsTxtGenerator
-from bengal.postprocess.rss import RSSGenerator
+from bengal.postprocess.rss import AtomGenerator, RSSGenerator
 from bengal.postprocess.sitemap import SitemapGenerator
 from bengal.postprocess.social_cards import (
     SocialCardGenerator,
@@ -198,6 +198,8 @@ class PostprocessOrchestrator:
 
             if self.site.config.get("generate_rss", True):
                 tasks.append(("rss", self._generate_rss))
+            if self.site.config.get("generate_atom", False):
+                tasks.append(("atom", self._generate_atom))
 
             redirects_config = self.site.config.get("redirects", {})
             if redirects_config.get("generate_html", True):
@@ -447,6 +449,12 @@ class PostprocessOrchestrator:
         """
         collector = getattr(self, "_collector", None)
         generator = RSSGenerator(self.site, collector=collector)
+        generator.generate()
+
+    def _generate_atom(self) -> None:
+        """Generate Atom feed."""
+        collector = getattr(self, "_collector", None)
+        generator = AtomGenerator(self.site, collector=collector)
         generator.generate()
 
     def _generate_redirects(self) -> None:

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -45,6 +45,7 @@ from bengal.postprocess.robots_txt import RobotsTxtGenerator
 from bengal.postprocess.rss import AtomGenerator, RSSGenerator
 from bengal.postprocess.sitemap import SitemapGenerator
 from bengal.postprocess.social_cards import (
+    SOCIAL_CARD_FINGERPRINT_PREFIX,
     SocialCardGenerator,
     parse_social_cards_config,
 )
@@ -187,6 +188,8 @@ class PostprocessOrchestrator:
         if cs_config.get("enabled", True):
             tasks.append(("robots.txt", self._generate_robots_txt))
 
+        social_cards_task = None
+
         if not incremental:
             # Full build: run all expensive tasks
 
@@ -194,7 +197,13 @@ class PostprocessOrchestrator:
             # Only on full builds, not dev server reloads
             social_cards_config = parse_social_cards_config(self.site.config)
             if social_cards_config.enabled:
-                tasks.append(("social cards", lambda: self._generate_social_cards(build_context)))
+                # Run after parallel postprocess tasks so social-card fingerprints
+                # never mutate the build-cache fingerprint map concurrently with
+                # output-format generation on free-threaded Python.
+                def run_social_cards() -> None:
+                    self._generate_social_cards(build_context)
+
+                social_cards_task = run_social_cards
 
             if self.site.config.get("generate_rss", True):
                 tasks.append(("rss", self._generate_rss))
@@ -217,15 +226,16 @@ class PostprocessOrchestrator:
                 sitemap="always_generated",
             )
 
-        if not tasks:
-            return
+        if tasks:
+            # Run in parallel if enabled and multiple tasks
+            # Threshold of 2 tasks (always parallel if multiple tasks since they're independent)
+            if parallel and len(tasks) > 1:
+                self._run_parallel(tasks, progress_manager, reporter)
+            else:
+                self._run_sequential(tasks, progress_manager, reporter)
 
-        # Run in parallel if enabled and multiple tasks
-        # Threshold of 2 tasks (always parallel if multiple tasks since they're independent)
-        if parallel and len(tasks) > 1:
-            self._run_parallel(tasks, progress_manager, reporter)
-        else:
-            self._run_sequential(tasks, progress_manager, reporter)
+        if social_cards_task is not None:
+            self._run_sequential([("social cards", social_cards_task)], progress_manager, reporter)
 
     def _run_sequential(
         self,
@@ -491,7 +501,11 @@ class PostprocessOrchestrator:
         collector = getattr(self, "_collector", None)
         fingerprint_cache = None
         if build_context is not None and build_context.cache is not None:
-            fingerprint_cache = build_context.cache.output_format_fingerprints
+            fingerprint_cache = {
+                key: value
+                for key, value in build_context.cache.output_format_fingerprints.items()
+                if key.startswith(SOCIAL_CARD_FINGERPRINT_PREFIX)
+            }
         generator = SocialCardGenerator(
             self.site,
             social_config,
@@ -501,6 +515,12 @@ class PostprocessOrchestrator:
         output_dir = self.site.output_dir / social_config.output_dir
 
         generated, cached = generator.generate_all(self.site.pages, output_dir)
+        if (
+            build_context is not None
+            and build_context.cache is not None
+            and fingerprint_cache is not None
+        ):
+            build_context.cache.output_format_fingerprints.update(fingerprint_cache)
 
         # Log results using CLI output pattern
         cli = get_cli_output()

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -194,7 +194,7 @@ class PostprocessOrchestrator:
             # Only on full builds, not dev server reloads
             social_cards_config = parse_social_cards_config(self.site.config)
             if social_cards_config.enabled:
-                tasks.append(("social cards", self._generate_social_cards))
+                tasks.append(("social cards", lambda: self._generate_social_cards(build_context)))
 
             if self.site.config.get("generate_rss", True):
                 tasks.append(("rss", self._generate_rss))
@@ -471,7 +471,7 @@ class PostprocessOrchestrator:
         generator = RedirectGenerator(self.site, collector=collector)
         generator.generate()
 
-    def _generate_social_cards(self) -> None:
+    def _generate_social_cards(self, build_context: BuildContext | None = None) -> None:
         """
         Generate social card (Open Graph) images for pages.
 
@@ -489,7 +489,15 @@ class PostprocessOrchestrator:
             return
 
         collector = getattr(self, "_collector", None)
-        generator = SocialCardGenerator(self.site, social_config, collector=collector)
+        fingerprint_cache = None
+        if build_context is not None and build_context.cache is not None:
+            fingerprint_cache = build_context.cache.output_format_fingerprints
+        generator = SocialCardGenerator(
+            self.site,
+            social_config,
+            collector=collector,
+            fingerprint_cache=fingerprint_cache,
+        )
         output_dir = self.site.output_dir / social_config.output_dir
 
         generated, cached = generator.generate_all(self.site.pages, output_dir)

--- a/bengal/parsing/backends/patitas/__init__.py
+++ b/bengal/parsing/backends/patitas/__init__.py
@@ -512,9 +512,11 @@ class Markdown:
         from bengal.parsing.backends.patitas.roles.registry import (
             create_default_registry as create_default_role_registry,
         )
+        from bengal.plugins import get_active_registry
 
-        directive_registry = create_default_registry()
-        role_registry = create_default_role_registry()
+        plugin_registry = get_active_registry()
+        directive_registry = create_default_registry(plugin_registry=plugin_registry)
+        role_registry = create_default_role_registry(plugin_registry=plugin_registry)
 
         # Build immutable configs once (reused for all parses)
         # text_transformer is set per-call, so we use None here as base

--- a/bengal/parsing/backends/patitas/directives/registry.py
+++ b/bengal/parsing/backends/patitas/directives/registry.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from bengal.parsing.backends.patitas.directives.protocol import DirectiveHandler
+    from bengal.plugins.registry import FrozenPluginRegistry
 
 
 class DirectiveRegistry:
@@ -185,7 +186,9 @@ class DirectiveRegistryBuilder:
         return len(self._handlers)
 
 
-def create_default_registry() -> DirectiveRegistry:
+def create_default_registry(
+    plugin_registry: FrozenPluginRegistry | None = None,
+) -> DirectiveRegistry:
     """Create registry with all built-in directives.
 
     Returns:
@@ -359,5 +362,10 @@ def create_default_registry() -> DirectiveRegistry:
 
     # Marimo (executable Python)
     builder.register(MarimoDirective())
+
+    if plugin_registry is not None:
+        from bengal.plugins.integration import apply_plugin_directives
+
+        apply_plugin_directives(plugin_registry, builder)
 
     return builder.build()

--- a/bengal/parsing/backends/patitas/roles/registry.py
+++ b/bengal/parsing/backends/patitas/roles/registry.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from bengal.parsing.backends.patitas.roles.protocol import RoleHandler
+    from bengal.plugins.registry import FrozenPluginRegistry
 
 
 class RoleRegistry:
@@ -185,7 +186,9 @@ class RoleRegistryBuilder:
         return len(self._handlers)
 
 
-def create_default_registry() -> RoleRegistry:
+def create_default_registry(
+    plugin_registry: FrozenPluginRegistry | None = None,
+) -> RoleRegistry:
     """Create registry with all built-in roles.
 
     Returns:
@@ -212,5 +215,10 @@ def create_default_registry() -> RoleRegistry:
     builder.register(SubRole())
     builder.register(SupRole())
     builder.register(IconRole())
+
+    if plugin_registry is not None:
+        from bengal.plugins.integration import apply_plugin_roles
+
+        apply_plugin_roles(plugin_registry, builder)
 
     return builder.build()

--- a/bengal/plugins/inspection.py
+++ b/bengal/plugins/inspection.py
@@ -26,8 +26,8 @@ CAPABILITY_FIELDS = (
 # Whether each registered plugin capability is currently wired into builds.
 CAPABILITY_INTEGRATION_STATUS = MappingProxyType(
     {
-        "directives": "pending",
-        "roles": "pending",
+        "directives": "ready",
+        "roles": "ready",
         "template_functions": "ready",
         "template_filters": "ready",
         "template_tests": "ready",
@@ -40,8 +40,8 @@ CAPABILITY_INTEGRATION_STATUS = MappingProxyType(
 
 CAPABILITY_NOTES = MappingProxyType(
     {
-        "directives": "Registered, but directive builder plugin hooks are not wired yet.",
-        "roles": "Registered, but role builder plugin hooks are not wired yet.",
+        "directives": "Applied to the Patitas directive registry during parser setup.",
+        "roles": "Applied to the Patitas role registry during parser setup.",
         "template_functions": "Applied to template environments during registration.",
         "template_filters": "Applied to template environments during registration.",
         "template_tests": "Applied to template environments during registration.",

--- a/bengal/postprocess/__init__.py
+++ b/bengal/postprocess/__init__.py
@@ -82,7 +82,7 @@ from bengal.postprocess.output_formats import (
 )
 from bengal.postprocess.redirects import RedirectGenerator
 from bengal.postprocess.robots_txt import RobotsTxtGenerator
-from bengal.postprocess.rss import RSSGenerator
+from bengal.postprocess.rss import AtomGenerator, RSSGenerator
 from bengal.postprocess.sitemap import SitemapGenerator
 from bengal.postprocess.social_cards import (
     SocialCardConfig,
@@ -98,6 +98,7 @@ from bengal.postprocess.speculation import (
 )
 
 __all__ = [
+    "AtomGenerator",
     # Output Formats
     "OutputFormatsGenerator",
     "PageJSONGenerator",

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -44,6 +44,10 @@ from bengal.postprocess.output_formats.lunr_index_generator import LunrIndexGene
 from bengal.postprocess.output_formats.md_generator import PageMarkdownGenerator
 from bengal.postprocess.output_formats.txt_generator import PageTxtGenerator
 from bengal.postprocess.output_formats.utils import get_i18n_output_path
+from bengal.postprocess.search_backends import (
+    create_search_backend,
+    resolve_search_backend_config,
+)
 from bengal.postprocess.utils import get_section_name
 from bengal.utils.observability.logger import get_logger
 
@@ -386,29 +390,21 @@ class OutputFormatsGenerator:
                 generated.append("index.json")
                 logger.debug("generated_site_index_json")
 
-            # Generate pre-built Lunr index if enabled
-            search_config = self.site.config.get("search", {})
-            lunr_config = search_config.get("lunr", {})
-            prebuilt_enabled = lunr_config.get("prebuilt", True)  # Default: enabled
-
-            if prebuilt_enabled:
-                lunr_gen = LunrIndexGenerator(self.site)
-                if lunr_gen.is_available():
-                    # Generate Lunr index for each version index
-                    for index_path in index_paths:
-                        lunr_path = self._timed_generate(
-                            timings,
-                            "site_lunr_index",
-                            lambda index_path=index_path: lunr_gen.generate(index_path),
-                        )
-                        if lunr_path:
-                            generated.append("search-index.json")
-                            logger.debug("generated_prebuilt_lunr_index", path=str(lunr_path))
-                else:
-                    logger.debug(
-                        "lunr_prebuilt_skipped",
-                        reason="lunr package not installed",
-                    )
+            search_backend_config = resolve_search_backend_config(
+                self.site.config.get("search", {})
+            )
+            search_backend = create_search_backend(self.site, search_backend_config)
+            generated_search = search_backend.generate(
+                index_paths,
+                lambda label, factory: self._timed_generate(timings, label, factory),
+            )
+            generated.extend(generated_search)
+            if generated_search:
+                logger.debug(
+                    "generated_search_backend_artifacts",
+                    backend=search_backend.name,
+                    count=len(generated_search),
+                )
 
         if "llm_full" in site_wide:
             separator_width = options.get("llm_separator_width", 80)

--- a/bengal/postprocess/rss.py
+++ b/bengal/postprocess/rss.py
@@ -405,7 +405,9 @@ class AtomGenerator:
         strategy: str,
         default_in_subdir: bool,
     ) -> str:
-        if strategy == "prefix" and (default_in_subdir or code != default_lang):
+        if (strategy == "prefix" and (default_in_subdir or code != default_lang)) or (
+            code != default_lang
+        ):
             return f"{baseurl}/{code}/atom.xml" if baseurl else f"/{code}/atom.xml"
         return f"{baseurl}/atom.xml" if baseurl else "/atom.xml"
 

--- a/bengal/postprocess/rss.py
+++ b/bengal/postprocess/rss.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import heapq
 import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bengal.errors import BengalRenderingError, ErrorCode, record_error
 from bengal.postprocess.utils import indent_xml
@@ -261,3 +261,160 @@ class RSSGenerator:
                     suggestion="Verify pages have valid dates in frontmatter. Add 'date:' to include in RSS.",
                 )
                 raise error from e
+
+
+class AtomGenerator:
+    """Generate Atom 1.0 feeds for content syndication."""
+
+    def __init__(self, site: SiteLike, collector: OutputCollector | None = None) -> None:
+        self.site = site
+        self.logger = get_logger(__name__)
+        self._collector = collector
+
+    def generate(self) -> None:
+        """Generate and write atom.xml to the output directory."""
+        pages_with_dates = [p for p in self.site.pages if p.date and p.in_rss]
+        if not pages_with_dates:
+            self.logger.info(
+                "atom_skipped",
+                reason="no_pages_with_dates",
+                total_pages=len(self.site.pages),
+                hint="No pages have dates set. Add 'date:' to frontmatter to include in Atom feed.",
+            )
+            return
+
+        i18n = self.site.config.get("i18n", {}) or {}
+        strategy = i18n.get("strategy") or "none"
+        default_lang = i18n.get("default_language", "en")
+        default_in_subdir = bool(i18n.get("default_in_subdir", False))
+        lang_codes = self._language_codes(i18n.get("languages") or [], default_lang)
+
+        for code in sorted(set(lang_codes)):
+            pages_for_lang = [
+                p
+                for p in self.site.pages
+                if p.date
+                and p.in_rss
+                and (strategy == "none" or getattr(p, "lang", default_lang) == code)
+            ]
+            sorted_pages = heapq.nlargest(20, pages_for_lang, key=lambda p: p.date)
+            if not sorted_pages:
+                continue
+
+            feed = ET.Element("feed")
+            feed.set("xmlns", "http://www.w3.org/2005/Atom")
+            title = str(self.site.title or "Bengal Site")
+            baseurl = str(self.site.baseurl or "").rstrip("/")
+            description = str(self.site.description or f"{title} Atom Feed")
+            feed_url = self._feed_url(baseurl, code, default_lang, strategy, default_in_subdir)
+
+            ET.SubElement(feed, "title").text = title
+            ET.SubElement(feed, "id").text = baseurl or "/"
+            ET.SubElement(feed, "subtitle").text = description
+            ET.SubElement(feed, "updated").text = sorted_pages[0].date.strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            ET.SubElement(
+                feed,
+                "link",
+                {"href": feed_url, "rel": "self", "type": "application/atom+xml"},
+            )
+            ET.SubElement(feed, "link", {"href": baseurl or "/", "rel": "alternate"})
+
+            for page in sorted_pages:
+                entry = ET.SubElement(feed, "entry")
+                link = self._page_url(page, baseurl)
+                ET.SubElement(entry, "title").text = page.title
+                ET.SubElement(entry, "id").text = link
+                ET.SubElement(entry, "link", {"href": link, "rel": "alternate"})
+                ET.SubElement(entry, "updated").text = page.date.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+                desc = page.metadata.get("description")
+                if not isinstance(desc, str):
+                    desc = getattr(page, "description", None) or getattr(page, "excerpt", "")
+                ET.SubElement(entry, "summary").text = str(desc or "").strip()
+
+            self._write_feed(
+                feed, self._atom_path(code, default_lang, strategy, default_in_subdir), code
+            )
+
+    def _write_feed(self, feed: ET.Element, atom_path: Any, code: str) -> None:
+        from bengal.utils.io.atomic_write import AtomicFile
+
+        atom_path.parent.mkdir(parents=True, exist_ok=True)
+        indent_xml(feed)
+        tree = ET.ElementTree(feed)
+        try:
+            with AtomicFile(atom_path, "wb") as f:
+                tree.write(f, encoding="utf-8", xml_declaration=True)
+
+            if self._collector:
+                from bengal.core.output import OutputType
+
+                self._collector.record(atom_path, OutputType.XML, phase="postprocess")
+
+            self.logger.info("atom_generation_complete", lang=code, atom_path=str(atom_path))
+        except Exception as e:
+            error = BengalRenderingError(
+                f"Atom generation failed for language '{code}': {e}",
+                code=ErrorCode.B008,
+                file_path=atom_path,
+                suggestion="Verify pages have valid dates in frontmatter. Add 'date:' to include in Atom.",
+                original_error=e,
+            )
+            record_error(error, build_phase="postprocess:atom")
+            self.logger.error(
+                "atom_generation_failed",
+                lang=code,
+                atom_path=str(atom_path),
+                error=str(e),
+                error_type=type(e).__name__,
+                error_code=ErrorCode.B008.value,
+            )
+            raise error from e
+
+    def _language_codes(self, languages_cfg: Any, default_lang: str) -> list[str]:
+        lang_codes = []
+        for entry in languages_cfg:
+            if isinstance(entry, dict) and "code" in entry:
+                lang_codes.append(entry["code"])
+            elif isinstance(entry, str):
+                lang_codes.append(entry)
+        if default_lang and default_lang not in lang_codes:
+            lang_codes.append(default_lang)
+        return lang_codes or [default_lang]
+
+    def _atom_path(
+        self,
+        code: str,
+        default_lang: str,
+        strategy: str,
+        default_in_subdir: bool,
+    ) -> Any:
+        if strategy == "prefix" and (default_in_subdir or code != default_lang):
+            return self.site.output_dir / code / "atom.xml"
+        if code == default_lang:
+            return self.site.output_dir / "atom.xml"
+        return self.site.output_dir / code / "atom.xml"
+
+    def _feed_url(
+        self,
+        baseurl: str,
+        code: str,
+        default_lang: str,
+        strategy: str,
+        default_in_subdir: bool,
+    ) -> str:
+        if strategy == "prefix" and (default_in_subdir or code != default_lang):
+            return f"{baseurl}/{code}/atom.xml" if baseurl else f"/{code}/atom.xml"
+        return f"{baseurl}/atom.xml" if baseurl else "/atom.xml"
+
+    def _page_url(self, page: Any, baseurl: str) -> str:
+        if page.output_path:
+            try:
+                rel_path = page.output_path.relative_to(self.site.output_dir)
+                link = f"{baseurl}/{to_posix(rel_path)}" if baseurl else f"/{to_posix(rel_path)}"
+                return link.replace("/index.html", "/")
+            except ValueError:
+                pass
+        return f"{baseurl}/{page.slug}/" if baseurl else f"/{page.slug}/"

--- a/bengal/postprocess/search_backends.py
+++ b/bengal/postprocess/search_backends.py
@@ -1,0 +1,139 @@
+"""Search backend contracts for generated search artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+from bengal.errors import BengalConfigError, ErrorCode
+from bengal.utils.observability.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from bengal.protocols import SiteLike
+
+
+SUPPORTED_SEARCH_BACKENDS = frozenset({"lunr"})
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class SearchBackendConfig:
+    """Resolved search backend configuration."""
+
+    enabled: bool = True
+    backend: str = "lunr"
+    lunr: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def prebuilt_enabled(self) -> bool:
+        """Whether this backend should emit prebuilt search artifacts."""
+        return bool(self.lunr.get("prebuilt", True))
+
+
+class SearchIndexBackend(Protocol):
+    """Provider interface for search artifacts generated from index.json."""
+
+    name: str
+
+    def generate(
+        self,
+        index_paths: list[Path],
+        timed_generate: Callable[[str, Callable[[], Path | None]], Path | None],
+    ) -> list[str]:
+        """Generate backend artifacts for the provided index.json files."""
+        ...
+
+
+def resolve_search_backend_config(config: dict[str, Any] | bool | None) -> SearchBackendConfig:
+    """Resolve public search config into an explicit backend selection."""
+    if config is False:
+        return SearchBackendConfig(enabled=False)
+    if config is True or config is None:
+        return SearchBackendConfig()
+    if not isinstance(config, dict):
+        raise BengalConfigError(
+            "Invalid search configuration: expected a table or boolean.",
+            code=ErrorCode.C004,
+            debug_payload={"value_type": type(config).__name__},
+            suggestion="Set search.enabled to true/false or configure search as a table.",
+        )
+
+    enabled = bool(config.get("enabled", True))
+    backend = str(config.get("backend", "lunr")).strip().lower()
+    if backend not in SUPPORTED_SEARCH_BACKENDS:
+        supported = ", ".join(sorted(SUPPORTED_SEARCH_BACKENDS))
+        raise BengalConfigError(
+            f"Unsupported search backend: {backend!r}.",
+            code=ErrorCode.C003,
+            debug_payload={"backend": backend, "supported": supported},
+            suggestion=f"Use search.backend = 'lunr'. Supported backends: {supported}.",
+        )
+
+    lunr_config = config.get("lunr", {})
+    if lunr_config is None:
+        lunr_config = {}
+    if not isinstance(lunr_config, dict):
+        raise BengalConfigError(
+            "Invalid search.lunr configuration: expected a table.",
+            code=ErrorCode.C004,
+            debug_payload={"value_type": type(lunr_config).__name__},
+            suggestion="Configure Lunr options under search.lunr, or remove the key.",
+        )
+
+    return SearchBackendConfig(enabled=enabled, backend=backend, lunr=dict(lunr_config))
+
+
+class LunrSearchBackend:
+    """Generate Lunr-compatible search artifacts."""
+
+    name = "lunr"
+
+    def __init__(self, site: SiteLike, config: SearchBackendConfig) -> None:
+        self.site = site
+        self.config = config
+
+    def generate(
+        self,
+        index_paths: list[Path],
+        timed_generate: Callable[[str, Callable[[], Path | None]], Path | None],
+    ) -> list[str]:
+        """Generate prebuilt Lunr indexes alongside each index.json."""
+        if not self.config.enabled or not self.config.prebuilt_enabled:
+            return []
+
+        from bengal.postprocess.output_formats.lunr_index_generator import LunrIndexGenerator
+
+        lunr_gen = LunrIndexGenerator(self.site)
+        if not lunr_gen.is_available():
+            logger.debug(
+                "lunr_prebuilt_skipped",
+                reason="lunr package not installed",
+            )
+            return []
+
+        generated = []
+        for index_path in index_paths:
+            lunr_path = timed_generate(
+                "site_lunr_index",
+                lambda index_path=index_path: lunr_gen.generate(index_path),
+            )
+            if lunr_path:
+                generated.append("search-index.json")
+        return generated
+
+
+def create_search_backend(site: SiteLike, config: SearchBackendConfig) -> SearchIndexBackend:
+    """Create the configured search backend adapter."""
+    if config.backend == "lunr":
+        return LunrSearchBackend(site, config)
+
+    supported = ", ".join(sorted(SUPPORTED_SEARCH_BACKENDS))
+    raise BengalConfigError(
+        f"Unsupported search backend: {config.backend!r}.",
+        code=ErrorCode.C003,
+        debug_payload={"backend": config.backend, "supported": supported},
+        suggestion=f"Use search.backend = 'lunr'. Supported backends: {supported}.",
+    )

--- a/bengal/postprocess/social_cards.py
+++ b/bengal/postprocess/social_cards.py
@@ -43,8 +43,9 @@ builds, not during dev server operation.
 from __future__ import annotations
 
 import hashlib
+import json
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 
@@ -54,7 +55,7 @@ from bengal.utils.observability.logger import get_logger
 from bengal.utils.paths.url_normalization import path_to_slug
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import MutableMapping, Sequence
     from pathlib import Path
 
     from bengal.core.output import OutputCollector
@@ -65,6 +66,7 @@ logger = get_logger(__name__)
 # Standard OG image dimensions
 CARD_WIDTH = 1200
 CARD_HEIGHT = 630
+SOCIAL_CARD_FINGERPRINT_PREFIX = "social_card:"
 
 
 # Check if running in free-threading (no-GIL) mode
@@ -168,6 +170,11 @@ def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
     return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))  # type: ignore[return-value]
 
 
+def _string_attr(value: Any) -> str:
+    """Return a stable string for optional site/page presentation values."""
+    return value if isinstance(value, str) else ""
+
+
 class SocialCardGenerator:
     """
     Generates social card (Open Graph) images for pages.
@@ -207,6 +214,7 @@ class SocialCardGenerator:
         site: SiteLike,
         config: SocialCardConfig,
         collector: OutputCollector | None = None,
+        fingerprint_cache: MutableMapping[str, str] | None = None,
     ) -> None:
         """
         Initialize social card generator.
@@ -215,11 +223,14 @@ class SocialCardGenerator:
             site: Site instance with pages and configuration
             config: SocialCardConfig with styling options
             collector: Optional output collector for hot reload tracking
+            fingerprint_cache: Optional persisted cache mapping for card hashes
         """
         self.site = site
         self.config = config
         self._collector = collector
-        self._cache: dict[str, str] = {}
+        self._cache: MutableMapping[str, str] = (
+            fingerprint_cache if fingerprint_cache is not None else {}
+        )
         self._cache_lock = Lock()
         self._title_font: ImageFont.FreeTypeFont | None = None
         self._body_font: ImageFont.FreeTypeFont | None = None
@@ -403,6 +414,23 @@ class SocialCardGenerator:
 
         return None
 
+    def _cache_key(self, page: PageLike) -> str:
+        """Return the persisted fingerprint cache key for a page."""
+        return f"{SOCIAL_CARD_FINGERPRINT_PREFIX}{page.source_path}"
+
+    def _effective_config(self, page: PageLike) -> SocialCardConfig:
+        """Apply supported per-page social card overrides without mutating defaults."""
+        social_card_meta = page.metadata.get("social_card")
+        if not isinstance(social_card_meta, dict):
+            return self.config
+
+        overrides = {}
+        if "background_color" in social_card_meta:
+            overrides["background_color"] = social_card_meta["background_color"]
+        if "accent_color" in social_card_meta:
+            overrides["accent_color"] = social_card_meta["accent_color"]
+        return replace(self.config, **overrides) if overrides else self.config
+
     def _compute_card_hash(self, page: PageLike) -> str:
         """
         Compute content hash for cache key.
@@ -418,14 +446,26 @@ class SocialCardGenerator:
         """
         title = page.title or ""
         description = page.description or ""
-        config_str = (
-            f"{self.config.background_color}|"
-            f"{self.config.text_color}|"
-            f"{self.config.accent_color}|"
-            f"{self.config.template}"
-        )
-        content = f"{title}|{description}|{config_str}"
-        return hashlib.md5(content.encode()).hexdigest()[:12]
+        config = self._effective_config(page)
+        payload = {
+            "accent_color": config.accent_color,
+            "background_color": config.background_color,
+            "body_font": config.body_font,
+            "description": description,
+            "format": config.format,
+            "logo": config.logo,
+            "quality": config.quality,
+            "secondary_color": config.secondary_color,
+            "show_site_name": config.show_site_name,
+            "site_name": _string_attr(getattr(self.site, "title", "")),
+            "site_url": _string_attr(getattr(self.site, "baseurl", "")),
+            "template": config.template,
+            "text_color": config.text_color,
+            "title": title,
+            "title_font": config.title_font,
+        }
+        content = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(content.encode()).hexdigest()[:16]
 
     def _should_regenerate(self, page: PageLike, output_path: Path) -> bool:
         """
@@ -448,7 +488,7 @@ class SocialCardGenerator:
             return True
 
         current_hash = self._compute_card_hash(page)
-        page_key = str(page.source_path)
+        page_key = self._cache_key(page)
 
         with self._cache_lock:
             cached_hash = self._cache.get(page_key)
@@ -728,22 +768,12 @@ class SocialCardGenerator:
         # Get content
         title = page.title or "Untitled"
         description = page.description or ""
-        site_name = self.site.title or ""
-        site_url = self.site.baseurl or ""
+        site_name = _string_attr(getattr(self.site, "title", ""))
+        site_url = _string_attr(getattr(self.site, "baseurl", ""))
 
         # Apply per-page overrides using a local copy to avoid mutating shared config
         # This prevents one page's overrides from affecting subsequent pages
-        config = self.config
-        if isinstance(social_card_meta, dict):
-            from dataclasses import replace
-
-            overrides = {}
-            if "background_color" in social_card_meta:
-                overrides["background_color"] = social_card_meta["background_color"]
-            if "accent_color" in social_card_meta:
-                overrides["accent_color"] = social_card_meta["accent_color"]
-            if overrides:
-                config = replace(self.config, **overrides)
+        config = self._effective_config(page)
 
         # Select template (use local config for per-page overrides)
         template = config.template
@@ -771,7 +801,7 @@ class SocialCardGenerator:
             self._collector.record(output_path, OutputType.IMAGE, phase="postprocess")
 
         # Update cache
-        page_key = str(page.source_path)
+        page_key = self._cache_key(page)
         current_hash = self._compute_card_hash(page)
         with self._cache_lock:
             self._cache[page_key] = current_hash

--- a/bengal/rendering/engines/kida.py
+++ b/bengal/rendering/engines/kida.py
@@ -748,7 +748,8 @@ class KidaTemplateEngine:
         Invalidate the menu dict cache.
 
         Call this after menus are rebuilt to ensure fresh dicts are generated.
-        This ensures active menu states are correct for each page render.
+        Page-specific active state is computed in templates from the current
+        page URL so cached menu dictionaries can be reused across renders.
         """
         self._menu_dict_cache.clear()
 

--- a/bengal/rendering/pipeline/autodoc_renderer.py
+++ b/bengal/rendering/pipeline/autodoc_renderer.py
@@ -201,8 +201,8 @@ class AutodocRenderer:
         Render an autodoc page using the site's template engine.
 
         NOTE: This is the ONLY rendering path for autodoc pages. The deferred
-        rendering architecture ensures full template context (menus, active states,
-        versioning) is available. See bengal/autodoc/README.md for details.
+        rendering architecture ensures full template context, including menus and
+        versioning, is available. See bengal/autodoc/README.md for details.
 
         This is called during the rendering phase (after menus are built),
         ensuring full template context is available for proper header/nav rendering.
@@ -212,10 +212,6 @@ class AutodocRenderer:
         """
         element = self._normalize_autodoc_element(page.metadata.get("autodoc_element"))
         template_name = page.metadata.get("_autodoc_template", "autodoc/python/module")
-
-        # Mark active menu items for this page
-        if hasattr(self.site, "mark_active_menu_items"):
-            self.site.mark_active_menu_items(page)
 
         # Load template with proper error handling
         # Distinguishes between syntax errors (fail fast) and not-found errors (fallback)

--- a/bengal/rendering/renderer.py
+++ b/bengal/rendering/renderer.py
@@ -399,10 +399,6 @@ class Renderer:
                     has_markers=has_markers,
                 )
 
-        # Mark active menu items for this page
-        if hasattr(self.site, "mark_active_menu_items"):
-            self.site.mark_active_menu_items(page)
-
         # Determine which template to use
         template_name = self._get_template_name(page)
 

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -1207,6 +1207,37 @@ class BuildTrigger:
                     if path == spec_path or path.resolve() == spec_path.resolve():
                         return True
 
+            try:
+                cache = getattr(self.site, "_cache", None)
+                if cache is None:
+                    from bengal.cache import BuildCache
+
+                    cache_path = self.site.config_service.paths.build_cache
+                    if cache_path.exists():
+                        cache = BuildCache.load(cache_path)
+
+                if cache is not None and hasattr(cache, "autodoc_tracker"):
+                    for source in cache.autodoc_tracker.get_autodoc_source_files():
+                        source_path = Path(source)
+                        candidates = [source_path]
+                        if not source_path.is_absolute():
+                            candidates.extend(
+                                [
+                                    self.site.root_path / source_path,
+                                    self.site.root_path.parent / source_path,
+                                ]
+                            )
+                        resolved_candidates = {candidate.resolve() for candidate in candidates}
+                        for path in changed_paths:
+                            if path.resolve() in resolved_candidates:
+                                return True
+            except Exception as exc:
+                logger.debug(
+                    "autodoc_dependency_change_check_failed",
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+
         return False
 
     def _display_stats(self, result: BuildResult, incremental: bool) -> None:

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -1052,11 +1052,18 @@ class BuildTrigger:
                     affected_pages=0,
                     reason="dependency_data_missing",
                 )
+                logger.info(
+                    "template_change_full_rebuild",
+                    template=str(path),
+                    affected_pages=0,
+                    reason="dependency_data_missing",
+                    suggestion="Run one full build to populate template dependency data.",
+                )
                 return True
 
             # Has dependents - check if we can do incremental update
             if self._can_use_incremental_template_update(path, cache):
-                logger.debug(
+                logger.info(
                     "template_change_incremental",
                     template=str(path),
                     affected_pages=len(affected),
@@ -1064,7 +1071,7 @@ class BuildTrigger:
                 continue  # Will be handled by incremental build
 
             # Must do full rebuild
-            logger.debug(
+            logger.info(
                 "template_change_full_rebuild",
                 template=str(path),
                 affected_pages=len(affected),

--- a/bengal/themes/default/templates/TEMPLATE-CONTEXT.md
+++ b/bengal/themes/default/templates/TEMPLATE-CONTEXT.md
@@ -230,7 +230,7 @@ Properties available on `site`:
 | `site.sections` | All sections |
 | `site.theme_config` | Theme configuration |
 | `site.versioning_enabled` | Is versioning on? |
-| `site.versions` | Available versions |
+| `site.versions` | Available versions; each item includes `id`, `label`, `latest`, `status`, `deprecated`, `url_prefix`, `release_date`, and `end_of_life` |
 
 ---
 

--- a/bengal/themes/default/templates/partials/version-selector.html
+++ b/bengal/themes/default/templates/partials/version-selector.html
@@ -6,7 +6,7 @@ Only renders when versioning is enabled.
 
 Available context:
 - versioning_enabled: bool - Whether versioning is enabled
-- versions: list[dict] - All versions with id, label, latest, url_prefix
+- versions: list[dict] - All versions with id, label, latest, status, deprecated, url_prefix
 - current_version: dict|None - Current page's version info
 - is_latest_version: bool - Whether current page is latest version
 
@@ -51,10 +51,10 @@ engine (Jinja2, Mako, or BYORenderer). No global function dependency.
   #}
   <select id="version-select" class="version-selector__select" aria-label="Select documentation version">
     {% for v in versions %}
-    <option value="{{ v.url_prefix or '/' }}" data-target="{{ site.get_version_target_url(page, v) }}" {% if
+    <option value="{{ v.url_prefix or '/' }}" data-target="{{ site.get_version_target_url(page, v) }}" data-status="{{ v.status or (v.deprecated and 'deprecated' or 'legacy') }}" {% if
       current_version and current_version.id==v.id %}selected{% end %} {% if v.deprecated %}class="version-deprecated"
       {% end %}>
-      {{ v.label }}{% if v.latest %} (Latest){% end %}{% if v.deprecated %} ⚠️{% end %}
+      {{ v.label }}{% if v.latest %} (Latest){% end %}{% if v.status == 'preview' %} (Preview){% end %}{% if v.deprecated %} ⚠️{% end %}
     </option>
     {% end %}
   </select>

--- a/changelog.d/atom-feed.changed.md
+++ b/changelog.d/atom-feed.changed.md
@@ -1,1 +1,1 @@
-Sites can now opt into Atom feed generation with `generate_atom` or `features.atom`, producing `atom.xml` alongside existing RSS support.
+Sites can now opt into Atom feed generation with `generate_atom` or `features.atom`, producing `atom.xml` alongside existing RSS support with language-specific self links.

--- a/changelog.d/atom-feed.changed.md
+++ b/changelog.d/atom-feed.changed.md
@@ -1,0 +1,1 @@
+Sites can now opt into Atom feed generation with `generate_atom` or `features.atom`, producing `atom.xml` alongside existing RSS support.

--- a/changelog.d/openapi-local-ref-dependencies.changed.md
+++ b/changelog.d/openapi-local-ref-dependencies.changed.md
@@ -1,0 +1,1 @@
+OpenAPI autodoc now resolves local file-relative `$ref` entries and tracks the resolved files as incremental build dependencies.

--- a/changelog.d/plugin-directive-role-wiring.changed.md
+++ b/changelog.d/plugin-directive-role-wiring.changed.md
@@ -1,0 +1,1 @@
+Wire plugin-provided Patitas directives and roles into parser setup and mark those plugin capabilities ready in plugin inspection.

--- a/changelog.d/rendering-social-jsonld-validation.changed.md
+++ b/changelog.d/rendering-social-jsonld-validation.changed.md
@@ -1,0 +1,1 @@
+Rendering health checks now warn about missing share-card metadata and malformed JSON-LD blocks in generated HTML.

--- a/changelog.d/search-backend-contract.changed.md
+++ b/changelog.d/search-backend-contract.changed.md
@@ -1,0 +1,1 @@
+Search configuration now has an explicit `search.backend` contract, defaulting to the existing Lunr backend without changing generated artifact paths.

--- a/changelog.d/server-template-rebuild-diagnostics.changed.md
+++ b/changelog.d/server-template-rebuild-diagnostics.changed.md
@@ -1,0 +1,1 @@
+Explain dev-server template rebuild decisions at info level, including template dependency cache misses and incremental template rebuilds.

--- a/changelog.d/social-card-persistent-fingerprints.changed.md
+++ b/changelog.d/social-card-persistent-fingerprints.changed.md
@@ -1,1 +1,1 @@
-Social cards now persist rendered-input fingerprints in the build cache so full builds can reuse unchanged generated card files.
+Social cards now persist rendered-input fingerprints in the build cache so full builds can reuse unchanged generated card files without sharing the output-format fingerprint map during card generation.

--- a/changelog.d/social-card-persistent-fingerprints.changed.md
+++ b/changelog.d/social-card-persistent-fingerprints.changed.md
@@ -1,0 +1,1 @@
+Social cards now persist rendered-input fingerprints in the build cache so full builds can reuse unchanged generated card files.

--- a/changelog.d/version-status-config.changed.md
+++ b/changelog.d/version-status-config.changed.md
@@ -1,0 +1,1 @@
+Versioned documentation configs can now set `status` to `current`, `legacy`, `deprecated`, `preview`, or `eol`; existing `deprecated: true` configs remain supported.

--- a/site/config/_default/features.yaml
+++ b/site/config/_default/features.yaml
@@ -6,6 +6,7 @@
 features:
   # Output Formats (files generated during build)
   rss: true        # Generate rss.xml feed
+  atom: false      # Generate atom.xml feed
   sitemap: true    # Generate sitemap.xml for SEO
   search: true     # Generate search index (index.json)
   json: true       # Generate per-page JSON files (page.json)

--- a/site/config/_default/outputs.yaml
+++ b/site/config/_default/outputs.yaml
@@ -7,6 +7,7 @@
 features:
   # Output Formats (files generated during build)
   rss: true        # Generate rss.xml feed
+  atom: false      # Generate atom.xml feed
   sitemap: true    # Generate sitemap.xml for SEO
   search: true     # Generate search index (index.json)
   json: true       # Generate per-page JSON files (page.json)

--- a/site/config/_default/search.yaml
+++ b/site/config/_default/search.yaml
@@ -4,6 +4,7 @@
 
 search:
   enabled: true  # Enable search functionality
+  backend: lunr  # Built-in local backend. Additional backends must declare their artifact contract.
 
   # Lunr.js settings (client-side search engine)
   lunr:

--- a/site/content/docs/building/output-formats.md
+++ b/site/content/docs/building/output-formats.md
@@ -102,6 +102,10 @@ pip install "bengal[search]"
 ```
 
 This generates `search-index.json` (a pre-serialized Lunr index) in addition to `index.json`, which loads faster in the browser.
+Bengal's search backend is explicit and defaults to `search.backend: lunr`.
+`index.json` remains the stable source artifact for client-side search, and
+`search-index.json` is emitted only by the Lunr backend when prebuilding is
+enabled.
 :::
 
 ```html

--- a/site/content/docs/building/seo.md
+++ b/site/content/docs/building/seo.md
@@ -75,6 +75,10 @@ For projects that rely on docs links shared in Slack, Discord, X, or GitHub,
 social cards are one of the highest-leverage discovery features after page titles and
 descriptions.
 
+Social card generation stores content fingerprints in Bengal's build cache. A
+full build reuses an existing generated card when the page title, description,
+site branding, image format, or card styling inputs have not changed.
+
 ### On-Site Discovery
 
 Bengal also improves discovery inside the site itself:

--- a/site/content/docs/building/seo.md
+++ b/site/content/docs/building/seo.md
@@ -53,7 +53,7 @@ template helpers that power these tags.
 Bengal's post-processing pipeline includes:
 
 - XML sitemap generation for search engines
-- RSS feeds for blog-style content
+- RSS and optional Atom feeds for blog-style content
 - Generated special pages such as `404`
 - Generated `robots.txt` with [Content Signals](https://contentsignals.org/) directives
 - Version-aware canonical URLs for versioned documentation

--- a/site/content/docs/content/sources/autodoc.md
+++ b/site/content/docs/content/sources/autodoc.md
@@ -103,6 +103,11 @@ Extracts:
 - Endpoint documentation
 - Request/response schemas
 - Authentication requirements
+
+Local OpenAPI `$ref` files are supported relative to the document that declares
+the reference, such as `./schemas.yaml#/User`. Bengal tracks those files as
+autodoc dependencies for incremental rebuilds. Remote URL refs are intentionally
+left unresolved.
 :::{/tab-item}
 :::{/tab-set}
 

--- a/site/content/docs/content/validation/validate-and-fix.md
+++ b/site/content/docs/content/validation/validate-and-fix.md
@@ -110,7 +110,7 @@ Bengal includes validators organized by phase:
 
 | Validator | Checks | Common Issues |
 |-----------|--------|---------------|
-| **Rendering** | HTML output quality | Template errors, undefined variables |
+| **Rendering** | HTML output quality | Template errors, undefined variables, missing social tags, malformed JSON-LD |
 | **Output** | Generated pages, assets | Missing output, structure errors |
 | **Asset URLs** | Asset references in HTML | Broken asset paths, fingerprinting mismatches, case issues |
 | **Performance** | Build metrics | Slow builds, large pages |

--- a/site/content/docs/content/versioning/_index.md
+++ b/site/content/docs/content/versioning/_index.md
@@ -121,12 +121,15 @@ Older versions automatically display a warning banner linking to the latest docs
 ```yaml
 versions:
   - id: v2
+    status: legacy
     banner:
       type: warning  # or: info, danger
       message: "You're viewing docs for v2. See the latest version."
 ```
 
 Banner types: `info` (blue), `warning` (yellow), `danger` (red for deprecated versions).
+Version status can be `current`, `legacy`, `deprecated`, `preview`, or `eol`.
+The older `deprecated: true` key still works and is treated like `status: deprecated`.
 
 ### Cross-Version Links
 

--- a/site/content/docs/content/versioning/folder-mode.md
+++ b/site/content/docs/content/versioning/folder-mode.md
@@ -122,7 +122,8 @@ versioning:
 
     - id: v1
       label: "1.0"
-      deprecated: true          # Marks version as deprecated
+      status: deprecated        # current, legacy, deprecated, preview, or eol
+      deprecated: true          # Backward-compatible alias for status: deprecated
       end_of_life: "2024-12-31" # Optional: EOL date
 
   # Aliases for version IDs

--- a/site/content/docs/reference/architecture/rendering/postprocess.md
+++ b/site/content/docs/reference/architecture/rendering/postprocess.md
@@ -213,3 +213,5 @@ with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
 - Social cards (if enabled)
 
 **Incremental builds**: Skip expensive tasks (sitemap, RSS, social cards) for faster dev server response. Output formats always regenerate to keep search index current.
+
+**Social card cache**: Full builds persist social-card input fingerprints in the build cache and skip writing cards whose generated file still exists and whose rendered inputs are unchanged.

--- a/site/content/docs/reference/architecture/rendering/postprocess.md
+++ b/site/content/docs/reference/architecture/rendering/postprocess.md
@@ -69,13 +69,14 @@ Sitemap behavior is automatic:
 </urlset>
 ```
 
-## RSS Generator (`bengal/postprocess/rss.py`)
+## RSS And Atom Generators (`bengal/postprocess/rss.py`)
 
 ### Purpose
-Generates RSS feed for blog posts
+Generates RSS and Atom feeds for blog posts
 
 ### Features
-- Generates RSS 2.0 feed
+- Generates RSS 2.0 feed as `rss.xml`
+- Generates Atom 1.0 feed as `atom.xml` when enabled
 - Includes 20 most recent posts with dates
 - Uses page description or excerpt (first 200 chars)
 - Sorted by date (newest first)
@@ -87,6 +88,9 @@ Generates RSS feed for blog posts
 ```toml
 # Enable/disable RSS generation (default: true)
 generate_rss = true
+
+# Enable/disable Atom generation (default: false)
+generate_atom = false
 ```
 
 RSS behavior is automatic:

--- a/site/content/docs/reference/architecture/subsystems/autodoc.md
+++ b/site/content/docs/reference/architecture/subsystems/autodoc.md
@@ -136,3 +136,9 @@ spec_file = "openapi.yaml"  # Or openapi.json
 ```
 
 This generates endpoint documentation with request/response schemas, parameters, and examples.
+
+OpenAPI `$ref` entries may point to local files relative to the document that
+contains the reference, for example `./schemas.yaml#/User`. Bengal resolves
+those local YAML/JSON files during extraction and records them as autodoc
+dependencies so warm and dev-server builds regenerate API pages when shared
+schema files change. Remote `http` and `https` refs are not fetched.

--- a/site/content/docs/reference/architecture/subsystems/health.md
+++ b/site/content/docs/reference/architecture/subsystems/health.md
@@ -128,7 +128,7 @@ Validators are registered in phases based on execution cost and dependencies.
 **Phase 2 - Content Validation:**
 | Validator | Validates |
 |-----------|-----------|
-| **RenderingValidator** | HTML quality, template function usage, SEO metadata |
+| **RenderingValidator** | HTML quality, unrendered template syntax, SEO/social metadata, JSON-LD syntax |
 | **DirectiveValidator** | Directive syntax, completeness, and performance |
 | **NavigationValidator** | Page navigation (next/prev, breadcrumbs, ancestors) |
 | **MenuValidator** | Menu structure integrity, circular reference detection |

--- a/site/content/docs/reference/template-functions/seo-image-functions.md
+++ b/site/content/docs/reference/template-functions/seo-image-functions.md
@@ -53,6 +53,8 @@ Generate Open Graph image URL. Supports manual image, auto-generated social card
 ## get_social_card_url
 
 Get URL to generated social card for a page (if social cards are enabled).
+Generated cards are cached by rendered inputs, so repeated full builds reuse
+unchanged card files.
 
 ```kida
 {% let card = get_social_card_url(page) %}

--- a/tests/unit/autodoc/test_openapi_external_refs.py
+++ b/tests/unit/autodoc/test_openapi_external_refs.py
@@ -1,0 +1,135 @@
+"""Tests for local OpenAPI $ref resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, Mock
+
+from bengal.autodoc.extractors.openapi import OpenAPIExtractor
+from bengal.autodoc.orchestration import VirtualAutodocOrchestrator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_openapi_with_external_schema(tmp_path: Path) -> tuple[Path, Path]:
+    spec_path = tmp_path / "openapi.yaml"
+    schemas_path = tmp_path / "schemas.yaml"
+
+    spec_path.write_text(
+        """openapi: 3.1.0
+info:
+  title: Demo API
+  version: "1.0.0"
+paths:
+  /users:
+    get:
+      tags: [users]
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas.yaml#/User"
+components:
+  schemas:
+    User:
+      $ref: "./schemas.yaml#/User"
+""",
+        encoding="utf-8",
+    )
+    schemas_path.write_text(
+        """User:
+  type: object
+  description: A user from a shared schema file.
+  properties:
+    id:
+      type: string
+    profile:
+      $ref: "./schemas.yaml#/Profile"
+Profile:
+  type: object
+  properties:
+    display_name:
+      type: string
+""",
+        encoding="utf-8",
+    )
+    return spec_path, schemas_path
+
+
+def _make_site(tmp_path: Path, spec_path: Path) -> MagicMock:
+    site = MagicMock()
+    site.root_path = tmp_path
+    site.output_dir = tmp_path / "public"
+    site.baseurl = "/"
+    site.config = {
+        "autodoc": {
+            "openapi": {
+                "enabled": True,
+                "spec_file": str(spec_path),
+            }
+        }
+    }
+    site.theme = "default"
+    site.theme_config = {}
+    site.menu = {"main": []}
+    site.menu_localized = {}
+    site.registry = Mock()
+    site.registry.epoch = 0
+    site.registry.register_section = Mock()
+    site.registry.get_section = Mock(return_value=None)
+    return site
+
+
+def test_resolves_file_relative_schema_refs_and_tracks_sources(tmp_path: Path) -> None:
+    spec_path, schemas_path = _write_openapi_with_external_schema(tmp_path)
+
+    elements = OpenAPIExtractor().extract(spec_path)
+    user_schema = next(element for element in elements if element.name == "User")
+
+    assert user_schema.description == "A user from a shared schema file."
+    assert user_schema.metadata["properties"]["id"]["type"] == "string"
+    assert (
+        user_schema.metadata["properties"]["profile"]["properties"]["display_name"]["type"]
+        == "string"
+    )
+    assert set(user_schema.metadata["source_dependencies"]) == {
+        str(spec_path.resolve()),
+        str(schemas_path.resolve()),
+    }
+
+
+def test_unresolved_file_refs_are_preserved_with_partial_extraction(tmp_path: Path) -> None:
+    spec_path = tmp_path / "openapi.yaml"
+    spec_path.write_text(
+        """openapi: 3.1.0
+info:
+  title: Demo API
+  version: "1.0.0"
+paths: {}
+components:
+  schemas:
+    Missing:
+      $ref: "./missing.yaml#/Missing"
+""",
+        encoding="utf-8",
+    )
+
+    elements = OpenAPIExtractor().extract(spec_path)
+    missing_schema = next(element for element in elements if element.name == "Missing")
+
+    assert missing_schema.metadata["raw_schema"] == {"$ref": "./missing.yaml#/Missing"}
+    assert missing_schema.metadata["source_dependencies"] == (str(spec_path.resolve()),)
+
+
+def test_virtual_openapi_pages_depend_on_external_ref_files(tmp_path: Path) -> None:
+    spec_path, schemas_path = _write_openapi_with_external_schema(tmp_path)
+    site = _make_site(tmp_path, spec_path)
+
+    _pages, _sections, result = VirtualAutodocOrchestrator(site).generate()
+
+    assert str(spec_path) in result.autodoc_dependencies
+    assert str(schemas_path.resolve()) in result.autodoc_dependencies
+    assert result.autodoc_dependencies[str(schemas_path.resolve())]

--- a/tests/unit/cli/test_plugin_command.py
+++ b/tests/unit/cli/test_plugin_command.py
@@ -53,12 +53,12 @@ def test_plugin_list_reports_no_plugins(monkeypatch) -> None:
 def test_plugin_validate_fails_on_pending_capability(monkeypatch) -> None:
     cli = FakeCLI()
     report = PluginInspection(
-        entry_point="directive",
-        value="example:DirectivePlugin",
-        plugin_name="directive-plugin",
+        entry_point="content-source",
+        value="example:ContentSourcePlugin",
+        plugin_name="content-source-plugin",
         version="1.0.0",
         status="partial",
-        capabilities={"directives": 1},
+        capabilities={"content_sources": 1},
     )
     monkeypatch.setattr(plugin_command, "_load_reports", lambda: [report])
     monkeypatch.setattr("bengal.output.get_cli_output", lambda: cli)
@@ -69,4 +69,4 @@ def test_plugin_validate_fails_on_pending_capability(monkeypatch) -> None:
     assert cli.renders
     _template, context = cli.renders[0]
     assert context["summary"]["warnings"] == 1
-    assert "directives registered" in context["issues"][0]["message"]
+    assert "content_sources registered" in context["issues"][0]["message"]

--- a/tests/unit/config/test_feature_mappings.py
+++ b/tests/unit/config/test_feature_mappings.py
@@ -20,6 +20,14 @@ class TestExpandFeatures:
         assert "rss" in result.get("output_formats", {}).get("site_wide", [])
         assert "features" not in result  # Features removed after expansion
 
+    def test_expand_atom_feature(self):
+        """Test Atom feature expansion."""
+        config = {"features": {"atom": True}}
+
+        result = expand_features(config)
+
+        assert result["generate_atom"] is True
+
     def test_expand_search_feature(self):
         """Test search feature expansion."""
         config = {"features": {"search": True}}
@@ -150,7 +158,7 @@ class TestGetAvailableFeatures:
         """Test returned list contains expected features."""
         features = get_available_features()
 
-        expected = ["rss", "sitemap", "search", "json", "llm_txt", "validate_links"]
+        expected = ["rss", "atom", "sitemap", "search", "json", "llm_txt", "validate_links"]
         for feature in expected:
             assert feature in features
 

--- a/tests/unit/core/test_version_status.py
+++ b/tests/unit/core/test_version_status.py
@@ -1,0 +1,81 @@
+"""Tests for version lifecycle status compatibility."""
+
+from __future__ import annotations
+
+import pytest
+
+from bengal.core.version import Version, VersionConfig
+
+
+def test_deprecated_bool_derives_deprecated_status() -> None:
+    version = Version(id="v1", deprecated=True)
+
+    assert version.status == "deprecated"
+    assert version.deprecated is True
+    assert version.to_dict()["status"] == "deprecated"
+    assert version.to_dict()["deprecated"] is True
+
+
+def test_explicit_status_wins_over_deprecated_alias() -> None:
+    version = Version(id="v1", status="legacy", deprecated=True)
+
+    assert version.status == "legacy"
+    assert version.deprecated is False
+
+
+def test_eol_status_remains_template_deprecated() -> None:
+    version = Version(id="v1", status="eol")
+
+    assert version.status == "eol"
+    assert version.deprecated is True
+    assert version.to_dict()["status"] == "eol"
+    assert version.to_dict()["deprecated"] is True
+
+
+def test_from_config_accepts_status_and_deprecated_alias() -> None:
+    config = VersionConfig.from_config(
+        {
+            "versioning": {
+                "enabled": True,
+                "versions": [
+                    {"id": "v3", "latest": True, "status": "current"},
+                    {"id": "v2", "status": "preview"},
+                    {"id": "v1", "deprecated": True},
+                ],
+            }
+        }
+    )
+
+    assert [version.status for version in config.versions] == [
+        "current",
+        "preview",
+        "deprecated",
+    ]
+    assert [version.deprecated for version in config.versions] == [False, False, True]
+
+
+def test_string_versions_keep_latest_current_and_older_legacy() -> None:
+    config = VersionConfig.from_config({"versioning": {"enabled": True, "versions": ["v3", "v2"]}})
+
+    assert [version.status for version in config.versions] == ["current", "legacy"]
+
+
+def test_first_version_inferred_as_current_when_latest_omitted() -> None:
+    config = VersionConfig(enabled=True, versions=[Version(id="v1")])
+
+    assert config.versions[0].latest is True
+    assert config.versions[0].status == "current"
+
+
+def test_invalid_status_says_what_to_use() -> None:
+    with pytest.raises(
+        ValueError, match="Expected one of: current, deprecated, eol, legacy, preview"
+    ):
+        VersionConfig.from_config(
+            {
+                "versioning": {
+                    "enabled": True,
+                    "versions": [{"id": "v1", "status": "unsupported"}],
+                }
+            }
+        )

--- a/tests/unit/health/validators/test_rendering.py
+++ b/tests/unit/health/validators/test_rendering.py
@@ -60,6 +60,9 @@ VALID_HTML = """<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta name="description" _raw_content="Test page">
+    <meta property="og:title" content="Test Page">
+    <meta property="og:url" content="https://example.com/test/">
+    <meta name="twitter:card" content="summary_large_image">
     <title>Test Page</title>
 </head>
 <body>
@@ -231,6 +234,85 @@ class TestRenderingValidatorSEOMetadata:
         warning_results = [r for r in results if r.status == CheckStatus.WARNING]
         seo_warnings = [r for r in warning_results if "seo" in r.message.lower()]
         assert len(seo_warnings) == 0
+
+
+class TestRenderingValidatorSocialMetadata:
+    """Tests for social metadata validation."""
+
+    def test_success_when_social_metadata_present(self, validator, mock_site, tmp_path):
+        """Returns success when Open Graph and Twitter metadata are present."""
+        page = create_page(mock_site.output_dir, "social.html", VALID_HTML)
+        mock_site.pages = [page]
+
+        results = validator.validate(mock_site)
+
+        assert "social metadata" in result_text(results).lower()
+
+    def test_warning_for_missing_social_metadata(self, validator, mock_site, tmp_path):
+        """Returns warning for pages missing share-card metadata."""
+        no_social = """<!DOCTYPE html>
+<html><head><title>Test</title>
+<meta name="description" _raw_content="Test"></head><body></body></html>"""
+        page = create_page(mock_site.output_dir, "no-social.html", no_social)
+        mock_site.pages = [page]
+
+        results = validator.validate(mock_site)
+
+        warning_results = [r for r in results if r.status == CheckStatus.WARNING]
+        assert any(r.code == "H034" for r in warning_results)
+
+    def test_skips_generated_pages_for_social_metadata(self, validator, mock_site, tmp_path):
+        """Generated pages do not need share-card metadata."""
+        no_social = """<!DOCTYPE html>
+<html><head><title>Generated</title>
+<meta name="description" _raw_content="Generated"></head><body></body></html>"""
+        page = create_page(mock_site.output_dir, "generated.html", no_social, generated=True)
+        mock_site.pages = [page]
+
+        results = validator.validate(mock_site)
+
+        warning_results = [r for r in results if r.status == CheckStatus.WARNING]
+        assert all(r.code != "H034" for r in warning_results)
+
+
+class TestRenderingValidatorJsonLd:
+    """Tests for JSON-LD validation."""
+
+    def test_success_when_json_ld_is_valid(self, validator, mock_site, tmp_path):
+        """Returns success for valid application/ld+json scripts."""
+        html = VALID_HTML.replace(
+            "</head>",
+            '<script type="application/ld+json">{"@context":"https://schema.org"}</script></head>',
+        )
+        page = create_page(mock_site.output_dir, "jsonld.html", html)
+        mock_site.pages = [page]
+
+        results = validator.validate(mock_site)
+
+        assert "json-ld" in result_text(results).lower()
+
+    def test_warning_for_invalid_json_ld(self, validator, mock_site, tmp_path):
+        """Returns warning for malformed application/ld+json scripts."""
+        html = VALID_HTML.replace(
+            "</head>",
+            '<script type="application/ld+json">{"@context":</script></head>',
+        )
+        page = create_page(mock_site.output_dir, "bad-jsonld.html", html)
+        mock_site.pages = [page]
+
+        results = validator.validate(mock_site)
+
+        warning_results = [r for r in results if r.status == CheckStatus.WARNING]
+        assert any(r.code == "H035" for r in warning_results)
+
+    def test_skips_pages_without_json_ld(self, validator, mock_site, tmp_path):
+        """Pages without JSON-LD scripts still get a JSON-LD success result."""
+        page = create_page(mock_site.output_dir, "no-jsonld.html", VALID_HTML)
+        mock_site.pages = [page]
+
+        results = validator.validate(mock_site)
+
+        assert "json-ld" in result_text(results).lower()
 
 
 class TestRenderingValidatorPrivateMethods:

--- a/tests/unit/plugins/test_plugin_inspection.py
+++ b/tests/unit/plugins/test_plugin_inspection.py
@@ -40,6 +40,14 @@ class DirectivePlugin:
         registry.add_directive(object())
 
 
+class RolePlugin:
+    name = "role-plugin"
+    version = "1.0.0"
+
+    def register(self, registry):
+        registry.add_role(object())
+
+
 class ExplodingPlugin:
     def __init__(self):
         msg = "boom"
@@ -61,15 +69,24 @@ def test_template_and_phase_plugin_reports_ready_capabilities() -> None:
     assert report.pending_capabilities == ()
 
 
-def test_pending_capability_reports_partial_status() -> None:
+def test_directive_plugin_reports_ready_capability() -> None:
     report = inspect_entry_point(
         FakeEntryPoint("directive", "example:DirectivePlugin", DirectivePlugin)
     )
 
-    assert report.status == "partial"
-    assert report.ready is False
+    assert report.status == "ready"
+    assert report.ready is True
     assert report.capabilities["directives"] == 1
-    assert report.pending_capabilities == ("directives",)
+    assert report.pending_capabilities == ()
+
+
+def test_role_plugin_reports_ready_capability() -> None:
+    report = inspect_entry_point(FakeEntryPoint("role", "example:RolePlugin", RolePlugin))
+
+    assert report.status == "ready"
+    assert report.ready is True
+    assert report.capabilities["roles"] == 1
+    assert report.pending_capabilities == ()
 
 
 def test_load_error_is_reported_without_raising() -> None:
@@ -97,10 +114,12 @@ def test_instantiation_error_is_reported_without_raising() -> None:
     assert report.errors == ("RuntimeError: boom",)
 
 
-def test_capability_details_mark_pending_integrations() -> None:
-    details = capability_details({"directives": 1, "template_filters": 1})
+def test_capability_details_mark_ready_integrations() -> None:
+    details = capability_details({"directives": 1, "roles": 1, "template_filters": 1})
     by_name = {item["name"]: item for item in details}
 
-    assert CAPABILITY_INTEGRATION_STATUS["directives"] == "pending"
-    assert by_name["directives"]["ready"] is False
+    assert CAPABILITY_INTEGRATION_STATUS["directives"] == "ready"
+    assert CAPABILITY_INTEGRATION_STATUS["roles"] == "ready"
+    assert by_name["directives"]["ready"] is True
+    assert by_name["roles"]["ready"] is True
     assert by_name["template_filters"]["ready"] is True

--- a/tests/unit/plugins/test_plugin_parser_wiring.py
+++ b/tests/unit/plugins/test_plugin_parser_wiring.py
@@ -1,0 +1,55 @@
+"""Tests for plugin directive and role wiring into Patitas parser registries."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from bengal.parsing import PatitasParser
+from bengal.parsing.backends.patitas.directives.registry import create_default_registry
+from bengal.parsing.backends.patitas.roles.registry import (
+    create_default_registry as create_default_role_registry,
+)
+from bengal.plugins import set_active_registry
+from bengal.plugins.registry import PluginRegistry
+
+
+class PluginDirective:
+    names: ClassVar[tuple[str, ...]] = ("plugin-note",)
+    token_type: ClassVar[str] = "plugin_note"
+
+
+class PluginRole:
+    names: ClassVar[tuple[str, ...]] = ("plugin-role",)
+    token_type: ClassVar[str] = "plugin_role"
+
+
+def _plugin_registry():
+    registry = PluginRegistry()
+    registry.add_directive(PluginDirective())
+    registry.add_role(PluginRole())
+    return registry.freeze()
+
+
+def test_plugin_directives_are_added_to_default_registry() -> None:
+    registry = create_default_registry(plugin_registry=_plugin_registry())
+
+    assert registry.get("plugin-note") is not None
+    assert registry.get_by_token_type("plugin_note") is not None
+
+
+def test_plugin_roles_are_added_to_default_registry() -> None:
+    registry = create_default_role_registry(plugin_registry=_plugin_registry())
+
+    assert registry.get("plugin-role") is not None
+    assert registry.get_by_token_type("plugin_role") is not None
+
+
+def test_patitas_parser_uses_active_plugin_registry() -> None:
+    set_active_registry(_plugin_registry())
+    try:
+        parser = PatitasParser(enable_highlighting=False)
+    finally:
+        set_active_registry(None)
+
+    assert parser._md._parse_config.directive_registry.get("plugin-note") is not None
+    assert parser._md._render_config.role_registry.get("plugin-role") is not None

--- a/tests/unit/postprocess/test_atom_generator.py
+++ b/tests/unit/postprocess/test_atom_generator.py
@@ -82,3 +82,30 @@ def test_atom_generates_prefixed_language_feeds(tmp_path: Path) -> None:
 
     assert (tmp_path / "fr" / "atom.xml").exists()
     assert not (tmp_path / "atom.xml").exists()
+
+
+def test_atom_self_link_matches_non_default_language_path_without_prefix_strategy(
+    tmp_path: Path,
+) -> None:
+    from bengal.postprocess.rss import AtomGenerator
+
+    page = _page(output_path=tmp_path / "fr" / "test-post" / "index.html")
+    page.lang = "fr"
+    site = _site(tmp_path, [page])
+    site.config = {
+        "i18n": {
+            "strategy": "none",
+            "default_language": "en",
+            "languages": ["en", "fr"],
+        }
+    }
+
+    AtomGenerator(site).generate()
+
+    atom_path = tmp_path / "fr" / "atom.xml"
+    assert atom_path.exists()
+    root = ET.parse(atom_path).getroot()
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    self_link = root.find("atom:link[@rel='self']", ns)
+    assert self_link is not None
+    assert self_link.attrib["href"] == "https://example.com/fr/atom.xml"

--- a/tests/unit/postprocess/test_atom_generator.py
+++ b/tests/unit/postprocess/test_atom_generator.py
@@ -1,0 +1,84 @@
+"""Tests for Atom feed generation."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _page(
+    title: str = "Test Post",
+    date: datetime | None = None,
+    in_rss: bool = True,
+    output_path: Path | None = None,
+) -> MagicMock:
+    page = MagicMock()
+    page.title = title
+    page.date = date or datetime(2024, 1, 15)
+    page.in_rss = in_rss
+    page.output_path = output_path
+    page.slug = "test-post"
+    page.metadata = {"description": "Summary"}
+    page.lang = "en"
+    return page
+
+
+def _site(tmp_path: Path, pages: list[MagicMock]) -> MagicMock:
+    site = MagicMock()
+    site.pages = pages
+    site.output_dir = tmp_path
+    site.title = "Test Site"
+    site.baseurl = "https://example.com"
+    site.description = "A test site"
+    site.config = {"i18n": {}}
+    return site
+
+
+def test_generates_atom_xml_with_pages(tmp_path: Path) -> None:
+    from bengal.postprocess.rss import AtomGenerator
+
+    page = _page(output_path=tmp_path / "test-post" / "index.html")
+    site = _site(tmp_path, [page])
+
+    AtomGenerator(site).generate()
+
+    atom_path = tmp_path / "atom.xml"
+    assert atom_path.exists()
+    root = ET.parse(atom_path).getroot()
+    assert root.tag.endswith("feed")
+    assert root.find("{http://www.w3.org/2005/Atom}entry") is not None
+
+
+def test_atom_excludes_pages_not_in_rss(tmp_path: Path) -> None:
+    from bengal.postprocess.rss import AtomGenerator
+
+    site = _site(tmp_path, [_page(in_rss=False)])
+
+    AtomGenerator(site).generate()
+
+    assert not (tmp_path / "atom.xml").exists()
+
+
+def test_atom_generates_prefixed_language_feeds(tmp_path: Path) -> None:
+    from bengal.postprocess.rss import AtomGenerator
+
+    page = _page(output_path=tmp_path / "fr" / "test-post" / "index.html")
+    page.lang = "fr"
+    site = _site(tmp_path, [page])
+    site.config = {
+        "i18n": {
+            "strategy": "prefix",
+            "default_language": "en",
+            "languages": ["en", "fr"],
+        }
+    }
+
+    AtomGenerator(site).generate()
+
+    assert (tmp_path / "fr" / "atom.xml").exists()
+    assert not (tmp_path / "atom.xml").exists()

--- a/tests/unit/postprocess/test_search_backends.py
+++ b/tests/unit/postprocess/test_search_backends.py
@@ -1,0 +1,43 @@
+"""Tests for search backend configuration contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from bengal.errors import BengalConfigError
+from bengal.postprocess.search_backends import (
+    LunrSearchBackend,
+    resolve_search_backend_config,
+)
+
+
+def test_search_backend_defaults_to_lunr() -> None:
+    config = resolve_search_backend_config({})
+
+    assert config.enabled is True
+    assert config.backend == "lunr"
+    assert config.prebuilt_enabled is True
+
+
+def test_search_false_disables_backend_artifacts() -> None:
+    config = resolve_search_backend_config(False)
+
+    assert config.enabled is False
+    assert LunrSearchBackend(object(), config).generate([], lambda _label, factory: factory()) == []
+
+
+def test_lunr_prebuilt_uses_existing_legacy_config() -> None:
+    config = resolve_search_backend_config({"backend": "lunr", "lunr": {"prebuilt": False}})
+
+    assert config.backend == "lunr"
+    assert config.prebuilt_enabled is False
+
+
+def test_unknown_search_backend_is_a_config_error() -> None:
+    with pytest.raises(BengalConfigError, match="Unsupported search backend"):
+        resolve_search_backend_config({"backend": "remote"})
+
+
+def test_invalid_lunr_config_is_a_config_error() -> None:
+    with pytest.raises(BengalConfigError, match=r"Invalid search\.lunr configuration"):
+        resolve_search_backend_config({"backend": "lunr", "lunr": True})

--- a/tests/unit/postprocess/test_social_cards.py
+++ b/tests/unit/postprocess/test_social_cards.py
@@ -26,6 +26,7 @@ import pytest
 from bengal.postprocess.social_cards import (
     CARD_HEIGHT,
     CARD_WIDTH,
+    SOCIAL_CARD_FINGERPRINT_PREFIX,
     SocialCardConfig,
     SocialCardGenerator,
     get_social_card_path,
@@ -198,6 +199,34 @@ class TestSocialCardGeneratorContentHash:
 
         assert hash1 != hash2
 
+    def test_page_override_changes_hash(self) -> None:
+        """Per-page social card color overrides affect the cached fingerprint."""
+        site = MagicMock()
+        config = SocialCardConfig(background_color="#000000")
+        generator = SocialCardGenerator(site, config)
+
+        page1 = self._create_mock_page(title="Test")
+        page2 = self._create_mock_page(title="Test")
+        page2.metadata = {"social_card": {"background_color": "#ffffff"}}
+
+        assert generator._compute_card_hash(page1) != generator._compute_card_hash(page2)
+
+    def test_site_branding_changes_hash(self) -> None:
+        """Site title/baseurl are part of the rendered card fingerprint."""
+        page = self._create_mock_page(title="Test")
+        site1 = MagicMock()
+        site1.title = "Site A"
+        site1.baseurl = "https://a.example"
+        site2 = MagicMock()
+        site2.title = "Site B"
+        site2.baseurl = "https://b.example"
+        config = SocialCardConfig()
+
+        hash1 = SocialCardGenerator(site1, config)._compute_card_hash(page)
+        hash2 = SocialCardGenerator(site2, config)._compute_card_hash(page)
+
+        assert hash1 != hash2
+
 
 class TestSocialCardGeneratorOutputPath:
     """Test output path generation."""
@@ -257,6 +286,58 @@ class TestSocialCardGeneratorOutputPath:
         path = generator._get_output_path(page, output_dir)
 
         assert path == Path("/output/my-page.jpg")
+
+
+class TestSocialCardGeneratorPersistentCache:
+    """Test persisted social-card fingerprints."""
+
+    def _create_mock_page(self, title: str = "Test Page") -> MagicMock:
+        page = MagicMock()
+        page.title = title
+        page.description = "Description"
+        page.source_path = Path("content/test.md")
+        page.metadata = {}
+        page._path = "test"
+        return page
+
+    def _create_mock_site(self) -> MagicMock:
+        site = MagicMock()
+        site.title = "Test Site"
+        site.baseurl = "https://example.com"
+        return site
+
+    def test_existing_file_with_matching_persisted_hash_is_cached(self, tmp_path: Path) -> None:
+        """A new generator can skip output when the persisted fingerprint matches."""
+        site = self._create_mock_site()
+        config = SocialCardConfig()
+        page = self._create_mock_page()
+        output_path = tmp_path / "test.png"
+        output_path.write_bytes(b"existing")
+
+        first_generator = SocialCardGenerator(site, config)
+        cache_key = f"{SOCIAL_CARD_FINGERPRINT_PREFIX}{page.source_path}"
+        persisted_cache = {cache_key: first_generator._compute_card_hash(page)}
+
+        second_generator = SocialCardGenerator(
+            site,
+            config,
+            fingerprint_cache=persisted_cache,
+        )
+
+        assert second_generator._should_regenerate(page, output_path) is False
+
+    def test_existing_file_with_stale_persisted_hash_regenerates(self, tmp_path: Path) -> None:
+        """Changed content invalidates a persisted social-card fingerprint."""
+        site = self._create_mock_site()
+        config = SocialCardConfig()
+        page = self._create_mock_page(title="New title")
+        output_path = tmp_path / "test.png"
+        output_path.write_bytes(b"existing")
+        persisted_cache = {f"{SOCIAL_CARD_FINGERPRINT_PREFIX}{page.source_path}": "old"}
+
+        generator = SocialCardGenerator(site, config, fingerprint_cache=persisted_cache)
+
+        assert generator._should_regenerate(page, output_path) is True
 
 
 class TestSocialCardGeneratorTextWrapping:

--- a/tests/unit/postprocess/test_social_cards.py
+++ b/tests/unit/postprocess/test_social_cards.py
@@ -339,6 +339,57 @@ class TestSocialCardGeneratorPersistentCache:
 
         assert generator._should_regenerate(page, output_path) is True
 
+    def test_orchestrator_isolates_social_fingerprints_before_merging(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Social cards do not mutate the shared output-format fingerprint map while running."""
+        from bengal.orchestration.postprocess import PostprocessOrchestrator
+
+        cache_key = f"{SOCIAL_CARD_FINGERPRINT_PREFIX}content/test.md"
+
+        class FakeSocialCardGenerator:
+            def __init__(
+                self,
+                site: MagicMock,
+                config: SocialCardConfig,
+                collector: Any | None = None,
+                fingerprint_cache: dict[str, str] | None = None,
+            ) -> None:
+                assert fingerprint_cache is not None
+                assert "site_index_json" not in fingerprint_cache
+                self.fingerprint_cache = fingerprint_cache
+
+            def generate_all(
+                self,
+                pages: list[MagicMock],
+                output_dir: Path,
+            ) -> tuple[int, int]:
+                self.fingerprint_cache[cache_key] = "new"
+                return (1, 0)
+
+        monkeypatch.setattr(
+            "bengal.orchestration.postprocess.SocialCardGenerator",
+            FakeSocialCardGenerator,
+        )
+
+        site = MagicMock()
+        site.config = {"social_cards": {"enabled": True}}
+        site.output_dir = tmp_path
+        site.pages = []
+
+        build_context = MagicMock()
+        build_context.cache.output_format_fingerprints = {
+            "site_index_json": "existing",
+            f"{SOCIAL_CARD_FINGERPRINT_PREFIX}old.md": "old",
+        }
+
+        PostprocessOrchestrator(site)._generate_social_cards(build_context)
+
+        assert build_context.cache.output_format_fingerprints["site_index_json"] == "existing"
+        assert build_context.cache.output_format_fingerprints[cache_key] == "new"
+
 
 class TestSocialCardGeneratorTextWrapping:
     """Test text wrapping functionality."""

--- a/tests/unit/rendering/test_renderer_menu_state.py
+++ b/tests/unit/rendering/test_renderer_menu_state.py
@@ -1,0 +1,49 @@
+"""Regression tests for render-time menu state handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from bengal.rendering import renderer as renderer_module
+from bengal.rendering.renderer import Renderer
+
+
+class _SiteWithExplodingMenuMutation:
+    def __init__(self) -> None:
+        self.config: dict[str, Any] = {"build": {}}
+        self.taxonomies: dict[str, Any] = {}
+
+    def mark_active_menu_items(self, page: Any) -> None:
+        raise AssertionError("rendering must not mutate shared menu active state")
+
+
+class _TemplateEngine:
+    def __init__(self, site: _SiteWithExplodingMenuMutation) -> None:
+        self.site = site
+
+    def render(self, template_name: str, context: dict[str, Any]) -> str:
+        return f"{template_name}:{context['content']}"
+
+
+class _Page:
+    def __init__(self) -> None:
+        self.title = "Page"
+        self.html_content = "<p>body</p>"
+        self.metadata: dict[str, Any] = {}
+        self.type = None
+        self.source_path = Path("/site/content/page.md")
+        self._section = None
+
+
+def test_renderer_does_not_mark_shared_menu_items(monkeypatch) -> None:
+    """Rendering must leave menu active state immutable across parallel pages."""
+
+    def fake_build_page_context(**kwargs: Any) -> dict[str, Any]:
+        return {"content": kwargs["content"], "page": kwargs["page"]}
+
+    monkeypatch.setattr(renderer_module, "build_page_context", fake_build_page_context)
+
+    renderer = Renderer(_TemplateEngine(_SiteWithExplodingMenuMutation()))
+
+    assert renderer.render_page(_Page()) == "page.html:<p>body</p>"

--- a/tests/unit/server/test_build_trigger.py
+++ b/tests/unit/server/test_build_trigger.py
@@ -53,6 +53,53 @@ class TestBuildTrigger:
         assert trigger.port == 5173
         assert trigger._executor is mock_executor
 
+    def test_openapi_ref_dependency_triggers_autodoc_regeneration(
+        self, mock_executor: MagicMock, tmp_path: Path
+    ) -> None:
+        """Changed OpenAPI ref files should regenerate autodoc, not only the root spec."""
+        from bengal.cache.paths import BengalPaths
+
+        root = tmp_path / "site"
+        api_dir = root / "api"
+        api_dir.mkdir(parents=True)
+        spec_path = api_dir / "openapi.yaml"
+        schema_path = api_dir / "schemas.yaml"
+        spec_path.write_text("openapi: 3.1.0\n", encoding="utf-8")
+        schema_path.write_text("User:\n  type: object\n", encoding="utf-8")
+
+        paths = BengalPaths(root)
+        paths.ensure_dirs()
+        cache = BuildCache()
+        cache.autodoc_tracker.add_autodoc_dependency(
+            schema_path.resolve(),
+            "api/demo/schemas/User.md",
+            site_root=root,
+            source_hash="schema-hash",
+            source_mtime=schema_path.stat().st_mtime,
+            content_hash="doc-hash",
+        )
+        cache.save(paths.build_cache)
+
+        site = MagicMock()
+        site.root_path = root
+        site.output_dir = root / "public"
+        site.config = {
+            "autodoc": {
+                "openapi": {
+                    "enabled": True,
+                    "spec_file": "api/openapi.yaml",
+                }
+            }
+        }
+        site.theme = None
+        site._cache = cache
+        site.config_service.paths.build_cache = paths.build_cache
+
+        trigger = BuildTrigger(site=site, executor=mock_executor)
+
+        with patch("bengal.server.build_trigger.SiteLike", object):
+            assert trigger._should_regenerate_autodoc({schema_path}) is True
+
     def test_shutdown_calls_executor_shutdown(
         self, mock_site: MagicMock, mock_executor: MagicMock
     ) -> None:

--- a/tests/unit/server/test_build_trigger.py
+++ b/tests/unit/server/test_build_trigger.py
@@ -264,6 +264,38 @@ class TestBuildTrigger:
 
         assert trigger._is_template_change({template_file}) is False
 
+    @patch("bengal.server.build_trigger.logger")
+    @patch("bengal.rendering.engines.create_engine")
+    def test_template_change_logs_incremental_decision(
+        self,
+        mock_create_engine: MagicMock,
+        mock_logger: MagicMock,
+        mock_site: MagicMock,
+        mock_executor: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Template changes with known dependents explain the incremental path."""
+        mock_site.root_path = tmp_path
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        template_file = templates_dir / "base.html"
+        template_file.write_text("<html></html>")
+
+        page_path = tmp_path / "content" / "page.md"
+        cache = BuildCache(site_root=tmp_path)
+        cache.record_page_templates(str(page_path), frozenset({"base.html"}))
+        mock_site._cache = cache
+        mock_create_engine.return_value.has_capability.return_value = True
+
+        trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+        assert trigger._is_template_change({template_file}) is False
+        mock_logger.info.assert_any_call(
+            "template_change_incremental",
+            template=str(template_file),
+            affected_pages=1,
+        )
+
     def test_template_change_without_dependency_data_stays_conservative(
         self, mock_site: MagicMock, mock_executor: MagicMock, tmp_path: Path
     ) -> None:
@@ -278,6 +310,33 @@ class TestBuildTrigger:
         trigger = BuildTrigger(site=mock_site, executor=mock_executor)
 
         assert trigger._is_template_change({template_file}) is True
+
+    @patch("bengal.server.build_trigger.logger")
+    def test_template_change_logs_missing_dependency_data(
+        self,
+        mock_logger: MagicMock,
+        mock_site: MagicMock,
+        mock_executor: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Template dependency cache misses explain why a full rebuild is needed."""
+        mock_site.root_path = tmp_path
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        template_file = templates_dir / "base.html"
+        template_file.write_text("<html></html>")
+        mock_site._cache = BuildCache(site_root=tmp_path)
+
+        trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+        assert trigger._is_template_change({template_file}) is True
+        mock_logger.info.assert_any_call(
+            "template_change_full_rebuild",
+            template=str(template_file),
+            affected_pages=0,
+            reason="dependency_data_missing",
+            suggestion="Run one full build to populate template dependency data.",
+        )
 
     def test_template_change_with_known_orphan_template_is_ignored(
         self, mock_site: MagicMock, mock_executor: MagicMock, tmp_path: Path


### PR DESCRIPTION
## Summary

This PR batches the accepted steward-safe Bengal priority work into separate commits:

- avoids mutating menu active state during rendering
- explains dev-server template rebuild decisions
- wires plugin directive and role registries into parser inspection
- adds additive version lifecycle status config
- resolves local file-relative OpenAPI `$ref` dependencies and rebuild triggers
- adds an explicit search backend contract with Lunr as the supported backend
- adds optional Atom feed output
- persists social-card fingerprints across full builds
- validates generated social metadata and JSON-LD syntax in health checks

## Why

These changes turn several implicit or partial behaviors into explicit contracts with tests, docs, defaults, and changelog fragments. The higher-risk public-contract items stayed out of scope unless the steward review found an additive path.

## Steward Notes

- Config: version status and Atom feature flags are additive, documented, typed, and defaulted.
- Postprocess: search, Atom, social-card cache, and feed artifacts keep atomic writes, deterministic paths, docs, and tests.
- Autodoc: local OpenAPI refs are file-relative only; URL refs remain deferred. Referenced files are recorded so incremental rebuild triggers see them.
- Health: rendering checks now warn on missing social metadata and malformed JSON-LD with unique health codes.
- Deferred: deleting `Page` and supporting remote URL OpenAPI refs remain not-now public-contract work.

## Validation

- `uv run pytest tests/unit/core/test_version_status.py tests/unit/content/versioning/test_artifacts.py tests/unit/rendering/test_engine_globals.py -q`
- `uv run pytest tests/unit/autodoc/test_openapi_external_refs.py tests/unit/autodoc/test_openapi_virtual_pages.py tests/unit/server/test_build_trigger.py -q`
- `uv run pytest tests/unit/postprocess/test_search_backends.py tests/unit/postprocess/test_output_formats_config.py tests/unit/postprocess/test_output_formats_index_json.py -q`
- `uv run pytest tests/unit/postprocess/test_atom_generator.py tests/unit/postprocess/test_rss_generator.py tests/unit/config/test_feature_mappings.py tests/unit/orchestration/build/test_artifact_inventory.py -q`
- `uv run pytest tests/unit/postprocess/test_social_cards.py tests/unit/orchestration/test_postprocess_reporter.py tests/unit/cache/test_build_cache.py -q`
- `uv run pytest tests/unit/health/validators/test_rendering.py tests/unit/health/test_health_code_uniqueness.py tests/unit/health/test_validator_contracts.py -q`
- focused `uv run ruff check ...` on touched modules for each commit
- `make changelog-check`

Known hook warnings remain existing repo warnings: 10 deferred-only cycles and 5 dependency-layer warnings.
