### PR TITLE
[codex] harden Bengal build correctness and planning

### DIFF
--- a/bengal/build/provenance/filter.py
+++ b/bengal/build/provenance/filter.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import contextlib
 import os
 import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -113,6 +114,8 @@ class ProvenanceFilter:
     ) -> None:
         self.site = site
         self.cache = cache
+        self._build_started_at = time.time()
+        self._build_started_at_ns = time.time_ns()
 
         # Precompute site config hash (affects all pages)
         self._config_hash = hash_dict(dict(site.config))
@@ -276,6 +279,7 @@ class ProvenanceFilter:
         page_path = self._get_page_key(page)
         input_paths = self.cache.get_input_paths(page_path)
         last_build = self.cache.get_last_build_time()
+        last_build_ns = self.cache.get_last_build_time_ns()
 
         if not input_paths or last_build is None:
             return False
@@ -287,7 +291,12 @@ class ProvenanceFilter:
                 try:
                     if full_path.exists():
                         found = True
-                        if full_path.stat().st_mtime > last_build:
+                        stat = full_path.stat()
+                        if last_build_ns is not None:
+                            changed_after_build = stat.st_mtime_ns > last_build_ns
+                        else:
+                            changed_after_build = stat.st_mtime > last_build
+                        if changed_after_build:
                             return False  # File changed, need full verification
                         break
                 except OSError:
@@ -402,7 +411,10 @@ class ProvenanceFilter:
 
     def save(self) -> None:
         """Save the provenance cache to disk."""
-        self.cache.save()
+        self.cache.save(
+            last_build_time=self._build_started_at,
+            last_build_time_ns=self._build_started_at_ns,
+        )
         self._save_asset_hashes()
 
     def _load_asset_hashes(self) -> None:
@@ -485,7 +497,7 @@ class ProvenanceFilter:
 
             # Check if section has an index page
             index_page = getattr(section, "index_page", None)
-            if index_page is not None and not getattr(index_page, "virtual", False):
+            if index_page is not None and getattr(index_page, "virtual", False) is not True:
                 # Only check filesystem for real (non-virtual) pages.
                 # Virtual pages (autodoc, section-indexes) have synthetic
                 # source paths that intentionally don't exist on disk.
@@ -833,7 +845,11 @@ class ProvenanceFilter:
         if (
             stored is not None
             and isinstance(stored, dict)
-            and stored.get("mtime") == current_mtime
+            and (
+                stored.get("mtime_ns") == stat.st_mtime_ns
+                if "mtime_ns" in stored
+                else stored.get("mtime") == current_mtime
+            )
             and stored.get("size") == current_size
         ):
             return False
@@ -853,6 +869,7 @@ class ProvenanceFilter:
             self._asset_hashes[asset_path] = {
                 "hash": current_hash,
                 "mtime": current_mtime,
+                "mtime_ns": stat.st_mtime_ns,
                 "size": current_size,
             }
             return True
@@ -862,6 +879,7 @@ class ProvenanceFilter:
             self._asset_hashes[asset_path] = {
                 "hash": current_hash,
                 "mtime": current_mtime,
+                "mtime_ns": stat.st_mtime_ns,
                 "size": current_size,
             }
             return True
@@ -871,6 +889,7 @@ class ProvenanceFilter:
             self._asset_hashes[asset_path] = {
                 "hash": current_hash,
                 "mtime": current_mtime,
+                "mtime_ns": stat.st_mtime_ns,
                 "size": current_size,
             }
         else:
@@ -878,6 +897,7 @@ class ProvenanceFilter:
             self._asset_hashes[asset_path] = {
                 "hash": current_hash,
                 "mtime": current_mtime,
+                "mtime_ns": stat.st_mtime_ns,
                 "size": current_size,
             }
         return False
@@ -903,6 +923,7 @@ class ProvenanceFilter:
             self._asset_hashes[asset_key] = {
                 "hash": current_hash,
                 "mtime": stat.st_mtime,
+                "mtime_ns": stat.st_mtime_ns,
                 "size": stat.st_size,
             }
         except OSError:

--- a/bengal/build/provenance/store.py
+++ b/bengal/build/provenance/store.py
@@ -56,6 +56,7 @@ class ProvenanceCache:
     _index: dict[CacheKey, ContentHash] = field(default_factory=dict)
     _input_paths: dict[CacheKey, list[str]] = field(default_factory=dict)
     _last_build_time: float | None = field(default=None)
+    _last_build_time_ns: int | None = field(default=None)
     _records: dict[ContentHash, ProvenanceRecord] = field(default_factory=dict)
     _subvenance: dict[ContentHash, set[CacheKey]] = field(default_factory=dict)
     _loaded: bool = False
@@ -79,7 +80,7 @@ class ProvenanceCache:
             return
 
         # Load index and subvenance outside lock (I/O can block)
-        index_data, input_paths_data, last_build = self._load_index_data()
+        index_data, input_paths_data, last_build, last_build_ns = self._load_index_data()
         subvenance_data = self._load_subvenance_data()
 
         with self._lock:
@@ -88,12 +89,13 @@ class ProvenanceCache:
             self._index = index_data
             self._input_paths = input_paths_data
             self._last_build_time = last_build
+            self._last_build_time_ns = last_build_ns
             self._subvenance = subvenance_data
             self._loaded = True
 
     def _load_index_data(
         self,
-    ) -> tuple[dict[CacheKey, ContentHash], dict[CacheKey, list[str]], float | None]:
+    ) -> tuple[dict[CacheKey, ContentHash], dict[CacheKey, list[str]], float | None, int | None]:
         """Load page index, input_paths, and last_build_time from disk (no lock)."""
         index_path = self.cache_dir / "index.json"
         try:
@@ -104,9 +106,12 @@ class ProvenanceCache:
                 for k, v in data["input_paths"].items():
                     input_paths[CacheKey(k)] = list(v) if isinstance(v, list) else []
             last_build = data.get("last_build_time")
-            return (pages, input_paths, last_build)
+            last_build_ns = data.get("last_build_time_ns")
+            if last_build_ns is not None:
+                last_build_ns = int(last_build_ns)
+            return (pages, input_paths, last_build, last_build_ns)
         except FileNotFoundError, JSONDecodeError, KeyError:
-            return ({}, {}, None)
+            return ({}, {}, None, None)
 
     def _load_subvenance_data(self) -> dict[ContentHash, set[CacheKey]]:
         """Load reverse index (input → pages) from disk (no lock)."""
@@ -192,6 +197,17 @@ class ProvenanceCache:
 
         with self._lock:
             return self._last_build_time
+
+    def get_last_build_time_ns(self) -> int | None:
+        """
+        Get last build timestamp in nanoseconds for mtime short-circuit.
+
+        Returns None for older provenance indexes that only stored seconds.
+        """
+        self._ensure_loaded()
+
+        with self._lock:
+            return self._last_build_time_ns
 
     def store(
         self,
@@ -309,7 +325,12 @@ class ProvenanceCache:
 
         return self.get_affected_by(current_hash)
 
-    def save(self) -> None:
+    def save(
+        self,
+        *,
+        last_build_time: float | None = None,
+        last_build_time_ns: int | None = None,
+    ) -> None:
         """Persist indexes to disk (thread-safe)."""
         with self._lock:
             if not self._dirty:
@@ -319,6 +340,10 @@ class ProvenanceCache:
             index_copy = dict(self._index)
             input_paths_copy = {k: list(v) for k, v in self._input_paths.items()}
             subvenance_copy = {k: sorted(v) for k, v in self._subvenance.items()}
+            saved_time = time.time() if last_build_time is None else last_build_time
+            saved_time_ns = time.time_ns() if last_build_time_ns is None else last_build_time_ns
+            self._last_build_time = saved_time
+            self._last_build_time_ns = saved_time_ns
             self._dirty = False
 
         # File writes outside lock
@@ -328,8 +353,9 @@ class ProvenanceCache:
         index_path = self.cache_dir / "index.json"
         json_dump(
             {
-                "version": 2,
-                "last_build_time": time.time(),
+                "version": 3,
+                "last_build_time": saved_time,
+                "last_build_time_ns": saved_time_ns,
                 "pages": index_copy,
                 "input_paths": input_paths_copy,
             },

--- a/bengal/cache/build_cache/file_tracking.py
+++ b/bengal/cache/build_cache/file_tracking.py
@@ -160,10 +160,16 @@ class FileTrackingMixin:
             current_mtime = stat.st_mtime
             current_size = stat.st_size
             cached_mtime = cached.get("mtime")
+            cached_mtime_ns = cached.get("mtime_ns")
             cached_size = cached.get("size")
 
             # Fast path: mtime + size unchanged = definitely no change
-            if cached_mtime == current_mtime and cached_size == current_size:
+            mtime_matches = (
+                cached_mtime_ns == stat.st_mtime_ns
+                if cached_mtime_ns is not None
+                else cached_mtime == current_mtime
+            )
+            if mtime_matches and cached_size == current_size:
                 logger.debug("cache_hit", file=file_key, reason="mtime_size_match")
                 return False
 
@@ -176,6 +182,7 @@ class FileTrackingMixin:
                     # Update mtime/size in fingerprint for future fast path
                     self.file_fingerprints[file_key] = {
                         "mtime": current_mtime,
+                        "mtime_ns": stat.st_mtime_ns,
                         "size": current_size,
                         "hash": cached_hash,
                     }
@@ -227,6 +234,7 @@ class FileTrackingMixin:
             # Store full fingerprint
             self.file_fingerprints[file_key] = {
                 "mtime": stat.st_mtime,
+                "mtime_ns": stat.st_mtime_ns,
                 "size": stat.st_size,
                 "hash": file_hash,
             }

--- a/bengal/cache/cache_store.py
+++ b/bengal/cache/cache_store.py
@@ -209,12 +209,11 @@ class CacheStore:
                 f"(version {version}, compressed)"
             )
         else:
-            # Create parent directory if missing
-            self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+            from bengal.utils.io.atomic_write import atomic_write_text
 
             # Write uncompressed JSON
             json_str = json.dumps(data, indent=indent)
-            self.cache_path.write_text(json_str, encoding="utf-8")
+            atomic_write_text(self.cache_path, json_str, encoding="utf-8")
 
             logger.debug(f"Saved {len(entries)} entries to {self.cache_path} (version {version})")
 

--- a/bengal/config/deprecation.py
+++ b/bengal/config/deprecation.py
@@ -152,7 +152,8 @@ def print_deprecation_warnings(
     from bengal.output import get_cli_output
 
     source_str = f" in {source}" if source else ""
-    get_cli_output().render_write(
+    cli = get_cli_output()
+    cli.render_write(
         "validation_report.kida",
         title=f"Deprecated configuration keys found{source_str}",
         issues=[
@@ -165,8 +166,8 @@ def print_deprecation_warnings(
         ],
         summary={"errors": 0, "warnings": len(deprecated_keys), "passed": 0},
     )
-    get_cli_output().tip("These keys may be removed in a future version.")
-    get_cli_output().tip("See `bengal config deprecations` for a full list.")
+    cli.warning("These keys may be removed in a future version.")
+    cli.tip("See `bengal config deprecations` for a full list.")
 
 
 def migrate_deprecated_keys(config: dict[str, Any], in_place: bool = False) -> dict[str, Any]:

--- a/bengal/config/snapshot.py
+++ b/bengal/config/snapshot.py
@@ -74,7 +74,7 @@ class BuildSection:
         validate_templates: Proactive template syntax validation
         validate_links: Validate internal links
         transform_links: Transform markdown links to permalinks
-        fast_writes: Use faster but less safe file writes
+        fast_writes: Compatibility flag for write cleanup tracking
         fast_mode: Skip non-essential processing for speed
         stable_section_references: Use stable section references
         min_page_size: Minimum page size for parallel processing

--- a/bengal/core/diagnostics.py
+++ b/bengal/core/diagnostics.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import Literal, Protocol
 
 type DiagnosticLevel = Literal["debug", "info", "warning", "error"]
@@ -74,13 +75,16 @@ class DiagnosticsCollector:
 
     def __init__(self) -> None:
         self._events: list[DiagnosticEvent] = []
+        self._lock = Lock()
 
     def emit(self, event: DiagnosticEvent) -> None:
-        self._events.append(event)
+        with self._lock:
+            self._events.append(event)
 
     def drain(self) -> list[DiagnosticEvent]:
-        events = list(self._events)
-        self._events.clear()
+        with self._lock:
+            events = list(self._events)
+            self._events.clear()
         return events
 
 

--- a/bengal/core/page/page_core.py
+++ b/bengal/core/page/page_core.py
@@ -97,12 +97,26 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from types import MappingProxyType
 from typing import Any
 
 from bengal.protocols import Cacheable
 from bengal.utils.observability.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _to_cache_value(value: Any) -> Any:
+    """Convert immutable container views back to JSON-compatible values."""
+    if isinstance(value, MappingProxyType):
+        return {k: _to_cache_value(v) for k, v in value.items()}
+    if isinstance(value, dict):
+        return {k: _to_cache_value(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_to_cache_value(v) for v in value]
+    if isinstance(value, set | frozenset):
+        return [_to_cache_value(v) for v in value]
+    return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -311,7 +325,7 @@ class PageCore(Cacheable):
             "source_path": self.source_path,
             "title": self.title,
             "date": self.date.isoformat() if self.date else None,
-            "tags": self.tags,
+            "tags": _to_cache_value(self.tags),
             "slug": self.slug,
             "weight": self.weight,
             "lang": self.lang,
@@ -319,12 +333,12 @@ class PageCore(Cacheable):
             "type": self.type,
             "variant": self.variant,
             "description": self.description,
-            "props": self.props,
+            "props": _to_cache_value(self.props),
             "section": self.section,
             "file_hash": self.file_hash,
-            "aliases": self.aliases,
+            "aliases": _to_cache_value(self.aliases),
             "version": self.version,
-            "cascade": self.cascade,
+            "cascade": _to_cache_value(self.cascade),
         }
 
     @classmethod

--- a/bengal/core/records.py
+++ b/bengal/core/records.py
@@ -14,15 +14,74 @@ See Also:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
     from bengal.core.page.page_core import PageCore
+
+
+class FrozenList(list[Any]):
+    """List-compatible immutable sequence for record boundary payloads."""
+
+    def __init__(self, values: Iterable[Any] = ()) -> None:
+        super().__init__(values)
+
+    def _blocked(self, *_args: Any, **_kwargs: Any) -> None:
+        raise TypeError("FrozenList is immutable")
+
+    __setitem__ = _blocked
+    __delitem__ = _blocked
+    append = _blocked
+    clear = _blocked
+    extend = _blocked
+    insert = _blocked
+    pop = _blocked
+    remove = _blocked
+    reverse = _blocked
+    sort = _blocked
+    __iadd__ = _blocked
+    __imul__ = _blocked
+
+
+def _deep_freeze(value: Any) -> Any:
+    """Recursively freeze JSON-like containers at record boundaries."""
+    if isinstance(value, MappingProxyType):
+        return value
+    if isinstance(value, dict):
+        return MappingProxyType({str(k): _deep_freeze(v) for k, v in value.items()})
+    if isinstance(value, FrozenList):
+        return value
+    if isinstance(value, list | tuple):
+        return FrozenList(_deep_freeze(v) for v in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_deep_freeze(v) for v in value)
+    return value
+
+
+def _deep_thaw(value: Any) -> Any:
+    """Return mutable JSON-like containers from frozen record payloads."""
+    if isinstance(value, MappingProxyType):
+        return {k: _deep_thaw(v) for k, v in value.items()}
+    if isinstance(value, FrozenList | tuple | list):
+        return [_deep_thaw(v) for v in value]
+    if isinstance(value, frozenset | set):
+        return [_deep_thaw(v) for v in value]
+    return value
+
+
+def _freeze_page_core(core: PageCore) -> PageCore:
+    """Return a PageCore copy whose nested containers are immutable."""
+    frozen_core = replace(core)
+    object.__setattr__(frozen_core, "tags", FrozenList(core.tags))
+    object.__setattr__(frozen_core, "aliases", FrozenList(core.aliases))
+    object.__setattr__(frozen_core, "props", _deep_freeze(core.props))
+    object.__setattr__(frozen_core, "cascade", _deep_freeze(core.cascade))
+    return frozen_core
 
 
 PAGE_CORE_MIGRATION_MAP = MappingProxyType(
@@ -111,6 +170,15 @@ class ParsedPage:
     links: tuple[str, ...]
     ast_cache: dict[str, Any] | list[Any] | None = None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "toc_items",
+            tuple(_deep_freeze(dict(item)) for item in self.toc_items),
+        )
+        object.__setattr__(self, "links", tuple(str(link) for link in self.links))
+        object.__setattr__(self, "ast_cache", _deep_freeze(self.ast_cache))
+
     def to_cache_dict(self) -> dict[str, Any]:
         """Serialize to a cache-storable dict.
 
@@ -120,14 +188,14 @@ class ParsedPage:
         return {
             "html": self.html_content,
             "toc": self.toc,
-            "toc_items": list(self.toc_items),
+            "toc_items": [_deep_thaw(item) for item in self.toc_items],
             "excerpt": self.excerpt,
             "meta_description": self.meta_description,
             "plain_text": self.plain_text,
             "word_count": self.word_count,
             "reading_time": self.reading_time,
             "links": list(self.links),
-            "ast": self.ast_cache,
+            "ast": _deep_thaw(self.ast_cache),
         }
 
     @classmethod
@@ -170,6 +238,9 @@ class RenderedPage:
     render_time_ms: float
     dependencies: frozenset[str] = frozenset()
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "dependencies", frozenset(str(dep) for dep in self.dependencies))
+
 
 @dataclass(frozen=True, slots=True)
 class SourcePage:
@@ -185,11 +256,8 @@ class SourcePage:
     content loading is deferred to the parse stage and ``raw_content`` becomes
     optional.
 
-    The record itself is frozen (field reassignment raises).  Composed
-    ``PageCore`` contains mutable containers (``tags``, ``props``,
-    ``cascade``) and ``raw_metadata`` is a shallow read-only view —
-    callers must not mutate nested values.  Full deep-freeze is deferred
-    to Sprint 6 when ``PageCore`` is replaced.
+    The record itself is frozen (field reassignment raises), and nested
+    metadata containers are recursively frozen when the record is constructed.
     """
 
     # Composed cache-compatible metadata (same contract as Page.core)
@@ -213,6 +281,10 @@ class SourcePage:
     lang: str | None = None
     translation_key: str | None = None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "core", _freeze_page_core(self.core))
+        object.__setattr__(self, "raw_metadata", _deep_freeze(dict(self.raw_metadata)))
+
     # ------------------------------------------------------------------
     # Convenience delegates (avoid core.field in hot paths)
     # ------------------------------------------------------------------
@@ -232,12 +304,8 @@ class SourcePage:
     # ------------------------------------------------------------------
 
     def raw_metadata_dict(self) -> dict[str, Any]:
-        """Return a shallow mutable copy of the frozen metadata.
-
-        Only the top-level mapping is copied; nested mutable values remain
-        shared with ``raw_metadata`` and must not be mutated in place.
-        """
-        return dict(self.raw_metadata)
+        """Return a deep mutable copy of the frozen metadata."""
+        return _deep_thaw(self.raw_metadata)
 
 
 def create_virtual_source_page(

--- a/bengal/core/registry.py
+++ b/bengal/core/registry.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import platform
 from dataclasses import dataclass, field
 from pathlib import Path
+from threading import Lock
 from typing import TYPE_CHECKING
 
 from bengal.core.url_ownership import URLRegistry
@@ -94,6 +95,8 @@ class ContentRegistry:
     # Site attribute. Invalidated on clear() and rebuilt when pages length
     # changes (covers taxonomy/archive page generation).
     _page_index_cache: dict[PageLike, int] | None = field(default=None, repr=False)
+    _page_index_cache_key: tuple[int, ...] = field(default=(), repr=False)
+    _page_index_lock: Lock = field(default_factory=Lock, repr=False)
 
     def get_page(self, path: Path) -> PageLike | None:
         """
@@ -167,9 +170,8 @@ class ContentRegistry:
         """
         Memoized page→index map for next/prev navigation.
 
-        Built lazily on first access and rebuilt whenever the pages list
-        length changes (covers taxonomy/archive page generation that appends
-        pages after initial discovery). Invalidated by clear().
+        Built lazily on first access and rebuilt whenever the page object
+        ordering changes. Invalidated by clear().
 
         Args:
             pages: Current ordered list of pages (typically site.pages)
@@ -177,11 +179,18 @@ class ContentRegistry:
         Returns:
             Dict mapping each Page to its index in the list
         """
+        cache_key = tuple(id(page) for page in pages)
         cached = self._page_index_cache
-        if cached is None or len(cached) != len(pages):
-            cached = {p: i for i, p in enumerate(pages)}
-            self._page_index_cache = cached
-        return cached
+        if cached is not None and self._page_index_cache_key == cache_key:
+            return cached
+
+        with self._page_index_lock:
+            cached = self._page_index_cache
+            if cached is None or self._page_index_cache_key != cache_key:
+                cached = {p: i for i, p in enumerate(pages)}
+                self._page_index_cache = cached
+                self._page_index_cache_key = cache_key
+            return cached
 
     def register_page(self, page: PageLike) -> None:
         """
@@ -282,6 +291,7 @@ class ContentRegistry:
         self._sections_by_url.clear()
         self.url_ownership = URLRegistry()
         self._page_index_cache = None
+        self._page_index_cache_key = ()
         self._frozen = False
         self._epoch += 1
 

--- a/bengal/core/section/cache.py
+++ b/bengal/core/section/cache.py
@@ -1,0 +1,65 @@
+"""Cache invalidation helpers for derived Section views."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bengal.core.section import Section
+
+
+_LOCAL_CACHE_KEYS = frozenset(
+    {
+        "icon",
+        "sorted_subsections",
+        "regular_pages",
+        "sorted_pages",
+        "regular_pages_recursive",
+        "href",
+        "_path",
+        "subsection_index_urls",
+        "has_nav_children",
+        "content_pages",
+        "post_count",
+        "post_count_recursive",
+        "word_count",
+        "total_reading_time",
+    }
+)
+
+_ANCESTOR_CACHE_KEYS = frozenset(
+    {
+        "regular_pages_recursive",
+        "subsection_index_urls",
+        "has_nav_children",
+        "content_pages",
+        "post_count",
+        "post_count_recursive",
+        "word_count",
+        "total_reading_time",
+    }
+)
+
+_HIERARCHY_CACHE_KEYS = frozenset({"hierarchy", "depth"})
+
+
+def invalidate_section_derived_caches(section: Section) -> None:
+    """Clear cached section views affected by page/subsection membership changes."""
+    current: Section | None = section
+    first = True
+    while current is not None:
+        keys = _LOCAL_CACHE_KEYS if first else _ANCESTOR_CACHE_KEYS
+        for key in keys:
+            current.__dict__.pop(key, None)
+        first = False
+        current = current.parent
+
+
+def invalidate_section_hierarchy_caches(section: Section) -> None:
+    """Clear cached hierarchy/depth values for a section subtree."""
+    stack = [section]
+    while stack:
+        current = stack.pop()
+        for key in _HIERARCHY_CACHE_KEYS:
+            current.__dict__.pop(key, None)
+        stack.extend(current.subsections)

--- a/bengal/core/section/hierarchy.py
+++ b/bengal/core/section/hierarchy.py
@@ -75,12 +75,16 @@ def add_subsection(section: Section, child: Section) -> None:
     Sets the parent reference on the child section and invalidates cached
     hierarchy/depth values on the child because they depend on the parent chain.
     """
-    child.parent = section
-    section.subsections.append(child)
-    child.__dict__.pop("hierarchy", None)
-    child.__dict__.pop("depth", None)
+    from bengal.core.section.cache import (
+        invalidate_section_derived_caches,
+        invalidate_section_hierarchy_caches,
+    )
     from bengal.core.section.navigation import invalidate_version_content_cache
 
+    child.parent = section
+    section.subsections.append(child)
+    invalidate_section_hierarchy_caches(child)
+    invalidate_section_derived_caches(section)
     invalidate_version_content_cache(section)
 
 

--- a/bengal/core/section/queries.py
+++ b/bengal/core/section/queries.py
@@ -115,12 +115,11 @@ def add_page(section: Section, page: PageLike) -> None:
 
     section.pages.append(page)
 
-    # Invalidate cached properties that depend on pages list.
-    section.__dict__.pop("regular_pages", None)
-    section.__dict__.pop("sorted_pages", None)
-    section.__dict__.pop("regular_pages_recursive", None)
+    # Invalidate cached properties that depend on page membership.
+    from bengal.core.section.cache import invalidate_section_derived_caches
     from bengal.core.section.navigation import invalidate_version_content_cache
 
+    invalidate_section_derived_caches(section)
     invalidate_version_content_cache(section)
 
     # Set as index page if it's named index.md or _index.md.
@@ -175,6 +174,10 @@ def sort_children_by_weight(section: Section) -> None:
 
     # Sort subsections by weight (ascending), then title (alphabetically).
     section.subsections.sort(key=weight_sort_key)
+
+    from bengal.core.section.cache import invalidate_section_derived_caches
+
+    invalidate_section_derived_caches(section)
 
 
 def needs_auto_index(section: Section) -> bool:

--- a/bengal/effects/render_integration.py
+++ b/bengal/effects/render_integration.py
@@ -182,15 +182,21 @@ class RenderEffectRecorder:
 
 class BuildEffectTracer:
     """
-    Global effect tracer for a build.
+    Effect tracer for the active build context.
 
-    Singleton-ish per build. Stores effects for post-build analysis
-    and incremental build planning.
+    Stores effects for post-build analysis and incremental build planning.
+    The active instance is held in a ContextVar so concurrent builds in the
+    same process do not share dependency state. Bengal's parallel executors
+    propagate context to worker threads, so workers inherit the right tracer.
 
     Thread-safe: Uses lock for effect storage.
     """
 
     _instance: BuildEffectTracer | None = None
+    _current: ContextVar[BuildEffectTracer | None] = ContextVar(
+        "bengal_build_effect_tracer",
+        default=None,
+    )
     _lock = threading.Lock()
 
     def __init__(self) -> None:
@@ -200,17 +206,36 @@ class BuildEffectTracer:
 
     @classmethod
     def get_instance(cls) -> BuildEffectTracer:
-        """Get or create the singleton instance."""
+        """Get or create the tracer for the current build context."""
+        current = cls._current.get()
+        if current is not None:
+            return current
+
         with cls._lock:
             if cls._instance is None:
                 cls._instance = cls()
-            return cls._instance
+            current = cls._instance
+        cls._current.set(current)
+        return current
 
     @classmethod
     def reset(cls) -> None:
-        """Reset singleton (for testing)."""
+        """Reset singleton and current context instance (for testing)."""
         with cls._lock:
             cls._instance = None
+        cls._current.set(None)
+
+    @classmethod
+    def activate(cls) -> BuildEffectTracer:
+        """Create and activate a fresh tracer for the current build context."""
+        tracer = cls()
+        cls._current.set(tracer)
+        return tracer
+
+    @classmethod
+    def clear_current(cls) -> None:
+        """Clear the tracer bound to the current context."""
+        cls._current.set(None)
 
     @property
     def tracer(self) -> EffectTracer:

--- a/bengal/orchestration/build/artifacts.py
+++ b/bengal/orchestration/build/artifacts.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from bengal.utils.io.atomic_write import AtomicFile
+from bengal.utils.io.atomic_write import write_if_changed_atomic
 
 
 def write_build_time_artifacts(site: Any, last_build_stats: dict[str, Any]) -> None:
@@ -100,8 +100,8 @@ def write_build_time_artifacts(site: Any, last_build_stats: dict[str, Any]) -> N
         target_dir = Path(root) / build_badge_cfg["dir_name"]
         target_dir.mkdir(parents=True, exist_ok=True)
 
-        write_if_changed_atomic(target_dir / "build.svg", svg, AtomicFile)
-        write_if_changed_atomic(target_dir / "build.json", json_text, AtomicFile)
+        write_if_changed_atomic(target_dir / "build.svg", svg)
+        write_if_changed_atomic(target_dir / "build.json", json_text)
 
 
 def write_versioning_artifacts(site: Any) -> None:
@@ -120,26 +120,6 @@ def write_versioning_artifacts(site: Any) -> None:
 
     write_versions_json(site, Path(output_dir))
     write_root_redirect(site, Path(output_dir))
-
-
-def write_if_changed_atomic(path: Any, content: str, atomic_file_cls: Any) -> None:
-    """
-    Write file atomically, but only if content differs.
-
-    This prevents unnecessary touching of outputs across builds.
-
-    """
-    try:
-        if path.exists():
-            existing = path.read_text(encoding="utf-8")
-            if existing == content:
-                return
-    except Exception:  # noqa: S110
-        # Best-effort; if read fails, proceed to write.
-        pass
-
-    with atomic_file_cls(path, "w", encoding="utf-8") as f:
-        f.write(content)
 
 
 def normalize_build_badge_config(value: Any) -> dict[str, Any]:

--- a/bengal/orchestration/build/rendering.py
+++ b/bengal/orchestration/build/rendering.py
@@ -168,7 +168,9 @@ def _optimize_css(
         cache_dir = orchestrator.site.root_path / ".bengal" / "cache" / "assets"
         cache_dir.mkdir(parents=True, exist_ok=True)
         optimized_file = cache_dir / "optimized-style.css"
-        optimized_file.write_text(optimized_css, encoding="utf-8")
+        from bengal.utils.io.atomic_write import atomic_write_text
+
+        atomic_write_text(optimized_file, optimized_css, encoding="utf-8", ensure_parent=False)
 
         # Find and update the style.css asset to use optimized content
         for asset in assets_to_process:

--- a/bengal/orchestration/incremental/cache_manager.py
+++ b/bengal/orchestration/incremental/cache_manager.py
@@ -179,7 +179,7 @@ class CacheManager:
         # so that RenderingPipeline._render_and_write() records to our tracer.
         # Previous effects are preserved for EffectBasedDetector change detection;
         # new effects recorded during rendering accumulate alongside them.
-        build_effect_tracer = BuildEffectTracer.get_instance()
+        build_effect_tracer = BuildEffectTracer.activate()
         build_effect_tracer.set_tracer(self._effect_tracer)
         build_effect_tracer.enable()
 

--- a/bengal/plugins/__init__.py
+++ b/bengal/plugins/__init__.py
@@ -52,4 +52,7 @@ def reset_active_registry(token: Token[FrozenPluginRegistry | None]) -> None:
 
 def get_active_registry() -> FrozenPluginRegistry | None:
     """Get the active plugin registry, or None if no plugins loaded."""
-    return _active_registry.get()
+    registry = _active_registry.get()
+    if registry == FrozenPluginRegistry():
+        return None
+    return registry

--- a/bengal/plugins/__init__.py
+++ b/bengal/plugins/__init__.py
@@ -13,6 +13,8 @@ Example:
 
 """
 
+from contextvars import ContextVar, Token
+
 from bengal.plugins.loader import load_plugins
 from bengal.plugins.protocol import Plugin
 from bengal.plugins.registry import FrozenPluginRegistry, PluginRegistry
@@ -23,20 +25,31 @@ __all__ = [
     "PluginRegistry",
     "get_active_registry",
     "load_plugins",
+    "reset_active_registry",
     "set_active_registry",
 ]
 
-# Module-level holder for the frozen registry active during a build.
-# Set by BuildOrchestrator before Phase 1; read by template registration.
-_active_registry: FrozenPluginRegistry | None = None
+# Context-scoped holder for the frozen registry active during a build.
+# Build parallelism uses context propagation, so worker threads inherit the
+# registry for their build without sharing it with concurrent builds.
+_active_registry: ContextVar[FrozenPluginRegistry | None] = ContextVar(
+    "bengal_active_plugin_registry",
+    default=None,
+)
 
 
-def set_active_registry(registry: FrozenPluginRegistry | None) -> None:
+def set_active_registry(
+    registry: FrozenPluginRegistry | None,
+) -> Token[FrozenPluginRegistry | None]:
     """Set the active plugin registry for the current build."""
-    global _active_registry
-    _active_registry = registry
+    return _active_registry.set(registry)
+
+
+def reset_active_registry(token: Token[FrozenPluginRegistry | None]) -> None:
+    """Restore the active plugin registry to a previous context value."""
+    _active_registry.reset(token)
 
 
 def get_active_registry() -> FrozenPluginRegistry | None:
     """Get the active plugin registry, or None if no plugins loaded."""
-    return _active_registry
+    return _active_registry.get()

--- a/bengal/plugins/registry.py
+++ b/bengal/plugins/registry.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class FrozenPluginRegistry:
     """Immutable snapshot of all registered plugin extensions.
 
@@ -42,6 +42,19 @@ class FrozenPluginRegistry:
     health_validators: tuple[Any, ...] = ()
     shortcodes: tuple[tuple[str, str], ...] = ()  # (name, template_str)
     phase_hooks: tuple[tuple[str, Callable], ...] = ()  # (phase_name, callback)
+
+
+def _validate_name(kind: str, name: str) -> str:
+    if not isinstance(name, str) or not name.strip():
+        msg = f"Plugin {kind} name must be a non-empty string"
+        raise ValueError(msg)
+    return name
+
+
+def _validate_callable(kind: str, name: str, fn: Callable) -> None:
+    if not callable(fn):
+        msg = f"Plugin {kind} '{name}' must be callable"
+        raise TypeError(msg)
 
 
 class PluginRegistry:
@@ -104,21 +117,34 @@ class PluginRegistry:
 
         """
         self._check_mutable()
+        name = _validate_name("template function", name)
+        _validate_callable("template function", name, fn)
+        if not isinstance(phase, int) or not 1 <= phase <= 9:
+            msg = f"Plugin template function '{name}' phase must be an integer from 1 to 9"
+            raise ValueError(msg)
         self._template_functions.append((name, fn, phase))
 
     def add_template_filter(self, name: str, fn: Callable) -> None:
         """Register a template filter (value transformer)."""
         self._check_mutable()
+        name = _validate_name("template filter", name)
+        _validate_callable("template filter", name, fn)
         self._template_filters.append((name, fn))
 
     def add_template_test(self, name: str, fn: Callable) -> None:
         """Register a template test (boolean predicate)."""
         self._check_mutable()
+        name = _validate_name("template test", name)
+        _validate_callable("template test", name, fn)
         self._template_tests.append((name, fn))
 
     def add_content_source(self, name: str, source_cls: type) -> None:
         """Register a content source type."""
         self._check_mutable()
+        name = _validate_name("content source", name)
+        if not isinstance(source_cls, type):
+            msg = f"Plugin content source '{name}' must be a class"
+            raise TypeError(msg)
         self._content_sources.append((name, source_cls))
 
     def add_health_validator(self, validator: BaseValidator) -> None:
@@ -129,6 +155,10 @@ class PluginRegistry:
     def add_shortcode(self, name: str, template_str: str) -> None:
         """Register a shortcode template."""
         self._check_mutable()
+        name = _validate_name("shortcode", name)
+        if not isinstance(template_str, str) or not template_str:
+            msg = f"Plugin shortcode '{name}' template must be a non-empty string"
+            raise ValueError(msg)
         self._shortcodes.append((name, template_str))
 
     def on_phase(self, phase_name: str, callback: Callable) -> None:
@@ -140,6 +170,8 @@ class PluginRegistry:
 
         """
         self._check_mutable()
+        phase_name = _validate_name("phase hook", phase_name)
+        _validate_callable("phase hook", phase_name, callback)
         self._phase_hooks.append((phase_name, callback))
 
     def freeze(self) -> FrozenPluginRegistry:

--- a/bengal/postprocess/output_formats/llm_generator.py
+++ b/bengal/postprocess/output_formats/llm_generator.py
@@ -220,7 +220,9 @@ class SiteLlmTxtGenerator:
                 f.write("\n\n" + separator + "\n")
 
         # Save hash for next build
-        hash_path.write_text(new_hash, encoding="utf-8")
+        from bengal.utils.io.atomic_write import atomic_write_text
+
+        atomic_write_text(hash_path, new_hash, encoding="utf-8")
 
         logger.info("site_llm_txt_generated", path=str(llm_path), page_count=len(pages))
         return llm_path

--- a/bengal/postprocess/special_pages.py
+++ b/bengal/postprocess/special_pages.py
@@ -251,6 +251,7 @@ class SpecialPagesGenerator:
                     return False
 
             output_path.parent.mkdir(parents=True, exist_ok=True)
+            from bengal.utils.io.atomic_write import atomic_write_text
 
             try:
                 existing = ""
@@ -258,8 +259,12 @@ class SpecialPagesGenerator:
                     with open(output_path, encoding="utf-8") as f:
                         existing = f.read()
                 if existing != rendered_html:
-                    with open(output_path, "w", encoding="utf-8") as f:
-                        f.write(rendered_html)
+                    atomic_write_text(
+                        output_path,
+                        rendered_html,
+                        encoding="utf-8",
+                        ensure_parent=False,
+                    )
             except Exception as e:
                 # Best-effort diff; on any error just write
                 logger.debug(
@@ -269,8 +274,12 @@ class SpecialPagesGenerator:
                     error_type=type(e).__name__,
                     action="writing_without_diff",
                 )
-                with open(output_path, "w", encoding="utf-8") as f:
-                    f.write(rendered_html)
+                atomic_write_text(
+                    output_path,
+                    rendered_html,
+                    encoding="utf-8",
+                    ensure_parent=False,
+                )
 
                 if self._collector:
                     from bengal.core.output import OutputType
@@ -400,8 +409,9 @@ class SpecialPagesGenerator:
                     return False
 
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_path, "w", encoding="utf-8") as f:
-                f.write(rendered_html)
+            from bengal.utils.io.atomic_write import atomic_write_text
+
+            atomic_write_text(output_path, rendered_html, encoding="utf-8", ensure_parent=False)
 
             if self._collector:
                 from bengal.core.output import OutputType

--- a/bengal/rendering/pipeline/output.py
+++ b/bengal/rendering/pipeline/output.py
@@ -12,14 +12,9 @@ Key Functions:
 - embed_content_hash(): Embed content hash in HTML meta tag
 - extract_content_hash(): Extract content hash from HTML
 
-Write Strategies:
-The module supports two write modes controlled by ``build.fast_writes``:
-
-- **Atomic writes (default)**: Crash-safe using temporary files and rename.
-  Slightly slower but ensures output is never corrupted on interruption.
-
-- **Fast writes**: Direct file writes without atomicity. Used by dev server
-  for maximum performance during rapid iteration.
+Write Strategy:
+HTML output uses atomic writes: content is written to a temporary file and
+renamed into place so readers never observe partial output.
 
 Content Hash Embedding (RFC: Output Cache Architecture):
 HTML pages include a content hash meta tag for accurate change detection.
@@ -249,42 +244,38 @@ def write_output(
     if mark_dir_created(str(parent_dir)):
         parent_dir.mkdir(parents=True, exist_ok=True)
 
-    # Write rendered HTML (atomic for safety, fast mode for performance)
-    # Fast mode skips atomic writes for dev server (PERFORMANCE OPTIMIZATION)
+    # Write rendered HTML atomically. ``fast_writes`` is retained as a
+    # compatibility knob for cleanup tracking, but the final write is always
+    # temp-then-rename so served output is never partial.
     fast_writes = site.config.get("build", {}).get("fast_writes", False)
 
     try:
-        if fast_writes:
-            # Direct write (faster, but not crash-safe)
-            output_path.write_text(rendered_html, encoding="utf-8")
-            track_fast_write(output_path)
-        else:
-            # Atomic write (crash-safe, slightly slower)
-            from bengal.utils.io.atomic_write import atomic_write_text
+        from bengal.utils.io.atomic_write import atomic_write_text
 
-            atomic_write_text(
-                output_path,
-                rendered_html,
-                encoding="utf-8",
-                ensure_parent=False,  # parent dir already ensured above (cached)
-            )
+        atomic_write_text(
+            output_path,
+            rendered_html,
+            encoding="utf-8",
+            ensure_parent=False,  # parent dir already ensured above (cached)
+        )
+        if fast_writes:
+            track_fast_write(output_path)
     except FileNotFoundError:
         # Robustness fallback: if write fails due to missing parent directory
         # (can happen if output_dir was cleaned but our thread-safe cache is stale),
         # force directory creation and retry once.
         parent_dir.mkdir(parents=True, exist_ok=True)
 
-        if fast_writes:
-            output_path.write_text(rendered_html, encoding="utf-8")
-        else:
-            from bengal.utils.io.atomic_write import atomic_write_text
+        from bengal.utils.io.atomic_write import atomic_write_text
 
-            atomic_write_text(
-                output_path,
-                rendered_html,
-                encoding="utf-8",
-                ensure_parent=False,
-            )
+        atomic_write_text(
+            output_path,
+            rendered_html,
+            encoding="utf-8",
+            ensure_parent=False,
+        )
+        if fast_writes:
+            track_fast_write(output_path)
 
     _copy_notebook_source(page)
     _track_and_record(

--- a/bengal/rendering/pipeline/write_behind.py
+++ b/bengal/rendering/pipeline/write_behind.py
@@ -21,7 +21,7 @@ enqueue simultaneously while the writer pool drains.
 
 Performance Optimizations:
 - Multiple writer threads (8 by default) for SSD parallelism
-- Auto-enables fast_writes in dev server mode (skips atomic rename)
+- Uses atomic temp-then-rename writes for every output
 - Pre-create directories to reduce lock contention
 - Atomic counter for temp file names (faster than uuid4)
 
@@ -99,7 +99,7 @@ class WriteBehindCollector:
     Benefits:
         - Overlaps CPU (rendering) with I/O (writing)
         - 8 writer threads for better I/O parallelism on SSDs
-        - Auto-enables fast_writes in dev server mode
+        - Keeps final output writes atomic in every mode
         - Pre-creates directories to reduce lock contention
         - Uses atomic counter instead of uuid4 for temp files
 
@@ -162,25 +162,9 @@ class WriteBehindCollector:
         cpu_count = os.cpu_count() or 8
         self._num_writers = num_writers if num_writers else min(8, cpu_count)
 
-        # Determine fast_writes mode:
-        # 1. Explicit config setting takes precedence
-        # 2. Auto-enable in dev server mode (crash safety less important)
-        # 3. Default to False (safe atomic writes) for production
+        # ``fast_writes`` is kept as a compatibility attribute for callers that
+        # report it, but output writes remain atomic in every mode.
         self._fast_writes = False
-        if site:
-            config_fast_writes = site.config.get("build", {}).get("fast_writes")
-            if config_fast_writes is not None:
-                # Explicit config setting
-                self._fast_writes = bool(config_fast_writes)
-            elif dev_mode is not None:
-                # Explicit dev_mode passed
-                self._fast_writes = dev_mode
-            else:
-                # Auto-detect from site's build state
-                build_state = getattr(site, "_current_build_state", None)
-                if build_state and getattr(build_state, "dev_mode", False):
-                    self._fast_writes = True
-                    logger.debug("fast_writes_auto_enabled", reason="dev_server_mode")
 
         # Start writer threads
         self._writer_threads: list[threading.Thread] = []
@@ -305,12 +289,8 @@ class WriteBehindCollector:
                     path.parent.mkdir(parents=True, exist_ok=True)
                     self._created_dirs.add(parent)
 
-        if self._fast_writes:
-            # Direct write (faster, not crash-safe) - used in dev server mode
-            path.write_text(content, encoding="utf-8")
-        else:
-            # Atomic write with fast temp file naming (counter instead of uuid4)
-            self._atomic_write_fast(path, content)
+        # Atomic write with fast temp file naming (counter instead of uuid4)
+        self._atomic_write_fast(path, content)
 
     def _atomic_write_fast(self, path: Path, content: str) -> None:
         """Atomic write using counter-based temp file names.

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -97,6 +97,7 @@ class FrontmatterCacheEntry:
     """Cache entry for frontmatter nav-key detection (mtime, has_nav_keys)."""
 
     mtime: float
+    mtime_ns: int
     has_nav_keys: bool
 
 
@@ -105,6 +106,7 @@ class ContentHashCacheEntry:
     """Cache entry for content-only change detection (mtime, fm_hash, content_hash)."""
 
     mtime: float
+    mtime_ns: int
     frontmatter_hash: str
     content_hash: str
 
@@ -642,16 +644,44 @@ class BuildTrigger:
     def _can_use_reactive_path(self, changed_paths: set[Path], event_types: set[str]) -> bool:
         """Check if content-only reactive path can be used (skips full build).
 
-        Content-only = frontmatter unchanged, body changed. Safe for leaf AND
-        section pages. Cascade, nav, and structure keys are in frontmatter;
-        if unchanged, no downstream impact.
+        Content-only = frontmatter unchanged, body changed. The fast reactive
+        path is only safe when no rendered dependents need excerpts/listings
+        refreshed; otherwise use the warm build path for parity.
         """
         if len(changed_paths) != 1 or event_types != {"modified"}:
             return False
         path = next(iter(changed_paths))
         if path.suffix.lower() not in {".md", ".markdown"}:
             return False
-        return self._is_content_only_change(path)
+        return self._is_content_only_change(path) and not self._has_rendered_dependents(path)
+
+    def _has_rendered_dependents(self, path: Path) -> bool:
+        """Return True when a content edit should rebuild dependent pages."""
+        try:
+            changed = path.resolve()
+        except OSError:
+            changed = path
+
+        for page in getattr(self.site, "pages", []):
+            source_path = getattr(page, "source_path", None)
+            if source_path is None:
+                continue
+            try:
+                page_path = Path(source_path).resolve()
+            except OSError, TypeError, ValueError:
+                continue
+            if page_path != changed:
+                continue
+
+            section = getattr(page, "_section", None)
+            if section is None:
+                return False
+            index_page = getattr(section, "index_page", None)
+            if index_page is None or index_page is page:
+                return False
+            return getattr(index_page, "output_path", None) is not None
+
+        return False
 
     def _is_shared_content_change(self, changed_paths: set[Path]) -> bool:
         """
@@ -799,11 +829,12 @@ class BuildTrigger:
         try:
             stat = path.stat()
             mtime = stat.st_mtime
+            mtime_ns = stat.st_mtime_ns
             resolved = path.resolve()
 
             # Check cache (keyed by resolved path for watcher/discovery consistency)
             cached = self._frontmatter_cache.get(resolved)
-            if cached is not None and cached.mtime == mtime:
+            if cached is not None and cached.mtime_ns == mtime_ns:
                 return cached.has_nav_keys
 
             # Read only first 4KB (frontmatter is at start)
@@ -832,7 +863,7 @@ class BuildTrigger:
                 first_key = next(iter(self._frontmatter_cache))
                 del self._frontmatter_cache[first_key]
             self._frontmatter_cache[resolved] = FrontmatterCacheEntry(
-                mtime=mtime, has_nav_keys=result
+                mtime=mtime, mtime_ns=mtime_ns, has_nav_keys=result
             )
 
             return result
@@ -854,7 +885,9 @@ class BuildTrigger:
             return None
 
         try:
-            mtime = path.stat().st_mtime
+            stat = path.stat()
+            mtime = stat.st_mtime
+            mtime_ns = stat.st_mtime_ns
             with open(path, encoding="utf-8") as f:
                 text = f.read()
 
@@ -866,6 +899,7 @@ class BuildTrigger:
             content_hash = hashlib.sha256(match.group(2).encode()).hexdigest()[:16]
             return ContentHashCacheEntry(
                 mtime=mtime,
+                mtime_ns=mtime_ns,
                 frontmatter_hash=fm_hash,
                 content_hash=content_hash,
             )

--- a/bengal/server/reactive/handler.py
+++ b/bengal/server/reactive/handler.py
@@ -69,6 +69,13 @@ class ReactiveContentHandler:
         if page is None:
             logger.debug("reactive_page_not_found", path=str(path))
             return None
+        if self._has_rendered_dependents(page):
+            logger.debug(
+                "reactive_page_has_dependents",
+                path=str(path),
+                fallback="warm_build",
+            )
+            return None
 
         try:
             raw_file = path.read_text(encoding="utf-8")
@@ -133,3 +140,13 @@ class ReactiveContentHandler:
             return self._page_index.get(path.resolve())
         except OSError, ValueError:
             return None
+
+    def _has_rendered_dependents(self, page: PageLike) -> bool:
+        """Return True when a single-page render would leave dependent HTML stale."""
+        section = getattr(page, "_section", None)
+        if section is None:
+            return False
+        index_page = getattr(section, "index_page", None)
+        if index_page is None or index_page is page:
+            return False
+        return getattr(index_page, "output_path", None) is not None

--- a/bengal/utils/io/atomic_write.py
+++ b/bengal/utils/io/atomic_write.py
@@ -197,3 +197,28 @@ class AtomicFile:
 
         # Success - rename atomically
         self.tmp_path.replace(self.path)
+
+
+def write_if_changed_atomic(
+    path: Path | str,
+    content: str,
+    atomic_file_cls: type[AtomicFile] = AtomicFile,
+    *,
+    encoding: str = "utf-8",
+) -> None:
+    """
+    Write text atomically, but skip the write when existing content matches.
+
+    This preserves unchanged file mtimes for deterministic generated outputs
+    while keeping the normal write path crash-safe.
+    """
+    path = Path(path)
+    try:
+        if path.exists() and path.read_text(encoding=encoding) == content:
+            return
+    except OSError, UnicodeError:
+        # Unreadable existing output should be replaced through the atomic path.
+        pass
+
+    with atomic_file_cls(path, "w", encoding=encoding) as f:
+        f.write(content)

--- a/changelog.d/atomic-output-writes.changed.md
+++ b/changelog.d/atomic-output-writes.changed.md
@@ -1,0 +1,1 @@
+Made additional rendered output, special page, optimized CSS, and output-format sidecar writes atomic so interrupted builds do not leave partial files behind.

--- a/changelog.d/build-scoped-state.changed.md
+++ b/changelog.d/build-scoped-state.changed.md
@@ -1,0 +1,1 @@
+Scoped active plugin and effect-tracing state to the current build context so concurrent builds do not share dependency or extension state.

--- a/changelog.d/pipeline-record-freeze.changed.md
+++ b/changelog.d/pipeline-record-freeze.changed.md
@@ -1,0 +1,1 @@
+Deep-froze nested payloads on pipeline records so cached page metadata, parsed AST data, TOC items, and render dependencies cannot be mutated after construction.

--- a/changelog.d/plugin-registry-contract.changed.md
+++ b/changelog.d/plugin-registry-contract.changed.md
@@ -1,0 +1,1 @@
+Hardened plugin registry validation so malformed extension names, non-callable hooks, invalid template phases, and mutable frozen snapshots fail early with explicit errors.

--- a/changelog.d/stale-output-prevention.changed.md
+++ b/changelog.d/stale-output-prevention.changed.md
@@ -1,0 +1,1 @@
+Tightened stale-output prevention for incremental builds by using build-start provenance timestamps, nanosecond file mtimes, section derived-cache invalidation, and conservative dev-server reactive fallbacks.

--- a/plan/README.md
+++ b/plan/README.md
@@ -27,6 +27,7 @@ Quick reference for RFC status. Run `rg "^\*\*Status\*\*" plan/rfc-*.md` to refr
 | rfc-theme-library-assets | Draft | First-class package/library assets for themes |
 | rfc-template-view-model-contracts | Draft | Engine-neutral view data for Kida and BYO templates |
 | rfc-incremental-dependency-indexes | Draft | Normalized dependency-to-output read model for warm-build correctness |
+| rfc-snapshot-build-plan-handoff | Draft | Frozen build/incremental plans for worker-safe handoff |
 
 ## Implemented
 

--- a/plan/README.md
+++ b/plan/README.md
@@ -26,6 +26,7 @@ Quick reference for RFC status. Run `rg "^\*\*Status\*\*" plan/rfc-*.md` to refr
 | rfc-health-diagnostics-audit | Active implementation | Splits health policy, rendering registries, artifact audit, and Kida output |
 | rfc-theme-library-assets | Draft | First-class package/library assets for themes |
 | rfc-template-view-model-contracts | Draft | Engine-neutral view data for Kida and BYO templates |
+| rfc-incremental-dependency-indexes | Draft | Normalized dependency-to-output read model for warm-build correctness |
 
 ## Implemented
 

--- a/plan/bengal-hardening-proof-2026-05.md
+++ b/plan/bengal-hardening-proof-2026-05.md
@@ -1,0 +1,51 @@
+# Bengal Hardening Proof Notes (May 2026)
+
+**Status**: implementation proof for the steward-prioritized hardening batch.
+
+## Accepted Focus
+
+- Build-scoped state isolation for plugin registries, effect tracers, registry
+  page indexes, and diagnostics collection.
+- Stale-output prevention for provenance mtime races, section derived caches,
+  and dev-server reactive fallbacks.
+- Atomic writes for rendered output and user-visible generated artifacts.
+- Deep-frozen pipeline records for source, parse, and render handoffs.
+- Plugin registry contract validation.
+
+## Proof Matrix
+
+| Area | Proof |
+| --- | --- |
+| Build-scoped state | `uv run pytest tests/unit/plugins/test_plugin_parser_wiring.py tests/unit/core/test_site_context_protocol.py tests/unit/core/test_diagnostics_collector.py tests/unit/effects/test_render_integration.py -q` |
+| Stale output | `uv run pytest tests/unit/build/provenance/test_mtime_short_circuit.py tests/unit/cache/test_build_cache.py tests/unit/core/test_section_sorting.py tests/unit/server/test_build_trigger.py tests/integration/warm_build/test_build_trigger_reactive.py -q` |
+| Provenance adjacency | `uv run pytest tests/unit/build/provenance/test_filter.py tests/unit/orchestration/build/test_provenance_filter_path_keys.py tests/integration/test_incremental_cache_stability.py -q` |
+| Atomic writes | `uv run pytest tests/unit/rendering/test_write_output_rendered_page.py tests/unit/postprocess/test_special_pages.py tests/unit/postprocess/test_output_formats_hash.py tests/unit/postprocess/test_output_formats_config.py -q` |
+| Atomic cache stores | `uv run pytest tests/unit/cache/test_cache_store.py -q` |
+| Atomic build badge helper | `uv run pytest tests/unit/orchestration/build/test_finalization.py::TestBuildBadgeIncremental::test_write_if_changed_skips_identical_content tests/unit/orchestration/build/test_finalization.py::TestBuildBadgeIncremental::test_write_if_changed_updates_on_different_content -q` |
+| Pipeline records | `uv run pytest tests/unit/core/test_source_page.py tests/unit/core/test_page_record_migration.py tests/unit/core/test_page_core.py tests/unit/core/page/test_yaml_edge_cases.py tests/unit/cache/test_page_discovery_cache.py -q` |
+| Plugin contracts | `uv run pytest tests/unit/plugins tests/unit/protocols tests/unit/cli/test_plugin_command.py -q` |
+| Site docs | `uv run bengal build` from `site/` |
+
+## Residual Risks
+
+- `uv run bengal build site` is rejected by the current CLI, so the site proof
+  was run as `uv run bengal build` from `site/`. That command completed and
+  wrote `site/public`, but it still reports existing site diagnostics: URL
+  collision at `/docs/content/i18n/`, missing `languages` icon, unserveable
+  `/assets/css/style.css` references, and four `dict.enum` autodoc template
+  rendering errors in `autodoc/openapi/partials/schema-viewer.html`.
+- A broad `tests/unit/postprocess tests/unit/orchestration/build/test_finalization.py`
+  run still includes pre-existing failures in finalization tests around
+  `MagicMock` serialization and stale patch targets. The narrower postprocess
+  proof for changed write paths passed.
+- Existing dependency-layer warnings remain unchanged in pre-commit:
+  `bengal.orchestration.site_runner -> bengal.server.dev_server`,
+  `bengal.errors.* -> bengal.rendering/utils`, and
+  `bengal.utils.paths.link_resolution -> bengal.rendering.reference_resolution`.
+
+## Not Now
+
+- Removing the `fast_writes` config key. The implementation now keeps output
+  writes atomic while preserving the compatibility flag.
+- Widening plugin protocols or adding new hook surfaces. This batch only
+  validates the existing registry contract.

--- a/plan/rfc-incremental-dependency-indexes.md
+++ b/plan/rfc-incremental-dependency-indexes.md
@@ -1,0 +1,110 @@
+# RFC: Incremental Dependency Indexes
+
+**Status**: Draft
+**Created**: 2026-05-10
+**Author**: Codex
+**Related**: `rfc-effect-traced-incremental-builds.md`, `rfc-output-cache-architecture.md`, `rfc-incremental-build-observability.md`
+
+## Problem
+
+Bengal already records provenance and effects, but some warm-build paths still
+rediscover affected pages by scanning effect records, page maps, or domain
+objects. That is correct when the site is small, but it weakens the larger
+contract Bengal wants:
+
+- stale output must be prevented by explicit dependency edges;
+- warm builds should explain why a page rebuilt or skipped;
+- free-threaded builds should consume frozen facts instead of repeatedly walking
+  mutable `Site` state.
+
+The next step is not a new build phase. It is a normalized read model over
+existing provenance: dependency-to-page and dependency-to-output indexes that
+incremental detectors can query first.
+
+## Goals
+
+- Persist deterministic indexes for template, data, generated-page, track-data,
+  asset, and output dependencies.
+- Preserve conservative rebuild behavior when an index is missing, stale,
+  corrupt, or ambiguous.
+- Keep invalidation reasons distinct enough for diagnostics and tests.
+- Build indexes from existing effect/provenance records before adding new hook
+  surfaces or public APIs.
+- Make warm-build lookup cost proportional to affected dependencies, not total
+  pages.
+
+## Non-Goals
+
+- Replacing the effect tracer or provenance store.
+- Introducing a new build phase without a separate design discussion.
+- Changing plugin hook signatures.
+- Skipping fallback scans until parity tests prove the index path is complete.
+- Content-addressing every intermediate artifact in this RFC.
+
+## Proposed Indexes
+
+Use frozen records that can be serialized through the cache layer:
+
+```python
+@dataclass(frozen=True, slots=True)
+class DependencyIndexEntry:
+    dependency_kind: str
+    dependency_key: str
+    page_keys: tuple[str, ...]
+    output_keys: tuple[str, ...]
+    invalidation_reason: str
+    producer: str
+```
+
+Indexes should be grouped by normalized dependency kind:
+
+| Kind | Key | Query Result |
+| --- | --- | --- |
+| `template` | normalized template path | pages and generated outputs using it |
+| `data` | normalized data file path | pages and generated outputs using it |
+| `content` | source page path | rendered output plus aggregate dependents |
+| `generated` | generated page key | output path and source dependencies |
+| `track` | track/data item key | pages whose listings or route pages depend on it |
+| `asset` | asset/source path | outputs whose HTML or manifests reference it |
+
+The first implementation slice should be template/data/generated indexes because
+those have the clearest existing provenance and user-visible stale-output risk.
+
+## Detector Flow
+
+1. Load cache/provenance.
+2. Build or load the dependency index read model.
+3. For each changed input, query the index for affected pages/outputs.
+4. If the index cannot prove coverage, emit a specific fallback reason and use
+   the existing broader rebuild path.
+5. Record the final invalidation reasons for diagnostics and tests.
+
+The fallback path is part of the contract. A fast miss is only valid when the
+index proves that no affected output exists.
+
+## Proof Matrix
+
+| Surface | Required Proof |
+| --- | --- |
+| Unit | Index serialization, path normalization, missing/corrupt index fallback |
+| Incremental | Template include chain, data-file edit, generated page dependency, deleted dependency |
+| Integration | Warm build parity against current detector behavior |
+| Performance | Before/after benchmark on representative large fixture |
+| Free-threading | Repeated parallel warm-build smoke once index reads are shared |
+
+## Steward Notes
+
+- **Build/Cache/Incremental**: dependency edges must stay explicit, and cache
+  uncertainty must rebuild with a named reason.
+- **Core/Rendering**: indexes should point to render-owned facts without moving
+  rendering behavior into core.
+- **Protocols/Plugins**: do not widen `SiteLike`, `PageLike`, `SectionLike`, or
+  plugin hooks for index convenience.
+- **Tests/Performance**: measure complete required work, not skipped paths.
+
+## Not Now
+
+- Parallelizing fingerprinting or index writes.
+- Removing existing scan fallbacks.
+- Migrating cache schema without migration tests.
+- Merging this with snapshot-and-swap build planning.

--- a/plan/rfc-snapshot-build-plan-handoff.md
+++ b/plan/rfc-snapshot-build-plan-handoff.md
@@ -1,0 +1,139 @@
+# RFC: Snapshot Build Plan Handoff
+
+**Status**: Draft
+**Created**: 2026-05-10
+**Author**: Codex
+**Related**: `rfc-bengal-snapshot-engine.md`, `rfc-template-view-model-contracts.md`, `rfc-incremental-dependency-indexes.md`
+
+## Problem
+
+Bengal has immutable page records, snapshot types, and some snapshot-aware
+rendering paths, but build and incremental orchestration can still fall back to
+mutable live `Site`, `Page`, and `Section` objects during planning and worker
+execution.
+
+That fallback preserves compatibility, but it limits the free-threading story:
+
+- workers may read mutable state whose lifecycle is owned elsewhere;
+- `@cached_property` compatibility values can hide rebuild invalidation;
+- plugin phase hooks can couple third-party code to mutable internal objects;
+- repeated lazy lookups make performance improvements harder to measure.
+
+The target design is a build-scoped immutable handoff: assemble a frozen
+`BuildPlan` or `IncrementalPlan`, then let render/build workers consume the plan
+instead of rediscovering mutable state.
+
+## Goals
+
+- Define the frozen facts each worker needs before rendering starts.
+- Keep `SourcePage -> ParsedPage -> RenderedPage` immutable.
+- Move hot template-facing facts toward rendering-owned precompute tables.
+- Provide plugin-facing read-only context before changing hook internals.
+- Preserve existing public `Page`, `Section`, `Site`, and plugin behavior while
+  the plan path proves parity.
+
+## Non-Goals
+
+- Removing compatibility shims in the first implementation.
+- Adding new build phases.
+- Changing plugin hook signatures without migration notes.
+- Hoisting deferred imports across core/rendering boundaries.
+- Replacing all `cached_property` usage at once.
+
+## Proposed Records
+
+```python
+@dataclass(frozen=True, slots=True)
+class BuildPlan:
+    config_hash: str
+    content_snapshot_id: str
+    pages: tuple[PagePlan, ...]
+    sections: tuple[SectionPlan, ...]
+    template_dependencies: Mapping[str, tuple[str, ...]]
+    generated_outputs: tuple[GeneratedOutputPlan, ...]
+    plugin_context: PluginBuildContext
+```
+
+`BuildPlan` should be assembled after content discovery and before parallel
+render execution. For warm builds, an `IncrementalPlan` can wrap the full plan
+with affected page/output sets and named invalidation reasons.
+
+```python
+@dataclass(frozen=True, slots=True)
+class IncrementalPlan:
+    build_plan: BuildPlan
+    changed_inputs: tuple[str, ...]
+    affected_pages: tuple[str, ...]
+    affected_outputs: tuple[str, ...]
+    fallback_reasons: tuple[str, ...]
+```
+
+The first slice should not require every consumer to migrate. It should add a
+plan path for one narrow render/incremental workflow, compare output parity, and
+leave the existing mutable path as the fallback.
+
+## Plugin Context
+
+Snapshot-and-swap is incomplete if plugins still receive broad mutable internals
+at the same boundary. Future plugin-facing context should be narrow and
+read-only:
+
+```python
+class PluginBuildContext(Protocol):
+    @property
+    def config(self) -> Mapping[str, object]: ...
+
+    @property
+    def pages(self) -> Sequence[PagePlan]: ...
+
+    @property
+    def outputs(self) -> Sequence[GeneratedOutputPlan]: ...
+```
+
+Existing phase hooks must remain compatible until a separate protocol migration
+lands. New context adapters should be additive, contract-tested, and documented
+before any hook signature changes.
+
+## Migration Shape
+
+1. Add internal plan records and construction tests.
+2. Route one measured hot path through the plan behind existing orchestration
+   boundaries.
+3. Prove output parity for cold build, warm build, template edit, and content
+   edit.
+4. Add plugin read-only context adapters without changing existing callback
+   forms.
+5. Expand plan consumers only after benchmarks show reduced lock contention or
+   repeated lookup work.
+
+## Proof Matrix
+
+| Surface | Required Proof |
+| --- | --- |
+| Unit | Frozen plan construction, no late mutation, serialization where needed |
+| Rendering | Rendered-output parity fixture and template compatibility fixture |
+| Incremental | Cold/warm/content-edit/template-edit parity |
+| Plugins | Existing hook compatibility plus read-only context adapter tests |
+| Performance | Worker-scaling and phase-breakdown benchmark before/after |
+| Free-threading | Repeated parallel render smoke with shared plan reads |
+
+## Steward Notes
+
+- **Core**: `Page`, `Section`, and `Site` remain compatibility/coordinator
+  surfaces; do not move rendering behavior into core.
+- **Rendering**: template-facing URLs, excerpts, TOCs, references, and listing
+  facts belong in rendering-owned plan/read-model data.
+- **Build/Cache/Incremental**: plans must carry explicit invalidation reasons
+  and conservative fallback paths.
+- **Protocols/Plugins**: prefer adapters and capability protocols over widened
+  `SiteLike`, `PageLike`, `SectionLike`, or hook signatures.
+- **Tests/Performance**: benchmark complete work, not a path that skipped
+  required output or dependency checks.
+
+## Not Now
+
+- Deleting mutable compatibility state.
+- Making plugin hooks receive only `PluginBuildContext`.
+- Broad `cached_property` removal.
+- Async rewrite or executor redesign.
+- Content-addressed intermediate artifact migration.

--- a/site/content/docs/building/performance/template-deps.md
+++ b/site/content/docs/building/performance/template-deps.md
@@ -50,9 +50,19 @@ On a 1,000-page site where you edit a partial used by 50 pages:
 
 The dependency data is stored in the build cache alongside content hashes. The lookup is O(1) per template via a lazy reverse index.
 
+Selective rebuilds are a correctness feature first. When dependency provenance
+is missing, unreadable, or ambiguous, Bengal falls back to a broader rebuild
+rather than serving stale HTML. The fast path is only taken after the cache can
+prove the source page, templates, cascade inputs, and expected outputs are fresh.
+
 ## Interaction with Dev Server
 
 Template dependency tracking works with `bengal serve`. When you save a template file, the dev server triggers a selective rebuild and hot-reloads only the affected pages.
+
+For markdown body-only edits, the dev server may use a reactive single-page
+render. That fast path is disabled when the edited page has a rendered section
+index or listing that may need updated excerpts or navigation data; Bengal then
+uses the normal warm build path so dependent HTML stays in sync.
 
 ## See Also
 

--- a/site/content/docs/extending/plugins.md
+++ b/site/content/docs/extending/plugins.md
@@ -109,6 +109,13 @@ def register(self, registry: PluginRegistry) -> None:
 
 The `phase` parameter on `add_template_function` controls registration order (1–9), matching Bengal's internal template function phases.
 
+Registry validation happens during `register()`. Bengal raises explicit errors
+for empty extension names, non-callable template helpers or phase hooks, content
+sources that are not classes, shortcode templates that are not non-empty
+strings, and template function phases outside `1..9`. The frozen registry
+returned after registration is immutable and safe to share across parallel
+build workers.
+
 ### Directives and Roles
 
 ```python
@@ -192,7 +199,8 @@ Bengal discovers plugins via the `bengal.plugins` [entry point group](https://pa
 3. Valid plugins call `register()` on a mutable `PluginRegistry`
 4. The registry is frozen into an immutable `FrozenPluginRegistry` before rendering begins
 
-The frozen registry is a dataclass with tuple fields — safe to share across threads during parallel rendering.
+The frozen registry is a frozen dataclass with tuple fields — safe to share
+across threads during parallel rendering.
 
 ## Combining Multiple Extensions
 

--- a/site/content/docs/reference/architecture/core/cache.md
+++ b/site/content/docs/reference/architecture/core/cache.md
@@ -176,6 +176,26 @@ Instead of relying on ad-hoc flags, the provenance store tracks content-addresse
 inputs and outputs so the detection pipeline can quickly prove what is fresh and
 what must be rebuilt.
 
+### Stale-Output Guards
+
+Warm builds should be conservative when freshness is uncertain. Bengal uses
+several guards before trusting cached output:
+
+- **Nanosecond fingerprints**: file fingerprints include `mtime_ns`, size, and
+  SHA256 content hash. Older cache entries without nanosecond data fall back to
+  the legacy mtime+size comparison, then hash verification.
+- **Build-start provenance time**: provenance mtime short-circuit data records
+  the build start timestamp, not the later cache-save timestamp. If a file
+  changes while a build is running, the next warm build verifies content instead
+  of incorrectly trusting the previous record.
+- **Missing output repair**: page outputs and site-wide postprocess artifacts
+  are checked before an incremental skip is accepted.
+- **Atomic cache persistence**: cache and provenance indexes use atomic writes
+  so interrupted builds do not leave partially-written JSON behind.
+
+If Bengal cannot resolve an input path, read a fingerprint, or prove an output
+exists, it treats the page or artifact as stale and rebuilds it.
+
 ## Zstandard Compression
 
 Bengal uses **Zstandard (zstd)** compression for all cache files, leveraging Python 3.14's new `compression.zstd` module (PEP 784).

--- a/site/content/docs/reference/architecture/core/pipeline.md
+++ b/site/content/docs/reference/architecture/core/pipeline.md
@@ -106,6 +106,26 @@ It short-circuits on full rebuild triggers for speed and clarity.
 bengal build --incremental
 ```
 
+## Immutable Page Records
+
+The render pipeline moves page data through immutable records:
+
+1. `SourcePage`: discovery output, including `PageCore`, raw body, metadata,
+   language, and source hashes.
+2. `ParsedPage`: parse output, including HTML fragments, TOC items, excerpts,
+   links, plain text, and AST cache data.
+3. `RenderedPage`: render output, including output path, rendered HTML,
+   render timing, and render dependencies.
+
+These records are frozen at construction time, and nested JSON-like payloads are
+deep-frozen. That means a cached AST node, metadata list, cascade mapping, or
+dependency collection cannot be mutated later by another pipeline stage or
+worker thread. Serialization helpers thaw those structures back into plain
+JSON-compatible containers when writing caches.
+
+Mutable `Page` compatibility objects still exist for public and template-facing
+APIs, but cross-stage handoff should prefer the records above.
+
 ## File Watching (Development Server)
 
 Bengal uses **`watchfiles`** (Rust-based) for fast file change detection:

--- a/tests/integration/warm_build/test_build_trigger_reactive.py
+++ b/tests/integration/warm_build/test_build_trigger_reactive.py
@@ -204,15 +204,10 @@ title: Home
         # Updated HTML written to disk
         warm_build_site.assert_output_contains("index.html", updated_body)
 
-    def test_reactive_path_does_not_update_dependent_pages(
+    def test_reactive_path_refuses_pages_with_rendered_dependents(
         self, site_with_nav: WarmBuildTestSite
     ) -> None:
-        """Reactive path updates only the edited page; section index stays stale.
-
-        Edge case (RFC Phase 7): When editing blog/post1.md, handle_content_change
-        re-renders only post1. The blog section index (blog/index.html) lists
-        post1 but is NOT re-rendered; it remains stale until full build.
-        """
+        """Reactive handler refuses leaf edits that would stale a section index."""
         site_dir = site_with_nav.site_dir
         output_dir = site_with_nav.output_dir
 
@@ -225,6 +220,7 @@ title: Home
         post1_output = output_dir / "blog" / "post1" / "index.html"
         section_index_output = output_dir / "blog" / "index.html"
         section_index_mtime_before = section_index_output.stat().st_mtime
+        post1_mtime_before = post1_output.stat().st_mtime
 
         # Edit post1 body only (content that affects post1 page)
         unique_content = "REACTIVE_EDGE_CASE_UNIQUE_STRING"
@@ -241,24 +237,14 @@ date: 2026-01-01
         handler = ReactiveContentHandler(site_with_nav.site, output_dir)
         result = handler.handle_content_change(post1_path)
 
-        assert result is not None
-        # Result may be relative or absolute; resolve for comparison
-        assert result.output_path.resolve() == post1_output.resolve()
+        assert result is None
 
-        # Post1 output updated with new content
-        site_with_nav.assert_output_contains("blog/post1/index.html", unique_content)
-
-        # Section index unchanged (mtime unchanged, content not updated)
+        # Nothing was rewritten; BuildTrigger will fall through to warm build.
+        assert post1_output.stat().st_mtime == post1_mtime_before
         section_index_mtime_after = section_index_output.stat().st_mtime
-        assert section_index_mtime_before == section_index_mtime_after, (
-            "Section index should not be touched by reactive path"
-        )
-        # Section index does not contain the new post1 body (excerpt would be stale)
+        assert section_index_mtime_before == section_index_mtime_after
         section_html = section_index_output.read_text()
-        assert unique_content not in section_html, (
-            "Section index should not include post1 body; reactive path doesn't "
-            "re-render dependent pages"
-        )
+        assert unique_content not in section_html
 
 
 class TestDevServerStyleFirstEdit:

--- a/tests/unit/build/provenance/test_mtime_short_circuit.py
+++ b/tests/unit/build/provenance/test_mtime_short_circuit.py
@@ -107,6 +107,7 @@ def test_store_persists_input_paths(provenance_dir: Path, site_root: Path) -> No
         "content/_index.md",
     ]
     assert cache2.get_last_build_time() is not None
+    assert cache2.get_last_build_time_ns() is not None
 
 
 def test_backward_compat_v1_index_skips_mtime_short_circuit(
@@ -226,6 +227,73 @@ def test_mtime_short_circuit_returns_false_when_content_changed(
 
     filter_obj = ProvenanceFilter(site, cache)
     assert filter_obj._mtime_short_circuit(page, ContentHash("abc123")) is False
+
+
+def test_mtime_short_circuit_uses_nanosecond_timestamp(
+    provenance_dir: Path, site_root: Path
+) -> None:
+    """Nanosecond build time prevents same-second edits from short-circuiting."""
+    from bengal.build.provenance.filter import ProvenanceFilter
+
+    content_file = site_root / "content" / "index.md"
+    stat = content_file.stat()
+
+    index_path = provenance_dir / "index.json"
+    index_path.write_text(
+        json.dumps(
+            {
+                "version": 3,
+                "last_build_time": 9999999999.0,
+                "last_build_time_ns": stat.st_mtime_ns - 1,
+                "pages": {"content/index.md": "abc123"},
+                "input_paths": {"content/index.md": ["content/index.md"]},
+            }
+        )
+    )
+
+    site = MagicMock()
+    site.root_path = site_root
+    site.config = {"site": {"title": "Test"}}
+
+    cache = ProvenanceCache(provenance_dir)
+    cache._ensure_loaded()
+
+    page = MagicMock()
+    page.source_path = content_file
+    page.virtual = False
+
+    filter_obj = ProvenanceFilter(site, cache)
+    assert filter_obj._mtime_short_circuit(page, ContentHash("abc123")) is False
+
+
+def test_filter_save_uses_filter_creation_time(provenance_dir: Path, site_root: Path) -> None:
+    """Saving provenance records uses build-start time, not cache-save time."""
+    from bengal.build.provenance.filter import ProvenanceFilter
+
+    site = MagicMock()
+    site.root_path = site_root
+    site.config = {}
+
+    cache = ProvenanceCache(provenance_dir)
+    filter_obj = ProvenanceFilter(site, cache)
+    filter_obj._build_started_at = 100.0
+    filter_obj._build_started_at_ns = 100_000_000_000
+
+    provenance = Provenance().with_input(
+        "content", CacheKey("content/index.md"), ContentHash("abc123")
+    )
+    record = ProvenanceRecord(
+        page_path=CacheKey("content/index.md"),
+        provenance=provenance,
+        output_hash=ContentHash("_rendered_"),
+    )
+    cache.store(record, input_paths=["content/index.md"])
+
+    filter_obj.save()
+
+    data = json.loads((provenance_dir / "index.json").read_text())
+    assert data["last_build_time"] == 100.0
+    assert data["last_build_time_ns"] == 100_000_000_000
 
 
 def test_extract_input_paths_skips_taxonomy(provenance_dir: Path, site_root: Path) -> None:

--- a/tests/unit/cache/test_build_cache.py
+++ b/tests/unit/cache/test_build_cache.py
@@ -53,6 +53,7 @@ class TestBuildCache:
 
         assert str(test_file) in cache.file_fingerprints
         assert cache.file_fingerprints[str(test_file)].get("hash") is not None
+        assert cache.file_fingerprints[str(test_file)].get("mtime_ns") is not None
         assert len(cache.file_fingerprints[str(test_file)].get("hash", "")) == 64
 
     def test_is_changed_new_file(self, tmp_path):
@@ -93,6 +94,23 @@ class TestBuildCache:
         test_file.write_text("This is modified content with a different length!")
 
         # Should be detected as changed
+        assert cache.is_changed(test_file) is True
+
+    def test_is_changed_uses_mtime_ns_when_seconds_match(self, tmp_path):
+        """Nanosecond mtime differences bypass stale same-second fast paths."""
+        cache = BuildCache()
+
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("new!")
+        stat = test_file.stat()
+
+        cache.file_fingerprints[str(test_file)] = {
+            "mtime": stat.st_mtime,
+            "mtime_ns": stat.st_mtime_ns - 1,
+            "size": stat.st_size,
+            "hash": "0" * 64,
+        }
+
         assert cache.is_changed(test_file) is True
 
     def test_is_changed_deleted_file(self, tmp_path):

--- a/tests/unit/cache/test_cache_store.py
+++ b/tests/unit/cache/test_cache_store.py
@@ -123,6 +123,32 @@ class TestCacheStoreSave:
         assert cache_path.exists()
         assert cache_path.parent.exists()
 
+    def test_save_uncompressed_uses_atomic_write(self, tmp_path, monkeypatch):
+        """Uncompressed cache saves should still use crash-safe writes."""
+        cache_path = tmp_path / "test.json"
+        store = CacheStore(cache_path, compress=False)
+        calls = []
+
+        def fake_atomic_write_text(path, content, encoding="utf-8"):
+            calls.append((path, content, encoding))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding=encoding)
+
+        monkeypatch.setattr(
+            "bengal.utils.io.atomic_write.atomic_write_text",
+            fake_atomic_write_text,
+        )
+
+        store.save([SimpleEntry(key="test", value=1)], version=1)
+
+        assert len(calls) == 1
+        assert calls[0][0] == cache_path
+        assert calls[0][2] == "utf-8"
+        assert json.loads(calls[0][1]) == {
+            "version": 1,
+            "entries": [{"key": "test", "value": 1}],
+        }
+
     def test_save_with_version(self, tmp_path):
         """Save should store specified version."""
         cache_path = tmp_path / "test.json"

--- a/tests/unit/config/test_deprecation.py
+++ b/tests/unit/config/test_deprecation.py
@@ -138,6 +138,22 @@ class TestPrintDeprecationWarnings:
         result = capsys.readouterr().out
         assert "may be removed in a future version" in result
 
+    def test_prints_future_removal_notice_in_quiet_mode(self, capsys):
+        """Future-removal notice is warning-level, not quiet-only guidance."""
+        from bengal.output import get_cli_output, reset_cli_output
+
+        reset_cli_output()
+        get_cli_output(quiet=True)
+        deprecated = [("minify_assets", "assets.minify", "Note")]
+
+        try:
+            print_deprecation_warnings(deprecated)
+            result = capsys.readouterr().out
+        finally:
+            reset_cli_output()
+
+        assert "may be removed in a future version" in result
+
 
 class TestMigrateDeprecatedKeys:
     """Tests for migrate_deprecated_keys function."""

--- a/tests/unit/core/test_diagnostics_collector.py
+++ b/tests/unit/core/test_diagnostics_collector.py
@@ -1,0 +1,37 @@
+"""Tests for thread-safe core diagnostics collection."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from bengal.core.diagnostics import DiagnosticEvent, DiagnosticsCollector
+
+pytestmark = pytest.mark.parallel_unsafe
+
+
+def test_diagnostics_collector_handles_concurrent_emit() -> None:
+    collector = DiagnosticsCollector()
+
+    def emit_one(index: int) -> None:
+        collector.emit(DiagnosticEvent(level="warning", code="test", data={"index": index}))
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(emit_one, range(100)))
+
+    events = collector.drain()
+
+    assert len(events) == 100
+    assert {event.data["index"] for event in events} == set(range(100))
+
+
+def test_diagnostics_collector_drain_is_atomic() -> None:
+    collector = DiagnosticsCollector()
+    collector.emit(DiagnosticEvent(level="warning", code="before"))
+
+    first = collector.drain()
+    second = collector.drain()
+
+    assert [event.code for event in first] == ["before"]
+    assert second == []

--- a/tests/unit/core/test_page_record_migration.py
+++ b/tests/unit/core/test_page_record_migration.py
@@ -13,6 +13,8 @@ from bengal.core.records import (
     PARSED_PAGE_MIGRATION_MAP,
     RENDERED_PAGE_MIGRATION_MAP,
     SOURCE_PAGE_MIGRATION_MAP,
+    ParsedPage,
+    RenderedPage,
     build_page_core,
     build_source_page,
     parsed_page_from_page_state,
@@ -73,13 +75,20 @@ def test_build_page_core_matches_page_field_rules():
 
 
 def test_build_source_page_freezes_metadata_and_preserves_hashes():
+    metadata = {
+        "title": "Hello",
+        "translation_key": "posts/hello",
+        "nested": {"items": ["one"]},
+    }
     source = build_source_page(
         source_path=Path("content/posts/hello.md"),
         raw_content="# Hello",
-        metadata={"title": "Hello", "translation_key": "posts/hello"},
+        metadata=metadata,
         content_hash="body123",
         file_hash="file123",
     )
+
+    metadata["nested"]["items"].append("source-mutated")
 
     assert source.core.file_hash == "file123"
     assert source.content_hash == "body123"
@@ -87,6 +96,9 @@ def test_build_source_page_freezes_metadata_and_preserves_hashes():
     assert isinstance(source.raw_metadata, MappingProxyType)
     with pytest.raises(TypeError):
         source.raw_metadata["title"] = "Changed"
+    with pytest.raises(TypeError):
+        source.raw_metadata["nested"]["items"].append("Changed")
+    assert source.raw_metadata["nested"]["items"] == ["one"]
 
 
 def test_build_source_page_does_not_compute_hashes_in_core():
@@ -133,6 +145,43 @@ def test_parsed_page_adapter_uses_supplied_toc_items_without_rendering_imports()
     assert parsed.toc_items == ({"id": "intro", "title": "Intro"},)
     assert parsed.links == ("/guide/", "42")
     assert parsed.ast_cache == {"_type": "Document"}
+
+
+def test_parsed_page_deep_freezes_nested_payloads():
+    ast = {"children": [{"type": "paragraph", "text": "Hello"}]}
+    parsed = ParsedPage(
+        html_content="<p>Hello</p>",
+        toc="",
+        toc_items=({"id": "intro", "children": [{"id": "child"}]},),
+        excerpt="Hello",
+        meta_description="Hello",
+        plain_text="Hello",
+        word_count=1,
+        reading_time=1,
+        links=["/guide/"],
+        ast_cache=ast,
+    )
+
+    ast["children"][0]["text"] = "Mutated"
+
+    with pytest.raises(TypeError):
+        parsed.toc_items[0]["children"].append({"id": "other"})
+    with pytest.raises(TypeError):
+        parsed.ast_cache["children"][0]["text"] = "Changed"
+    assert parsed.ast_cache["children"][0]["text"] == "Hello"
+    assert parsed.to_cache_dict()["ast"]["children"][0]["text"] == "Hello"
+
+
+def test_rendered_page_freezes_dependencies():
+    rendered = RenderedPage(
+        source_path=Path("content/index.md"),
+        output_path=Path("public/index.html"),
+        rendered_html="<html></html>",
+        render_time_ms=1.0,
+        dependencies=["templates/base.html"],
+    )
+
+    assert rendered.dependencies == frozenset({"templates/base.html"})
 
 
 def test_rendered_page_adapter_requires_output_path():

--- a/tests/unit/core/test_section_sorting.py
+++ b/tests/unit/core/test_section_sorting.py
@@ -47,6 +47,30 @@ class TestSectionSortedPagesProperty:
         assert sorted_pages[1] == page3
         assert sorted_pages[2] == page1
 
+    def test_add_page_invalidates_ancestor_recursive_cache(self, tmp_path):
+        """Adding a page to a child section refreshes ancestor recursive listings."""
+        root = Section(name="root", path=tmp_path)
+        docs = Section(name="docs", path=tmp_path / "docs")
+        root.add_subsection(docs)
+
+        first = Page(
+            source_path=tmp_path / "docs/first.md",
+            _raw_content="First",
+            _raw_metadata={"title": "First"},
+        )
+        docs.add_page(first)
+
+        assert root.regular_pages_recursive == [first]
+
+        second = Page(
+            source_path=tmp_path / "docs/second.md",
+            _raw_content="Second",
+            _raw_metadata={"title": "Second"},
+        )
+        docs.add_page(second)
+
+        assert root.regular_pages_recursive == [first, second]
+
     def test_sorted_pages_no_weights(self, tmp_path):
         """Pages without weights default to weight=0 and sort by title."""
         section = Section(name="docs", path=tmp_path / "docs")
@@ -219,6 +243,27 @@ class TestSectionSortedPagesProperty:
 
 class TestSectionSortedSubsectionsProperty:
     """Test Section.sorted_subsections property."""
+
+    def test_add_subsection_invalidates_sorted_subsections_cache(self, tmp_path):
+        """Adding a subsection refreshes sorted_subsections."""
+        root = Section(name="root", path=tmp_path)
+        first = Section(
+            name="first",
+            path=tmp_path / "first",
+            metadata={"title": "First", "weight": 10},
+        )
+        root.add_subsection(first)
+
+        assert root.sorted_subsections == [first]
+
+        second = Section(
+            name="second",
+            path=tmp_path / "second",
+            metadata={"title": "Second", "weight": 1},
+        )
+        root.add_subsection(second)
+
+        assert root.sorted_subsections == [second, first]
 
     def test_sorted_subsections_basic(self, tmp_path):
         """Subsections are sorted by weight (ascending)."""

--- a/tests/unit/core/test_site_context_protocol.py
+++ b/tests/unit/core/test_site_context_protocol.py
@@ -13,11 +13,15 @@ between them is what these tests catch.
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from bengal.core.registry import ContentRegistry
 from bengal.core.site import Site
 from bengal.core.site.context import RegistryContext, SiteContext
+
+pytestmark = pytest.mark.parallel_unsafe
 
 
 @pytest.fixture
@@ -71,6 +75,59 @@ def test_registry_page_index_invalidates_on_length_change():
     second = registry.page_index(pages)
     assert first is not second
     assert second[pages[2]] == 2
+
+
+def test_registry_page_index_invalidates_on_same_length_reorder():
+    """Reordering pages with the same length rebuilds the index."""
+    registry = ContentRegistry()
+
+    class FakePage:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    pages = [FakePage("a"), FakePage("b")]
+    first = registry.page_index(pages)
+    reordered = [pages[1], pages[0]]
+    second = registry.page_index(reordered)
+
+    assert first is not second
+    assert second[pages[1]] == 0
+    assert second[pages[0]] == 1
+
+
+def test_registry_page_index_invalidates_on_same_length_replacement():
+    """Replacing pages with the same length rebuilds the index."""
+    registry = ContentRegistry()
+
+    class FakePage:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    pages = [FakePage("a"), FakePage("b")]
+    first = registry.page_index(pages)
+    replacement = [FakePage("c"), pages[1]]
+    second = registry.page_index(replacement)
+
+    assert first is not second
+    assert replacement[0] in second
+    assert pages[0] not in second
+
+
+def test_registry_page_index_concurrent_first_access():
+    """Concurrent first access returns a complete index without racing lazy construction."""
+    registry = ContentRegistry()
+
+    class FakePage:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    pages = [FakePage(str(i)) for i in range(25)]
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        indexes = list(executor.map(lambda _: registry.page_index(pages), range(16)))
+
+    assert all(index is indexes[0] for index in indexes)
+    assert indexes[0][pages[-1]] == 24
 
 
 def test_registry_page_index_resets_on_clear():

--- a/tests/unit/core/test_source_page.py
+++ b/tests/unit/core/test_source_page.py
@@ -65,6 +65,46 @@ class TestSourcePageImmutability:
         with pytest.raises(TypeError):
             sp.raw_metadata["new_key"] = "value"
 
+    def test_nested_metadata_is_readonly(self):
+        original = {
+            "title": "Hello",
+            "tags": ["a"],
+            "nested": {"items": ["one"]},
+        }
+        sp = SourcePage(
+            core=make_page_core(metadata=original),
+            raw_content="# Hello",
+            raw_metadata=MappingProxyType(original),
+            content_hash="abc123",
+        )
+
+        original["nested"]["items"].append("source-mutated")
+
+        with pytest.raises(TypeError):
+            sp.raw_metadata["nested"]["items"].append("record-mutated")
+        assert sp.raw_metadata["nested"]["items"] == ["one"]
+
+    def test_core_payloads_are_readonly_on_source_page(self):
+        sp = create_virtual_source_page(
+            source_id="__virtual__/tags/go.md",
+            title="Go Posts",
+            metadata={
+                "tags": ["go"],
+                "aliases": ["/old-go/"],
+                "custom_field": {"items": ["value"]},
+                "cascade": {"type": "doc", "items": ["a"]},
+            },
+        )
+
+        with pytest.raises(TypeError):
+            sp.core.tags.append("python")
+        with pytest.raises(TypeError):
+            sp.core.aliases.append("/older-go/")
+        with pytest.raises(TypeError):
+            sp.core.props["custom_field"]["items"].append("other")
+        with pytest.raises(TypeError):
+            sp.core.cascade["items"].append("b")
+
 
 class TestSourcePageDelegates:
     """Property delegates forward to core."""
@@ -97,9 +137,11 @@ class TestSourcePageMetadataRoundTrip:
         result = sp.raw_metadata_dict()
         assert result == original
         assert isinstance(result, dict)
-        # Mutating the copy doesn't affect the record
+        # Mutating the copy doesn't affect the record, including nested values.
         result["new_key"] = "new_value"
+        result["tags"].append("c")
         assert "new_key" not in sp.raw_metadata
+        assert sp.raw_metadata["tags"] == ["a", "b"]
 
 
 class TestSourcePageCoreCache:

--- a/tests/unit/effects/test_render_integration.py
+++ b/tests/unit/effects/test_render_integration.py
@@ -2,6 +2,8 @@
 Unit tests for render_integration module.
 """
 
+import contextvars
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -19,6 +21,8 @@ from bengal.effects.render_integration import (
     record_template_include,
 )
 from bengal.effects.tracer import EffectTracer
+
+pytestmark = pytest.mark.parallel_unsafe
 
 
 @dataclass
@@ -230,6 +234,26 @@ class TestBuildEffectTracer:
         BuildEffectTracer.reset()
         instance2 = BuildEffectTracer.get_instance()
         assert instance1 is not instance2
+
+    def test_activate_creates_context_scoped_instance(self) -> None:
+        """activate() binds a fresh tracer to the current context."""
+        instance1 = BuildEffectTracer.get_instance()
+        active = BuildEffectTracer.activate()
+        instance2 = BuildEffectTracer.get_instance()
+
+        assert active is instance2
+        assert instance1 is not instance2
+
+    def test_context_scoped_instance_propagates_to_worker_context(self) -> None:
+        """Worker contexts inherit the active build tracer."""
+        active = BuildEffectTracer.activate()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                contextvars.copy_context().run,
+                BuildEffectTracer.get_instance,
+            )
+            assert future.result() is active
 
     def test_disabled_by_default(self) -> None:
         """Tracing is disabled by default."""

--- a/tests/unit/orchestration/build/test_finalization.py
+++ b/tests/unit/orchestration/build/test_finalization.py
@@ -18,7 +18,6 @@ import pytest
 
 from bengal.orchestration.build.artifacts import (
     normalize_build_badge_config,
-    write_if_changed_atomic,
 )
 from bengal.orchestration.build.finalization import (
     phase_cache_save,
@@ -27,6 +26,7 @@ from bengal.orchestration.build.finalization import (
     phase_postprocess,
     run_health_check,
 )
+from bengal.utils.io.atomic_write import write_if_changed_atomic
 
 
 class MockPhaseContext:
@@ -428,20 +428,18 @@ class TestBuildBadgeIncremental:
 
     def test_write_if_changed_skips_identical_content(self, tmp_path):
         """write_if_changed_atomic skips write when content is identical."""
-        from bengal.utils.io.atomic_write import AtomicFile
-
         test_file = tmp_path / "test.txt"
         content = "test content"
 
         # First write
-        write_if_changed_atomic(test_file, content, AtomicFile)
+        write_if_changed_atomic(test_file, content)
         first_mtime = test_file.stat().st_mtime
 
         # Small delay to ensure mtime could differ
         time.sleep(0.1)
 
         # Second write with identical content
-        write_if_changed_atomic(test_file, content, AtomicFile)
+        write_if_changed_atomic(test_file, content)
         second_mtime = test_file.stat().st_mtime
 
         # mtime should NOT change (file not rewritten)
@@ -449,19 +447,17 @@ class TestBuildBadgeIncremental:
 
     def test_write_if_changed_updates_on_different_content(self, tmp_path):
         """write_if_changed_atomic updates when content differs."""
-        from bengal.utils.io.atomic_write import AtomicFile
-
         test_file = tmp_path / "test.txt"
 
         # First write
-        write_if_changed_atomic(test_file, "content v1", AtomicFile)
+        write_if_changed_atomic(test_file, "content v1")
         first_mtime = test_file.stat().st_mtime
 
         # Small delay to ensure mtime could differ
         time.sleep(0.1)
 
         # Second write with different content
-        write_if_changed_atomic(test_file, "content v2", AtomicFile)
+        write_if_changed_atomic(test_file, "content v2")
         second_mtime = test_file.stat().st_mtime
 
         # mtime should change (file rewritten)

--- a/tests/unit/plugins/test_plugin_parser_wiring.py
+++ b/tests/unit/plugins/test_plugin_parser_wiring.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import contextvars
+from concurrent.futures import ThreadPoolExecutor
 from typing import ClassVar
+
+import pytest
 
 from bengal.parsing import PatitasParser
 from bengal.parsing.backends.patitas.directives.registry import create_default_registry
 from bengal.parsing.backends.patitas.roles.registry import (
     create_default_registry as create_default_role_registry,
 )
-from bengal.plugins import set_active_registry
+from bengal.plugins import get_active_registry, reset_active_registry, set_active_registry
 from bengal.plugins.registry import PluginRegistry
+
+pytestmark = pytest.mark.parallel_unsafe
 
 
 class PluginDirective:
@@ -53,3 +59,25 @@ def test_patitas_parser_uses_active_plugin_registry() -> None:
 
     assert parser._md._parse_config.directive_registry.get("plugin-note") is not None
     assert parser._md._render_config.role_registry.get("plugin-role") is not None
+
+
+def test_active_plugin_registry_is_context_scoped() -> None:
+    registry = _plugin_registry()
+    token = set_active_registry(registry)
+    try:
+        assert get_active_registry() is registry
+    finally:
+        reset_active_registry(token)
+
+    assert get_active_registry() is None
+
+
+def test_active_plugin_registry_propagates_to_worker_context() -> None:
+    registry = _plugin_registry()
+    token = set_active_registry(registry)
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(contextvars.copy_context().run, get_active_registry)
+            assert future.result() is registry
+    finally:
+        reset_active_registry(token)

--- a/tests/unit/plugins/test_plugin_parser_wiring.py
+++ b/tests/unit/plugins/test_plugin_parser_wiring.py
@@ -72,6 +72,15 @@ def test_active_plugin_registry_is_context_scoped() -> None:
     assert get_active_registry() is None
 
 
+def test_empty_active_plugin_registry_reads_as_none() -> None:
+    registry = PluginRegistry().freeze()
+    token = set_active_registry(registry)
+    try:
+        assert get_active_registry() is None
+    finally:
+        reset_active_registry(token)
+
+
 def test_active_plugin_registry_propagates_to_worker_context() -> None:
     registry = _plugin_registry()
     token = set_active_registry(registry)

--- a/tests/unit/plugins/test_plugin_registry.py
+++ b/tests/unit/plugins/test_plugin_registry.py
@@ -1,0 +1,50 @@
+"""Tests for plugin registry contract validation."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from bengal.plugins.registry import PluginRegistry
+
+
+def test_freeze_returns_immutable_snapshot() -> None:
+    registry = PluginRegistry()
+    registry.add_template_filter("shout", lambda value: str(value).upper())
+
+    frozen = registry.freeze()
+
+    assert frozen.template_filters[0][0] == "shout"
+    with pytest.raises(FrozenInstanceError):
+        frozen.template_filters = ()
+    with pytest.raises(RuntimeError, match="Cannot modify"):
+        registry.add_template_filter("quiet", lambda value: value)
+
+
+def test_template_function_validates_phase() -> None:
+    registry = PluginRegistry()
+
+    with pytest.raises(ValueError, match="phase must be an integer from 1 to 9"):
+        registry.add_template_function("helper", lambda: None, phase=0)
+
+
+def test_template_filter_requires_callable() -> None:
+    registry = PluginRegistry()
+
+    with pytest.raises(TypeError, match="must be callable"):
+        registry.add_template_filter("broken", "not-callable")  # type: ignore[arg-type]
+
+
+def test_extension_names_must_be_non_empty() -> None:
+    registry = PluginRegistry()
+
+    with pytest.raises(ValueError, match="non-empty string"):
+        registry.add_shortcode("", "<span />")
+
+
+def test_content_source_must_be_class() -> None:
+    registry = PluginRegistry()
+
+    with pytest.raises(TypeError, match="must be a class"):
+        registry.add_content_source("remote", object())  # type: ignore[arg-type]

--- a/tests/unit/server/test_build_trigger.py
+++ b/tests/unit/server/test_build_trigger.py
@@ -169,6 +169,7 @@ class TestBuildTrigger:
 
         page = MagicMock()
         page.source_path = md_file
+        page._section = None
         mock_site.pages = [page]
 
         trigger = BuildTrigger(site=mock_site, executor=mock_executor)
@@ -189,6 +190,7 @@ class TestBuildTrigger:
 
         page = MagicMock()
         page.source_path = md_file
+        page._section = None
         mock_site.pages = [page]
 
         trigger = BuildTrigger(site=mock_site, executor=mock_executor)
@@ -198,6 +200,30 @@ class TestBuildTrigger:
         md_file.write_text("---\ntitle: Test\n---\nEdited body")
         result = trigger._can_use_reactive_path({md_file}, {"modified"})
         assert result is True
+
+    def test_reactive_path_rejects_page_with_rendered_section_index(
+        self, mock_site: MagicMock, mock_executor: MagicMock, tmp_path: Path
+    ) -> None:
+        """Leaf pages with rendered section indexes need the warm build path."""
+        md_file = tmp_path / "content" / "docs" / "page.md"
+        md_file.parent.mkdir(parents=True)
+        md_file.write_text("---\ntitle: Test\n---\nOriginal body")
+
+        index_page = MagicMock()
+        index_page.output_path = tmp_path / "public" / "docs" / "index.html"
+        section = MagicMock()
+        section.index_page = index_page
+        page = MagicMock()
+        page.source_path = md_file
+        page._section = section
+        mock_site.pages = [page]
+
+        trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+        trigger.seed_content_hash_cache([page])
+
+        md_file.write_text("---\ntitle: Test\n---\nEdited body")
+
+        assert trigger._can_use_reactive_path({md_file}, {"modified"}) is False
 
     def test_seed_content_hash_cache_section_page(
         self, mock_site: MagicMock, mock_executor: MagicMock, tmp_path: Path
@@ -209,6 +235,7 @@ class TestBuildTrigger:
 
         page = MagicMock()
         page.source_path = index_file
+        page._section = None
         mock_site.pages = [page]
 
         trigger = BuildTrigger(site=mock_site, executor=mock_executor)

--- a/tests/unit/server/test_reactive_handler.py
+++ b/tests/unit/server/test_reactive_handler.py
@@ -99,6 +99,7 @@ class TestReactiveContentHandler:
         page._raw_content = "---\ntitle: Test\n---\nBody"
         page.html_content = "<p>Body</p>"
         page.output_path = output_path
+        page._section = None
         mock_site.pages = [page]
         mock_site.output_dir = output_dir
 


### PR DESCRIPTION
## Summary
- isolate build-scoped state and stale-output guards across incremental/rendering paths
- make output/cache writes safer, including atomic uncompressed cache saves and a shared write-if-changed helper
- harden plugin registry contracts and document follow-up RFCs for dependency indexes and snapshot build-plan handoff

## Validation
- uv run pytest tests/unit/cache/test_cache_store.py tests/unit/orchestration/build/test_finalization.py::TestBuildBadgeIncremental::test_write_if_changed_skips_identical_content tests/unit/orchestration/build/test_finalization.py::TestBuildBadgeIncremental::test_write_if_changed_updates_on_different_content -q
- commit hooks ran ruff, ruff format, ty, check-cycles, and check-deps

## Notes
- check-cycles reports existing deferred-only cycles as warnings
- check-deps still reports the existing 5 dependency-layer warnings
- broad finalization tests still include known pre-existing mock/patch-path failures captured in the proof notes