### PR TITLE
[codex] speed up serve-ready post-render pipeline

### DIFF
--- a/bengal/build/provenance/filter.py
+++ b/bengal/build/provenance/filter.py
@@ -381,7 +381,8 @@ class ProvenanceFilter:
         page_path = self._get_page_key(page)
 
         # Thread-safe access to session cache
-        provenance = self._computed_provenance.get(page_path)
+        with self._session_lock:
+            provenance = self._computed_provenance.get(page_path)
 
         if provenance is None:
             provenance = self._compute_provenance(page)
@@ -439,8 +440,9 @@ class ProvenanceFilter:
 
     def _get_file_hash(self, path: Path) -> ContentHash:
         """Get file hash from session cache or compute it (thread-safe)."""
-        # Fast path: check without lock
-        cached = self._file_hashes.get(path)
+        # Fast path: protect reads as well as writes for free-threaded builds.
+        with self._session_lock:
+            cached = self._file_hashes.get(path)
         if cached is not None:
             return cached
 
@@ -569,9 +571,10 @@ class ProvenanceFilter:
         if is_virtual:
             return None  # Need full computation for virtual pages
 
-        # Check if already computed for this page (fast path without lock)
+        # Check if already computed for this page.
         page_path = self._get_page_key(page)
-        cached = self._computed_provenance.get(page_path)
+        with self._session_lock:
+            cached = self._computed_provenance.get(page_path)
         if cached is not None:
             return cached
 
@@ -630,8 +633,9 @@ class ProvenanceFilter:
         """
         page_path = self._get_page_key(page)
 
-        # Check cache first (fast path without lock)
-        cached = self._computed_provenance.get(page_path)
+        # Check cache first.
+        with self._session_lock:
+            cached = self._computed_provenance.get(page_path)
         if cached is not None:
             return cached
 

--- a/bengal/cache/build_cache/core.py
+++ b/bengal/cache/build_cache/core.py
@@ -499,7 +499,7 @@ class BuildCache(
 
         return None
 
-    def save(self, cache_path: Path, use_lock: bool = True) -> None:
+    def save(self, cache_path: Path, use_lock: bool = True) -> bool:
         """
         Save build cache to disk with optional file locking.
 
@@ -513,10 +513,9 @@ class BuildCache(
             cache_path: Path to cache file
             use_lock: Whether to use file locking (default: True)
 
-        Raises:
-            IOError: If cache file cannot be written
-            json.JSONEncodeError: If cache data cannot be serialized
-            LockAcquisitionError: If lock cannot be acquired (when use_lock=True)
+        Returns:
+            True when the cache was persisted, False when persistence failed
+            and the error was recorded.
         """
         # Ensure parent directory exists
         cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -530,6 +529,7 @@ class BuildCache(
                     self._save_to_file(cache_path)
             else:
                 self._save_to_file(cache_path)
+            return True
 
         except Exception as e:
             from bengal.errors import (
@@ -558,6 +558,7 @@ class BuildCache(
                 error_code=ErrorCode.A004.value,
                 impact="incremental_builds_disabled",
             )
+            return False
 
     def _save_to_file(self, cache_path: Path, compress: bool = True) -> None:
         """

--- a/bengal/cache/build_cache/core.py
+++ b/bengal/cache/build_cache/core.py
@@ -42,6 +42,7 @@ from bengal.cache.build_cache.parsed_content_cache import ParsedContentCacheMixi
 from bengal.cache.build_cache.rendered_output_cache import RenderedOutputCacheMixin
 from bengal.cache.build_cache.taxonomy_index_mixin import BuildTaxonomyIndex
 from bengal.cache.build_cache.validation_cache import ValidationCacheMixin
+from bengal.utils.io import json_compat
 from bengal.utils.observability.logger import get_logger
 from bengal.utils.paths.normalize import to_posix
 
@@ -49,6 +50,15 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = get_logger(__name__)
+
+HOT_STORE_FIELDS = frozenset(
+    {
+        "parsed_content",
+        "rendered_output",
+        "validation_results",
+        "synthetic_pages",
+    }
+)
 
 
 @dataclass
@@ -283,6 +293,8 @@ class BuildCache(
                 )
                 return cls()
 
+            cls._load_external_stores(cache_path, data)
+
             # Convert lists back to sets in dependencies
             if "dependencies" in data:
                 data["dependencies"] = {k: set(v) for k, v in data["dependencies"].items()}
@@ -436,6 +448,7 @@ class BuildCache(
             # Inject default version if missing
             if "version" not in data:
                 data["version"] = cls.VERSION
+            data.pop("external_stores", None)
 
             return cls(**data)
         except (json.JSONDecodeError, KeyError, TypeError) as e:
@@ -498,6 +511,41 @@ class BuildCache(
                 return dict(data) if isinstance(data, dict) else None
 
         return None
+
+    @classmethod
+    def _load_external_stores(cls, cache_path: Path, data: dict[str, Any]) -> None:
+        """Load split hot cache stores referenced by the main cache payload."""
+        external_stores = data.get("external_stores")
+        if not isinstance(external_stores, dict):
+            return
+
+        for field_name, relative_path in external_stores.items():
+            if field_name not in HOT_STORE_FIELDS or not isinstance(relative_path, str):
+                continue
+            store_path = cache_path.parent / relative_path
+            if not store_path.exists():
+                logger.warning(
+                    "cache_external_store_missing",
+                    field=field_name,
+                    path=str(store_path),
+                    action="using_inline_or_empty_store",
+                )
+                data.setdefault(field_name, {})
+                continue
+            try:
+                store_data = json_compat.load(store_path)
+            except Exception as e:
+                logger.warning(
+                    "cache_external_store_load_failed",
+                    field=field_name,
+                    path=str(store_path),
+                    error=str(e),
+                    action="using_inline_or_empty_store",
+                )
+                data.setdefault(field_name, {})
+                continue
+            if isinstance(store_data, dict):
+                data[field_name] = store_data
 
     def save(self, cache_path: Path, use_lock: bool = True) -> bool:
         """
@@ -587,6 +635,7 @@ class BuildCache(
 
         ti = self.taxonomy_index
         at = self.autodoc_tracker
+        external_stores = self._save_external_stores(cache_path)
 
         data = {
             "version": self.VERSION,
@@ -600,9 +649,9 @@ class BuildCache(
             "page_tags": {k: list(v) for k, v in ti.page_tags.items()},
             "tag_to_pages": {k: list(v) for k, v in ti.tag_to_pages.items()},
             "known_tags": list(ti.known_tags),
-            "parsed_content": self.parsed_content,  # Already in dict format
-            "rendered_output": self.rendered_output,  # Already in dict format (Optimization #3)
-            "validation_results": self.validation_results,  # Already in dict format
+            "parsed_content": {},
+            "rendered_output": {},
+            "validation_results": {},
             "page_artifacts": self.page_artifacts,  # Serialized post-render page records
             "output_format_fingerprints": self.output_format_fingerprints,
             "autodoc_dependencies": {
@@ -612,14 +661,14 @@ class BuildCache(
             "autodoc_source_metadata": {k: list(v) for k, v in at.autodoc_source_metadata.items()},
             # Autodoc content cache (CachedModuleInfo serialized to dict)
             "autodoc_content_cache": autodoc_content_serialized,
-            # Cached synthetic payloads (e.g., autodoc elements)
-            "synthetic_pages": self.synthetic_pages,
+            "synthetic_pages": {},
             "template_dependencies": {
                 k: list(v) for k, v in self.template_dependencies.items()
             },  # Per-page template deps
             "url_claims": self.url_claims,  # URL ownership claims (already dict format)
             "discovered_assets": self.discovered_assets,  # Discovered assets
             "config_hash": self.config_hash,  # Config hash for auto-invalidation
+            "external_stores": external_stores,
             "last_build": datetime.now(UTC).isoformat(),
         }
 
@@ -651,6 +700,23 @@ class BuildCache(
                 dependencies=len(self.dependencies),
                 cached_content=len(self.parsed_content),
             )
+
+    def _save_external_stores(self, cache_path: Path) -> dict[str, str]:
+        """Save hot cache maps outside the compressed monolithic cache payload."""
+        stores_dir = cache_path.parent / "stores"
+        stores_dir.mkdir(parents=True, exist_ok=True)
+        stores = {
+            "parsed_content": self.parsed_content,
+            "rendered_output": self.rendered_output,
+            "validation_results": self.validation_results,
+            "synthetic_pages": self.synthetic_pages,
+        }
+        relative_paths: dict[str, str] = {}
+        for field_name, payload in stores.items():
+            store_path = stores_dir / f"{field_name}.json"
+            json_compat.dump(payload, store_path, indent=None)
+            relative_paths[field_name] = str(store_path.relative_to(cache_path.parent))
+        return relative_paths
 
     def clear(self) -> None:
         """Clear all cache data."""

--- a/bengal/cache/page_artifact_store.py
+++ b/bengal/cache/page_artifact_store.py
@@ -43,9 +43,20 @@ class PageArtifactStore:
                         records[str(key)] = value
         return records
 
-    def save(self, records: dict[str, dict[str, Any]]) -> None:
+    def save(
+        self,
+        records: dict[str, dict[str, Any]],
+        *,
+        dirty_keys: set[str] | None = None,
+        deleted_keys: set[str] | None = None,
+    ) -> None:
         """Write records into deterministic shards and prune stale shards."""
         self.root.mkdir(parents=True, exist_ok=True)
+
+        if dirty_keys is not None or deleted_keys is not None:
+            self._save_dirty(records, dirty_keys or set(), deleted_keys or set())
+            return
+
         shards: dict[str, dict[str, dict[str, Any]]] = {}
         for key, record in records.items():
             shard = self._shard_name(key)
@@ -65,6 +76,33 @@ class PageArtifactStore:
             "page_artifact_shards_saved",
             records=len(records),
             shards=len(shards),
+            path=str(self.root),
+        )
+
+    def _save_dirty(
+        self,
+        records: dict[str, dict[str, Any]],
+        dirty_keys: set[str],
+        deleted_keys: set[str],
+    ) -> None:
+        """Rewrite only shards affected by dirty or deleted record keys."""
+        affected_shards = {self._shard_name(key) for key in dirty_keys | deleted_keys}
+        for shard in affected_shards:
+            shard_path = self.root / f"{shard}.json"
+            shard_records = {
+                key: record for key, record in records.items() if self._shard_name(key) == shard
+            }
+            if shard_records:
+                json_compat.dump(shard_records, shard_path, indent=None)
+            elif shard_path.exists():
+                shard_path.unlink()
+
+        logger.debug(
+            "page_artifact_dirty_shards_saved",
+            records=len(records),
+            dirty_keys=len(dirty_keys),
+            deleted_keys=len(deleted_keys),
+            shards=len(affected_shards),
             path=str(self.root),
         )
 

--- a/bengal/cache/page_artifact_store.py
+++ b/bengal/cache/page_artifact_store.py
@@ -1,0 +1,72 @@
+"""Sharded persistence for post-render page artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any
+
+from bengal.utils.io import json_compat
+from bengal.utils.observability.logger import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = get_logger(__name__)
+
+
+class PageArtifactStore:
+    """Persist page artifacts in small shards outside the main build cache."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def load(self) -> dict[str, dict[str, Any]]:
+        """Load all page artifact shards."""
+        if not self.root.exists():
+            return {}
+
+        records: dict[str, dict[str, Any]] = {}
+        for shard_path in self.root.glob("*.json"):
+            try:
+                data = json_compat.load(shard_path)
+            except Exception as e:
+                logger.warning(
+                    "page_artifact_shard_load_failed",
+                    path=str(shard_path),
+                    error=str(e),
+                    action="ignoring_shard",
+                )
+                continue
+            if isinstance(data, dict):
+                for key, value in data.items():
+                    if isinstance(value, dict):
+                        records[str(key)] = value
+        return records
+
+    def save(self, records: dict[str, dict[str, Any]]) -> None:
+        """Write records into deterministic shards and prune stale shards."""
+        self.root.mkdir(parents=True, exist_ok=True)
+        shards: dict[str, dict[str, dict[str, Any]]] = {}
+        for key, record in records.items():
+            shard = self._shard_name(key)
+            shards.setdefault(shard, {})[key] = record
+
+        live_paths = set()
+        for shard, shard_records in shards.items():
+            shard_path = self.root / f"{shard}.json"
+            live_paths.add(shard_path)
+            json_compat.dump(shard_records, shard_path, indent=None)
+
+        for shard_path in self.root.glob("*.json"):
+            if shard_path not in live_paths:
+                shard_path.unlink()
+
+        logger.debug(
+            "page_artifact_shards_saved",
+            records=len(records),
+            shards=len(shards),
+            path=str(self.root),
+        )
+
+    def _shard_name(self, key: str) -> str:
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()[:2]

--- a/bengal/cli/milo_commands/serve.py
+++ b/bengal/cli/milo_commands/serve.py
@@ -20,6 +20,10 @@ def serve(
     profile: Annotated[str, Description("Config profile: writer, theme-dev, dev")] = "",
     version_scope: Annotated[str, Description("Focus on single version (e.g., v2, latest)")] = "",
     all_versions: Annotated[bool, Description("Build all versions (git versioning mode)")] = False,
+    complete: Annotated[
+        bool,
+        Description("Wait for deploy-quality artifacts, health checks, and caches before serving"),
+    ] = False,
     verbose: Annotated[bool, Description("Show detailed server activity")] = False,
     debug: Annotated[bool, Description("Show debug output and full tracebacks")] = False,
     style: Annotated[str, Description("Output style: dense, ascii, or ci")] = "dense",
@@ -93,6 +97,7 @@ def serve(
             cfg["build"]["debug"] = True
 
         try:
+            from bengal.orchestration.build.options import BuildCompletionPolicy
             from bengal.orchestration.site_runner import SiteRunner
 
             SiteRunner(site).serve(
@@ -102,6 +107,11 @@ def serve(
                 auto_port=auto_port,
                 open_browser=open_browser,
                 version_scope=version_scope_val,
+                completion_policy=(
+                    BuildCompletionPolicy.COMPLETE
+                    if complete
+                    else BuildCompletionPolicy.SERVE_READY
+                ),
             )
 
             return {"status": "ok", "message": "Server stopped"}

--- a/bengal/core/site/__init__.py
+++ b/bengal/core/site/__init__.py
@@ -1185,6 +1185,7 @@ class Site:
         auto_port: bool = True,
         open_browser: bool = False,
         version_scope: str | None = None,
+        completion_policy: Any | None = None,
     ) -> None:
         """
         Start a development server with file watching and live reload.
@@ -1202,6 +1203,7 @@ class Site:
             auto_port=auto_port,
             open_browser=open_browser,
             version_scope=version_scope,
+            completion_policy=completion_policy,
         )
 
     def clean(self) -> None:

--- a/bengal/effects/tracer.py
+++ b/bengal/effects/tracer.py
@@ -16,13 +16,13 @@ Thread-safe because it only reads frozen SiteSnapshot.
 
 import json
 import threading
-import time
 from collections import defaultdict
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from bengal.effects.effect import Effect
+from bengal.utils.io import json_compat
 
 
 class EffectTracerDict(TypedDict):
@@ -102,6 +102,12 @@ class EffectTracer:
         Args:
             effect: Effect to index
         """
+        replaced_effects = {
+            existing for output in effect.outputs if (existing := self._output_index.get(output))
+        }
+        for existing in replaced_effects:
+            self._remove_effect(existing)
+
         self._effects.append(effect)
 
         # Update dependency index
@@ -116,7 +122,26 @@ class EffectTracer:
         for key in effect.invalidates:
             self._invalidation_index[key].append(effect)
 
-    def _effects_for_path(self, path: Path) -> list[Effect]:
+    def _remove_effect(self, effect: Effect) -> None:
+        """Remove an existing effect from all indexes before replacement."""
+        self._effects = [candidate for candidate in self._effects if candidate is not effect]
+        for dep in effect.depends_on:
+            effects = self._dep_index.get(dep)
+            if effects is not None:
+                effects[:] = [candidate for candidate in effects if candidate is not effect]
+                if not effects:
+                    self._dep_index.pop(dep, None)
+        for output in effect.outputs:
+            if self._output_index.get(output) is effect:
+                self._output_index.pop(output, None)
+        for key in effect.invalidates:
+            effects = self._invalidation_index.get(key)
+            if effects is not None:
+                effects[:] = [candidate for candidate in effects if candidate is not effect]
+                if not effects:
+                    self._invalidation_index.pop(key, None)
+
+    def _effects_for_path(self, path: Path, *, include_name: bool = True) -> list[Effect]:
         """
         Get effects depending on a path (checks both Path and name forms).
 
@@ -133,8 +158,16 @@ class EffectTracer:
         """
         effects = list(self._dep_index.get(path, []))
         # Also check template name form
-        effects.extend(self._dep_index.get(path.name, []))
+        if include_name:
+            effects.extend(self._dep_index.get(path.name, []))
         return effects
+
+    def get_effects_depending_on(self, path: Path, *, include_name: bool = True) -> list[Effect]:
+        """Return effects that depend on a path using the tracer dependency index."""
+        with self._lock:
+            effects = self._effects_for_path(path, include_name=include_name)
+            deduped = dict.fromkeys(effects)
+            return list(deduped)
 
     def record(self, effect: Effect) -> None:
         """
@@ -333,15 +366,7 @@ class EffectTracer:
     def save(self, path: Path) -> None:
         """Save tracer state to a JSON file."""
         data = self.to_dict()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_name(f"{path.name}.{threading.get_ident()}.{time.time_ns()}.tmp")
-        try:
-            with open(tmp_path, "w") as f:
-                json.dump(data, f, separators=(",", ":"))
-            tmp_path.replace(path)
-        finally:
-            with suppress(Exception):
-                tmp_path.unlink(missing_ok=True)
+        json_compat.dump(data, path, indent=None)
 
     @classmethod
     def load(cls, path: Path) -> EffectTracer:
@@ -353,8 +378,7 @@ class EffectTracer:
         if not path.exists():
             return cls()
         try:
-            with open(path) as f:
-                data = json.load(f)
+            data = json_compat.load(path)
         except json.JSONDecodeError:
             import logging
 

--- a/bengal/health/health_check.py
+++ b/bengal/health/health_check.py
@@ -538,6 +538,7 @@ class HealthCheck:
         cached_results_by_file: dict[Path, tuple[CheckResult, ...]] = {}
         use_cache = cache is not None and len(files_to_validate) < len(self.site.pages)
         cache_context = self._validation_cache_context(validator)
+        missing_cached_files = 0
         if use_cache:
             for page in self.site.pages:
                 source_path = getattr(page, "source_path", None)
@@ -551,6 +552,11 @@ class HealthCheck:
                     cached_results_by_file[source_path] = tuple(
                         CheckResult.from_cache_dict(result) for result in cached
                     )
+                else:
+                    missing_cached_files += 1
+
+        if use_cache and missing_cached_files:
+            return None
 
         return ValidationScope(
             incremental=True,
@@ -565,7 +571,7 @@ class HealthCheck:
         scope: ValidationScope | None,
     ) -> None:
         """Persist validator-provided per-file results for changed files."""
-        if cache is None or scope is None or scope.files_to_validate is None:
+        if cache is None:
             return
 
         file_results = getattr(validator, "last_file_results", None)
@@ -573,7 +579,12 @@ class HealthCheck:
             return
 
         cache_context = self._validation_cache_context(validator)
-        for source_path in scope.files_to_validate:
+        source_paths = (
+            scope.files_to_validate
+            if scope is not None and scope.files_to_validate is not None
+            else frozenset(file_results)
+        )
+        for source_path in source_paths:
             fresh_results = list(file_results.get(source_path, []))
             if cache_context is None:
                 cache.cache_validation_results(source_path, validator.name, fresh_results)

--- a/bengal/health/validators/directives/__init__.py
+++ b/bengal/health/validators/directives/__init__.py
@@ -17,6 +17,7 @@ Structure:
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, override
 
 from bengal.health.base import BaseValidator
@@ -89,6 +90,7 @@ class DirectiveValidator(BaseValidator):
 
     # Store stats from last validation for observability
     last_stats: ValidatorStats | None = None
+    last_file_results: dict[Path, list[CheckResult]] | None = None
 
     @override
     def validate(self, site: SiteLike, build_context: Any = None) -> list[CheckResult]:
@@ -109,6 +111,7 @@ class DirectiveValidator(BaseValidator):
         """
         results = []
         sub_timings: dict[str, float] = {}
+        self.last_file_results = None
 
         # Gather all directive data from source files
         # Uses cached content if build_context is provided (build-integrated validation)
@@ -131,6 +134,7 @@ class DirectiveValidator(BaseValidator):
         t3 = time.time()
         results.extend(check_directive_performance(directive_data))
         sub_timings["performance"] = (time.time() - t3) * 1000
+        self.last_file_results = _file_results_by_source(directive_data)
 
         # Note: Rendering validation (H207) was removed - it parsed all HTML output
         # files which took ~1.2s and never caught any issues. Syntax validation (H201)
@@ -158,3 +162,48 @@ class DirectiveValidator(BaseValidator):
         )
 
         return results
+
+
+def _file_results_by_source(directive_data: dict[str, Any]) -> dict[Path, list[CheckResult]]:
+    """Build per-source directive results for incremental health caching."""
+    results_by_source: dict[Path, list[CheckResult]] = {}
+    for source_path in directive_data.get("_analyzed_paths", []):
+        if not isinstance(source_path, Path):
+            continue
+        file_data = _directive_data_for_source(directive_data, source_path)
+        results: list[CheckResult] = []
+        results.extend(check_directive_syntax(file_data))
+        results.extend(check_directive_completeness(file_data))
+        results.extend(check_directive_performance(file_data))
+        results_by_source[source_path] = results
+    return results_by_source
+
+
+def _directive_data_for_source(directive_data: dict[str, Any], source_path: Path) -> dict[str, Any]:
+    """Filter aggregate directive data down to one source path."""
+    source_key = str(source_path)
+    return {
+        "total_directives": len(directive_data.get("by_page", {}).get(source_key, [])),
+        "by_type": {},
+        "by_page": {source_key: directive_data.get("by_page", {}).get(source_key, [])},
+        "syntax_errors": [
+            item
+            for item in directive_data.get("syntax_errors", [])
+            if item.get("page") == source_path
+        ],
+        "completeness_errors": [
+            item
+            for item in directive_data.get("completeness_errors", [])
+            if item.get("page") == source_path
+        ],
+        "performance_warnings": [
+            item
+            for item in directive_data.get("performance_warnings", [])
+            if item.get("page") == source_path
+        ],
+        "fence_nesting_warnings": [
+            item
+            for item in directive_data.get("fence_nesting_warnings", [])
+            if item.get("page") == source_path
+        ],
+    }

--- a/bengal/health/validators/directives/analysis.py
+++ b/bengal/health/validators/directives/analysis.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bengal.health.scope import get_validation_scope
 from bengal.utils.autodoc import is_autodoc_page
 from bengal.utils.observability.logger import get_logger
 
@@ -97,6 +98,7 @@ class DirectiveAnalyzer:
             "completeness_errors": [],
             "performance_warnings": [],
             "fence_nesting_warnings": [],
+            "_analyzed_paths": [],
         }
 
         # Use cached content if available (build-integrated validation)
@@ -112,12 +114,16 @@ class DirectiveAnalyzer:
         skip_no_path = 0
         skip_generated = 0
         skip_autodoc = 0
-        skip_no_changes = 0
+        skip_unscoped = 0
         cache_hits = 0
         disk_reads = 0
+        scope = get_validation_scope(build_context)
+        pages_to_analyze = scope.pages_to_validate(site) if scope is not None else list(site.pages)
+        if scope is not None:
+            skip_unscoped = max(0, len(site.pages) - len(pages_to_analyze))
 
         # Analyze each page's source content
-        for page in site.pages:
+        for page in pages_to_analyze:
             if not page.source_path or not page.source_path.exists():
                 skip_no_path += 1
                 continue
@@ -132,22 +138,8 @@ class DirectiveAnalyzer:
                 skip_autodoc += 1
                 continue
 
-            # Incremental fast path: when build context provides changed pages, only analyze those.
-            # This keeps dev-server rebuilds fast when only templates/assets changed.
-            if (
-                build_context is not None
-                and getattr(build_context, "incremental", False)
-                and hasattr(build_context, "changed_page_paths")
-            ):
-                changed_page_paths = getattr(build_context, "changed_page_paths", None)
-                if (
-                    isinstance(changed_page_paths, set)
-                    and page.source_path not in changed_page_paths
-                ):
-                    skip_no_changes += 1
-                    continue
-
             pages_processed += 1
+            data["_analyzed_paths"].append(page.source_path)
 
             try:
                 # Use cached content if available (eliminates disk I/O)
@@ -237,7 +229,7 @@ class DirectiveAnalyzer:
                 "no_path": skip_no_path,
                 "generated": skip_generated,
                 "autodoc": skip_autodoc,
-                "no_changes": skip_no_changes,
+                "unscoped": skip_unscoped,
             },
             "cache_hits": cache_hits,
             "cache_misses": disk_reads,

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -338,8 +338,13 @@ class BuildOrchestrator:
 
         # Initialize cache (ALWAYS, even for full builds)
         # We need cache for cleanup of deleted files and auto-mode decision
+        initialization_start = time.perf_counter()
         with logger.phase("initialization"):
             cache = self.incremental.initialize(enabled=True)  # Always load cache
+        self.stats.record_phase_timing(
+            "Initialization",
+            (time.perf_counter() - initialization_start) * 1000,
+        )
 
         # RFC: Output Cache Architecture - Initialize GeneratedPageCache for tag page caching
         # This enables skipping unchanged tag pages based on member content hashes
@@ -454,6 +459,7 @@ class BuildOrchestrator:
         initialization.phase_cache_metadata(self)
 
         discovery_duration_ms = (time.time() - discovery_start) * 1000
+        self.stats.record_phase_timing("Discovery", discovery_duration_ms)
 
         notify_phase_complete(
             "discovery",
@@ -463,6 +469,7 @@ class BuildOrchestrator:
         run_plugin_phase("post_discovery")
 
         # Phase 4: Config Check and Cleanup
+        filter_start = time.perf_counter()
         config_result = initialization.phase_config_check(self, cli, cache, incremental)
         incremental = config_result.incremental
         config_changed = config_result.config_changed
@@ -482,6 +489,10 @@ class BuildOrchestrator:
             build_start,
             changed_sources=changed_sources,
             nav_changed_sources=nav_changed_sources,
+        )
+        self.stats.record_phase_timing(
+            "Config/filter",
+            (time.perf_counter() - filter_start) * 1000,
         )
 
         if filter_result is None:
@@ -565,6 +576,7 @@ class BuildOrchestrator:
             )
 
         content_duration_ms = (time.time() - content_start) * 1000
+        self.stats.record_phase_timing("Content", content_duration_ms)
         taxonomy_count = len(self.site.taxonomies) if hasattr(self.site, "taxonomies") else 0
         notify_phase_complete(
             "content",
@@ -586,6 +598,7 @@ class BuildOrchestrator:
                 parallel=not force_sequential,
             )
         parsing_duration_ms = (time.time() - parsing_start) * 1000
+        self.stats.record_phase_timing("Parsing", parsing_duration_ms)
         if hasattr(self.stats, "parsing_time_ms"):
             self.stats.parsing_time_ms = parsing_duration_ms
 
@@ -605,6 +618,7 @@ class BuildOrchestrator:
         with self.logger.phase("snapshot"):
             site_snapshot = create_site_snapshot(self.site)
             snapshot_duration_ms = (time.time() - snapshot_start) * 1000
+            self.stats.record_phase_timing("Snapshot", snapshot_duration_ms)
             # Store snapshot in build context for rendering phase
             early_ctx.snapshot = site_snapshot
             # Store snapshot time in stats if available
@@ -684,6 +698,7 @@ class BuildOrchestrator:
         )
 
         assets_duration_ms = (time.time() - assets_start) * 1000
+        self.stats.record_phase_timing("Assets", assets_duration_ms)
         notify_phase_complete(
             "assets",
             assets_duration_ms,
@@ -748,6 +763,7 @@ class BuildOrchestrator:
             record_all_page_builds(self, pages_to_build, parallel=not force_sequential)
 
         rendering_duration_ms = (time.time() - rendering_start) * 1000
+        self.stats.record_phase_timing("Rendering", rendering_duration_ms)
         notify_phase_complete(
             "rendering",
             rendering_duration_ms,
@@ -766,6 +782,7 @@ class BuildOrchestrator:
         finalization.phase_postprocess(
             self, cli, not force_sequential, ctx, incremental, collector=output_collector
         )
+        self.stats.record_phase_timing("Post-process", self.stats.postprocess_time_ms)
 
         from bengal.orchestration.build.artifact_inventory import populate_artifact_inventory
 
@@ -777,6 +794,10 @@ class BuildOrchestrator:
         self.stats.post_render_timings_ms["artifact_inventory"] = round(
             (time.perf_counter() - artifact_inventory_start) * 1000,
             1,
+        )
+        self.stats.record_phase_timing(
+            "Artifact inventory",
+            self.stats.post_render_timings_ms["artifact_inventory"],
         )
 
         # RFC: Output Cache Architecture - Update GeneratedPageCache for tag pages that were rendered
@@ -862,6 +883,7 @@ class BuildOrchestrator:
 
         cache_duration_ms = (time.perf_counter() - cache_start) * 1000
         self.stats.post_render_timings_ms["cache_save"] = round(cache_duration_ms, 1)
+        self.stats.record_phase_timing("Cache save", cache_duration_ms)
         if cli is not None:
             cli.phase("Cache save", duration_ms=cache_duration_ms)
         self.logger.info("cache_saved")
@@ -873,6 +895,7 @@ class BuildOrchestrator:
             (time.perf_counter() - stats_start) * 1000,
             1,
         )
+        self.stats.record_phase_timing("Stats", self.stats.post_render_timings_ms["stats"])
 
         # Phase 19.5: Finalize Error Session (track build errors for pattern detection)
         self._finalize_error_session()
@@ -947,9 +970,6 @@ class BuildOrchestrator:
         notify_phase_complete("health", health_duration_ms, health_summary)
         run_plugin_phase("post_health")
 
-        # Phase 21: Finalize Build
-        finalization.phase_finalize(self, verbose, collector)
-
         # Save provenance cache if using provenance-based filtering
         if hasattr(self, "_provenance_filter"):
             from bengal.orchestration.build.provenance_filter import save_provenance_cache
@@ -960,6 +980,20 @@ class BuildOrchestrator:
                 (time.perf_counter() - provenance_save_start) * 1000,
                 1,
             )
+            self.stats.record_phase_timing(
+                "Provenance save",
+                self.stats.post_render_timings_ms["provenance_save"],
+            )
+
+        # Phase 21: Finalize Build
+        finalization_start = time.perf_counter()
+        self.stats.build_time_ms = (time.time() - build_start) * 1000
+        finalization.phase_finalize(self, verbose, collector)
+        self.stats.record_phase_timing(
+            "Finalize",
+            (time.perf_counter() - finalization_start) * 1000,
+        )
+        self.stats.build_time_ms = (time.time() - build_start) * 1000
 
         # Clean up partial fast-write files if build had errors
         if self.stats.template_errors or (isinstance(self.stats, HasErrors) and self.stats.errors):

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -67,7 +67,7 @@ from bengal.utils.observability.logger import get_logger
 
 from . import content, finalization, initialization, parsing, rendering
 from .inputs import BuildInput
-from .options import BuildOptions  # noqa: TC001 — runtime re-export for health.py et al.
+from .options import BuildCompletionPolicy, BuildOptions
 
 logger = get_logger(__name__)
 
@@ -185,6 +185,7 @@ class BuildOrchestrator:
         changed_sources = options.changed_sources or None
         nav_changed_sources = options.nav_changed_sources or None
         structural_changed = options.structural_changed
+        serve_ready_policy = options.completion_policy is BuildCompletionPolicy.SERVE_READY
 
         # Explain mode options (RFC: rfc-incremental-build-observability Phase 2)
         explain = options.explain
@@ -781,30 +782,38 @@ class BuildOrchestrator:
         # Phase 17: Post-processing
         # Enable parallel post-processing for independent tasks (sitemap, RSS, output formats)
         finalization.phase_postprocess(
-            self, cli, not force_sequential, ctx, incremental, collector=output_collector
+            self,
+            cli,
+            not force_sequential,
+            ctx,
+            incremental,
+            collector=output_collector,
+            enabled_task_names={"special pages"} if serve_ready_policy else None,
+            run_asset_audit=not serve_ready_policy,
         )
         self.stats.record_phase_timing("Post-process", self.stats.postprocess_time_ms)
 
         from bengal.orchestration.build.artifact_inventory import populate_artifact_inventory
 
-        if ctx is not None:
-            ctx.output_collector = output_collector
-            ctx.artifact_collector = artifact_collector
-        artifact_inventory_start = time.perf_counter()
-        populate_artifact_inventory(self.site, ctx)
-        self.stats.post_render_timings_ms["artifact_inventory"] = round(
-            (time.perf_counter() - artifact_inventory_start) * 1000,
-            1,
-        )
-        self.stats.record_phase_timing(
-            "Artifact inventory",
-            self.stats.post_render_timings_ms["artifact_inventory"],
-        )
+        if not serve_ready_policy:
+            if ctx is not None:
+                ctx.output_collector = output_collector
+                ctx.artifact_collector = artifact_collector
+            artifact_inventory_start = time.perf_counter()
+            populate_artifact_inventory(self.site, ctx)
+            self.stats.post_render_timings_ms["artifact_inventory"] = round(
+                (time.perf_counter() - artifact_inventory_start) * 1000,
+                1,
+            )
+            self.stats.record_phase_timing(
+                "Artifact inventory",
+                self.stats.post_render_timings_ms["artifact_inventory"],
+            )
 
         # RFC: Output Cache Architecture - Update GeneratedPageCache for tag pages that were rendered
         # This enables skipping them on future builds if member content hasn't changed
         # Note: Update on ALL builds (not just incremental) to populate cache for first build
-        if generated_page_cache:
+        if generated_page_cache and not serve_ready_policy:
             # Build content hash lookup from parsed_content cache
             content_hash_lookup: dict[str, str] = {}
             if cache and hasattr(cache, "parsed_content"):
@@ -875,19 +884,27 @@ class BuildOrchestrator:
         # Run cache saves in parallel
         from bengal.utils.concurrency.work_scope import WorkScope
 
-        with WorkScope("CacheSave", max_workers=2) as scope:
-            results = scope.map(lambda fn: fn(), [_save_main_cache, _save_generated_cache])
+        if serve_ready_policy:
+            self.stats.post_render_timings_ms["cache_save"] = 0
+            if cli is not None:
+                cli.detail(
+                    "cache save deferred for serve-ready build", indent=1, icon=cli.icons.arrow
+                )
+            self.logger.info("cache_save_deferred", policy=options.completion_policy.value)
+        else:
+            with WorkScope("CacheSave", max_workers=2) as scope:
+                results = scope.map(lambda fn: fn(), [_save_main_cache, _save_generated_cache])
 
-        for r in results:
-            if r.error:
-                raise r.error
+            for r in results:
+                if r.error:
+                    raise r.error
 
-        cache_duration_ms = (time.perf_counter() - cache_start) * 1000
-        self.stats.post_render_timings_ms["cache_save"] = round(cache_duration_ms, 1)
-        self.stats.record_phase_timing("Cache save", cache_duration_ms)
-        if cli is not None:
-            cli.phase("Cache save", duration_ms=cache_duration_ms)
-        self.logger.info("cache_saved")
+            cache_duration_ms = (time.perf_counter() - cache_start) * 1000
+            self.stats.post_render_timings_ms["cache_save"] = round(cache_duration_ms, 1)
+            self.stats.record_phase_timing("Cache save", cache_duration_ms)
+            if cli is not None:
+                cli.phase("Cache save", duration_ms=cache_duration_ms)
+            self.logger.info("cache_saved")
 
         # Phase 19: Collect Final Stats
         stats_start = time.perf_counter()
@@ -946,33 +963,41 @@ class BuildOrchestrator:
         )
         run_plugin_phase("post_finalization")
 
-        # === HEALTH PHASE GROUP (dashboard-integrated) ===
-        run_plugin_phase("pre_health")
-        notify_phase_start("health")
-        health_start = time.time()
+        if serve_ready_policy:
+            self.stats.post_render_timings_ms["health"] = 0
+            if cli is not None:
+                cli.detail(
+                    "health check deferred for serve-ready build", indent=1, icon=cli.icons.arrow
+                )
+            self.logger.info("health_check_deferred", policy=options.completion_policy.value)
+        else:
+            # === HEALTH PHASE GROUP (dashboard-integrated) ===
+            run_plugin_phase("pre_health")
+            notify_phase_start("health")
+            health_start = time.time()
 
-        # Phase 20: Health Check
-        with logger.phase("health_check"):
-            finalization.run_health_check(
-                self,
-                profile=profile,
-                incremental=incremental,
-                build_context=ctx,
-            )
+            # Phase 20: Health Check
+            with logger.phase("health_check"):
+                finalization.run_health_check(
+                    self,
+                    profile=profile,
+                    incremental=incremental,
+                    build_context=ctx,
+                )
 
-        health_duration_ms = (time.time() - health_start) * 1000
-        self.stats.post_render_timings_ms["health"] = round(health_duration_ms, 1)
-        health_report = getattr(self.stats, "health_report", None)
-        health_summary = ""
-        if health_report:
-            passed = health_report.total_passed
-            total = health_report.total_checks
-            health_summary = f"{passed}/{total} checks passed"
-        notify_phase_complete("health", health_duration_ms, health_summary)
-        run_plugin_phase("post_health")
+            health_duration_ms = (time.time() - health_start) * 1000
+            self.stats.post_render_timings_ms["health"] = round(health_duration_ms, 1)
+            health_report = getattr(self.stats, "health_report", None)
+            health_summary = ""
+            if health_report:
+                passed = health_report.total_passed
+                total = health_report.total_checks
+                health_summary = f"{passed}/{total} checks passed"
+            notify_phase_complete("health", health_duration_ms, health_summary)
+            run_plugin_phase("post_health")
 
         # Save provenance cache if using provenance-based filtering
-        if hasattr(self, "_provenance_filter"):
+        if hasattr(self, "_provenance_filter") and not serve_ready_policy:
             from bengal.orchestration.build.provenance_filter import save_provenance_cache
 
             provenance_save_start = time.perf_counter()

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -278,6 +278,7 @@ class BuildOrchestrator:
         # Initialize stats (incremental may be None, resolve later)
         self.stats = BuildStats(parallel=False, incremental=bool(incremental))
         self.stats.strict_mode = strict
+        self.stats.completion_policy = options.completion_policy.value
 
         logger.info(
             "build_start",

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -829,7 +829,22 @@ class BuildOrchestrator:
         cache_start = time.perf_counter()
 
         def _save_main_cache() -> None:
-            self.incremental.save_cache(pages_to_build, assets_to_process, build_context=ctx)
+            saved = self.incremental.save_cache(
+                pages_to_build,
+                assets_to_process,
+                build_context=ctx,
+            )
+            if saved is False:
+                from bengal.errors import BengalCacheError, ErrorCode
+
+                raise BengalCacheError(
+                    "Build cache could not be saved.",
+                    code=ErrorCode.A004,
+                    suggestion=(
+                        "Check disk space and permissions. Incremental builds may be stale "
+                        "until the cache can be saved."
+                    ),
+                )
 
         def _save_generated_cache() -> None:
             if generated_page_cache:

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -498,6 +498,7 @@ class BuildOrchestrator:
         # health validators) can make safe incremental decisions without re-scanning everything.
         early_ctx.incremental = bool(incremental)
         early_ctx.changed_page_paths = set(changed_page_paths)
+        early_ctx.config_changed = bool(config_changed)
 
         # === CONTENT PHASE GROUP (dashboard-integrated) ===
         run_plugin_phase("pre_content")
@@ -549,6 +550,7 @@ class BuildOrchestrator:
             self._filter_sections_by_variant(self.site.sections, variant)
             if hasattr(self.site, "invalidate_regular_pages_cache"):
                 self.site.invalidate_regular_pages_cache()
+        early_ctx.pages_to_build = list(pages_to_build)
 
         # Phase 12.5: URL Collision Detection (proactive validation)
         collisions = self.site.validate_no_url_collisions(strict=options.strict)
@@ -770,7 +772,12 @@ class BuildOrchestrator:
         if ctx is not None:
             ctx.output_collector = output_collector
             ctx.artifact_collector = artifact_collector
+        artifact_inventory_start = time.perf_counter()
         populate_artifact_inventory(self.site, ctx)
+        self.stats.post_render_timings_ms["artifact_inventory"] = round(
+            (time.perf_counter() - artifact_inventory_start) * 1000,
+            1,
+        )
 
         # RFC: Output Cache Architecture - Update GeneratedPageCache for tag pages that were rendered
         # This enables skipping them on future builds if member content hasn't changed
@@ -839,12 +846,18 @@ class BuildOrchestrator:
                 raise r.error
 
         cache_duration_ms = (time.perf_counter() - cache_start) * 1000
+        self.stats.post_render_timings_ms["cache_save"] = round(cache_duration_ms, 1)
         if cli is not None:
             cli.phase("Cache save", duration_ms=cache_duration_ms)
         self.logger.info("cache_saved")
 
         # Phase 19: Collect Final Stats
+        stats_start = time.perf_counter()
         finalization.phase_collect_stats(self, build_start, cli=cli)
+        self.stats.post_render_timings_ms["stats"] = round(
+            (time.perf_counter() - stats_start) * 1000,
+            1,
+        )
 
         # Phase 19.5: Finalize Error Session (track build errors for pattern detection)
         self._finalize_error_session()
@@ -909,6 +922,7 @@ class BuildOrchestrator:
             )
 
         health_duration_ms = (time.time() - health_start) * 1000
+        self.stats.post_render_timings_ms["health"] = round(health_duration_ms, 1)
         health_report = getattr(self.stats, "health_report", None)
         health_summary = ""
         if health_report:
@@ -925,7 +939,12 @@ class BuildOrchestrator:
         if hasattr(self, "_provenance_filter"):
             from bengal.orchestration.build.provenance_filter import save_provenance_cache
 
+            provenance_save_start = time.perf_counter()
             save_provenance_cache(self)
+            self.stats.post_render_timings_ms["provenance_save"] = round(
+                (time.perf_counter() - provenance_save_start) * 1000,
+                1,
+            )
 
         # Clean up partial fast-write files if build had errors
         if self.stats.template_errors or (isinstance(self.stats, HasErrors) and self.stats.errors):

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -83,9 +83,18 @@ def phase_postprocess(
 
         from bengal.rendering.asset_audit import find_missing_local_asset_references
 
+        audit_start = time.perf_counter()
+        strict = getattr(ctx, "strict", False) or getattr(orchestrator.stats, "strict_mode", False)
+        html_paths = None if strict or not incremental else _changed_html_output_paths(collector)
         missing_refs = find_missing_local_asset_references(
             orchestrator.site.output_dir,
             baseurl=getattr(orchestrator.site, "baseurl", "") or "",
+            html_paths=html_paths,
+        )
+        _record_post_render_timing(
+            orchestrator,
+            "asset_audit",
+            (time.perf_counter() - audit_start) * 1000,
         )
         if missing_refs:
             samples = [
@@ -99,9 +108,6 @@ def phase_postprocess(
                 }
                 for ref in missing_refs[:5]
             ]
-            strict = getattr(ctx, "strict", False) or getattr(
-                orchestrator.stats, "strict_mode", False
-            )
             if strict:
                 from bengal.errors import BengalAssetError, ErrorCode
 
@@ -135,6 +141,36 @@ def _relative_output_path(path: Any, output_dir: Any) -> str:
         return str(path.relative_to(output_dir))
     except ValueError:
         return str(path)
+
+
+def _changed_html_output_paths(collector: OutputCollector | None) -> list[Any] | None:
+    """Return changed HTML output paths from the build collector, or None for full audit."""
+    if collector is None:
+        return None
+    get_outputs = getattr(collector, "get_outputs", None)
+    if not callable(get_outputs):
+        return None
+    try:
+        outputs = get_outputs()
+    except Exception:
+        return None
+    html_paths = [
+        record.path
+        for record in outputs
+        if getattr(getattr(record, "output_type", None), "value", None) == "html"
+    ]
+    return html_paths
+
+
+def _record_post_render_timing(
+    orchestrator: BuildOrchestrator,
+    name: str,
+    duration_ms: float,
+) -> None:
+    """Record a post-render/finalization timing when supported by BuildStats."""
+    timings = getattr(orchestrator.stats, "post_render_timings_ms", None)
+    if isinstance(timings, dict):
+        timings[name] = round(duration_ms, 1)
 
 
 def phase_cache_save(
@@ -307,6 +343,7 @@ def run_health_check(
     report = health_check.run(
         profile=profile,
         incremental=incremental,
+        context=_health_validation_context(build_context) if incremental else None,
         cache=cache,
         build_context=build_context,
     )
@@ -375,6 +412,25 @@ def run_health_check(
             "Review output or disable strict_mode.",
             suggestion="Review the health check report above and fix the errors, or set health_check.strict_mode=false",
         )
+
+
+def _health_validation_context(build_context: BuildContext | Any | None) -> list[Any] | None:
+    """Return changed source paths for incremental health validation."""
+    if build_context is None:
+        return None
+    paths: list[Any] = []
+    pages_to_build = getattr(build_context, "pages_to_build", None)
+    if pages_to_build:
+        for page in pages_to_build:
+            source_path = getattr(page, "source_path", None)
+            if source_path is not None:
+                paths.append(source_path)
+    if paths:
+        return paths
+    changed_page_paths = getattr(build_context, "changed_page_paths", None)
+    if changed_page_paths:
+        return list(changed_page_paths)
+    return None
 
 
 def phase_finalize(

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -29,6 +29,8 @@ def phase_postprocess(
     ctx: BuildContext | Any | None,
     incremental: bool,
     collector: OutputCollector | None = None,
+    enabled_task_names: set[str] | None = None,
+    run_asset_audit: bool = True,
 ) -> None:
     """
     Phase 17: Post-processing.
@@ -42,6 +44,8 @@ def phase_postprocess(
         ctx: Build context
         incremental: Whether this is an incremental build
         collector: Optional output collector for hot reload tracking
+        enabled_task_names: Optional postprocess task allow list
+        run_asset_audit: Whether to run rendered asset-reference audit
 
     """
     # Enable parallel post-processing for independent tasks (sitemap, RSS, output formats)
@@ -55,6 +59,7 @@ def phase_postprocess(
             build_context=ctx,
             incremental=incremental,
             collector=collector,
+            enabled_task_names=enabled_task_names,
         )
 
         orchestrator.stats.postprocess_time_ms = (time.time() - postprocess_start) * 1000
@@ -85,54 +90,61 @@ def phase_postprocess(
                 hint="ContextVar not set in some paths - check asset_manifest_context() coverage",
             )
 
-        from bengal.rendering.asset_audit import find_missing_local_asset_references
+        if run_asset_audit:
+            from bengal.rendering.asset_audit import find_missing_local_asset_references
 
-        audit_start = time.perf_counter()
-        strict = getattr(ctx, "strict", False) or getattr(orchestrator.stats, "strict_mode", False)
-        html_paths = None if strict or not incremental else _changed_html_output_paths(collector)
-        missing_refs = find_missing_local_asset_references(
-            orchestrator.site.output_dir,
-            baseurl=getattr(orchestrator.site, "baseurl", "") or "",
-            html_paths=html_paths,
-        )
-        _record_post_render_timing(
-            orchestrator,
-            "asset_audit",
-            (time.perf_counter() - audit_start) * 1000,
-        )
-        if missing_refs:
-            samples = [
-                {
-                    "html": str(ref.html_path.relative_to(orchestrator.site.output_dir)),
-                    "url": ref.url,
-                    "expected": _relative_output_path(
-                        ref.expected_path,
-                        orchestrator.site.output_dir,
-                    ),
-                }
-                for ref in missing_refs[:5]
-            ]
-            if strict:
-                from bengal.errors import BengalAssetError, ErrorCode
-
-                first = missing_refs[0]
-                raise BengalAssetError(
-                    f"Build emitted {len(missing_refs)} local CSS/JS reference(s) "
-                    f"without matching output files. First missing reference: {first.url}",
-                    code=ErrorCode.X001,
-                    suggestion=(
-                        "Declare the asset through the theme library contract, use asset_url(), "
-                        "or remove the stale HTML reference."
-                    ),
-                    file_path=first.html_path,
-                )
-            orchestrator.logger.warning(
-                "rendered_asset_reference_missing",
-                count=len(missing_refs),
-                url=missing_refs[0].url,
-                samples=samples,
-                hint="Declare missing assets or route references through asset_url().",
+            audit_start = time.perf_counter()
+            strict = getattr(ctx, "strict", False) or getattr(
+                orchestrator.stats, "strict_mode", False
             )
+            html_paths = (
+                None if strict or not incremental else _changed_html_output_paths(collector)
+            )
+            missing_refs = find_missing_local_asset_references(
+                orchestrator.site.output_dir,
+                baseurl=getattr(orchestrator.site, "baseurl", "") or "",
+                html_paths=html_paths,
+            )
+            _record_post_render_timing(
+                orchestrator,
+                "asset_audit",
+                (time.perf_counter() - audit_start) * 1000,
+            )
+            if missing_refs:
+                samples = [
+                    {
+                        "html": str(ref.html_path.relative_to(orchestrator.site.output_dir)),
+                        "url": ref.url,
+                        "expected": _relative_output_path(
+                            ref.expected_path,
+                            orchestrator.site.output_dir,
+                        ),
+                    }
+                    for ref in missing_refs[:5]
+                ]
+                if strict:
+                    from bengal.errors import BengalAssetError, ErrorCode
+
+                    first = missing_refs[0]
+                    raise BengalAssetError(
+                        f"Build emitted {len(missing_refs)} local CSS/JS reference(s) "
+                        f"without matching output files. First missing reference: {first.url}",
+                        code=ErrorCode.X001,
+                        suggestion=(
+                            "Declare the asset through the theme library contract, use asset_url(), "
+                            "or remove the stale HTML reference."
+                        ),
+                        file_path=first.html_path,
+                    )
+                orchestrator.logger.warning(
+                    "rendered_asset_reference_missing",
+                    count=len(missing_refs),
+                    url=missing_refs[0].url,
+                    samples=samples,
+                    hint="Declare missing assets or route references through asset_url().",
+                )
+        else:
+            _record_post_render_timing(orchestrator, "asset_audit", 0)
 
         # Show phase completion
         cli.phase("Post-process", duration_ms=orchestrator.stats.postprocess_time_ms)

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -320,6 +320,7 @@ def run_health_check(
         return
 
     health_start = time.time()
+    cli.detail("health check: preparing reference registry...", indent=2, icon=cli.icons.arrow)
 
     # Build rendering-owned link registry before health checks (zero-cost: reuses toc_items)
     from bengal.rendering.reference_registry import (
@@ -345,6 +346,7 @@ def run_health_check(
 
     # Run health checks with profile filtering
     health_check = HealthCheck(orchestrator.site)
+    cli.detail("health check: running validators...", indent=2, icon=cli.icons.arrow)
 
     # Pass cache for incremental validation if available
     cache = None

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -195,7 +195,18 @@ def phase_cache_save(
     """
     with orchestrator.logger.phase("cache_save"):
         start = time.perf_counter()
-        orchestrator.incremental.save_cache(pages_to_build, assets_to_process)
+        saved = orchestrator.incremental.save_cache(pages_to_build, assets_to_process)
+        if saved is False:
+            from bengal.errors import BengalCacheError, ErrorCode
+
+            raise BengalCacheError(
+                "Build cache could not be saved.",
+                code=ErrorCode.A004,
+                suggestion=(
+                    "Check disk space and permissions. Incremental builds may be stale "
+                    "until the cache can be saved."
+                ),
+            )
         duration_ms = (time.perf_counter() - start) * 1000
         if cli is not None:
             cli.phase("Cache save", duration_ms=duration_ms)
@@ -308,6 +319,8 @@ def run_health_check(
     if not health_config.get("enabled", True):
         return
 
+    health_start = time.time()
+
     # Build rendering-owned link registry before health checks (zero-cost: reuses toc_items)
     from bengal.rendering.reference_registry import (
         build_link_registry,
@@ -329,8 +342,6 @@ def run_health_check(
     orchestrator.site.link_registry = artifact_registry or build_link_registry(
         orchestrator.site, output_records=output_records
     )
-
-    health_start = time.time()
 
     # Run health checks with profile filtering
     health_check = HealthCheck(orchestrator.site)

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -6,7 +6,11 @@ Phases 17-21: Post-processing, cache save, collect stats, health check, finalize
 
 from __future__ import annotations
 
+import hashlib
+import json
 import time
+from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -353,13 +357,30 @@ def run_health_check(
     if incremental and orchestrator.incremental.cache:
         cache = orchestrator.incremental.cache
 
-    report = health_check.run(
-        profile=profile,
-        incremental=incremental,
-        context=_health_validation_context(build_context) if incremental else None,
-        cache=cache,
-        build_context=build_context,
+    health_fingerprint = _health_report_fingerprint(
+        orchestrator.site,
+        cache,
+        health_config,
+        profile,
     )
+    report = (
+        _load_cached_health_report(cache, health_fingerprint)
+        if incremental and health_fingerprint is not None
+        else None
+    )
+    reused_health_report = report is not None
+    if reused_health_report:
+        cli.detail("health check: reused cached report", indent=2, icon=cli.icons.success)
+    else:
+        report = health_check.run(
+            profile=profile,
+            incremental=incremental,
+            context=_health_validation_context(build_context) if incremental else None,
+            cache=cache,
+            build_context=build_context,
+        )
+        if health_fingerprint is not None:
+            _store_cached_health_report(cache, health_fingerprint, report)
 
     health_time_ms = (time.time() - health_start) * 1000
     orchestrator.stats.health_check_time_ms = health_time_ms
@@ -425,6 +446,108 @@ def run_health_check(
             "Review output or disable strict_mode.",
             suggestion="Review the health check report above and fix the errors, or set health_check.strict_mode=false",
         )
+
+
+def _health_report_fingerprint(
+    site: Any,
+    cache: Any,
+    health_config: dict[str, Any],
+    profile: BuildProfile | Any | None,
+) -> str | None:
+    """Fingerprint inputs that affect build health validation."""
+    if cache is None:
+        return None
+    page_fingerprints = []
+    for page in getattr(site, "pages", []):
+        source_path = getattr(page, "source_path", None)
+        if source_path is None:
+            return None
+        key = str(cache._cache_key(Path(source_path)))
+        fingerprint = cache.file_fingerprints.get(key)
+        if fingerprint is None:
+            fingerprint = cache.file_fingerprints.get(str(source_path))
+        if fingerprint is None:
+            return None
+        page_fingerprints.append((key, fingerprint))
+    link_registry = getattr(site, "link_registry", None)
+    payload = {
+        "version": 1,
+        "health_config": health_config,
+        "profile": getattr(profile, "value", str(profile)),
+        "link_registry": getattr(link_registry, "fingerprint", None),
+        "pages": sorted(page_fingerprints),
+    }
+    encoded = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _load_cached_health_report(cache: Any, fingerprint: str | None) -> Any | None:
+    """Return a cached HealthReport when the fingerprint matches."""
+    if cache is None or fingerprint is None:
+        return None
+    record = cache.validation_results.get("__bengal_health_report__")
+    if not isinstance(record, dict) or record.get("fingerprint") != fingerprint:
+        return None
+    report_data = record.get("report")
+    if not isinstance(report_data, dict):
+        return None
+    try:
+        return _health_report_from_cache_dict(report_data)
+    except KeyError, TypeError, ValueError:
+        return None
+
+
+def _store_cached_health_report(cache: Any, fingerprint: str, report: Any) -> None:
+    """Persist a whole-report health cache entry."""
+    if cache is None:
+        return
+    try:
+        cache.validation_results["__bengal_health_report__"] = {
+            "fingerprint": fingerprint,
+            "report": _health_report_to_cache_dict(report),
+        }
+    except AttributeError, TypeError, ValueError:
+        return
+
+
+def _health_report_to_cache_dict(report: Any) -> dict[str, Any]:
+    """Serialize a HealthReport for cache reuse."""
+    return {
+        "timestamp": report.timestamp.isoformat(),
+        "build_stats": report.build_stats,
+        "validator_reports": [
+            {
+                "validator_name": validator_report.validator_name,
+                "duration_ms": validator_report.duration_ms,
+                "results": [result.to_cache_dict() for result in validator_report.results],
+            }
+            for validator_report in report.validator_reports
+        ],
+    }
+
+
+def _health_report_from_cache_dict(data: dict[str, Any]) -> Any:
+    """Deserialize a cached HealthReport."""
+    from bengal.health.report import CheckResult, HealthReport, ValidatorReport
+
+    report = HealthReport(
+        timestamp=datetime.fromisoformat(data["timestamp"]),
+        build_stats=data.get("build_stats"),
+    )
+    for item in data.get("validator_reports", []):
+        results = [
+            CheckResult.from_cache_dict(result)
+            for result in item.get("results", [])
+            if isinstance(result, dict)
+        ]
+        report.validator_reports.append(
+            ValidatorReport(
+                validator_name=item["validator_name"],
+                results=results,
+                duration_ms=float(item.get("duration_ms", 0.0)),
+            )
+        )
+    return report
 
 
 def _health_validation_context(build_context: BuildContext | Any | None) -> list[Any] | None:

--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -384,6 +384,7 @@ def run_health_check(
 
     health_time_ms = (time.time() - health_start) * 1000
     orchestrator.stats.health_check_time_ms = health_time_ms
+    orchestrator.stats.record_phase_timing("Health check", health_time_ms)
 
     # Show phase completion timing (before report)
     cli.phase("Health check", duration_ms=health_time_ms)

--- a/bengal/orchestration/build/finalization_tasks.py
+++ b/bengal/orchestration/build/finalization_tasks.py
@@ -1,0 +1,136 @@
+"""Finalization task contracts for build completion policies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from bengal.orchestration.build.options import BuildCompletionPolicy
+
+
+class FinalizationTaskTier(StrEnum):
+    """Product tier produced by a finalization task."""
+
+    SERVE_READY = "serve_ready"
+    ARTIFACTS = "artifacts"
+    QUALITY = "quality"
+    PERSISTENCE = "persistence"
+
+
+class FinalizationFailurePolicy(StrEnum):
+    """How a task failure affects the build."""
+
+    FAIL_BUILD = "fail_build"
+    WARN = "warn"
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizationTaskSpec:
+    """Contract for a post-render build task."""
+
+    name: str
+    tier: FinalizationTaskTier
+    blocks_complete: bool
+    blocks_serve_ready: bool
+    failure_policy: FinalizationFailurePolicy
+    outputs: tuple[str, ...] = ()
+
+    def blocks(self, policy: BuildCompletionPolicy) -> bool:
+        """Return whether this task blocks the requested completion policy."""
+        if policy is BuildCompletionPolicy.SERVE_READY:
+            return self.blocks_serve_ready
+        return self.blocks_complete
+
+
+def default_finalization_task_specs() -> tuple[FinalizationTaskSpec, ...]:
+    """Return Bengal's built-in post-render task contracts."""
+    return (
+        FinalizationTaskSpec(
+            name="special_pages",
+            tier=FinalizationTaskTier.SERVE_READY,
+            blocks_complete=True,
+            blocks_serve_ready=True,
+            failure_policy=FinalizationFailurePolicy.FAIL_BUILD,
+            outputs=("404.html",),
+        ),
+        FinalizationTaskSpec(
+            name="output_formats",
+            tier=FinalizationTaskTier.ARTIFACTS,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+            outputs=("index.json", "llms.txt", "llm-full.txt"),
+        ),
+        FinalizationTaskSpec(
+            name="sitemap",
+            tier=FinalizationTaskTier.ARTIFACTS,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+            outputs=("sitemap.xml",),
+        ),
+        FinalizationTaskSpec(
+            name="robots",
+            tier=FinalizationTaskTier.ARTIFACTS,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+            outputs=("robots.txt",),
+        ),
+        FinalizationTaskSpec(
+            name="feeds",
+            tier=FinalizationTaskTier.ARTIFACTS,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+            outputs=("rss.xml", "atom.xml"),
+        ),
+        FinalizationTaskSpec(
+            name="redirects",
+            tier=FinalizationTaskTier.ARTIFACTS,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+        ),
+        FinalizationTaskSpec(
+            name="xref",
+            tier=FinalizationTaskTier.ARTIFACTS,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+            outputs=("xref.json",),
+        ),
+        FinalizationTaskSpec(
+            name="asset_audit",
+            tier=FinalizationTaskTier.QUALITY,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+        ),
+        FinalizationTaskSpec(
+            name="health",
+            tier=FinalizationTaskTier.QUALITY,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+        ),
+        FinalizationTaskSpec(
+            name="cache_save",
+            tier=FinalizationTaskTier.PERSISTENCE,
+            blocks_complete=True,
+            blocks_serve_ready=False,
+            failure_policy=FinalizationFailurePolicy.WARN,
+        ),
+        FinalizationTaskSpec(
+            name="stats",
+            tier=FinalizationTaskTier.PERSISTENCE,
+            blocks_complete=True,
+            blocks_serve_ready=True,
+            failure_policy=FinalizationFailurePolicy.FAIL_BUILD,
+        ),
+    )
+
+
+def blocking_finalization_task_names(policy: BuildCompletionPolicy) -> tuple[str, ...]:
+    """Return task names that block the requested policy."""
+    return tuple(spec.name for spec in default_finalization_task_specs() if spec.blocks(policy))

--- a/bengal/orchestration/build/inputs.py
+++ b/bengal/orchestration/build/inputs.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from bengal.orchestration.build.options import BuildOptions
+from bengal.orchestration.build.options import BuildCompletionPolicy, BuildOptions
 
 if TYPE_CHECKING:
     from bengal.server.build_executor import BuildRequest
@@ -96,6 +96,9 @@ class BuildInput:
             incremental=request.incremental,
             profile=profile,
             memory_optimized=getattr(request, "memory_optimized", False),
+            completion_policy=BuildCompletionPolicy.from_value(
+                getattr(request, "completion_policy", None)
+            ),
             explain=getattr(request, "explain", False),
             dry_run=getattr(request, "dry_run", False),
             profile_templates=getattr(request, "profile_templates", False),
@@ -128,6 +131,7 @@ class BuildInput:
             force_sequential=self.options.force_sequential,
             version_scope=self.version_scope,
             memory_optimized=self.options.memory_optimized,
+            completion_policy=self.options.completion_policy.value,
             explain=self.options.explain,
             dry_run=self.options.dry_run,
             profile_templates=self.options.profile_templates,

--- a/bengal/orchestration/build/inputs.py
+++ b/bengal/orchestration/build/inputs.py
@@ -96,6 +96,7 @@ class BuildInput:
             incremental=request.incremental,
             profile=profile,
             memory_optimized=getattr(request, "memory_optimized", False),
+            quiet=getattr(request, "quiet", False),
             completion_policy=BuildCompletionPolicy.from_value(
                 getattr(request, "completion_policy", None)
             ),
@@ -135,4 +136,5 @@ class BuildInput:
             explain=self.options.explain,
             dry_run=self.options.dry_run,
             profile_templates=self.options.profile_templates,
+            quiet=self.options.quiet,
         )

--- a/bengal/orchestration/build/options.py
+++ b/bengal/orchestration/build/options.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -27,6 +28,25 @@ if TYPE_CHECKING:
 # on_phase_complete receives: (phase_name, duration_ms, details)
 type PhaseStartCallback = Callable[[str], None]
 type PhaseCompleteCallback = Callable[[str, float, str], None]
+
+
+class BuildCompletionPolicy(StrEnum):
+    """Which build products must finish before a build is considered ready."""
+
+    COMPLETE = "complete"
+    SERVE_READY = "serve_ready"
+
+    @classmethod
+    def from_value(cls, value: str | BuildCompletionPolicy | None) -> BuildCompletionPolicy:
+        """Normalize serialized policy values."""
+        if isinstance(value, cls):
+            return value
+        if value is None:
+            return cls.COMPLETE
+        try:
+            return cls(str(value))
+        except ValueError:
+            return cls.COMPLETE
 
 
 @dataclass
@@ -59,6 +79,7 @@ class BuildOptions:
         changed_sources: Set of paths to content files that changed (for dev server)
         nav_changed_sources: Set of paths to nav-affecting files that changed
         structural_changed: Whether structural changes occurred (file create/delete/move)
+        completion_policy: Which build products must complete before readiness
 
     Example:
             >>> # Preferred: Use resolver for proper precedence
@@ -82,6 +103,7 @@ class BuildOptions:
     verbose: bool = False
     quiet: bool = False
     memory_optimized: bool = False
+    completion_policy: BuildCompletionPolicy = BuildCompletionPolicy.COMPLETE
 
     # Output behavior
     strict: bool = False

--- a/bengal/orchestration/build_context.py
+++ b/bengal/orchestration/build_context.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from bengal.protocols.core import PageLike
     from bengal.rendering.api_doc_enhancer import APIDocEnhancerProtocol
     from bengal.rendering.assets import AssetManifestContext
+    from bengal.rendering.page_artifact import PageArtifact
     from bengal.rendering.pipeline.write_behind import WriteBehindCollector
     from bengal.services.data import DataService
     from bengal.services.query import QueryService
@@ -282,6 +283,8 @@ class BuildContext:
     _accumulated_page_index: dict[Path, AccumulatedPageData] = field(
         default_factory=dict, repr=False
     )
+    _page_artifacts: list[PageArtifact] = field(default_factory=list, repr=False)
+    _page_artifact_index: dict[Path, PageArtifact] = field(default_factory=dict, repr=False)
 
     @property
     def knowledge_graph(self) -> KnowledgeGraph | None:
@@ -684,6 +687,11 @@ class BuildContext:
         with self._accumulated_page_data_lock:
             self._accumulated_page_data.append(data)
             self._accumulated_page_index[data.source_path] = data
+            from bengal.rendering.page_artifact import PageArtifact
+
+            artifact = PageArtifact.from_accumulated(data)
+            self._page_artifacts.append(artifact)
+            self._page_artifact_index[artifact.source_path] = artifact
 
     def get_accumulated_page_data(self) -> list[AccumulatedPageData]:
         """
@@ -702,6 +710,20 @@ class BuildContext:
         """
         with self._accumulated_page_data_lock:
             return list(self._accumulated_page_data)
+
+    def get_page_artifacts(self) -> list[PageArtifact]:
+        """
+        Get frozen page artifacts for post-processing and cache persistence.
+
+        Returns a copy so callers cannot mutate the build-context collection.
+        """
+        with self._accumulated_page_data_lock:
+            return list(self._page_artifacts)
+
+    def get_artifact_for_page(self, source_path: Path) -> PageArtifact | None:
+        """Get the frozen artifact for a specific rendered page."""
+        with self._accumulated_page_data_lock:
+            return self._page_artifact_index.get(source_path)
 
     def get_accumulated_for_page(self, source_path: Path) -> AccumulatedPageData | None:
         """
@@ -765,3 +787,5 @@ class BuildContext:
         with self._accumulated_page_data_lock:
             self._accumulated_page_data.clear()
             self._accumulated_page_index.clear()
+            self._page_artifacts.clear()
+            self._page_artifact_index.clear()

--- a/bengal/orchestration/incremental/cache_manager.py
+++ b/bengal/orchestration/incremental/cache_manager.py
@@ -18,7 +18,7 @@ Related Modules:
 from __future__ import annotations
 
 import shutil
-from datetime import date, datetime
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -464,31 +464,13 @@ class CacheManager:
 
 def _serialize_page_artifact(data: Any, anchors: frozenset[str]) -> dict[str, Any]:
     """Convert AccumulatedPageData into a JSON-serializable cache record."""
-    source_path = data.source_path
-    json_output_path = getattr(data, "json_output_path", None)
-    return {
-        "source_path": str(source_path),
-        "url": data.url,
-        "uri": data.uri,
-        "title": data.title,
-        "description": data.description,
-        "date": data.date,
-        "date_iso": data.date_iso,
-        "plain_text": data.plain_text,
-        "excerpt": data.excerpt,
-        "content_preview": data.content_preview,
-        "word_count": data.word_count,
-        "reading_time": data.reading_time,
-        "section": data.section,
-        "tags": list(data.tags),
-        "dir": data.dir,
-        "enhanced_metadata": _json_safe(data.enhanced_metadata),
-        "is_autodoc": data.is_autodoc,
-        "full_json_data": _json_safe(data.full_json_data),
-        "json_output_path": str(json_output_path) if json_output_path else None,
-        "raw_metadata": _json_safe(data.raw_metadata),
-        "anchors": sorted(anchors),
-    }
+    from bengal.rendering.page_artifact import PageArtifact
+
+    if isinstance(data, PageArtifact):
+        artifact = replace(data, anchors=tuple(sorted(str(anchor) for anchor in anchors)))
+    else:
+        artifact = PageArtifact.from_accumulated(data, anchors)
+    return artifact.to_cache_record()
 
 
 def _site_relative_path(root_path: Path, source_path: Path) -> Path:
@@ -515,18 +497,3 @@ def _page_anchor_ids_by_source(
             key_path = _site_relative_path(root_path, source_path)
             anchors[str(cache._cache_key(key_path))] = ids
     return anchors
-
-
-def _json_safe(value: Any) -> Any:
-    """Return a JSON-serializable representation for cache persistence."""
-    if isinstance(value, str | int | float | bool | type(None)):
-        return value
-    if isinstance(value, Path):
-        return str(value)
-    if isinstance(value, date | datetime):
-        return value.isoformat()
-    if isinstance(value, dict):
-        return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, list | tuple | set | frozenset):
-        return [_json_safe(item) for item in value]
-    return str(value)

--- a/bengal/orchestration/incremental/cache_manager.py
+++ b/bengal/orchestration/incremental/cache_manager.py
@@ -233,7 +233,7 @@ class CacheManager:
         pages_built: Sequence[PageLike],
         assets_processed: list[Asset],
         build_context: Any | None = None,
-    ) -> None:
+    ) -> bool:
         """
         Update cache with processed files.
 
@@ -245,7 +245,7 @@ class CacheManager:
             build_context: Optional BuildContext with rendered page artifacts.
         """
         if not self.cache:
-            return
+            return False
 
         # Use same cache location as initialize()
         paths = self.site.config_service.paths
@@ -365,7 +365,7 @@ class CacheManager:
             )
 
         # Save cache
-        self.cache.save(cache_path)
+        return self.cache.save(cache_path)
 
     def _store_page_artifacts(self, build_context: Any | None) -> None:
         """Persist post-render page artifacts accumulated during rendering."""

--- a/bengal/orchestration/incremental/cache_manager.py
+++ b/bengal/orchestration/incremental/cache_manager.py
@@ -69,6 +69,8 @@ class CacheManager:
         self.cache: BuildCache | None = None
         self.coordinator: CacheCoordinator | None = None
         self._effect_tracer: EffectTracer | None = None
+        self._dirty_page_artifact_keys: set[str] | None = None
+        self._deleted_page_artifact_keys: set[str] | None = None
 
     @property
     def effect_tracer(self) -> EffectTracer | None:
@@ -368,7 +370,11 @@ class CacheManager:
         # Save large post-render page artifacts separately so the hot cache-save
         # path does not rewrite every page artifact inside cache.json.zst.
         page_artifacts = self.cache.page_artifacts
-        self._page_artifact_store().save(page_artifacts)
+        self._page_artifact_store().save(
+            page_artifacts,
+            dirty_keys=self._dirty_page_artifact_keys,
+            deleted_keys=self._deleted_page_artifact_keys,
+        )
         self.cache.page_artifacts = {}
         try:
             return self.cache.save(cache_path)
@@ -383,27 +389,40 @@ class CacheManager:
         if not callable(get_accumulated):
             return
 
+        previous_keys = set(self.cache.page_artifacts)
         current_keys = {
             str(self.cache._cache_key(_site_relative_path(self.site.root_path, page.source_path)))
             for page in getattr(self.site, "pages", [])
             if getattr(page, "source_path", None)
         }
+        deleted_keys = previous_keys - current_keys
         self.cache.page_artifacts = {
             key: value for key, value in self.cache.page_artifacts.items() if key in current_keys
         }
+        dirty_keys = set[str]()
 
         anchors_by_source = _page_anchor_ids_by_source(
             getattr(self.site, "pages", []), self.site.root_path, self.cache
         )
+        changed_keys = _changed_page_artifact_keys(self.site.root_path, build_context, self.cache)
         for data in get_accumulated():
             source_path = getattr(data, "source_path", None)
             if not source_path:
                 continue
             key_path = _site_relative_path(self.site.root_path, source_path)
             artifact_key = str(self.cache._cache_key(key_path))
-            self.cache.page_artifacts[artifact_key] = _serialize_page_artifact(
+            serialized = _serialize_page_artifact(
                 data, anchors_by_source.get(artifact_key, frozenset())
             )
+            if (
+                artifact_key in changed_keys
+                or artifact_key not in self.cache.page_artifacts
+                or self.cache.page_artifacts[artifact_key] != serialized
+            ):
+                dirty_keys.add(artifact_key)
+            self.cache.page_artifacts[artifact_key] = serialized
+        self._dirty_page_artifact_keys = dirty_keys
+        self._deleted_page_artifact_keys = deleted_keys
 
     def _page_artifact_store(self) -> Any:
         """Return the sharded page artifact store for this site's state dir."""
@@ -474,6 +493,18 @@ class CacheManager:
                 "data_file_fingerprints_updated",
                 count=updated_count,
             )
+
+
+def _changed_page_artifact_keys(root_path: Path, build_context: Any, cache: BuildCache) -> set[str]:
+    """Return cache keys for pages rendered or marked changed in this build."""
+    changed: set[str] = set()
+    for page in getattr(build_context, "pages_to_build", None) or []:
+        source_path = getattr(page, "source_path", None)
+        if source_path:
+            changed.add(str(cache._cache_key(_site_relative_path(root_path, source_path))))
+    for source_path in getattr(build_context, "changed_page_paths", None) or set():
+        changed.add(str(cache._cache_key(_site_relative_path(root_path, Path(source_path)))))
+    return changed
 
 
 def _serialize_page_artifact(data: Any, anchors: frozenset[str]) -> dict[str, Any]:

--- a/bengal/orchestration/incremental/cache_manager.py
+++ b/bengal/orchestration/incremental/cache_manager.py
@@ -127,6 +127,7 @@ class CacheManager:
                         "cache_migration_failed", error=str(e), action="using_fresh_cache"
                     )
             self.cache = BuildCache.load(cache_path, site_root=self.site.root_path)
+            self.cache.page_artifacts.update(self._page_artifact_store().load())
             cache_exists = cache_path.exists()
             try:
                 file_count = len(self.cache.file_fingerprints)
@@ -364,8 +365,15 @@ class CacheManager:
                 path=str(effects_path),
             )
 
-        # Save cache
-        return self.cache.save(cache_path)
+        # Save large post-render page artifacts separately so the hot cache-save
+        # path does not rewrite every page artifact inside cache.json.zst.
+        page_artifacts = self.cache.page_artifacts
+        self._page_artifact_store().save(page_artifacts)
+        self.cache.page_artifacts = {}
+        try:
+            return self.cache.save(cache_path)
+        finally:
+            self.cache.page_artifacts = page_artifacts
 
     def _store_page_artifacts(self, build_context: Any | None) -> None:
         """Persist post-render page artifacts accumulated during rendering."""
@@ -396,6 +404,12 @@ class CacheManager:
             self.cache.page_artifacts[artifact_key] = _serialize_page_artifact(
                 data, anchors_by_source.get(artifact_key, frozenset())
             )
+
+    def _page_artifact_store(self) -> Any:
+        """Return the sharded page artifact store for this site's state dir."""
+        from bengal.cache.page_artifact_store import PageArtifactStore
+
+        return PageArtifactStore(self.site.config_service.paths.state_dir / "page-artifacts")
 
     def _get_theme_templates_dir(self) -> Path | None:
         """

--- a/bengal/orchestration/incremental/effect_detector.py
+++ b/bengal/orchestration/incremental/effect_detector.py
@@ -137,12 +137,13 @@ class EffectBasedDetector:
         template_name = template_path.name
 
         # Check EffectTracer for pages using this template
-        for effect in self.tracer.effects:
-            if template_name in effect.depends_on or template_path in effect.depends_on:
-                # Find source path in dependencies
-                for dep in effect.depends_on:
-                    if isinstance(dep, Path) and dep.suffix == ".md":
-                        pages.add(dep)
+        effects = self.tracer.get_effects_depending_on(template_path)
+        effects.extend(self.tracer.get_effects_depending_on(Path(template_name)))
+        for effect in effects:
+            # Find source path in dependencies
+            for dep in effect.depends_on:
+                if isinstance(dep, Path) and dep.suffix == ".md":
+                    pages.add(dep)
 
         # Fallback: scan all pages if tracer doesn't have info
         if not pages:
@@ -159,13 +160,12 @@ class EffectBasedDetector:
         # Check EffectTracer for render_page effects using this data file.
         # Use metadata["source_path"] to identify the page rather than
         # scanning depends_on for .md files (which includes cascade sources).
-        for effect in self.tracer.effects:
+        for effect in self.tracer.get_effects_depending_on(data_path, include_name=False):
             if effect.operation != "render_page":
                 continue
-            if data_path in effect.depends_on:
-                source = effect.metadata.get("source_path")
-                if source:
-                    pages.add(Path(source))
+            source = effect.metadata.get("source_path")
+            if source:
+                pages.add(Path(source))
 
         return pages
 

--- a/bengal/orchestration/incremental/orchestrator.py
+++ b/bengal/orchestration/incremental/orchestrator.py
@@ -729,7 +729,7 @@ class IncrementalOrchestrator:
         pages_built: Sequence[PageLike],
         assets_processed: list[Asset],
         build_context: Any | None = None,
-    ) -> None:
+    ) -> bool:
         """
         Update cache with processed files.
 
@@ -742,7 +742,7 @@ class IncrementalOrchestrator:
         self._cache_manager.cache = self.cache
         # Sync EffectTracer back to CacheManager for persistence
         self._cache_manager._effect_tracer = self.effect_tracer
-        self._cache_manager.save(pages_built, assets_processed, build_context=build_context)
+        return self._cache_manager.save(pages_built, assets_processed, build_context=build_context)
 
     def _check_shared_content_changes(
         self, forced_changed_sources: set[Path] | None = None

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -25,6 +25,7 @@ See Also:
 
 from __future__ import annotations
 
+import time
 from threading import Lock
 from typing import TYPE_CHECKING
 
@@ -67,6 +68,23 @@ def _emit_postprocess_line(message: str) -> None:
     from bengal.output import get_cli_output
 
     get_cli_output().raw(message, stream="stderr", level=None)
+
+
+def _emit_task_started(task_name: str) -> None:
+    """Show long-running postprocess work before it completes."""
+    from bengal.output import get_cli_output
+
+    cli = get_cli_output()
+    cli.detail(f"{task_name}...", icon=cli.icons.arrow)
+
+
+def _emit_task_finished(task_name: str, duration_ms: float) -> None:
+    """Show a completed postprocess subtask with its elapsed time."""
+    from bengal.output import get_cli_output
+
+    cli = get_cli_output()
+    duration = f"{int(duration_ms)}ms"
+    cli.detail(f"{task_name} {duration}", icon=cli.icons.success)
 
 
 class PostprocessOrchestrator:
@@ -130,6 +148,7 @@ class PostprocessOrchestrator:
         """
         # Store collector for use in task methods
         self._collector = collector
+        self._stats = getattr(build_context, "stats", None) if build_context else None
         # Resolve from context if absent
         if (
             not progress_manager
@@ -146,6 +165,7 @@ class PostprocessOrchestrator:
 
             cli = get_cli_output()
             cli.section("Post-processing")
+        emit_cli_task_progress = progress_manager is None
 
         # Collect enabled tasks
         tasks = []
@@ -160,7 +180,14 @@ class PostprocessOrchestrator:
             # Build graph first if we want to include graph data in page JSON
             graph_data = None
             if output_formats_config.get("options", {}).get("include_graph_connections", True):
+                graph_start = time.perf_counter()
+                if emit_cli_task_progress:
+                    _emit_task_started("graph data")
                 graph_data = self._build_graph_data(build_context)
+                graph_duration_ms = (time.perf_counter() - graph_start) * 1000
+                self._record_task_timing("graph data", graph_duration_ms)
+                if emit_cli_task_progress:
+                    _emit_task_finished("graph data", graph_duration_ms)
             tasks.append(
                 ("output formats", lambda: self._generate_output_formats(graph_data, build_context))
             )
@@ -237,6 +264,13 @@ class PostprocessOrchestrator:
         if social_cards_task is not None:
             self._run_sequential([("social cards", social_cards_task)], progress_manager, reporter)
 
+    def _record_task_timing(self, task_name: str, duration_ms: float) -> None:
+        """Record postprocess task timing when build stats are available."""
+        stats = getattr(self, "_stats", None)
+        timings = getattr(stats, "postprocess_task_timings_ms", None)
+        if isinstance(timings, dict):
+            timings[task_name] = round(duration_ms, 1)
+
     def _run_sequential(
         self,
         tasks: list[tuple[str, Callable[[], None]]],
@@ -251,6 +285,11 @@ class PostprocessOrchestrator:
             progress_manager: Live progress manager (optional)
         """
         for i, (task_name, task_fn) in enumerate(tasks):
+            task_start = time.perf_counter()
+            emit_cli_task_progress = progress_manager is None
+            if emit_cli_task_progress:
+                with _print_lock:
+                    _emit_task_started(task_name)
             try:
                 if progress_manager:
                     progress_manager.update_phase(
@@ -304,6 +343,15 @@ class PostprocessOrchestrator:
                                 _emit_postprocess_line(f"  ✗ {task_name}: {e}")
                         else:
                             _emit_postprocess_line(f"  ✗ {task_name}: {e}")
+            finally:
+                duration_ms = (time.perf_counter() - task_start) * 1000
+                self._record_task_timing(
+                    task_name,
+                    duration_ms,
+                )
+                if emit_cli_task_progress:
+                    with _print_lock:
+                        _emit_task_finished(task_name, duration_ms)
 
     def _run_parallel(
         self,
@@ -323,12 +371,25 @@ class PostprocessOrchestrator:
 
         def _run_task(name_fn_tuple: tuple[str, Callable[[], None]]) -> str:
             name, fn = name_fn_tuple
+            start = time.perf_counter()
+            if progress_manager is None:
+                with _print_lock:
+                    _emit_task_started(name)
             try:
                 fn()
             except Exception as e:
+                duration_ms = (time.perf_counter() - start) * 1000
                 e.__task_name__ = name  # type: ignore[attr-defined]
+                e.__duration_ms__ = duration_ms  # type: ignore[attr-defined]
+                if progress_manager is None:
+                    with _print_lock:
+                        _emit_task_finished(name, duration_ms)
                 raise
-            return name
+            duration_ms = (time.perf_counter() - start) * 1000
+            if progress_manager is None:
+                with _print_lock:
+                    _emit_task_finished(name, duration_ms)
+            return f"{name}\0{duration_ms}"
 
         from bengal.utils.concurrency.work_scope import WorkScope
 
@@ -337,7 +398,10 @@ class PostprocessOrchestrator:
 
         for r in results:
             if r.ok:
-                task_name = r.value
+                encoded = r.value or ""
+                task_name, _, duration = encoded.partition("\0")
+                if duration:
+                    self._record_task_timing(task_name, float(duration))
                 if progress_manager:
                     completed_count += 1
                     progress_manager.update_phase(
@@ -351,6 +415,9 @@ class PostprocessOrchestrator:
 
                 # Extract task name from the error if possible
                 task_name = getattr(e, "__task_name__", "unknown")
+                duration_ms = getattr(e, "__duration_ms__", None)
+                if isinstance(duration_ms, int | float):
+                    self._record_task_timing(task_name, float(duration_ms))
                 error_msg = str(e)
                 errors.append((task_name, error_msg))
 

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -165,7 +165,6 @@ class PostprocessOrchestrator:
 
             cli = get_cli_output()
             cli.section("Post-processing")
-        emit_cli_task_progress = progress_manager is None
 
         # Collect enabled tasks
         tasks = []
@@ -177,20 +176,7 @@ class PostprocessOrchestrator:
         # These are essential for search functionality and must reflect current site state
         output_formats_config = self.site.config.get("output_formats", {})
         if output_formats_config.get("enabled", True):
-            # Build graph first if we want to include graph data in page JSON
-            graph_data = None
-            if output_formats_config.get("options", {}).get("include_graph_connections", True):
-                graph_start = time.perf_counter()
-                if emit_cli_task_progress:
-                    _emit_task_started("graph data")
-                graph_data = self._build_graph_data(build_context)
-                graph_duration_ms = (time.perf_counter() - graph_start) * 1000
-                self._record_task_timing("graph data", graph_duration_ms)
-                if emit_cli_task_progress:
-                    _emit_task_finished("graph data", graph_duration_ms)
-            tasks.append(
-                ("output formats", lambda: self._generate_output_formats(graph_data, build_context))
-            )
+            tasks.append(("output formats", lambda: self._generate_output_formats(build_context)))
 
         # OPTIMIZATION: For incremental builds, skip expensive post-processing
         # except for sitemap which must always be regenerated for correctness.
@@ -649,14 +635,12 @@ class PostprocessOrchestrator:
 
     def _generate_output_formats(
         self,
-        graph_data: dict[str, object] | None = None,
         build_context: BuildContext | None = None,
     ) -> None:
         """
         Generate custom output formats like JSON, plain text (extracted for parallel execution).
 
         Args:
-            graph_data: Optional pre-computed graph data to include in page JSON
             build_context: Optional BuildContext with accumulated JSON data from rendering phase
 
         Raises:
@@ -664,7 +648,10 @@ class PostprocessOrchestrator:
         """
         config = self.site.config.get("output_formats", {})
         generator = OutputFormatsGenerator(
-            self.site, config, graph_data=graph_data, build_context=build_context
+            self.site,
+            config,
+            graph_data_provider=lambda: self._build_graph_data(build_context),
+            build_context=build_context,
         )
         generator.generate()
 

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -136,6 +136,7 @@ class PostprocessOrchestrator:
         build_context: BuildContext | None = None,
         incremental: bool = False,
         collector: OutputCollector | None = None,
+        enabled_task_names: set[str] | None = None,
     ) -> None:
         """
         Perform post-processing tasks (sitemap, RSS, output formats, link validation, etc.).
@@ -145,6 +146,7 @@ class PostprocessOrchestrator:
             progress_manager: Live progress manager (optional)
             incremental: Whether this is an incremental build (can skip some tasks)
             collector: Optional output collector for hot reload tracking
+            enabled_task_names: Optional task-name allow list for serve-ready builds
         """
         # Store collector for use in task methods
         self._collector = collector
@@ -166,16 +168,20 @@ class PostprocessOrchestrator:
             cli = get_cli_output()
             cli.section("Post-processing")
 
+        def task_enabled(name: str) -> bool:
+            return enabled_task_names is None or name in enabled_task_names
+
         # Collect enabled tasks
         tasks = []
 
         # Always generate special pages (404, etc.) - important for deployment
-        tasks.append(("special pages", lambda: self._generate_special_pages(build_context)))
+        if task_enabled("special pages"):
+            tasks.append(("special pages", lambda: self._generate_special_pages(build_context)))
 
         # CRITICAL: Always generate output formats (index.json, llm-full.txt)
         # These are essential for search functionality and must reflect current site state
         output_formats_config = self.site.config.get("output_formats", {})
-        if output_formats_config.get("enabled", True):
+        if output_formats_config.get("enabled", True) and task_enabled("output formats"):
             tasks.append(("output formats", lambda: self._generate_output_formats(build_context)))
 
         # OPTIMIZATION: For incremental builds, skip expensive post-processing
@@ -193,12 +199,12 @@ class PostprocessOrchestrator:
         # - Redirects: Regenerated on full builds (aliases rarely change)
 
         # Sitemap: Always regenerate for correctness (fast: ~10ms for 1K pages)
-        if self.site.config.get("generate_sitemap", True):
+        if self.site.config.get("generate_sitemap", True) and task_enabled("sitemap"):
             tasks.append(("sitemap", self._generate_sitemap))
 
         # robots.txt with Content-Signal directives (fast, always regenerated)
         cs_config = self.site.config.get("content_signals", {})
-        if cs_config.get("enabled", True):
+        if cs_config.get("enabled", True) and task_enabled("robots.txt"):
             tasks.append(("robots.txt", self._generate_robots_txt))
 
         social_cards_task = None
@@ -216,19 +222,20 @@ class PostprocessOrchestrator:
                 def run_social_cards() -> None:
                     self._generate_social_cards(build_context)
 
-                social_cards_task = run_social_cards
+                if task_enabled("social cards"):
+                    social_cards_task = run_social_cards
 
-            if self.site.config.get("generate_rss", True):
+            if self.site.config.get("generate_rss", True) and task_enabled("rss"):
                 tasks.append(("rss", self._generate_rss))
-            if self.site.config.get("generate_atom", False):
+            if self.site.config.get("generate_atom", False) and task_enabled("atom"):
                 tasks.append(("atom", self._generate_atom))
 
             redirects_config = self.site.config.get("redirects", {})
-            if redirects_config.get("generate_html", True):
+            if redirects_config.get("generate_html", True) and task_enabled("redirects"):
                 tasks.append(("redirects", self._generate_redirects))
 
             # Generate xref.json for cross-project linking (RFC: External References)
-            if should_export_xref_index(self.site):
+            if should_export_xref_index(self.site) and task_enabled("xref index"):
                 tasks.append(("xref index", self._generate_xref_index))
         else:
             # Incremental: skip expensive tasks for dev server responsiveness

--- a/bengal/orchestration/postprocess.py
+++ b/bengal/orchestration/postprocess.py
@@ -87,6 +87,15 @@ def _emit_task_finished(task_name: str, duration_ms: float) -> None:
     cli.detail(f"{task_name} {duration}", icon=cli.icons.success)
 
 
+def _emit_task_failed(task_name: str, duration_ms: float) -> None:
+    """Show a failed postprocess subtask with its elapsed time."""
+    from bengal.output import get_cli_output
+
+    cli = get_cli_output()
+    duration = f"{int(duration_ms)}ms"
+    cli.detail(f"{task_name} failed {duration}", icon=cli.icons.warning)
+
+
 class PostprocessOrchestrator:
     """
     Orchestrates post-processing tasks after page rendering.
@@ -279,6 +288,7 @@ class PostprocessOrchestrator:
         """
         for i, (task_name, task_fn) in enumerate(tasks):
             task_start = time.perf_counter()
+            failed = False
             emit_cli_task_progress = progress_manager is None
             if emit_cli_task_progress:
                 with _print_lock:
@@ -290,6 +300,7 @@ class PostprocessOrchestrator:
                     )
                 task_fn()
             except Exception as e:
+                failed = True
                 from bengal.errors import (
                     BengalError,
                     ErrorCode,
@@ -344,7 +355,10 @@ class PostprocessOrchestrator:
                 )
                 if emit_cli_task_progress:
                     with _print_lock:
-                        _emit_task_finished(task_name, duration_ms)
+                        if failed:
+                            _emit_task_failed(task_name, duration_ms)
+                        else:
+                            _emit_task_finished(task_name, duration_ms)
 
     def _run_parallel(
         self,
@@ -376,7 +390,7 @@ class PostprocessOrchestrator:
                 e.__duration_ms__ = duration_ms  # type: ignore[attr-defined]
                 if progress_manager is None:
                     with _print_lock:
-                        _emit_task_finished(name, duration_ms)
+                        _emit_task_failed(name, duration_ms)
                 raise
             duration_ms = (time.perf_counter() - start) * 1000
             if progress_manager is None:

--- a/bengal/orchestration/site_runner.py
+++ b/bengal/orchestration/site_runner.py
@@ -22,6 +22,7 @@ from bengal.core.diagnostics import emit as emit_diagnostic
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Any
 
     from bengal.core.site import Site
     from bengal.orchestration.build.inputs import BuildInput
@@ -71,6 +72,7 @@ class SiteRunner:
         auto_port: bool = True,
         open_browser: bool = False,
         version_scope: str | None = None,
+        completion_policy: Any | None = None,
     ) -> None:
         """
         Start a development server.
@@ -82,6 +84,7 @@ class SiteRunner:
             auto_port: Whether to automatically find an available port
             open_browser: Whether to automatically open the browser
             version_scope: Focus rebuilds on a single version
+            completion_policy: Initial and watched build completion policy
 
         """
         from bengal.server.dev_server import DevServer
@@ -94,6 +97,7 @@ class SiteRunner:
             auto_port=auto_port,
             open_browser=open_browser,
             version_scope=version_scope,
+            completion_policy=completion_policy,
         )
         server.start()
 

--- a/bengal/orchestration/stats/display.py
+++ b/bengal/orchestration/stats/display.py
@@ -44,16 +44,24 @@ def _build_context(stats: DisplayableStats, output_dir: str | None = None) -> di
     pages_per_sec = (stats.total_pages / render_ms) * 1000 if render_ms > 0 else 0
 
     # Phase breakdown — show the slowest phases, not insertion order.
-    phase_items = [
-        ("Fonts", getattr(stats, "fonts_time_ms", 0)),
-        ("Discovery", getattr(stats, "discovery_time_ms", 0)),
-        ("Menus", getattr(stats, "menu_time_ms", 0)),
-        ("Related", getattr(stats, "related_posts_time_ms", 0)),
-        ("Render", getattr(stats, "rendering_time_ms", 0)),
-        ("Assets", getattr(stats, "assets_time_ms", 0)),
-        ("Post", getattr(stats, "postprocess_time_ms", 0)),
-        ("Health", getattr(stats, "health_check_time_ms", 0)),
-    ]
+    recorded_phases = getattr(stats, "phase_timings_ms", None)
+    if isinstance(recorded_phases, dict) and recorded_phases:
+        phase_items = [
+            (str(name), float(duration_ms))
+            for name, duration_ms in recorded_phases.items()
+            if isinstance(duration_ms, int | float)
+        ]
+    else:
+        phase_items = [
+            ("Fonts", getattr(stats, "fonts_time_ms", 0)),
+            ("Discovery", getattr(stats, "discovery_time_ms", 0)),
+            ("Menus", getattr(stats, "menu_time_ms", 0)),
+            ("Related", getattr(stats, "related_posts_time_ms", 0)),
+            ("Render", getattr(stats, "rendering_time_ms", 0)),
+            ("Assets", getattr(stats, "assets_time_ms", 0)),
+            ("Post", getattr(stats, "postprocess_time_ms", 0)),
+            ("Health", getattr(stats, "health_check_time_ms", 0)),
+        ]
     phases = [
         f"{name} {format_time(duration_ms)}"
         for name, duration_ms in sorted(phase_items, key=lambda item: item[1], reverse=True)
@@ -62,7 +70,10 @@ def _build_context(stats: DisplayableStats, output_dir: str | None = None) -> di
     postprocess_detail = _format_slowest_postprocess(stats)
     if postprocess_detail:
         phases.append(postprocess_detail)
-    visible_phases = [*phases[:3], postprocess_detail] if postprocess_detail else phases[:4]
+    unaccounted_ms = getattr(stats, "overhead_ms", 0)
+    if isinstance(unaccounted_ms, int | float) and unaccounted_ms > 250:
+        phases.append(f"Unaccounted {format_time(unaccounted_ms)}")
+    visible_phases = phases[:8]
 
     # Breakdown string
     breakdown = f"{stats.regular_pages}+{stats.generated_pages}"

--- a/bengal/orchestration/stats/display.py
+++ b/bengal/orchestration/stats/display.py
@@ -42,6 +42,8 @@ def _build_context(stats: DisplayableStats, output_dir: str | None = None) -> di
     # Throughput
     render_ms = stats.rendering_time_ms if stats.rendering_time_ms > 0 else stats.build_time_ms
     pages_per_sec = (stats.total_pages / render_ms) * 1000 if render_ms > 0 else 0
+    completion_policy = getattr(stats, "completion_policy", "complete")
+    ready_label = "HTML ready" if completion_policy == "serve_ready" else "Built"
 
     # Phase breakdown — show the slowest phases, not insertion order.
     recorded_phases = getattr(stats, "phase_timings_ms", None)
@@ -134,6 +136,7 @@ def _build_context(stats: DisplayableStats, output_dir: str | None = None) -> di
         "glyphs": glyphs,
         "has_errors": stats.has_errors,
         "has_warnings": len(stats.warnings) > 0,
+        "ready_label": ready_label,
         "total_pages": stats.total_pages,
         "breakdown": breakdown,
         "build_time": format_time(stats.build_time_ms),

--- a/bengal/orchestration/stats/display.py
+++ b/bengal/orchestration/stats/display.py
@@ -43,24 +43,26 @@ def _build_context(stats: DisplayableStats, output_dir: str | None = None) -> di
     render_ms = stats.rendering_time_ms if stats.rendering_time_ms > 0 else stats.build_time_ms
     pages_per_sec = (stats.total_pages / render_ms) * 1000 if render_ms > 0 else 0
 
-    # Phase breakdown — collect non-zero phases
-    phases = []
-    if stats.fonts_time_ms > 0:
-        phases.append(f"Fonts {format_time(stats.fonts_time_ms)}")
-    if stats.discovery_time_ms > 0:
-        phases.append(f"Discovery {format_time(stats.discovery_time_ms)}")
-    if stats.menu_time_ms > 0:
-        phases.append(f"Menus {format_time(stats.menu_time_ms)}")
-    if stats.related_posts_time_ms > 0:
-        phases.append(f"Related {format_time(stats.related_posts_time_ms)}")
-    if stats.rendering_time_ms > 0:
-        phases.append(f"Render {format_time(stats.rendering_time_ms)}")
-    if stats.assets_time_ms > 0:
-        phases.append(f"Assets {format_time(stats.assets_time_ms)}")
-    if stats.postprocess_time_ms > 0:
-        phases.append(f"Post {format_time(stats.postprocess_time_ms)}")
-    if stats.health_check_time_ms > 0:
-        phases.append(f"Health {format_time(stats.health_check_time_ms)}")
+    # Phase breakdown — show the slowest phases, not insertion order.
+    phase_items = [
+        ("Fonts", getattr(stats, "fonts_time_ms", 0)),
+        ("Discovery", getattr(stats, "discovery_time_ms", 0)),
+        ("Menus", getattr(stats, "menu_time_ms", 0)),
+        ("Related", getattr(stats, "related_posts_time_ms", 0)),
+        ("Render", getattr(stats, "rendering_time_ms", 0)),
+        ("Assets", getattr(stats, "assets_time_ms", 0)),
+        ("Post", getattr(stats, "postprocess_time_ms", 0)),
+        ("Health", getattr(stats, "health_check_time_ms", 0)),
+    ]
+    phases = [
+        f"{name} {format_time(duration_ms)}"
+        for name, duration_ms in sorted(phase_items, key=lambda item: item[1], reverse=True)
+        if duration_ms > 0
+    ]
+    postprocess_detail = _format_slowest_postprocess(stats)
+    if postprocess_detail:
+        phases.append(postprocess_detail)
+    visible_phases = [*phases[:3], postprocess_detail] if postprocess_detail else phases[:4]
 
     # Breakdown string
     breakdown = f"{stats.regular_pages}+{stats.generated_pages}"
@@ -127,7 +129,7 @@ def _build_context(stats: DisplayableStats, output_dir: str | None = None) -> di
         "mode": mode_text,
         "pages_per_sec": pages_per_sec,
         "content_parts": content_parts,
-        "phases": phases[:4],
+        "phases": visible_phases,
         "render_dist": render_dist,
         "regression": regression,
         "regression_positive": regression_positive,
@@ -140,6 +142,25 @@ def _build_context(stats: DisplayableStats, output_dir: str | None = None) -> di
         else len(stats.warnings),
         "error_code_summary": error_code_summary,
     }
+
+
+def _format_slowest_postprocess(stats: DisplayableStats) -> str | None:
+    """Return a compact detail for the slowest post-render subtask."""
+    timing_maps = [
+        getattr(stats, "postprocess_task_timings_ms", None),
+        getattr(stats, "postprocess_output_timings_ms", None),
+        getattr(stats, "post_render_timings_ms", None),
+    ]
+    combined: dict[str, float] = {}
+    for timings in timing_maps:
+        if isinstance(timings, dict):
+            for name, duration_ms in timings.items():
+                if isinstance(duration_ms, int | float) and duration_ms > 0:
+                    combined[str(name)] = float(duration_ms)
+    if not combined:
+        return None
+    name, duration_ms = max(combined.items(), key=lambda item: item[1])
+    return f"Slowest post {name} {format_time(duration_ms)}"
 
 
 def _build_warning_groups(stats: DisplayableStats) -> list[dict]:

--- a/bengal/orchestration/stats/models.py
+++ b/bengal/orchestration/stats/models.py
@@ -87,7 +87,9 @@ class BuildStats:
     pages_rendered: int = 0  # Set by RenderOrchestrator from WaveScheduler
     assets_time_ms: float = 0
     postprocess_time_ms: float = 0
+    postprocess_task_timings_ms: dict[str, float] = field(default_factory=dict)
     postprocess_output_timings_ms: dict[str, float] = field(default_factory=dict)
+    post_render_timings_ms: dict[str, float] = field(default_factory=dict)
     health_check_time_ms: float = 0
 
     # Memory metrics (Phase 1 - Performance Tracking)
@@ -398,7 +400,9 @@ class BuildStats:
             "pages_rendered": self.pages_rendered,
             "assets_time_ms": self.assets_time_ms,
             "postprocess_time_ms": self.postprocess_time_ms,
+            "postprocess_task_timings_ms": self.postprocess_task_timings_ms,
             "postprocess_output_timings_ms": self.postprocess_output_timings_ms,
+            "post_render_timings_ms": self.post_render_timings_ms,
             "health_check_time_ms": self.health_check_time_ms,
             # Memory
             "memory_rss_mb": self.memory_rss_mb,

--- a/bengal/orchestration/stats/models.py
+++ b/bengal/orchestration/stats/models.py
@@ -90,6 +90,7 @@ class BuildStats:
     postprocess_task_timings_ms: dict[str, float] = field(default_factory=dict)
     postprocess_output_timings_ms: dict[str, float] = field(default_factory=dict)
     post_render_timings_ms: dict[str, float] = field(default_factory=dict)
+    phase_timings_ms: dict[str, float] = field(default_factory=dict)
     health_check_time_ms: float = 0
 
     # Memory metrics (Phase 1 - Performance Tracking)
@@ -259,6 +260,12 @@ class BuildStats:
             },
         }
 
+    def record_phase_timing(self, name: str, duration_ms: float) -> None:
+        """Record a named build phase timing for cold-build accounting."""
+        if duration_ms <= 0:
+            return
+        self.phase_timings_ms[name] = round(duration_ms, 1)
+
     def add_directive(self, directive_type: str) -> None:
         """Track a directive usage."""
         with self._lock:
@@ -352,17 +359,20 @@ class BuildStats:
     @property
     def overhead_ms(self) -> float:
         """Unaccounted time: build_time minus sum of all phase timings."""
-        phase_sum = (
-            self.fonts_time_ms
-            + self.discovery_time_ms
-            + self.taxonomy_time_ms
-            + self.menu_time_ms
-            + self.related_posts_time_ms
-            + self.rendering_time_ms
-            + self.assets_time_ms
-            + self.postprocess_time_ms
-            + self.health_check_time_ms
-        )
+        if self.phase_timings_ms:
+            phase_sum = sum(self.phase_timings_ms.values())
+        else:
+            phase_sum = (
+                self.fonts_time_ms
+                + self.discovery_time_ms
+                + self.taxonomy_time_ms
+                + self.menu_time_ms
+                + self.related_posts_time_ms
+                + self.rendering_time_ms
+                + self.assets_time_ms
+                + self.postprocess_time_ms
+                + self.health_check_time_ms
+            )
         return max(0, self.build_time_ms - phase_sum)
 
     @property
@@ -403,6 +413,7 @@ class BuildStats:
             "postprocess_task_timings_ms": self.postprocess_task_timings_ms,
             "postprocess_output_timings_ms": self.postprocess_output_timings_ms,
             "post_render_timings_ms": self.post_render_timings_ms,
+            "phase_timings_ms": self.phase_timings_ms,
             "health_check_time_ms": self.health_check_time_ms,
             # Memory
             "memory_rss_mb": self.memory_rss_mb,

--- a/bengal/orchestration/stats/models.py
+++ b/bengal/orchestration/stats/models.py
@@ -75,6 +75,7 @@ class BuildStats:
     incremental: bool = False
     skipped: bool = False
     dry_run: bool = False
+    completion_policy: str = "complete"
 
     # Directive statistics
     total_directives: int = 0
@@ -400,6 +401,7 @@ class BuildStats:
             "parallel": self.parallel,
             "incremental": self.incremental,
             "skipped": self.skipped,
+            "completion_policy": self.completion_policy,
             # Phase timings
             "fonts_time_ms": self.fonts_time_ms,
             "discovery_time_ms": self.discovery_time_ms,

--- a/bengal/output/templates/build_summary.kida
+++ b/bengal/output/templates/build_summary.kida
@@ -76,7 +76,7 @@ Build Failed
 
 {%- elif has_warnings -%}
 {#- Built with warnings -#}
-{{ warn | yellow }} {{ brand | fg("#FF9D00") | bold }}  {{ ("Built " ~ (total_pages | string) ~ " pages in " ~ build_time ~ " (" ~ mode ~ ") with warnings") | yellow }}
+{{ warn | yellow }} {{ brand | fg("#FF9D00") | bold }}  {{ ((ready_label | default("Built")) ~ " " ~ (total_pages | string) ~ " pages in " ~ build_time ~ " (" ~ mode ~ ") with warnings") | yellow }}
    {{ content_parts | join(", ") | dim }}
 {%- if phases %}
    {{ phases | join(", ") | dim }}
@@ -84,7 +84,7 @@ Build Failed
 
 {%- else -%}
 {#- Clean success -#}
-{{ ok | green }} {{ brand | fg("#FF9D00") | bold }}  {{ ("Built " ~ (total_pages | string) ~ " pages") | green }} {{ ("(" ~ breakdown ~ ")") | dim }} in {{ build_time | fg("#F1C40F") | bold }} {{ ("(" ~ mode ~ ")") | dim }} {{ sep }} {{ (pages_per_sec | round(1) | string) | fg("#F1C40F") | bold }} {{ "pages/sec" | dim }}
+{{ ok | green }} {{ brand | fg("#FF9D00") | bold }}  {{ ((ready_label | default("Built")) ~ " " ~ (total_pages | string) ~ " pages") | green }} {{ ("(" ~ breakdown ~ ")") | dim }} in {{ build_time | fg("#F1C40F") | bold }} {{ ("(" ~ mode ~ ")") | dim }} {{ sep }} {{ (pages_per_sec | round(1) | string) | fg("#F1C40F") | bold }} {{ "pages/sec" | dim }}
    {{ content_parts | join(", ") | dim }}
 {%- if phases %}
    {{ phases | join(", ") | dim }}

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -127,6 +127,7 @@ class OutputFormatsGenerator:
         site: SiteLike,
         config: dict[str, Any] | None = None,
         graph_data: dict[str, Any] | None = None,
+        graph_data_provider: Callable[[], dict[str, Any] | None] | None = None,
         build_context: BuildContext | Any | None = None,
     ) -> None:
         """
@@ -136,11 +137,14 @@ class OutputFormatsGenerator:
             site: Site instance
             config: Configuration dict from bengal.toml
             graph_data: Optional pre-computed graph data for including in page JSON
+            graph_data_provider: Optional lazy graph builder for page JSON
             build_context: Optional BuildContext with accumulated JSON data from rendering phase
         """
         self.site = site
         self.config = self._normalize_config(config or {})
         self.graph_data = graph_data
+        self._graph_data_provider = graph_data_provider
+        self._graph_data_loaded = graph_data is not None
         self.build_context = build_context
 
     def _normalize_config(self, config: dict[str, Any]) -> dict[str, Any]:
@@ -301,13 +305,14 @@ class OutputFormatsGenerator:
         # Per-page outputs — use ai_input_pages (machine-readable for AI)
         if "json" in per_page:
             per_page_targets["json"] = self._per_page_target_pages(ai_input_pages, "json")
+            graph_data = self._get_graph_data_if_needed(per_page_targets["json"])
             # Get config options for HTML/text inclusion
             include_html = options.get("include_html_content", False)
             include_text = options.get("include_plain_text", True)
             include_chunks = options.get("include_chunks", True)
             json_gen = PageJSONGenerator(
                 self.site,
-                graph_data=self.graph_data,
+                graph_data=graph_data,
                 include_html=include_html,
                 include_text=include_text,
                 include_chunks=include_chunks,
@@ -573,6 +578,28 @@ class OutputFormatsGenerator:
         for path in changed_page_paths:
             changed.update(_path_keys(path))
         return changed
+
+    def _get_graph_data_if_needed(self, pages: list[PageLike]) -> dict[str, Any] | None:
+        """Build graph data lazily only when page JSON will actually use it."""
+        if not pages:
+            return None
+        if not self.config.get("options", {}).get("include_graph_connections", True):
+            return None
+        if self._graph_data_loaded:
+            return self.graph_data
+        if self._graph_data_provider is None:
+            self._graph_data_loaded = True
+            return self.graph_data
+
+        start = time.perf_counter()
+        self.graph_data = self._graph_data_provider()
+        self._graph_data_loaded = True
+        duration_ms = (time.perf_counter() - start) * 1000
+        stats = getattr(self.build_context, "stats", None)
+        timings = getattr(stats, "postprocess_task_timings_ms", None)
+        if isinstance(timings, dict):
+            timings["graph data"] = round(duration_ms, 1)
+        return self.graph_data
 
     def _generate_site_wide_if_needed(
         self,

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -28,7 +28,6 @@ import hashlib
 import json
 import time
 from contextlib import suppress
-from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -765,29 +764,9 @@ class OutputFormatsGenerator:
 
 def _page_artifact_to_accumulated(record: dict[str, Any], accumulated_type: Any) -> Any:
     """Rehydrate a cached page artifact into an AccumulatedPageData record."""
-    json_output_path = record.get("json_output_path")
-    return accumulated_type(
-        source_path=Path(record["source_path"]),
-        url=record["url"],
-        uri=record["uri"],
-        title=record["title"],
-        description=record.get("description", ""),
-        date=record.get("date"),
-        date_iso=record.get("date_iso"),
-        plain_text=record.get("plain_text", ""),
-        excerpt=record.get("excerpt", ""),
-        content_preview=record.get("content_preview", ""),
-        word_count=int(record.get("word_count") or 0),
-        reading_time=int(record.get("reading_time") or 0),
-        section=record.get("section", ""),
-        tags=list(record.get("tags") or []),
-        dir=record.get("dir", ""),
-        enhanced_metadata=dict(record.get("enhanced_metadata") or {}),
-        is_autodoc=bool(record.get("is_autodoc", False)),
-        full_json_data=record.get("full_json_data"),
-        json_output_path=Path(json_output_path) if json_output_path else None,
-        raw_metadata=dict(record.get("raw_metadata") or {}),
-    )
+    from bengal.rendering.page_artifact import PageArtifact
+
+    return PageArtifact.from_cache_record(record).to_accumulated(accumulated_type)
 
 
 def _site_relative_path(site: SiteLike, source_path: Path) -> Path:
@@ -825,27 +804,10 @@ def _path_matches(path: Path | str, keys: set[str]) -> bool:
 
 def _fingerprint_page_artifact(data: Any) -> dict[str, Any]:
     """Return stable page artifact fields that affect site-wide output formats."""
-    return {
-        "source_path": str(data.source_path),
-        "url": data.url,
-        "uri": data.uri,
-        "title": data.title,
-        "description": data.description,
-        "date": data.date,
-        "date_iso": data.date_iso,
-        "plain_text": data.plain_text,
-        "excerpt": data.excerpt,
-        "content_preview": data.content_preview,
-        "word_count": data.word_count,
-        "reading_time": data.reading_time,
-        "section": data.section,
-        "tags": list(data.tags),
-        "dir": data.dir,
-        "enhanced_metadata": _json_safe(data.enhanced_metadata),
-        "is_autodoc": data.is_autodoc,
-        "full_json_data": _json_safe(data.full_json_data),
-        "raw_metadata": _json_safe(data.raw_metadata),
-    }
+    from bengal.rendering.page_artifact import PageArtifact
+
+    artifact = data if isinstance(data, PageArtifact) else PageArtifact.from_accumulated(data)
+    return artifact.fingerprint_record()
 
 
 def _site_fingerprint(site: SiteLike) -> dict[str, Any]:
@@ -859,23 +821,3 @@ def _site_fingerprint(site: SiteLike) -> dict[str, Any]:
         "dev_mode": bool(getattr(site, "dev_mode", False)),
         "build_time": None if getattr(site, "dev_mode", False) else build_time_value,
     }
-
-
-def _json_safe(value: Any) -> Any:
-    """Return a stable JSON-serializable representation for fingerprinting."""
-    if isinstance(value, str | int | float | bool | type(None)):
-        return value
-    if isinstance(value, Path):
-        return str(value)
-    if isinstance(value, date | datetime):
-        return value.isoformat()
-    if isinstance(value, dict):
-        return {
-            str(key): _json_safe(item)
-            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
-        }
-    if isinstance(value, list | tuple):
-        return [_json_safe(item) for item in value]
-    if isinstance(value, set | frozenset):
-        return sorted(_json_safe(item) for item in value)
-    return str(value)

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
+from contextlib import suppress
 from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -43,7 +44,12 @@ from bengal.postprocess.output_formats.llms_txt_generator import SiteLlmsTxtGene
 from bengal.postprocess.output_formats.lunr_index_generator import LunrIndexGenerator
 from bengal.postprocess.output_formats.md_generator import PageMarkdownGenerator
 from bengal.postprocess.output_formats.txt_generator import PageTxtGenerator
-from bengal.postprocess.output_formats.utils import get_i18n_output_path
+from bengal.postprocess.output_formats.utils import (
+    get_i18n_output_path,
+    get_page_json_path,
+    get_page_md_path,
+    get_page_txt_path,
+)
 from bengal.postprocess.search_backends import (
     create_search_backend,
     resolve_search_backend_config,
@@ -276,6 +282,7 @@ class OutputFormatsGenerator:
         generated = []
         timings: dict[str, float] = {}
         options = self.config.get("options", {})
+        per_page_targets: dict[str, list[PageLike]] = {}
 
         # Get accumulated page data once (shared by multiple generators)
         # See: plan/drafted/rfc-unified-page-data-accumulation.md
@@ -294,6 +301,7 @@ class OutputFormatsGenerator:
 
         # Per-page outputs — use ai_input_pages (machine-readable for AI)
         if "json" in per_page:
+            per_page_targets["json"] = self._per_page_target_pages(ai_input_pages, "json")
             # Get config options for HTML/text inclusion
             include_html = options.get("include_html_content", False)
             include_text = options.get("include_plain_text", True)
@@ -311,7 +319,7 @@ class OutputFormatsGenerator:
             accumulated_json = None
             if accumulated_data:
                 # Filter accumulated data to ai_input-permitted pages
-                ai_input_urls = {p.href for p in ai_input_pages}
+                ai_input_urls = {p.href for p in per_page_targets["json"]}
                 accumulated_json = [
                     (data.json_output_path, data.full_json_data)
                     for data in accumulated_data
@@ -321,28 +329,36 @@ class OutputFormatsGenerator:
             count = self._timed_generate(
                 timings,
                 "page_json",
-                lambda: json_gen.generate(ai_input_pages, accumulated_json=accumulated_json),
+                lambda: json_gen.generate(
+                    per_page_targets["json"],
+                    accumulated_json=accumulated_json,
+                ),
             )
             generated.append(f"JSON ({count} files)")
             logger.debug("generated_page_json", file_count=count)
 
         if "llm_txt" in per_page:
+            per_page_targets["llm_txt"] = self._per_page_target_pages(ai_input_pages, "llm_txt")
             separator_width = options.get("llm_separator_width", 80)
             txt_gen = PageTxtGenerator(self.site, separator_width=separator_width)
             count = self._timed_generate(
                 timings,
                 "page_llm_txt",
-                lambda: txt_gen.generate(ai_input_pages),
+                lambda: txt_gen.generate(per_page_targets["llm_txt"]),
             )
             generated.append(f"LLM text ({count} files)")
             logger.debug("generated_page_txt", file_count=count)
 
         if "markdown" in per_page:
+            per_page_targets["markdown"] = self._per_page_target_pages(
+                ai_input_pages,
+                "markdown",
+            )
             md_gen = PageMarkdownGenerator(self.site)
             count = self._timed_generate(
                 timings,
                 "page_markdown",
-                lambda: md_gen.generate(ai_input_pages),
+                lambda: md_gen.generate(per_page_targets["markdown"]),
             )
             generated.append(f"Markdown ({count} files)")
             logger.debug("generated_page_markdown", file_count=count)
@@ -497,6 +513,51 @@ class OutputFormatsGenerator:
             merged.append(_page_artifact_to_accumulated(record, AccumulatedPageData))
         return merged
 
+    def _per_page_target_pages(self, pages: list[PageLike], output_format: str) -> list[PageLike]:
+        """Return pages that need per-page companion artifacts for this build."""
+        if not self.build_context or not getattr(self.build_context, "incremental", False):
+            return pages
+        if getattr(self.build_context, "config_changed", False):
+            return pages
+
+        changed_keys = self._changed_page_source_keys()
+        if not changed_keys:
+            return pages
+
+        targets = []
+        for page in pages:
+            source_path = getattr(page, "source_path", None)
+            if source_path is None:
+                continue
+            output_path = _per_page_output_path(page, output_format)
+            if output_path is None:
+                continue
+            if _path_matches(source_path, changed_keys) or not output_path.exists():
+                targets.append(page)
+        logger.debug(
+            "per_page_output_targets_selected",
+            format=output_format,
+            targets=len(targets),
+            total=len(pages),
+            reason="incremental_changed_pages",
+        )
+        return targets
+
+    def _changed_page_source_keys(self) -> set[str]:
+        """Return normalized source path keys for pages rendered in this build."""
+        changed: set[str] = set()
+        pages_to_build = getattr(self.build_context, "pages_to_build", None)
+        if pages_to_build:
+            for page in pages_to_build:
+                source_path = getattr(page, "source_path", None)
+                if source_path is not None:
+                    changed.update(_path_keys(source_path))
+
+        changed_page_paths = getattr(self.build_context, "changed_page_paths", set()) or set()
+        for path in changed_page_paths:
+            changed.update(_path_keys(path))
+        return changed
+
     def _generate_site_wide_if_needed(
         self,
         timings: dict[str, float],
@@ -596,7 +657,13 @@ class OutputFormatsGenerator:
     ) -> Any:
         """Run one output-format generator and record its elapsed time."""
         start = time.perf_counter()
-        result = generate_fn()
+        self._emit_output_format_started(format_name)
+        try:
+            result = generate_fn()
+        except Exception:
+            duration_ms = (time.perf_counter() - start) * 1000
+            self._emit_output_format_finished(format_name, duration_ms)
+            raise
         duration_ms = (time.perf_counter() - start) * 1000
         timings[format_name] = round(duration_ms, 1)
         stats = getattr(self.build_context, "stats", None)
@@ -607,7 +674,35 @@ class OutputFormatsGenerator:
             format=format_name,
             duration_ms=timings[format_name],
         )
+        self._emit_output_format_finished(format_name, duration_ms)
         return result
+
+    def _emit_output_format_started(self, format_name: str) -> None:
+        """Show long-running output-format work before it completes."""
+        if not self._should_emit_cli_progress():
+            return
+        from bengal.output import get_cli_output
+
+        cli = get_cli_output()
+        cli.detail(f"output formats: {format_name}...", indent=2, icon=cli.icons.arrow)
+
+    def _emit_output_format_finished(self, format_name: str, duration_ms: float) -> None:
+        """Show a completed output-format generator with elapsed time."""
+        if not self._should_emit_cli_progress():
+            return
+        from bengal.output import get_cli_output
+
+        cli = get_cli_output()
+        cli.detail(
+            f"output formats: {format_name} {int(duration_ms)}ms",
+            indent=2,
+            icon=cli.icons.success,
+        )
+
+    def _should_emit_cli_progress(self) -> bool:
+        """Return whether output-format progress should be printed directly."""
+        progress_manager = getattr(self.build_context, "progress_manager", None)
+        return progress_manager is None
 
     def _filter_pages(self) -> list[PageLike]:
         """
@@ -701,6 +796,31 @@ def _site_relative_path(site: SiteLike, source_path: Path) -> Path:
         return source_path
     root_path = getattr(site, "root_path", None)
     return root_path / source_path if root_path else source_path
+
+
+def _per_page_output_path(page: PageLike, output_format: str) -> Path | None:
+    """Return the expected per-page artifact path for a configured output format."""
+    if output_format == "json":
+        return get_page_json_path(page)
+    if output_format == "llm_txt":
+        return get_page_txt_path(page)
+    if output_format == "markdown":
+        return get_page_md_path(page)
+    return None
+
+
+def _path_keys(path: Path | str) -> set[str]:
+    """Return stable path keys for matching absolute/relative source paths."""
+    path = Path(path)
+    keys = {str(path)}
+    with suppress(OSError):
+        keys.add(str(path.resolve()))
+    return keys
+
+
+def _path_matches(path: Path | str, keys: set[str]) -> bool:
+    """Return whether path matches one of the normalized changed-path keys."""
+    return bool(_path_keys(path) & keys)
 
 
 def _fingerprint_page_artifact(data: Any) -> dict[str, Any]:

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -521,7 +521,20 @@ class OutputFormatsGenerator:
 
         changed_keys = self._changed_page_source_keys()
         if not changed_keys:
-            return pages
+            targets = [
+                page
+                for page in pages
+                if (output_path := _per_page_output_path(page, output_format)) is not None
+                and not output_path.exists()
+            ]
+            logger.debug(
+                "per_page_output_targets_selected",
+                format=output_format,
+                targets=len(targets),
+                total=len(pages),
+                reason="incremental_missing_outputs_only",
+            )
+            return targets
 
         targets = []
         for page in pages:

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -145,6 +145,7 @@ class OutputFormatsGenerator:
         self.graph_data = graph_data
         self._graph_data_provider = graph_data_provider
         self._graph_data_loaded = graph_data is not None
+        self._pending_site_wide_page_hashes: dict[str, dict[str, str]] = {}
         self.build_context = build_context
 
     def _normalize_config(self, config: dict[str, Any]) -> dict[str, Any]:
@@ -626,6 +627,7 @@ class OutputFormatsGenerator:
             and fingerprints.get(format_name) == fingerprint
         )
         if can_skip:
+            self._pending_site_wide_page_hashes.pop(format_name, None)
             timings[format_name] = 0.0
             stats = getattr(self.build_context, "stats", None)
             if stats is not None:
@@ -642,6 +644,13 @@ class OutputFormatsGenerator:
         result = self._timed_generate(timings, format_name, generate_fn)
         if fingerprint is not None and isinstance(fingerprints, dict):
             fingerprints[format_name] = fingerprint
+            page_hashes = self._pending_site_wide_page_hashes.pop(format_name, None)
+            if page_hashes is not None:
+                fingerprints[_page_hash_manifest_key(format_name)] = json.dumps(
+                    page_hashes,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
         return result
 
     def _generate_search_backend_if_needed(
@@ -712,25 +721,44 @@ class OutputFormatsGenerator:
         if not accumulated_data:
             return None
 
-        by_source = {data.source_path: data for data in accumulated_data}
-        records = []
+        cache = getattr(self.build_context, "cache", None)
+        fingerprints = getattr(cache, "output_format_fingerprints", None)
+        if not isinstance(fingerprints, dict):
+            return None
+
+        prior_hashes = _load_page_hash_manifest(
+            fingerprints.get(_page_hash_manifest_key(format_name))
+        )
+        changed_keys = self._changed_page_source_keys()
+        data_by_source = _accumulated_data_by_source(self.site, accumulated_data)
+        page_hashes: dict[str, str] = {}
+
         for page in pages:
             source_path = getattr(page, "source_path", None)
             if not source_path:
                 return None
-            data = by_source.get(source_path)
+            source_key = _source_manifest_key(self.site, source_path)
+            lookup_keys = _source_lookup_keys(self.site, source_path)
+            prior_hash = prior_hashes.get(source_key)
+            if prior_hash is not None and not (lookup_keys & changed_keys):
+                page_hashes[source_key] = prior_hash
+                continue
+
+            data = _lookup_accumulated_data(data_by_source, lookup_keys)
             if data is None:
                 return None
-            records.append(_fingerprint_page_artifact(data))
+            page_hashes[source_key] = _hash_page_artifact(data)
 
         payload = {
             "format": format_name,
             "options": options,
             "site": _site_fingerprint(self.site),
-            "pages": records,
+            "pages": sorted(page_hashes.items()),
         }
         encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-        return hashlib.sha256(encoded).hexdigest()
+        fingerprint = hashlib.sha256(encoded).hexdigest()
+        self._pending_site_wide_page_hashes[format_name] = page_hashes
+        return fingerprint
 
     def _expected_site_wide_outputs(self, format_name: str) -> list[Path] | None:
         """Return outputs that must exist before a site-wide generator can be skipped."""
@@ -911,12 +939,85 @@ def _path_matches(path: Path | str, keys: set[str]) -> bool:
     return bool(_path_keys(path) & keys)
 
 
+def _source_manifest_key(site: SiteLike, source_path: Path | str) -> str:
+    """Return a stable source key for persisted per-page aggregate hashes."""
+    path = Path(source_path)
+    root_path = getattr(site, "root_path", None)
+    if path.is_absolute() and root_path is not None:
+        with suppress(ValueError):
+            return str(path.relative_to(root_path))
+    return str(path)
+
+
+def _source_lookup_keys(site: SiteLike, source_path: Path | str) -> set[str]:
+    """Return relative and absolute source variants for artifact lookup."""
+    path = Path(source_path)
+    keys = _path_keys(path)
+    root_path = getattr(site, "root_path", None)
+    if root_path is not None:
+        if path.is_absolute():
+            with suppress(ValueError):
+                keys.update(_path_keys(path.relative_to(root_path)))
+        else:
+            keys.update(_path_keys(root_path / path))
+    return keys
+
+
+def _accumulated_data_by_source(site: SiteLike, accumulated_data: list[Any]) -> dict[str, Any]:
+    """Index accumulated page data by normalized source path variants."""
+    by_source: dict[str, Any] = {}
+    for data in accumulated_data:
+        source_path = getattr(data, "source_path", None)
+        if source_path is None:
+            continue
+        for key in _source_lookup_keys(site, source_path):
+            by_source[key] = data
+    return by_source
+
+
+def _lookup_accumulated_data(data_by_source: dict[str, Any], lookup_keys: set[str]) -> Any | None:
+    """Return accumulated data matching any source path variant."""
+    for key in lookup_keys:
+        data = data_by_source.get(key)
+        if data is not None:
+            return data
+    return None
+
+
 def _fingerprint_page_artifact(data: Any) -> dict[str, Any]:
     """Return stable page artifact fields that affect site-wide output formats."""
     from bengal.rendering.page_artifact import PageArtifact
 
     artifact = data if isinstance(data, PageArtifact) else PageArtifact.from_accumulated(data)
     return artifact.fingerprint_record()
+
+
+def _hash_page_artifact(data: Any) -> str:
+    """Hash a page artifact fingerprint record for aggregate manifests."""
+    encoded = json.dumps(
+        _fingerprint_page_artifact(data),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _page_hash_manifest_key(format_name: str) -> str:
+    """Return the cache key for a format's per-page aggregate hash manifest."""
+    return f"{format_name}:page_hashes"
+
+
+def _load_page_hash_manifest(value: Any) -> dict[str, str]:
+    """Load a persisted per-page hash manifest, falling back to empty on mismatch."""
+    if not isinstance(value, str) or not value:
+        return {}
+    try:
+        loaded = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {str(key): str(hash_value) for key, hash_value in loaded.items()}
 
 
 def _site_fingerprint(site: SiteLike) -> dict[str, Any]:

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -409,9 +409,13 @@ class OutputFormatsGenerator:
                 self.site.config.get("search", {})
             )
             search_backend = create_search_backend(self.site, search_backend_config)
-            generated_search = search_backend.generate(
+            generated_search = self._generate_search_backend_if_needed(
+                timings,
+                search_backend,
+                search_backend_config,
                 index_paths,
-                lambda label, factory: self._timed_generate(timings, label, factory),
+                search_pages,
+                accumulated_data,
             )
             generated.extend(generated_search)
             if generated_search:
@@ -579,6 +583,7 @@ class OutputFormatsGenerator:
         options: dict[str, Any],
         expected_outputs: list[Path] | None,
         generate_fn: Callable[[], Any],
+        skip_result: Any = None,
     ) -> Any:
         """Skip unchanged site-wide generators when their artifact input fingerprint matches."""
         fingerprint = self._site_wide_input_fingerprint(
@@ -603,12 +608,67 @@ class OutputFormatsGenerator:
                 format=format_name,
                 reason="input_fingerprint_unchanged",
             )
+            if skip_result is not None:
+                return skip_result
             return expected_outputs if len(expected_outputs) > 1 else expected_outputs[0]
 
         result = self._timed_generate(timings, format_name, generate_fn)
         if fingerprint is not None and isinstance(fingerprints, dict):
             fingerprints[format_name] = fingerprint
         return result
+
+    def _generate_search_backend_if_needed(
+        self,
+        timings: dict[str, float],
+        search_backend: Any,
+        search_backend_config: Any,
+        index_paths: list[Path],
+        pages: list[PageLike],
+        accumulated_data: list[Any] | None,
+    ) -> list[str]:
+        """Skip derived search backend artifacts when aggregate inputs are unchanged."""
+        if not search_backend_config.enabled or not search_backend_config.prebuilt_enabled:
+            return search_backend.generate(
+                index_paths,
+                lambda label, factory: self._timed_generate(timings, label, factory),
+            )
+
+        result = self._generate_site_wide_if_needed(
+            timings,
+            "site_lunr_index",
+            pages,
+            accumulated_data,
+            self._search_backend_fingerprint_options(search_backend_config, index_paths),
+            self._expected_search_backend_outputs(search_backend_config, index_paths),
+            lambda: search_backend.generate(
+                index_paths,
+                lambda label, factory: self._timed_generate(timings, label, factory),
+            ),
+            skip_result=[],
+        )
+        return list(result or [])
+
+    def _search_backend_fingerprint_options(
+        self,
+        search_backend_config: Any,
+        index_paths: list[Path],
+    ) -> dict[str, Any]:
+        """Return search backend options that affect derived aggregate outputs."""
+        return {
+            "backend": search_backend_config.backend,
+            "lunr": search_backend_config.lunr,
+            "index_paths": [_output_relative_path(self.site, path) for path in index_paths],
+        }
+
+    def _expected_search_backend_outputs(
+        self,
+        search_backend_config: Any,
+        index_paths: list[Path],
+    ) -> list[Path] | None:
+        """Return backend outputs that must exist before derived search can skip."""
+        if search_backend_config.backend == "lunr" and search_backend_config.prebuilt_enabled:
+            return [path.parent / "search-index.json" for path in index_paths]
+        return None
 
     def _site_wide_input_fingerprint(
         self,
@@ -788,6 +848,15 @@ def _site_relative_path(site: SiteLike, source_path: Path) -> Path:
         return source_path
     root_path = getattr(site, "root_path", None)
     return root_path / source_path if root_path else source_path
+
+
+def _output_relative_path(site: SiteLike, path: Path) -> str:
+    """Return an output-relative path for stable fingerprint payloads."""
+    output_dir = getattr(site, "output_dir", None)
+    if output_dir is not None:
+        with suppress(ValueError):
+            return str(path.relative_to(output_dir))
+    return str(path)
 
 
 def _per_page_output_path(page: PageLike, output_format: str) -> Path | None:

--- a/bengal/postprocess/output_formats/llm_generator.py
+++ b/bengal/postprocess/output_formats/llm_generator.py
@@ -64,6 +64,7 @@ Related:
 from __future__ import annotations
 
 import hashlib
+import json
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -153,12 +154,7 @@ class SiteLlmTxtGenerator:
         llm_path = self.site.output_dir / "llm-full.txt"
         hash_path = self.site.output_dir / ".llm-full.hash"
 
-        # OPTIMIZATION: Compute content hash incrementally to detect changes
-        # without loading entire file into memory. O(n) time but O(1) memory.
-        hasher = hashlib.sha256()
-        for page in pages:
-            hasher.update(page.plain_text.encode("utf-8"))
-        new_hash = hasher.hexdigest()
+        new_hash = self._emitted_content_hash(pages)
 
         # Check if content unchanged via hash comparison (O(1) instead of O(n))
         if self._is_unchanged(hash_path, new_hash):
@@ -241,3 +237,34 @@ class SiteLlmTxtGenerator:
                 error_type=type(e).__name__,
             )
         return False
+
+    def _emitted_content_hash(self, pages: Sequence[PageLike]) -> str:
+        """Hash all fields that affect the emitted llm-full.txt content."""
+        build_time = getattr(self.site, "build_time", None)
+        dev_mode = bool(getattr(self.site, "dev_mode", False))
+        payload = {
+            "separator_width": self.separator_width,
+            "site": {
+                "title": str(getattr(self.site, "title", None) or "Bengal Site"),
+                "baseurl": str(getattr(self.site, "baseurl", None) or ""),
+                "dev_mode": dev_mode,
+                "build_time": build_time.isoformat()
+                if not dev_mode and isinstance(build_time, datetime)
+                else None,
+            },
+            "pages": [
+                {
+                    "index": idx,
+                    "total": len(pages),
+                    "title": page.title,
+                    "url": get_page_url(page, self.site),
+                    "section": get_section_name(page),
+                    "tags": [str(tag) for tag in tags_to_list(page.tags)],
+                    "date": page.date.strftime("%Y-%m-%d") if page.date else None,
+                    "plain_text": page.plain_text,
+                }
+                for idx, page in enumerate(pages, 1)
+            ],
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()

--- a/bengal/postprocess/output_formats/md_generator.py
+++ b/bengal/postprocess/output_formats/md_generator.py
@@ -89,15 +89,34 @@ class PageMarkdownGenerator:
         Returns:
             Number of .md files generated.
         """
-        page_items: list[tuple[Path, str]] = []
+        page_targets: list[tuple[Path, PageLike]] = []
         for page in pages:
             md_path = get_page_md_path(page)
             if not md_path:
                 continue
+            page_targets.append((md_path, page))
 
+        if not page_targets:
+            return 0
+
+        def render_markdown(item: tuple[Path, PageLike]) -> tuple[Path, str] | None:
+            md_path, page = item
             content = self._page_to_markdown(page)
             if content:
-                page_items.append((md_path, content))
+                return md_path, content
+            return None
+
+        from bengal.utils.concurrency.work_scope import WorkScope
+
+        with WorkScope("MarkdownOutput", max_workers=8) as scope:
+            results = scope.map(render_markdown, page_targets)
+
+        page_items: list[tuple[Path, str]] = []
+        for result in results:
+            if result.error:
+                raise result.error
+            if result.value is not None:
+                page_items.append(result.value)
 
         if not page_items:
             return 0

--- a/bengal/rendering/asset_audit.py
+++ b/bengal/rendering/asset_audit.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 LOCAL_CSS_JS_RE = re.compile(r"""(?:href|src)=["']([^"']+\.(?:css|js)(?:\?[^"']*)?)["']""")
@@ -22,7 +23,9 @@ class MissingAssetReference:
 
 
 def find_missing_local_asset_references(
-    output_dir: Path, baseurl: str = ""
+    output_dir: Path,
+    baseurl: str = "",
+    html_paths: Iterable[Path] | None = None,
 ) -> list[MissingAssetReference]:
     """Find local CSS/JS URLs in rendered HTML that do not exist on disk."""
     if not output_dir.exists():
@@ -30,12 +33,22 @@ def find_missing_local_asset_references(
 
     missing: list[MissingAssetReference] = []
     base_prefix = _normalized_base_prefix(baseurl)
-    for html_path in output_dir.rglob("*.html"):
+    candidates = html_paths if html_paths is not None else output_dir.rglob("*.html")
+    for html_path in candidates:
+        if html_path.suffix.lower() != ".html":
+            continue
+        if not html_path.is_absolute():
+            html_path = output_dir / html_path
+        if not html_path.exists():
+            continue
         try:
             html = html_path.read_text(encoding="utf-8")
         except OSError:
             continue
-        html_rel = html_path.relative_to(output_dir)
+        try:
+            html_rel = html_path.relative_to(output_dir)
+        except ValueError:
+            continue
         for raw_url in LOCAL_CSS_JS_RE.findall(html):
             parsed = urlparse(raw_url)
             if parsed.scheme or parsed.netloc or parsed.path.startswith("//"):

--- a/bengal/rendering/page_artifact.py
+++ b/bengal/rendering/page_artifact.py
@@ -1,0 +1,186 @@
+"""Immutable per-page rendering artifacts for post-render consumers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+type JsonFrozen = str | int | float | bool | None | tuple[str, tuple[Any, ...]]
+
+
+@dataclass(frozen=True, slots=True)
+class PageArtifact:
+    """Frozen page record handed from rendering to postprocess/cache code."""
+
+    source_path: Path
+    url: str
+    uri: str
+    title: str
+    description: str
+    date: str | None
+    date_iso: str | None
+    plain_text: str
+    excerpt: str
+    content_preview: str
+    word_count: int
+    reading_time: int
+    section: str
+    tags: tuple[str, ...]
+    dir: str
+    enhanced_metadata: JsonFrozen = ("dict", ())
+    is_autodoc: bool = False
+    full_json_data: JsonFrozen | None = None
+    json_output_path: Path | None = None
+    raw_metadata: JsonFrozen = ("dict", ())
+    anchors: tuple[str, ...] = ()
+
+    @classmethod
+    def from_accumulated(
+        cls, data: Any, anchors: frozenset[str] | tuple[str, ...] = ()
+    ) -> PageArtifact:
+        """Create a frozen artifact from legacy AccumulatedPageData-like data."""
+        json_output_path = getattr(data, "json_output_path", None)
+        return cls(
+            source_path=Path(data.source_path),
+            url=str(getattr(data, "url", "")),
+            uri=str(getattr(data, "uri", "")),
+            title=str(getattr(data, "title", "")),
+            description=str(getattr(data, "description", "")),
+            date=getattr(data, "date", None),
+            date_iso=getattr(data, "date_iso", None),
+            plain_text=str(getattr(data, "plain_text", "")),
+            excerpt=str(getattr(data, "excerpt", "")),
+            content_preview=str(getattr(data, "content_preview", "")),
+            word_count=int(getattr(data, "word_count", 0) or 0),
+            reading_time=int(getattr(data, "reading_time", 0) or 0),
+            section=str(getattr(data, "section", "")),
+            tags=tuple(str(tag) for tag in getattr(data, "tags", ()) or ()),
+            dir=str(getattr(data, "dir", "")),
+            enhanced_metadata=_freeze_mapping(getattr(data, "enhanced_metadata", {}) or {}),
+            is_autodoc=bool(getattr(data, "is_autodoc", False)),
+            full_json_data=_freeze_json(getattr(data, "full_json_data", None)),
+            json_output_path=Path(json_output_path) if json_output_path else None,
+            raw_metadata=_freeze_mapping(getattr(data, "raw_metadata", {}) or {}),
+            anchors=tuple(sorted(str(anchor) for anchor in anchors)),
+        )
+
+    @classmethod
+    def from_cache_record(cls, record: dict[str, Any]) -> PageArtifact:
+        """Create a frozen artifact from a persisted cache record."""
+        json_output_path = record.get("json_output_path")
+        return cls(
+            source_path=Path(record["source_path"]),
+            url=str(record.get("url", "")),
+            uri=str(record.get("uri", "")),
+            title=str(record.get("title", "")),
+            description=str(record.get("description", "")),
+            date=record.get("date"),
+            date_iso=record.get("date_iso"),
+            plain_text=str(record.get("plain_text", "")),
+            excerpt=str(record.get("excerpt", "")),
+            content_preview=str(record.get("content_preview", "")),
+            word_count=int(record.get("word_count") or 0),
+            reading_time=int(record.get("reading_time") or 0),
+            section=str(record.get("section", "")),
+            tags=tuple(str(tag) for tag in record.get("tags", ()) or ()),
+            dir=str(record.get("dir", "")),
+            enhanced_metadata=_freeze_mapping(record.get("enhanced_metadata", {}) or {}),
+            is_autodoc=bool(record.get("is_autodoc", False)),
+            full_json_data=_freeze_json(record.get("full_json_data")),
+            json_output_path=Path(json_output_path) if json_output_path else None,
+            raw_metadata=_freeze_mapping(record.get("raw_metadata", {}) or {}),
+            anchors=tuple(str(anchor) for anchor in record.get("anchors", ()) or ()),
+        )
+
+    def to_accumulated(self, accumulated_type: Any) -> Any:
+        """Rehydrate this artifact into the legacy AccumulatedPageData shape."""
+        return accumulated_type(
+            source_path=self.source_path,
+            url=self.url,
+            uri=self.uri,
+            title=self.title,
+            description=self.description,
+            date=self.date,
+            date_iso=self.date_iso,
+            plain_text=self.plain_text,
+            excerpt=self.excerpt,
+            content_preview=self.content_preview,
+            word_count=self.word_count,
+            reading_time=self.reading_time,
+            section=self.section,
+            tags=list(self.tags),
+            dir=self.dir,
+            enhanced_metadata=_thaw_mapping(self.enhanced_metadata),
+            is_autodoc=self.is_autodoc,
+            full_json_data=_thaw_json(self.full_json_data),
+            json_output_path=self.json_output_path,
+            raw_metadata=_thaw_mapping(self.raw_metadata),
+        )
+
+    def to_cache_record(self) -> dict[str, Any]:
+        """Serialize this artifact to the durable BuildCache record shape."""
+        return {
+            "source_path": str(self.source_path),
+            "url": self.url,
+            "uri": self.uri,
+            "title": self.title,
+            "description": self.description,
+            "date": self.date,
+            "date_iso": self.date_iso,
+            "plain_text": self.plain_text,
+            "excerpt": self.excerpt,
+            "content_preview": self.content_preview,
+            "word_count": self.word_count,
+            "reading_time": self.reading_time,
+            "section": self.section,
+            "tags": list(self.tags),
+            "dir": self.dir,
+            "enhanced_metadata": _thaw_mapping(self.enhanced_metadata),
+            "is_autodoc": self.is_autodoc,
+            "full_json_data": _thaw_json(self.full_json_data),
+            "json_output_path": str(self.json_output_path) if self.json_output_path else None,
+            "raw_metadata": _thaw_mapping(self.raw_metadata),
+            "anchors": list(self.anchors),
+        }
+
+    def fingerprint_record(self) -> dict[str, Any]:
+        """Return stable fields that affect generated site-wide outputs."""
+        record = self.to_cache_record()
+        record.pop("anchors", None)
+        record.pop("json_output_path", None)
+        return record
+
+
+def _freeze_mapping(value: dict[Any, Any]) -> JsonFrozen:
+    return ("dict", tuple(sorted((str(key), _freeze_json(item)) for key, item in value.items())))
+
+
+def _freeze_json(value: Any) -> JsonFrozen:
+    if isinstance(value, str | int | float | bool | type(None)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, date | datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return _freeze_mapping(value)
+    if isinstance(value, list | tuple | set | frozenset):
+        return ("list", tuple(_freeze_json(item) for item in value))
+    return str(value)
+
+
+def _thaw_mapping(value: JsonFrozen) -> dict[str, Any]:
+    thawed = _thaw_json(value)
+    return thawed if isinstance(thawed, dict) else {}
+
+
+def _thaw_json(value: JsonFrozen) -> Any:
+    if isinstance(value, tuple) and len(value) == 2:
+        kind, payload = value
+        if kind == "dict":
+            return {str(key): _thaw_json(item) for key, item in payload}
+        if kind == "list":
+            return [_thaw_json(item) for item in payload]
+    return value

--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -34,6 +34,22 @@ type RequestCallback = Callable[[str, str, int, float], None]
 # Getter for lazy callback resolution (set after backend creation)
 type RequestCallbackGetter = Callable[[], RequestCallback | None]
 
+_DEFERRED_GENERATED_ARTIFACT_NAMES = frozenset(
+    {
+        "agent.json",
+        "atom.xml",
+        "changelog.json",
+        "index.json",
+        "llm-full.txt",
+        "llms.txt",
+        "robots.txt",
+        "rss.xml",
+        "search-index.json",
+        "sitemap.xml",
+        "xref.json",
+    }
+)
+
 
 def create_bengal_dev_app(
     *,
@@ -261,6 +277,14 @@ def _resolve_file_path(output_dir: Path, path: str) -> Path | None:
     return full
 
 
+def _is_deferred_generated_artifact_path(path: str) -> bool:
+    """True for generated artifacts that serve-ready builds may finish later."""
+    raw = path.split("?")[0].rstrip("/")
+    if not raw:
+        return False
+    return raw.rsplit("/", 1)[-1] in _DEFERRED_GENERATED_ARTIFACT_NAMES
+
+
 async def _serve_markdown_negotiated(
     send: Any,
     *,
@@ -342,6 +366,9 @@ async def _serve_static(
 
     # File doesn't exist: always 404 (with badge when build in progress)
     if not resolved.is_file():
+        if build_in_progress() and _is_deferred_generated_artifact_path(path):
+            await _send_deferred_artifact_response(send)
+            return
         await _send_404(send, output_dir=output_dir, build_in_progress=build_in_progress)
         return
 
@@ -393,6 +420,24 @@ async def _send_404(
             "headers": [
                 [b"content-type", content_type],
                 [b"content-length", str(len(body)).encode()],
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+async def _send_deferred_artifact_response(send: Any) -> None:
+    """Tell clients that a generated artifact is still being prepared."""
+    body = b"Generated artifact is still being prepared by the Bengal dev server.\n"
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 503,
+            "headers": [
+                [b"content-type", b"text/plain; charset=utf-8"],
+                [b"content-length", str(len(body)).encode()],
+                [b"cache-control", b"no-store, no-cache, must-revalidate, max-age=0"],
+                [b"retry-after", b"1"],
             ],
         }
     )

--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -277,7 +277,7 @@ def _resolve_file_path(output_dir: Path, path: str) -> Path | None:
     return full
 
 
-def _is_deferred_generated_artifact_path(path: str) -> bool:
+def is_deferred_generated_artifact_path(path: str) -> bool:
     """True for generated artifacts that serve-ready builds may finish later."""
     raw = path.split("?")[0].rstrip("/")
     if not raw:
@@ -366,7 +366,7 @@ async def _serve_static(
 
     # File doesn't exist: always 404 (with badge when build in progress)
     if not resolved.is_file():
-        if build_in_progress() and _is_deferred_generated_artifact_path(path):
+        if build_in_progress() and is_deferred_generated_artifact_path(path):
             await _send_deferred_artifact_response(send)
             return
         await _send_404(send, output_dir=output_dir, build_in_progress=build_in_progress)

--- a/bengal/server/buffer_manager.py
+++ b/bengal/server/buffer_manager.py
@@ -27,12 +27,13 @@ from __future__ import annotations
 import os
 import shutil
 import threading
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Iterable
 
 logger = get_logger(__name__)
 
@@ -105,6 +106,73 @@ class BufferManager:
 
         return staging
 
+    def prepare_delta_staging(self, changed_paths: Iterable[Path | str]) -> Path:
+        """Bring staging up to date by syncing only known changed outputs.
+
+        The inactive buffer is usually a complete snapshot from the previous
+        generation. After one successful incremental swap it only differs from
+        active by that build's changed outputs, so copying just those paths is
+        enough to make staging a complete base for the next incremental build.
+        If staging is empty or a path cannot be made relative safely, this
+        falls back to the full hardlink seed.
+        """
+        staging = self.staging_dir
+        active = self.active_dir
+
+        if not staging.exists() or not any(staging.iterdir()):
+            return self.prepare_staging()
+
+        staging.mkdir(parents=True, exist_ok=True)
+
+        synced = 0
+        removed = 0
+        for raw_path in changed_paths:
+            rel_path = self._normalize_relative_output_path(Path(raw_path), active)
+            if rel_path is None:
+                logger.debug(
+                    "staging_delta_seed_fallback",
+                    reason="unsafe_path",
+                    path=str(raw_path),
+                )
+                return self.prepare_staging()
+
+            src_path = active / rel_path
+            dst_path = staging / rel_path
+
+            if src_path.is_dir():
+                dst_path.mkdir(parents=True, exist_ok=True)
+                continue
+
+            if not src_path.exists():
+                if dst_path.is_dir():
+                    shutil.rmtree(dst_path)
+                    removed += 1
+                elif dst_path.exists():
+                    dst_path.unlink()
+                    removed += 1
+                continue
+
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            if dst_path.is_dir():
+                shutil.rmtree(dst_path)
+            elif dst_path.exists():
+                dst_path.unlink()
+
+            try:
+                os.link(src_path, dst_path)
+            except OSError:
+                shutil.copy2(src_path, dst_path)
+            synced += 1
+
+        logger.debug(
+            "staging_delta_seeded",
+            files=synced,
+            removed=removed,
+            active=str(active),
+            staging=str(staging),
+        )
+        return staging
+
     def swap(self) -> int:
         """Atomically swap staging to active.
 
@@ -149,3 +217,15 @@ class BufferManager:
             count += 1
 
         logger.debug("staging_seeded", files=count, src=str(src), dst=str(dst))
+
+    def _normalize_relative_output_path(self, path: Path, active: Path) -> Path | None:
+        """Normalize an output path so it cannot escape the buffer root."""
+        if path.is_absolute():
+            try:
+                path = path.resolve().relative_to(active.resolve())
+            except OSError, ValueError:
+                return None
+
+        if any(part == ".." for part in path.parts):
+            return None
+        return path

--- a/bengal/server/build_executor.py
+++ b/bengal/server/build_executor.py
@@ -128,6 +128,7 @@ class BuildResult:
         build_time_ms: Build duration in milliseconds
         error_message: Error message if build failed
         changed_outputs: Serialized output records for reload decision.
+        completion_policy: Serialized BuildCompletionPolicy value used by the build.
 
     """
 
@@ -138,6 +139,7 @@ class BuildResult:
     changed_outputs: tuple[SerializedOutputRecord, ...] = field(default_factory=tuple)
     # Advisory reload hint from build for smarter dev server decisions
     reload_hint: ReloadHint | None = None
+    completion_policy: str = "complete"
 
 
 def _execute_build(request: BuildRequest) -> BuildResult:
@@ -202,6 +204,7 @@ def _execute_build(request: BuildRequest) -> BuildResult:
             build_time_ms=build_time_ms,
             changed_outputs=changed_outputs,
             reload_hint=stats.reload_hint,
+            completion_policy=request.completion_policy,
         )
 
     except Exception as e:
@@ -212,6 +215,7 @@ def _execute_build(request: BuildRequest) -> BuildResult:
             pages_built=0,
             build_time_ms=build_time_ms,
             error_message=str(e),
+            completion_policy=request.completion_policy,
         )
 
 

--- a/bengal/server/build_executor.py
+++ b/bengal/server/build_executor.py
@@ -94,6 +94,7 @@ class BuildRequest:
         explain: Show detailed incremental build decisions
         dry_run: Preview build without writing files
         profile_templates: Enable template profiling
+        completion_policy: Serialized BuildCompletionPolicy value
 
     """
 
@@ -109,6 +110,7 @@ class BuildRequest:
     explain: bool = False
     dry_run: bool = False
     profile_templates: bool = False
+    completion_policy: str = "complete"
 
 
 @dataclass(frozen=True, slots=True)

--- a/bengal/server/build_executor.py
+++ b/bengal/server/build_executor.py
@@ -95,6 +95,7 @@ class BuildRequest:
         dry_run: Preview build without writing files
         profile_templates: Enable template profiling
         completion_policy: Serialized BuildCompletionPolicy value
+        quiet: Suppress routine build transcript output
 
     """
 
@@ -111,6 +112,7 @@ class BuildRequest:
     dry_run: bool = False
     profile_templates: bool = False
     completion_policy: str = "complete"
+    quiet: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -1711,13 +1711,14 @@ class BuildTrigger:
                     changed_count=len(changed_files),
                 )
                 self._reload_notifier.send("reload", "source-changes-bypass", ())
-        else:
-            logger.info(
-                "reload_decision",
-                action=decision.action,
-                reason=decision.reason,
-                source=decision_source,
-            )
+            return
+
+        logger.info(
+            "reload_decision",
+            action=decision.action,
+            reason=decision.reason,
+            source=decision_source,
+        )
         self._reload_notifier.send(decision.action, decision.reason, decision.changed_paths)
 
     def _should_capture_content_hash_baseline(self, changed_files: Sequence[str]) -> bool:

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -55,7 +55,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import yaml
 
@@ -305,6 +305,12 @@ class BuildTrigger:
             # run_pre_build_hooks expects a dict, use .raw for serialization
             raw = getattr(config, "raw", config)
             config_dict: dict[str, Any] = raw if isinstance(raw, dict) else {}
+
+            if not needs_full_rebuild and self._try_fast_asset_reload(
+                changed_paths, event_types, config_dict
+            ):
+                return
+
             if not run_pre_build_hooks(config_dict, self.site.root_path):
                 show_error("Pre-build hook failed - skipping build", show_art=False)
                 cli.request_log_header()
@@ -656,6 +662,202 @@ class BuildTrigger:
         if path.suffix.lower() not in {".md", ".markdown"}:
             return False
         return self._is_content_only_change(path) and not self._has_rendered_dependents(path)
+
+    def _try_fast_asset_reload(
+        self,
+        changed_paths: set[Path],
+        event_types: set[str],
+        config: dict[str, Any],
+    ) -> bool:
+        """Copy direct asset/static edits to output without running a warm build."""
+        mapped = self._direct_asset_output_mappings(changed_paths, event_types, config)
+        if mapped is None:
+            return False
+
+        from bengal.core.output import OutputRecord, OutputType
+        from bengal.server.reload_types import SerializedOutputRecord
+        from bengal.utils.io.atomic_write import atomic_write_bytes
+
+        changed_outputs: list[SerializedOutputRecord] = []
+        written = 0
+
+        try:
+            for source, rel_output, phase in mapped:
+                source_mode = source.stat().st_mode & 0o777
+                content = source.read_bytes()
+                for output_root in self._served_output_roots():
+                    atomic_write_bytes(output_root / rel_output, content, mode=source_mode)
+                    written += 1
+
+                record = OutputRecord.from_path(rel_output, phase=phase)
+                changed_outputs.append(
+                    SerializedOutputRecord(
+                        path=str(rel_output),
+                        type_value=record.output_type.value,
+                        phase=record.phase,
+                    )
+                )
+
+            reload_hint = (
+                ReloadHint.CSS_ONLY
+                if changed_outputs
+                and all(record.type_value == OutputType.CSS.value for record in changed_outputs)
+                else ReloadHint.FULL
+            )
+            self._handle_reload(
+                BuildReloadInfo(
+                    changed_files=tuple(str(path) for path in changed_paths),
+                    changed_outputs=tuple(changed_outputs),
+                    reload_hint=reload_hint,
+                )
+            )
+            self._clear_html_cache()
+            logger.info(
+                "fast_asset_reload_complete",
+                changed_files=len(changed_paths),
+                outputs=len(changed_outputs),
+                writes=written,
+                reload_hint=reload_hint.value,
+            )
+            return True
+        except OSError as exc:
+            logger.warning(
+                "fast_asset_reload_failed",
+                error=str(exc),
+                fallback="warm_build",
+            )
+            return False
+
+    def _direct_asset_output_mappings(
+        self,
+        changed_paths: set[Path],
+        event_types: set[str],
+        config: dict[str, Any],
+    ) -> tuple[tuple[Path, Path, Literal["asset"]], ...] | None:
+        """Return source-to-output mappings when a direct asset copy is safe."""
+        if not changed_paths or event_types != {"modified"}:
+            return None
+        if self._has_configured_build_hooks(config):
+            return None
+
+        mappings: list[tuple[Path, Path, Literal["asset"]]] = []
+        static_root = self._static_source_root(config)
+        asset_root = self.site.root_path / "assets"
+
+        for changed_path in changed_paths:
+            source = changed_path
+            if not source.is_file():
+                return None
+
+            static_rel = self._relative_to(source, static_root)
+            if static_rel is not None:
+                if not self._active_output_exists(static_rel):
+                    return None
+                mappings.append((source, static_rel, "asset"))
+                continue
+
+            asset_rel = self._relative_to(source, asset_root)
+            if asset_rel is None:
+                return None
+            if not self._can_copy_site_asset_directly(source):
+                return None
+
+            output_rel = Path("assets") / asset_rel
+            if not self._active_output_exists(output_rel):
+                return None
+            mappings.append((source, output_rel, "asset"))
+
+        return tuple(mappings)
+
+    def _has_configured_build_hooks(self, config: dict[str, Any]) -> bool:
+        """Return True when external hooks must participate in rebuilds."""
+        dev_server = config.get("dev_server", {})
+        if not isinstance(dev_server, dict):
+            return False
+        return bool(dev_server.get("pre_build") or dev_server.get("post_build"))
+
+    def _static_source_root(self, config: dict[str, Any]) -> Path:
+        """Return configured static source root."""
+        static_config = config.get("static", {})
+        if not isinstance(static_config, dict):
+            static_config = {}
+        static_dir_name = static_config.get("dir", "static")
+        return self.site.root_path / str(static_dir_name)
+
+    def _can_copy_site_asset_directly(self, source: Path) -> bool:
+        """Return True when the asset pipeline would preserve this file verbatim."""
+        config = self.site.config or {}
+        if config.get("fingerprint_assets", True):
+            return False
+
+        suffix = source.suffix.lower()
+        if suffix in {".css", ".js", ".mjs"} and config.get("minify_assets", True):
+            return False
+        if suffix in {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico"} and config.get(
+            "optimize_assets", True
+        ):
+            return False
+
+        asset = self._site_asset_for_source(source)
+        if asset is None:
+            return False
+        if suffix == ".css" and (
+            asset.is_css_entry_point() or (asset.is_css_module() and not asset.standalone)
+        ):
+            return False
+
+        assets_config = getattr(getattr(self.site, "config_service", None), "assets_config", {})
+        if isinstance(assets_config, dict) and assets_config.get("bundle_js", False):
+            with suppress(AttributeError):
+                if asset.is_js_module():
+                    return False
+
+        return True
+
+    def _site_asset_for_source(self, source: Path) -> Any | None:
+        """Find the discovered site asset for a source path."""
+        try:
+            resolved = source.resolve()
+        except OSError:
+            resolved = source
+
+        for asset in getattr(self.site, "assets", []):
+            asset_source = getattr(asset, "source_path", None)
+            if asset_source is None:
+                continue
+            try:
+                if Path(asset_source).resolve() == resolved:
+                    return asset
+            except OSError, TypeError, ValueError:
+                continue
+        return None
+
+    def _served_output_roots(self) -> tuple[Path, ...]:
+        """Return output roots that should stay current for direct asset edits."""
+        if self._buffer_manager is None:
+            return (self.site.output_dir,)
+
+        roots: list[Path] = []
+        for root in (self._buffer_manager.active_dir, self._buffer_manager.staging_dir):
+            if root not in roots:
+                roots.append(root)
+        return tuple(roots)
+
+    def _active_output_exists(self, rel_output: Path) -> bool:
+        """Return True when the currently served output already exists."""
+        output_root = (
+            self._buffer_manager.active_dir
+            if self._buffer_manager is not None
+            else self.site.output_dir
+        )
+        return (output_root / rel_output).is_file()
+
+    def _relative_to(self, path: Path, root: Path) -> Path | None:
+        """Return path relative to root, resolving symlinks where possible."""
+        try:
+            return path.resolve().relative_to(root.resolve())
+        except OSError, ValueError:
+            return None
 
     def _has_rendered_dependents(self, path: Path) -> bool:
         """Return True when a content edit should rebuild dependent pages."""

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -86,6 +86,8 @@ from bengal.utils.paths.normalize import to_posix
 from bengal.utils.stats_minimal import MinimalStats
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from bengal.server.buffer_manager import BufferManager
     from bengal.server.reload_protocols import ReloadNotifier
 
@@ -295,7 +297,7 @@ class BuildTrigger:
 
             # RFC: Output Cache Architecture - Capture content hash baseline BEFORE build
             # This enables accurate change detection vs regeneration noise
-            if self._reload_controller._use_content_hashes:
+            if self._should_capture_content_hash_baseline(changed_files):
                 self._reload_controller.capture_content_hash_baseline(self.site.output_dir)
 
             # Run pre-build hooks
@@ -1469,7 +1471,11 @@ class BuildTrigger:
                 reason=decision.reason,
                 source=decision_source,
             )
-            self._reload_notifier.send(decision.action, decision.reason, decision.changed_paths)
+        self._reload_notifier.send(decision.action, decision.reason, decision.changed_paths)
+
+    def _should_capture_content_hash_baseline(self, changed_files: Sequence[str]) -> bool:
+        """Return whether this build still needs pre-build output hash scanning."""
+        return self._reload_controller._use_content_hashes and not changed_files
 
     def _set_build_in_progress(self, building: bool) -> None:
         """Signal build state to shared registry (handler and ASGI app read from it)."""

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -193,6 +193,9 @@ class BuildTrigger:
         # Track whether the previous build surfaced template errors so we
         # know when to push a `build_ok` message that dismisses the overlay.
         self._had_template_errors_last_build: bool = False
+        # Paths changed by the previous successful incremental buffered build.
+        # The next staging buffer can be repaired by syncing only these paths.
+        self._last_buffer_delta_paths: tuple[Path, ...] | None = None
 
     def trigger_build(
         self,
@@ -403,7 +406,12 @@ class BuildTrigger:
             original_output_dir = self.site.output_dir
             swapped = False
             if self._buffer_manager is not None:
-                staging = self._buffer_manager.prepare_staging()
+                if use_incremental and self._last_buffer_delta_paths is not None:
+                    staging = self._buffer_manager.prepare_delta_staging(
+                        self._last_buffer_delta_paths
+                    )
+                else:
+                    staging = self._buffer_manager.prepare_staging()
                 self.site.output_dir = staging
                 logger.debug(
                     "build_to_staging",
@@ -456,6 +464,12 @@ class BuildTrigger:
                         self._stats = stats
 
                 result = WarmBuildResult(stats, build_duration)
+                if self._buffer_manager is not None:
+                    self._last_buffer_delta_paths = (
+                        self._buffer_delta_paths(result.changed_outputs)
+                        if use_incremental
+                        else None
+                    )
 
                 # Seed content hash cache so first edit can use reactive path
                 self.seed_content_hash_cache(list(self.site.pages))
@@ -469,6 +483,7 @@ class BuildTrigger:
                         self.site.output_dir = self._buffer_manager.active_dir
                     else:
                         self.site.output_dir = original_output_dir
+                    self._last_buffer_delta_paths = None
 
                 # Build crashed - log error and reinitialize site for next build
                 build_duration = time.time() - build_start
@@ -842,6 +857,36 @@ class BuildTrigger:
             if root not in roots:
                 roots.append(root)
         return tuple(roots)
+
+    def _buffer_delta_paths(
+        self,
+        changed_outputs: tuple[Any, ...],
+    ) -> tuple[Path, ...] | None:
+        """Normalize changed output records for the next buffered rebuild."""
+        paths: list[Path] = []
+        seen: set[Path] = set()
+        active_root = (
+            self._buffer_manager.active_dir
+            if self._buffer_manager is not None
+            else self.site.output_dir
+        )
+
+        for output in changed_outputs:
+            raw_path = Path(getattr(output, "path", ""))
+            if raw_path == Path("."):
+                continue
+            if raw_path.is_absolute():
+                try:
+                    raw_path = raw_path.resolve().relative_to(active_root.resolve())
+                except OSError, ValueError:
+                    return None
+            if any(part == ".." for part in raw_path.parts):
+                return None
+            if raw_path not in seen:
+                seen.add(raw_path)
+                paths.append(raw_path)
+
+        return tuple(paths)
 
     def _active_output_exists(self, rel_output: Path) -> bool:
         """Return True when the currently served output already exists."""

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -379,7 +379,7 @@ class BuildTrigger:
 
             # Warm build: reuse the existing site object instead of creating a new one
             # This eliminates Site.from_config() overhead (~250ms per rebuild)
-            from bengal.orchestration.build.options import BuildOptions
+            from bengal.orchestration.build.options import BuildCompletionPolicy, BuildOptions
             from bengal.utils.observability.profile import BuildProfile
 
             # Reset all per-build mutable state in one call.
@@ -392,6 +392,7 @@ class BuildTrigger:
                 force_sequential=False,  # Auto-detect based on page count
                 incremental=use_incremental,
                 profile=BuildProfile.WRITER,
+                completion_policy=BuildCompletionPolicy.SERVE_READY,
                 changed_sources={Path(p) for p in changed_files} if changed_files else None,
                 nav_changed_sources=nav_changed_files,
                 structural_changed=structural_changed,

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -154,6 +154,7 @@ class BuildTrigger:
         notifier: ReloadNotifier | None = None,
         version_scope: str | None = None,
         buffer_manager: BufferManager | None = None,
+        completion_policy: Any | None = None,
     ) -> None:
         """
         Initialize build trigger.
@@ -169,11 +170,17 @@ class BuildTrigger:
                 If None, all versions are rebuilt on changes.
             buffer_manager: Optional BufferManager for double-buffered output.
                 When set, full builds write to staging and swap on completion.
+            completion_policy: Build completion policy for watched rebuilds.
         """
+        from bengal.orchestration.build.options import BuildCompletionPolicy
+
         self.site = site
         self.host = host
         self.port = port
         self.version_scope = version_scope
+        self.completion_policy = BuildCompletionPolicy.from_value(
+            completion_policy or BuildCompletionPolicy.SERVE_READY
+        )
         self._buffer_manager = buffer_manager
         self._executor = executor or BuildExecutor(max_workers=1)
         self._reload_controller = controller or default_reload_controller
@@ -379,7 +386,7 @@ class BuildTrigger:
 
             # Warm build: reuse the existing site object instead of creating a new one
             # This eliminates Site.from_config() overhead (~250ms per rebuild)
-            from bengal.orchestration.build.options import BuildCompletionPolicy, BuildOptions
+            from bengal.orchestration.build.options import BuildOptions
             from bengal.utils.observability.profile import BuildProfile
 
             # Reset all per-build mutable state in one call.
@@ -392,7 +399,7 @@ class BuildTrigger:
                 force_sequential=False,  # Auto-detect based on page count
                 incremental=use_incremental,
                 profile=BuildProfile.WRITER,
-                completion_policy=BuildCompletionPolicy.SERVE_READY,
+                completion_policy=self.completion_policy,
                 changed_sources={Path(p) for p in changed_files} if changed_files else None,
                 nav_changed_sources=nav_changed_files,
                 structural_changed=structural_changed,

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -447,7 +447,12 @@ class BuildTrigger:
 
                 # Build succeeded - convert stats to result-like object for display
                 class WarmBuildResult:
-                    def __init__(self, stats: Any, build_time: float) -> None:
+                    def __init__(
+                        self,
+                        stats: Any,
+                        build_time: float,
+                        completion_policy: Any,
+                    ) -> None:
                         from bengal.server.reload_types import (
                             SerializedOutputRecord,
                         )
@@ -456,6 +461,7 @@ class BuildTrigger:
                         self.pages_built = stats.total_pages
                         self.build_time_ms = build_time * 1000
                         self.error_message = None
+                        self.completion_policy = completion_policy
                         self.changed_outputs = (
                             tuple(
                                 SerializedOutputRecord(
@@ -471,7 +477,7 @@ class BuildTrigger:
                         self.reload_hint = stats.reload_hint
                         self._stats = stats
 
-                result = WarmBuildResult(stats, build_duration)
+                result = WarmBuildResult(stats, build_duration, self.completion_policy)
                 if self._buffer_manager is not None:
                     self._last_buffer_delta_paths = (
                         self._buffer_delta_paths(result.changed_outputs)

--- a/bengal/server/dev_server.py
+++ b/bengal/server/dev_server.py
@@ -233,6 +233,7 @@ class DevServer:
             os.environ["BENGAL_BUILD_EXECUTOR"] = "process"
 
             # 2. Prepare dev-specific configuration
+            from bengal.orchestration.build.options import BuildCompletionPolicy
             from bengal.utils.observability.profile import BuildProfile
 
             baseurl_was_cleared = self._prepare_dev_config()
@@ -240,7 +241,11 @@ class DevServer:
             # 3. Determine startup strategy: serve-first or build-first
             # Serve-first when: cache exists AND baseurl wasn't cleared
             has_cache = self._has_cached_output()
-            can_serve_first = not baseurl_was_cleared and has_cache
+            can_serve_first = (
+                self.completion_policy is BuildCompletionPolicy.SERVE_READY
+                and not baseurl_was_cleared
+                and has_cache
+            )
 
             logger.debug(
                 "serve_first_decision",
@@ -325,10 +330,7 @@ class DevServer:
 
                 # Initial build (process-isolated for clean Ctrl+C shutdown)
                 show_building_indicator("Initial build")
-                from bengal.orchestration.build.options import (
-                    BuildCompletionPolicy,
-                    BuildOptions,
-                )
+                from bengal.orchestration.build.options import BuildOptions
 
                 build_opts = BuildOptions(
                     profile=BuildProfile.WRITER,

--- a/bengal/server/dev_server.py
+++ b/bengal/server/dev_server.py
@@ -140,6 +140,7 @@ class DevServer:
         auto_port: bool = True,
         open_browser: bool = False,
         version_scope: str | None = None,
+        completion_policy: Any | None = None,
     ) -> None:
         """
         Initialize the dev server.
@@ -154,7 +155,11 @@ class DevServer:
             open_browser: Whether to automatically open the browser
             version_scope: Focus rebuilds on a single version (e.g., "v2", "latest").
                 If None, all versions are rebuilt on changes.
+            completion_policy: Build completion policy. Defaults to serve-ready
+                for fast local browsing; pass "complete" for production parity.
         """
+        from bengal.orchestration.build.options import BuildCompletionPolicy
+
         self.site = site
         self.host = host
         self.port = port
@@ -162,6 +167,9 @@ class DevServer:
         self.auto_port = auto_port
         self.open_browser = open_browser
         self.version_scope = version_scope
+        self.completion_policy = BuildCompletionPolicy.from_value(
+            completion_policy or BuildCompletionPolicy.SERVE_READY
+        )
 
         # Mark site as running in dev mode to prevent timestamp churn in output files
         self.site.dev_mode = True
@@ -325,7 +333,7 @@ class DevServer:
                 build_opts = BuildOptions(
                     profile=BuildProfile.WRITER,
                     incremental=not baseurl_was_cleared,
-                    completion_policy=BuildCompletionPolicy.SERVE_READY,
+                    completion_policy=self.completion_policy,
                 )
                 stats = self._run_build_via_executor(build_opts, "Initial build")
                 display_build_stats(stats, show_art=False, output_dir=str(self.site.output_dir))
@@ -866,6 +874,7 @@ class DevServer:
             port=actual_port,
             version_scope=self.version_scope,
             buffer_manager=self._buffer_manager,
+            completion_policy=self.completion_policy,
         )
 
         # Create ignore filter from config using class method

--- a/bengal/server/dev_server.py
+++ b/bengal/server/dev_server.py
@@ -356,15 +356,14 @@ class DevServer:
                 rm.register_sse_shutdown()
                 actual_port = backend.port
 
-                # Start file watcher if enabled
+                watcher_runner = None
+                build_trigger = None
                 if self.watch:
                     watcher_runner, build_trigger = self._create_watcher(actual_port)
                     rm.register_watcher_runner(watcher_runner)
                     rm.register_build_trigger(build_trigger)
                     # Seed content hash cache so first edit can use reactive path
                     build_trigger.seed_content_hash_cache(list(self.site.pages))
-                    watcher_runner.start()
-                    logger.info("file_watcher_started", watch_dirs=self._get_watched_directories())
 
                 # Print startup message
                 self._print_startup_message(actual_port)
@@ -381,6 +380,15 @@ class DevServer:
                 # Open browser when server is ready (runs in background thread)
                 if self.open_browser:
                     self._open_browser_when_ready(actual_port)
+
+                if build_opts.completion_policy is BuildCompletionPolicy.SERVE_READY:
+                    self._start_background_completion_build(
+                        BuildProfile.WRITER,
+                        watcher_runner=watcher_runner,
+                    )
+                elif watcher_runner is not None:
+                    watcher_runner.start()
+                    logger.info("file_watcher_started", watch_dirs=self._get_watched_directories())
 
                 # Run until interrupted
                 try:
@@ -569,6 +577,51 @@ class DevServer:
             return MinimalStats.from_build_result(result, incremental=incremental)
         finally:
             executor.shutdown(wait=True)
+
+    def _start_background_completion_build(
+        self,
+        profile: Any,
+        *,
+        watcher_runner: WatcherRunner | None = None,
+    ) -> threading.Thread:
+        """Finish non-browse-critical build work without blocking server startup."""
+        from bengal.orchestration.build.options import BuildCompletionPolicy, BuildOptions
+        from bengal.orchestration.stats import show_error
+
+        def run_completion() -> None:
+            cli = get_cli_output()
+            cli.detail("completing artifacts and health checks in background...", indent=1)
+            try:
+                build_opts = BuildOptions(
+                    profile=profile,
+                    incremental=True,
+                    completion_policy=BuildCompletionPolicy.COMPLETE,
+                )
+                stats = self._run_build_via_executor(build_opts, "Background completion")
+                display_build_stats(stats, show_art=False, output_dir=str(self.site.output_dir))
+                self._clear_html_cache_after_build()
+                self._set_active_palette()
+                self._init_reload_controller()
+                cli.success("Background completion finished")
+            except BengalServerError as exc:
+                show_error(f"Background completion failed: {exc}", show_art=False)
+                logger.warning(
+                    "background_completion_failed",
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+            finally:
+                if watcher_runner is not None:
+                    watcher_runner.start()
+                    logger.info("file_watcher_started", watch_dirs=self._get_watched_directories())
+
+        thread = threading.Thread(
+            target=run_completion,
+            name="bengal-background-completion",
+            daemon=True,
+        )
+        thread.start()
+        return thread
 
     def _clear_html_cache_after_build(self) -> None:
         """Clear HTML injection cache after a build to ensure fresh pages."""

--- a/bengal/server/dev_server.py
+++ b/bengal/server/dev_server.py
@@ -591,6 +591,7 @@ class DevServer:
         def run_completion() -> None:
             cli = get_cli_output()
             cli.detail("completing artifacts and health checks in background...", indent=1)
+            build_state.set_build_in_progress(True)
             try:
                 build_opts = BuildOptions(
                     profile=profile,
@@ -611,6 +612,7 @@ class DevServer:
                     error_type=type(exc).__name__,
                 )
             finally:
+                build_state.set_build_in_progress(False)
                 if watcher_runner is not None:
                     watcher_runner.start()
                     logger.info("file_watcher_started", watch_dirs=self._get_watched_directories())

--- a/bengal/server/dev_server.py
+++ b/bengal/server/dev_server.py
@@ -317,11 +317,15 @@ class DevServer:
 
                 # Initial build (process-isolated for clean Ctrl+C shutdown)
                 show_building_indicator("Initial build")
-                from bengal.orchestration.build.options import BuildOptions
+                from bengal.orchestration.build.options import (
+                    BuildCompletionPolicy,
+                    BuildOptions,
+                )
 
                 build_opts = BuildOptions(
                     profile=BuildProfile.WRITER,
                     incremental=not baseurl_was_cleared,
+                    completion_policy=BuildCompletionPolicy.SERVE_READY,
                 )
                 stats = self._run_build_via_executor(build_opts, "Initial build")
                 display_build_stats(stats, show_art=False, output_dir=str(self.site.output_dir))
@@ -553,6 +557,7 @@ class DevServer:
             incremental=incremental,
             profile=profile_str,
             version_scope=self.version_scope,
+            completion_policy=build_opts.completion_policy.value,
         )
         executor = BuildExecutor(max_workers=1)
         try:

--- a/bengal/server/dev_server.py
+++ b/bengal/server/dev_server.py
@@ -170,6 +170,7 @@ class DevServer:
         self.completion_policy = BuildCompletionPolicy.from_value(
             completion_policy or BuildCompletionPolicy.SERVE_READY
         )
+        self._deferred_artifact_request_count = 0
 
         # Mark site as running in dev mode to prevent timestamp churn in output files
         self.site.dev_mode = True
@@ -576,6 +577,7 @@ class DevServer:
             profile=profile_str,
             version_scope=self.version_scope,
             completion_policy=build_opts.completion_policy.value,
+            quiet=bool(getattr(build_opts, "quiet", False)),
         )
         executor = BuildExecutor(max_workers=1)
         try:
@@ -606,14 +608,16 @@ class DevServer:
                 build_opts = BuildOptions(
                     profile=profile,
                     incremental=True,
+                    quiet=True,
                     completion_policy=BuildCompletionPolicy.COMPLETE,
                 )
                 stats = self._run_build_via_executor(build_opts, "Background completion")
-                display_build_stats(stats, show_art=False, output_dir=str(self.site.output_dir))
                 self._clear_html_cache_after_build()
                 self._set_active_palette()
                 self._init_reload_controller()
-                cli.success("Background completion finished")
+                from bengal.orchestration.stats.helpers import format_time
+
+                cli.success(f"Background completion finished in {format_time(stats.build_time_ms)}")
             except BengalServerError as exc:
                 show_error(f"Background completion failed: {exc}", show_art=False)
                 logger.warning(
@@ -1253,8 +1257,26 @@ class DevServer:
         # Request log header
         from datetime import datetime
 
+        from bengal.server.asgi_app import is_deferred_generated_artifact_path
+
         def _log_request(method: str, path: str, status: int, _duration_ms: float) -> None:
+            if path == "/__bengal_reload__":
+                return
             ts = datetime.now().strftime("%H:%M:%S")
+            if status == 503 and is_deferred_generated_artifact_path(path):
+                self._deferred_artifact_request_count += 1
+                count = self._deferred_artifact_request_count
+                if count != 1 and count % 10 != 0:
+                    return
+                suffix = "" if count == 1 else f" ({count} requests)"
+                cli.http_request(
+                    ts,
+                    method,
+                    "PND",
+                    f"generated artifacts still completing{suffix}",
+                    is_asset=True,
+                )
+                return
             cli.http_request(ts, method, str(status), path, is_asset=False)
 
         if hasattr(self, "_request_callback_holder"):

--- a/bengal/server/reload_controller.py
+++ b/bengal/server/reload_controller.py
@@ -62,7 +62,7 @@ import time
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bengal.orchestration.stats import ReloadHint
 from bengal.utils.primitives.hashing import hash_file
@@ -809,6 +809,13 @@ class ReloadController:
         filtered_path_set = set(filtered_paths)
         filtered_outputs = [o for o in outputs if str(o.path) in filtered_path_set]
 
+        if _outputs_are_aggregate_only(filtered_outputs):
+            return ReloadDecision(
+                action="none",
+                reason="aggregate-only",
+                changed_paths=(),
+            )
+
         # Record notification time
         self._record_notification()
 
@@ -869,6 +876,19 @@ class ReloadController:
         css_paths = [p for p in paths if p.lower().endswith(".css")]
 
         return self._make_css_decision(paths, css_paths)
+
+
+def _outputs_are_aggregate_only(outputs: list[Any]) -> bool:
+    """Return whether outputs only contain non-visible aggregate artifacts."""
+    if not outputs:
+        return False
+    from bengal.orchestration.build.output_types import classify_output, is_aggregate_output
+
+    return all(
+        getattr(output, "phase", None) == "postprocess"
+        and is_aggregate_output(classify_output(output.path))
+        for output in outputs
+    )
 
 
 # Global controller for dev server

--- a/bengal/utils/stats_minimal.py
+++ b/bengal/utils/stats_minimal.py
@@ -92,6 +92,9 @@ class MinimalStats:
     rendering_time_ms: float = 0.0
     assets_time_ms: float = 0.0
     postprocess_time_ms: float = 0.0
+    postprocess_task_timings_ms: dict[str, float] = field(default_factory=dict)
+    postprocess_output_timings_ms: dict[str, float] = field(default_factory=dict)
+    post_render_timings_ms: dict[str, float] = field(default_factory=dict)
     health_check_time_ms: float = 0.0
 
     # Per-page render time aggregates

--- a/bengal/utils/stats_minimal.py
+++ b/bengal/utils/stats_minimal.py
@@ -95,6 +95,7 @@ class MinimalStats:
     postprocess_task_timings_ms: dict[str, float] = field(default_factory=dict)
     postprocess_output_timings_ms: dict[str, float] = field(default_factory=dict)
     post_render_timings_ms: dict[str, float] = field(default_factory=dict)
+    phase_timings_ms: dict[str, float] = field(default_factory=dict)
     health_check_time_ms: float = 0.0
 
     # Per-page render time aggregates

--- a/bengal/utils/stats_minimal.py
+++ b/bengal/utils/stats_minimal.py
@@ -75,6 +75,7 @@ class MinimalStats:
     # Flags
     parallel: bool = True
     skipped: bool = False
+    completion_policy: str = "complete"
 
     # Dev server / reload
     reload_hint: ReloadHint | None = None
@@ -179,4 +180,5 @@ class MinimalStats:
             incremental=incremental,
             reload_hint=result.reload_hint,
             pages_rebuilt=result.pages_built,
+            completion_policy=result.completion_policy,
         )

--- a/bengal/utils/stats_protocol.py
+++ b/bengal/utils/stats_protocol.py
@@ -79,6 +79,8 @@ class DisplayableStats(CoreStats, Protocol):
         rendering_time_ms: Template rendering phase duration
         assets_time_ms: Asset processing phase duration
         postprocess_time_ms: Post-processing phase duration
+        postprocess_task_timings_ms: Post-processing task timings by task name
+        post_render_timings_ms: Finalization/cache/audit timings after rendering
         health_check_time_ms: Health check phase duration
 
     Methods:
@@ -113,6 +115,8 @@ class DisplayableStats(CoreStats, Protocol):
     rendering_time_ms: float
     assets_time_ms: float
     postprocess_time_ms: float
+    postprocess_task_timings_ms: dict[str, float]
+    post_render_timings_ms: dict[str, float]
     health_check_time_ms: float
 
     # Error tracking

--- a/bengal/utils/stats_protocol.py
+++ b/bengal/utils/stats_protocol.py
@@ -81,6 +81,7 @@ class DisplayableStats(CoreStats, Protocol):
         postprocess_time_ms: Post-processing phase duration
         postprocess_task_timings_ms: Post-processing task timings by task name
         post_render_timings_ms: Finalization/cache/audit timings after rendering
+        phase_timings_ms: Named build phase timings for full cold-build accounting
         health_check_time_ms: Health check phase duration
 
     Methods:
@@ -117,6 +118,7 @@ class DisplayableStats(CoreStats, Protocol):
     postprocess_time_ms: float
     postprocess_task_timings_ms: dict[str, float]
     post_render_timings_ms: dict[str, float]
+    phase_timings_ms: dict[str, float]
     health_check_time_ms: float
 
     # Error tracking

--- a/changelog.d/build-completion-policy.changed.md
+++ b/changelog.d/build-completion-policy.changed.md
@@ -1,0 +1,1 @@
+Build requests now carry an explicit completion policy so `bengal serve` can distinguish browse-ready work from complete deployable builds.

--- a/changelog.d/build-finalization-task-policy.changed.md
+++ b/changelog.d/build-finalization-task-policy.changed.md
@@ -1,0 +1,1 @@
+Post-render build work now has explicit finalization task contracts, separating serve-ready, artifact, quality, and persistence responsibilities.

--- a/changelog.d/build-phase-accounting.changed.md
+++ b/changelog.d/build-phase-accounting.changed.md
@@ -1,0 +1,1 @@
+Build summaries now use recorded phase timings for colder builds, including previously hidden parsing, snapshot, filtering, artifact inventory, cache-save, and stats work.

--- a/changelog.d/cache-dirty-page-artifact-shards.changed.md
+++ b/changelog.d/cache-dirty-page-artifact-shards.changed.md
@@ -1,0 +1,1 @@
+Page artifact persistence now rewrites only shards affected by changed or deleted page artifacts during warm builds.

--- a/changelog.d/cache-split-hot-stores.changed.md
+++ b/changelog.d/cache-split-hot-stores.changed.md
@@ -1,0 +1,1 @@
+Build cache saves now split parsed content, rendered output, validation results, and synthetic pages into separate hot-store files to reduce the main cache payload rewritten after builds.

--- a/changelog.d/deferred-artifact-response.changed.md
+++ b/changelog.d/deferred-artifact-response.changed.md
@@ -1,0 +1,1 @@
+During dev-server background completion, requests for missing generated artifacts now return a short retryable response instead of looking like ordinary missing pages.

--- a/changelog.d/health-directive-scope-cache.fixed.md
+++ b/changelog.d/health-directive-scope-cache.fixed.md
@@ -1,0 +1,1 @@
+Directive health validation now uses the shared validation scope and seeds per-file cached results, preventing stale directive findings from disappearing during incremental checks.

--- a/changelog.d/health-report-reuse.changed.md
+++ b/changelog.d/health-report-reuse.changed.md
@@ -1,0 +1,1 @@
+Incremental health checks can now reuse a cached whole-report result when source, configuration, and link-registry inputs are unchanged.

--- a/changelog.d/incremental-effect-trace-replacement.changed.md
+++ b/changelog.d/incremental-effect-trace-replacement.changed.md
@@ -1,0 +1,1 @@
+Effect tracing now replaces stale records for regenerated outputs and uses dependency indexes for template/data invalidation lookups.

--- a/changelog.d/post-render-build-tail.changed.md
+++ b/changelog.d/post-render-build-tail.changed.md
@@ -1,0 +1,1 @@
+Improve post-render build diagnostics and reduce incremental per-page output work.

--- a/changelog.d/post-render-correctness.fixed.md
+++ b/changelog.d/post-render-correctness.fixed.md
@@ -1,0 +1,1 @@
+Harden post-render correctness around aggregate LLM text hashing, incremental validation caching, cache-save failures, and provenance session caches.

--- a/changelog.d/postprocess-delta-aggregate-fingerprints.changed.md
+++ b/changelog.d/postprocess-delta-aggregate-fingerprints.changed.md
@@ -1,0 +1,1 @@
+Incremental site-wide output fingerprints now reuse cached per-page artifact hashes, reducing no-op aggregate skip work on large sites.

--- a/changelog.d/postprocess-lazy-graph.changed.md
+++ b/changelog.d/postprocess-lazy-graph.changed.md
@@ -1,0 +1,1 @@
+Output-format graph data is now built lazily, avoiding graph construction when incremental JSON outputs are already up to date.

--- a/changelog.d/serve-background-completion.changed.md
+++ b/changelog.d/serve-background-completion.changed.md
@@ -1,0 +1,1 @@
+`bengal serve` now starts a background completion build after the browse-ready cold start so deferred artifacts, health checks, and caches finish without blocking first paint.

--- a/changelog.d/serve-background-console.changed.md
+++ b/changelog.d/serve-background-console.changed.md
@@ -1,0 +1,1 @@
+Background completion for `bengal serve` now runs in quiet mode, reports one concise completion line, and coalesces deferred generated-artifact polling in the request log.

--- a/changelog.d/serve-complete-cached-blocking.fixed.md
+++ b/changelog.d/serve-complete-cached-blocking.fixed.md
@@ -1,0 +1,1 @@
+`bengal serve --complete` now blocks through the full initial build even when cached output exists instead of taking the cached serve-first shortcut.

--- a/changelog.d/serve-complete-policy.changed.md
+++ b/changelog.d/serve-complete-policy.changed.md
@@ -1,0 +1,1 @@
+`bengal serve` now exposes `--complete` for users who want dev-server startup and watched rebuilds to wait for the full artifact, health, and cache tail instead of the default browse-ready fast path.

--- a/changelog.d/serve-ready-defers-tail.changed.md
+++ b/changelog.d/serve-ready-defers-tail.changed.md
@@ -1,0 +1,1 @@
+`bengal serve` builds now honor the serve-ready policy by deferring non-browse-critical post-render work such as artifact inventories, cache persistence, provenance saves, health checks, and asset audits.

--- a/changelog.d/serve-ready-summary.changed.md
+++ b/changelog.d/serve-ready-summary.changed.md
@@ -1,0 +1,1 @@
+Serve-ready build summaries now say `HTML ready` instead of `Built` so local dev output distinguishes first paint from full background artifact completion.

--- a/changelog.d/server-asset-fast-path.changed.md
+++ b/changelog.d/server-asset-fast-path.changed.md
@@ -1,0 +1,1 @@
+Dev server static/CSS edits can now use a direct atomic output copy and reload without running the full warm build when Bengal can prove the output is an existing verbatim asset.

--- a/changelog.d/server-delta-buffer-staging.changed.md
+++ b/changelog.d/server-delta-buffer-staging.changed.md
@@ -1,0 +1,1 @@
+Dev server double buffering now delta-seeds the inactive output buffer after successful incremental builds, avoiding full-tree staging copies on the next rebuild when typed output records identify the changed files.

--- a/changelog.d/server-none-reload-suppressed.fixed.md
+++ b/changelog.d/server-none-reload-suppressed.fixed.md
@@ -1,0 +1,1 @@
+Dev server reload suppression no longer emits a follow-up `"none"` reload event after deciding no browser reload should be sent.

--- a/changelog.d/server-reload-health-ux.changed.md
+++ b/changelog.d/server-reload-health-ux.changed.md
@@ -1,0 +1,1 @@
+Improve dev-server reload and health-check feedback by suppressing aggregate-only reloads and showing health-check progress before validators finish.

--- a/changelog.d/server-skip-reload-baseline.changed.md
+++ b/changelog.d/server-skip-reload-baseline.changed.md
@@ -1,0 +1,1 @@
+Dev-server watcher rebuilds now skip the pre-build output content-hash scan when typed build outputs can drive the reload decision.

--- a/site/content/docs/reference/architecture/tooling/server.md
+++ b/site/content/docs/reference/architecture/tooling/server.md
@@ -26,10 +26,12 @@ Provide a local development environment with automatic rebuilds.
 - Automatic rebuild on changes
 - Live reload via SSE (Server-Sent Events)
 - CSS hot reload (no full page refresh for CSS changes)
+- Browse-ready cold start: local `serve` starts once HTML is ready, then finishes
+  generated artifacts, health checks, and cache writes in the background
 - Automatic browser opening
 - Stale process detection and cleanup
 - Automatic port fallback if port is in use
-- In-process builds for clean Ctrl+C shutdown
+- Process-isolated builds for clean Ctrl+C shutdown
 
 ### Architecture
 
@@ -69,8 +71,11 @@ bengal serve --no-watch
 # Disable automatic browser opening
 bengal serve --no-open
 
+# Wait for deploy-quality artifacts, health checks, and caches before serving
+bengal serve --complete
+
 # Focus rebuilds on a single version (faster for versioned docs)
-bengal serve --version v2
+bengal serve --version-scope v2
 
 # Verbose output for debugging
 bengal serve --verbose
@@ -143,11 +148,15 @@ The dev server uses a double-buffered output strategy to prevent flash-of-unstyl
 
 ### Performance Considerations
 
+- **Serve-ready startup**: Cold `bengal serve` blocks on HTML and special pages,
+  then completes search indexes, feeds, health checks, and cache persistence in
+  the background. Use `--complete` when validating deploy-quality output before
+  the server starts.
 - **Incremental builds**: Only rebuild changed files (5-10x faster than full builds)
 - **Debouncing**: Groups rapid changes (300ms delay) to avoid multiple rebuilds
 - **Efficient watching**: Uses watchfiles with native file system events
 - **Selective injection**: Reload script only in HTML, not assets
-- **In-process builds**: Builds run in the server process for clean Ctrl+C shutdown
+- **Process-isolated builds**: Builds run outside the server process for clean Ctrl+C shutdown
 
 ### Configuration
 
@@ -160,8 +169,7 @@ exclude_patterns = ["*.tmp", "*.log", ".git/**"]
 
 # Pre-build hooks (run before each rebuild)
 pre_build = [
-    "npm run build:icons",
-    "npx tailwindcss -i src/input.css -o assets/css/tailwind.css"
+    "python scripts/check-content.py"
 ]
 
 # Post-build hooks (run after each rebuild)
@@ -207,6 +215,7 @@ server = DevServer(
     watch=True,
     auto_port=True,      # Find available port if 5173 is taken
     open_browser=False,  # Don't auto-open browser
+    completion_policy="serve_ready",  # Use "complete" for production parity
 )
 server.start()  # Runs until Ctrl+C
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,6 +430,13 @@ def reset_bengal_state(request):
     # Setup: Clear all registered caches before test (ensures fresh state)
     # This is done before test to ensure clean state, and again after test for cleanup
     try:
+        from bengal.output import reset_cli_output
+
+        reset_cli_output()
+    except ImportError:
+        logger.debug("CLI output reset skipped: reset_cli_output not available")
+
+    try:
         from bengal.utils.cache_registry import clear_all_caches
 
         clear_all_caches()
@@ -447,6 +454,12 @@ def reset_bengal_state(request):
     yield
 
     # Teardown: Reset all stateful components after each test
+    try:
+        from bengal.output import reset_cli_output
+
+        reset_cli_output()
+    except ImportError:
+        logger.debug("CLI output reset skipped: reset_cli_output not available")
 
     # 0. Kill leaked WriteBehind threads from builds
     # WriteBehindCollector spawns 8 daemon threads per build that poll forever

--- a/tests/integration/test_thread_safety.py
+++ b/tests/integration/test_thread_safety.py
@@ -95,6 +95,36 @@ class TestConcurrentEffectRecording:
         assert stats["unique_outputs"] == 800
         assert stats["by_operation"]["render_page"] == 800
 
+    def test_effect_recording_replaces_existing_output(self) -> None:
+        """Repeated warm renders replace stale effect edges for the same output."""
+        from bengal.effects.effect import Effect
+        from bengal.effects.tracer import EffectTracer
+
+        tracer = EffectTracer()
+        output_path = Path("public/page/index.html")
+        tracer.record(
+            Effect.for_page_render(
+                source_path=Path("content/page.md"),
+                output_path=output_path,
+                template_name="old.html",
+                template_includes=frozenset(),
+                page_href="/page/",
+            )
+        )
+        tracer.record(
+            Effect.for_page_render(
+                source_path=Path("content/page.md"),
+                output_path=output_path,
+                template_name="new.html",
+                template_includes=frozenset(),
+                page_href="/page/",
+            )
+        )
+
+        assert tracer.get_statistics()["total_effects"] == 1
+        assert tracer.get_effects_depending_on(Path("old.html")) == []
+        assert len(tracer.get_effects_depending_on(Path("new.html"))) == 1
+
 
 class TestConcurrentTaxonomyUpdates:
     """Verify BuildTaxonomyIndex is safe under concurrent tag updates."""

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -89,7 +89,30 @@ python tests/performance/benchmark_full_build.py
 
 ---
 
-### 5. Incremental Build Scaling ⭐ NEW (`benchmark_incremental_scale.py`)
+### 5. Post-Render Pipeline (`benchmark_post_render_pipeline.py`) ⭐ NEW
+**Purpose:** Measure the tail after rendering, including postprocess, artifact inventory, health, and cache stores
+
+Tests:
+- Cold build
+- Warm no-op build
+- Single-page edit
+- Section-index edit
+- CSS-only edit
+
+Produces structured metrics for:
+- Postprocess task/output timings
+- Post-render finalization timings
+- Pages rendered and changed outputs
+- Cache/store sizes by state area
+
+```bash
+python tests/performance/benchmark_post_render_pipeline.py --scales 100,1000,5000
+pytest -o addopts= -n 0 -q -m performance tests/performance/test_post_render_pipeline_budget.py
+```
+
+---
+
+### 6. Incremental Build Scaling ⭐ NEW (`benchmark_incremental_scale.py`)
 **Purpose:** Validate incremental build performance at documentation site scale
 
 Tests:

--- a/tests/performance/benchmark_post_render_pipeline.py
+++ b/tests/performance/benchmark_post_render_pipeline.py
@@ -1,0 +1,57 @@
+"""Manual/scheduled benchmark for the post-render pipeline tail."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import tempfile
+from pathlib import Path
+
+from tests.performance.post_render_harness import (
+    create_post_render_site,
+    run_post_render_scenarios,
+)
+
+
+def run_scale(page_count: int) -> list[dict[str, object]]:
+    root = Path(tempfile.mkdtemp(prefix="bengal_post_render_"))
+    try:
+        site_root = create_post_render_site(root, page_count=page_count)
+        metrics = run_post_render_scenarios(site_root)
+        return [metric.to_dict() | {"page_count": page_count} for metric in metrics]
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark Bengal post-render tail work")
+    parser.add_argument(
+        "--scales",
+        default="100,1000,5000",
+        help="Comma-separated page counts to benchmark",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("tests/performance/benchmark_results/post_render_pipeline/latest.json"),
+        help="Path for JSON metrics output",
+    )
+    args = parser.parse_args()
+
+    all_rows: list[dict[str, object]] = []
+    for raw_scale in args.scales.split(","):
+        scale = int(raw_scale.strip())
+        all_rows.extend(run_scale(scale))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    # Reuse the same writer contract through lightweight metric shims.
+    import json
+
+    args.output.write_text(
+        json.dumps(all_rows, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/performance/post_render_harness.py
+++ b/tests/performance/post_render_harness.py
@@ -1,0 +1,285 @@
+"""Shared post-render pipeline benchmark harness.
+
+The harness intentionally measures the work after rendering because that is the
+tail authors feel after the "Track assets" phase completes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+from bengal.orchestration.stats.models import BuildStats, ReloadHint
+from bengal.utils.observability.profile import BuildProfile
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class StoreSizes:
+    """Measured byte sizes for persistent build state stores."""
+
+    state_total_bytes: int
+    main_cache_bytes: int
+    page_artifact_bytes: int
+    effects_bytes: int
+    generated_page_cache_bytes: int
+    page_artifact_file_count: int
+
+
+@dataclass(frozen=True)
+class PostRenderMetrics:
+    """Metrics for one build in the post-render pipeline harness."""
+
+    scenario: str
+    timestamp: str
+    wall_time_ms: float
+    build_time_ms: float
+    total_pages: int
+    pages_rendered: int
+    changed_output_count: int
+    reload_hint: str | None
+    rendering_time_ms: float
+    assets_time_ms: float
+    postprocess_time_ms: float
+    health_check_time_ms: float
+    postprocess_task_timings_ms: dict[str, float] = field(default_factory=dict)
+    postprocess_output_timings_ms: dict[str, float] = field(default_factory=dict)
+    post_render_timings_ms: dict[str, float] = field(default_factory=dict)
+    store_sizes: StoreSizes | None = None
+
+    @property
+    def tail_time_ms(self) -> float:
+        """Measured post-render tail from tracked phase timings."""
+        post_render_total = sum(self.post_render_timings_ms.values())
+        return self.postprocess_time_ms + self.health_check_time_ms + post_render_total
+
+    def to_dict(self) -> dict[str, object]:
+        data = asdict(self)
+        data["tail_time_ms"] = round(self.tail_time_ms, 1)
+        return data
+
+
+def create_post_render_site(root: Path, *, page_count: int = 100) -> Path:
+    """Create a deterministic docs-like fixture for post-render timing."""
+    site_root = root / "post-render-site"
+    content_dir = site_root / "content"
+    assets_dir = site_root / "assets" / "css"
+    content_dir.mkdir(parents=True, exist_ok=True)
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    (site_root / "bengal.toml").write_text(
+        """
+[site]
+title = "Post Render Benchmark"
+baseurl = "/"
+
+[build]
+output_dir = "public"
+incremental = true
+parallel = true
+
+[output_formats]
+enabled = true
+per_page = ["json", "llm_txt"]
+site_wide = ["index_json", "llms_txt", "agent_manifest"]
+
+[health_check]
+enabled = true
+""",
+        encoding="utf-8",
+    )
+
+    (assets_dir / "site.css").write_text(
+        """
+:root { color-scheme: light; }
+body { font-family: system-ui, sans-serif; margin: 0; }
+.doc { max-width: 72ch; margin: 0 auto; padding: 2rem; }
+""",
+        encoding="utf-8",
+    )
+
+    (content_dir / "index.md").write_text(
+        "---\ntitle: Home\n---\n# Home\n\nWelcome to the post-render benchmark.\n",
+        encoding="utf-8",
+    )
+    for section_idx in range(max(1, page_count // 25)):
+        section_dir = content_dir / f"section-{section_idx + 1:02d}"
+        section_dir.mkdir(exist_ok=True)
+        (section_dir / "_index.md").write_text(
+            f"---\ntitle: Section {section_idx + 1}\n---\n# Section {section_idx + 1}\n",
+            encoding="utf-8",
+        )
+
+    for idx in range(page_count):
+        section_dir = content_dir / f"section-{idx // 25 + 1:02d}"
+        section_dir.mkdir(exist_ok=True)
+        (section_dir / f"page-{idx + 1:04d}.md").write_text(
+            f"""---
+title: "Page {idx + 1}"
+date: 2026-01-{idx % 28 + 1:02d}
+tags: ["bench", "tag-{idx % 7}"]
+---
+
+# Page {idx + 1}
+
+This page exists to exercise post-render artifacts.
+
+## Details
+
+The content is deterministic so benchmark output can be compared over time.
+""",
+            encoding="utf-8",
+        )
+
+    return site_root
+
+
+def collect_store_sizes(site: Site) -> StoreSizes:
+    """Measure the durable build-state stores used by the benchmark."""
+    state_dir = site.config_service.paths.state_dir
+    page_artifacts_dir = state_dir / "page-artifacts"
+
+    def file_size(path: Path) -> int:
+        return path.stat().st_size if path.exists() and path.is_file() else 0
+
+    def tree_size(path: Path) -> int:
+        if not path.exists():
+            return 0
+        return sum(item.stat().st_size for item in path.rglob("*") if item.is_file())
+
+    page_artifact_files = (
+        sum(1 for item in page_artifacts_dir.rglob("*") if item.is_file())
+        if page_artifacts_dir.exists()
+        else 0
+    )
+    return StoreSizes(
+        state_total_bytes=tree_size(state_dir),
+        main_cache_bytes=file_size(state_dir / "cache.json.zst"),
+        page_artifact_bytes=tree_size(page_artifacts_dir),
+        effects_bytes=file_size(state_dir / "effects.json"),
+        generated_page_cache_bytes=file_size(state_dir / "generated_page_cache.json"),
+        page_artifact_file_count=page_artifact_files,
+    )
+
+
+def run_build(site: Site, scenario: str, options: BuildOptions) -> PostRenderMetrics:
+    """Run one build and collect post-render metrics."""
+    start = time.perf_counter()
+    stats = site.build(options)
+    wall_time_ms = (time.perf_counter() - start) * 1000
+    return metrics_from_stats(site, scenario, stats, wall_time_ms)
+
+
+def metrics_from_stats(
+    site: Site,
+    scenario: str,
+    stats: BuildStats,
+    wall_time_ms: float,
+) -> PostRenderMetrics:
+    """Convert BuildStats to stable benchmark metrics."""
+    reload_hint = stats.reload_hint.value if isinstance(stats.reload_hint, ReloadHint) else None
+    return PostRenderMetrics(
+        scenario=scenario,
+        timestamp=datetime.now(UTC).isoformat(),
+        wall_time_ms=round(wall_time_ms, 1),
+        build_time_ms=round(stats.build_time_ms, 1),
+        total_pages=stats.total_pages,
+        pages_rendered=stats.pages_rendered,
+        changed_output_count=len(stats.changed_outputs),
+        reload_hint=reload_hint,
+        rendering_time_ms=round(stats.rendering_time_ms, 1),
+        assets_time_ms=round(stats.assets_time_ms, 1),
+        postprocess_time_ms=round(stats.postprocess_time_ms, 1),
+        health_check_time_ms=round(stats.health_check_time_ms, 1),
+        postprocess_task_timings_ms=dict(stats.postprocess_task_timings_ms),
+        postprocess_output_timings_ms=dict(stats.postprocess_output_timings_ms),
+        post_render_timings_ms=dict(stats.post_render_timings_ms),
+        store_sizes=collect_store_sizes(site),
+    )
+
+
+def run_post_render_scenarios(site_root: Path) -> list[PostRenderMetrics]:
+    """Run the canonical post-render scenarios for a site root."""
+    site = Site.from_config(site_root)
+    content_dir = site_root / "content"
+    page = sorted(content_dir.glob("section-*/page-*.md"))[0]
+    section_index = sorted(content_dir.glob("section-*/_index.md"))[0]
+    css = site_root / "assets" / "css" / "site.css"
+
+    metrics: list[PostRenderMetrics] = []
+    metrics.append(
+        run_build(site, "cold", BuildOptions(incremental=False, profile=BuildProfile.WRITER))
+    )
+
+    site.prepare_for_rebuild()
+    metrics.append(
+        run_build(
+            site,
+            "warm_noop",
+            BuildOptions(incremental=True, profile=BuildProfile.WRITER, changed_sources=set()),
+        )
+    )
+
+    _touch(page, "\n\n<!-- single-page-edit -->\n")
+    site.prepare_for_rebuild()
+    metrics.append(
+        run_build(
+            site,
+            "single_page_edit",
+            BuildOptions(
+                incremental=True,
+                profile=BuildProfile.WRITER,
+                changed_sources={page},
+            ),
+        )
+    )
+
+    _touch(section_index, "\n\n<!-- section-index-edit -->\n")
+    site.prepare_for_rebuild()
+    metrics.append(
+        run_build(
+            site,
+            "section_index_edit",
+            BuildOptions(
+                incremental=True,
+                profile=BuildProfile.WRITER,
+                changed_sources={section_index},
+            ),
+        )
+    )
+
+    _touch(css, "\n/* css edit */\n")
+    site.prepare_for_rebuild()
+    metrics.append(
+        run_build(
+            site,
+            "css_only_edit",
+            BuildOptions(
+                incremental=True,
+                profile=BuildProfile.WRITER,
+                changed_sources={css},
+            ),
+        )
+    )
+
+    return metrics
+
+
+def write_metrics(path: Path, metrics: list[PostRenderMetrics]) -> None:
+    """Persist metrics in the same JSON shape used by benchmark scripts."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps([metric.to_dict() for metric in metrics], indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _touch(path: Path, suffix: str) -> None:
+    path.write_text(path.read_text(encoding="utf-8") + suffix, encoding="utf-8")

--- a/tests/performance/test_post_render_pipeline_budget.py
+++ b/tests/performance/test_post_render_pipeline_budget.py
@@ -1,0 +1,41 @@
+"""Post-render pipeline budget smoke tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.performance.post_render_harness import (
+    create_post_render_site,
+    run_post_render_scenarios,
+    write_metrics,
+)
+
+
+@pytest.mark.performance
+def test_post_render_pipeline_tail_is_measured_and_bounded(tmp_path: Path) -> None:
+    """Exercise the user-visible tail after rendering on common warm scenarios."""
+    site_root = create_post_render_site(tmp_path, page_count=40)
+    metrics = run_post_render_scenarios(site_root)
+    by_name = {metric.scenario: metric for metric in metrics}
+
+    write_metrics(Path(".pytest_cache/post_render_pipeline_metrics.json"), metrics)
+
+    cold = by_name["cold"]
+    warm_noop = by_name["warm_noop"]
+    single_page = by_name["single_page_edit"]
+    css_only = by_name["css_only_edit"]
+
+    assert cold.postprocess_task_timings_ms
+    assert cold.post_render_timings_ms
+    assert warm_noop.pages_rendered <= 1
+    assert single_page.pages_rendered <= 3
+
+    cold_tail = max(cold.tail_time_ms, 1.0)
+    assert warm_noop.tail_time_ms <= cold_tail * 1.25
+    assert single_page.tail_time_ms <= cold_tail * 1.50
+    assert css_only.tail_time_ms <= cold_tail * 1.50
+
+    assert warm_noop.store_sizes is not None
+    assert warm_noop.store_sizes.state_total_bytes > 0

--- a/tests/unit/cache/test_build_cache.py
+++ b/tests/unit/cache/test_build_cache.py
@@ -20,6 +20,17 @@ class TestBuildCache:
         assert cache.taxonomy_index.taxonomy_deps == {}
         assert cache.last_build is None
 
+    def test_save_reports_persistence_failure(self, tmp_path, monkeypatch):
+        """Cache save failures are visible to build orchestration."""
+        cache = BuildCache()
+
+        def fail_save(_cache_path):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(cache, "_save_to_file", fail_save)
+
+        assert cache.save(tmp_path / "cache.json", use_lock=False) is False
+
     def test_hash_file(self, tmp_path):
         """Test file hashing."""
         cache = BuildCache()

--- a/tests/unit/cache/test_build_cache.py
+++ b/tests/unit/cache/test_build_cache.py
@@ -330,6 +330,39 @@ class TestBuildCache:
         assert str(template) in loaded_cache.dependencies[str(page)]
         assert "tag:python" in loaded_cache.taxonomy_index.taxonomy_deps
 
+    def test_hot_cache_stores_save_outside_main_payload(self, tmp_path):
+        """Large hot-path stores are split from the compressed build cache."""
+        from bengal.cache.compression import load_compressed
+
+        cache = BuildCache()
+        cache.parsed_content["content/page.md"] = {"frontmatter": {"title": "Page"}}
+        cache.rendered_output["content/page.md"] = {"html": "<h1>Page</h1>"}
+        cache.validation_results["content/page.md"] = {"Links": {"results": []}}
+        cache.synthetic_pages["autodoc/module.md"] = {"title": "Module"}
+        cache_file = tmp_path / ".bengal" / "cache.json"
+
+        assert cache.save(cache_file, use_lock=False) is True
+
+        main_payload = load_compressed(cache_file.with_suffix(".json.zst"))
+        assert main_payload["parsed_content"] == {}
+        assert main_payload["rendered_output"] == {}
+        assert main_payload["validation_results"] == {}
+        assert main_payload["synthetic_pages"] == {}
+        assert set(main_payload["external_stores"]) == {
+            "parsed_content",
+            "rendered_output",
+            "validation_results",
+            "synthetic_pages",
+        }
+        assert (cache_file.parent / "stores" / "parsed_content.json").exists()
+
+        loaded_cache = BuildCache.load(cache_file)
+
+        assert loaded_cache.parsed_content["content/page.md"]["frontmatter"]["title"] == "Page"
+        assert loaded_cache.rendered_output["content/page.md"]["html"] == "<h1>Page</h1>"
+        assert loaded_cache.validation_results["content/page.md"]["Links"]["results"] == []
+        assert loaded_cache.synthetic_pages["autodoc/module.md"]["title"] == "Module"
+
     def test_page_artifacts_survive_save_load(self, tmp_path):
         """Post-render page artifact records are persisted in the build cache."""
         cache = BuildCache()

--- a/tests/unit/cache/test_page_artifact_store.py
+++ b/tests/unit/cache/test_page_artifact_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from bengal.cache.page_artifact_store import PageArtifactStore
 
 
@@ -27,3 +29,49 @@ def test_page_artifact_store_prunes_stale_shards(tmp_path):
     store.save({})
 
     assert list((tmp_path / "page-artifacts").glob("*.json")) == []
+
+
+def test_page_artifact_store_dirty_save_rewrites_only_affected_shard(tmp_path):
+    """Dirty saves touch only shards for changed keys."""
+    store = PageArtifactStore(tmp_path / "page-artifacts")
+    changed_key = "content/a.md"
+    stable_key = _key_in_different_shard(store, changed_key)
+    records = {
+        changed_key: {"uri": "/a/"},
+        stable_key: {"uri": "/stable/"},
+    }
+    store.save(records)
+    changed_path = store.root / f"{store._shard_name(changed_key)}.json"
+    stable_path = store.root / f"{store._shard_name(stable_key)}.json"
+    changed_mtime = changed_path.stat().st_mtime_ns
+    stable_mtime = stable_path.stat().st_mtime_ns
+    time.sleep(0.01)
+
+    records[changed_key] = {"uri": "/a-updated/"}
+    store.save(records, dirty_keys={changed_key}, deleted_keys=set())
+
+    assert changed_path.stat().st_mtime_ns > changed_mtime
+    assert stable_path.stat().st_mtime_ns == stable_mtime
+    assert store.load()[changed_key]["uri"] == "/a-updated/"
+
+
+def test_page_artifact_store_dirty_save_deletes_empty_shard(tmp_path):
+    """Dirty deletion removes a shard when no records remain in it."""
+    store = PageArtifactStore(tmp_path / "page-artifacts")
+    records = {"content/a.md": {"uri": "/a/"}}
+    store.save(records)
+    shard_path = store.root / f"{store._shard_name('content/a.md')}.json"
+    assert shard_path.exists()
+
+    store.save({}, dirty_keys=set(), deleted_keys={"content/a.md"})
+
+    assert not shard_path.exists()
+
+
+def _key_in_different_shard(store: PageArtifactStore, key: str) -> str:
+    source_shard = store._shard_name(key)
+    for index in range(1000):
+        candidate = f"content/stable-{index}.md"
+        if store._shard_name(candidate) != source_shard:
+            return candidate
+    raise AssertionError("could not find test key in different shard")

--- a/tests/unit/cache/test_page_artifact_store.py
+++ b/tests/unit/cache/test_page_artifact_store.py
@@ -1,0 +1,29 @@
+"""Tests for sharded page artifact persistence."""
+
+from __future__ import annotations
+
+from bengal.cache.page_artifact_store import PageArtifactStore
+
+
+def test_page_artifact_store_round_trips_records(tmp_path):
+    """Records are persisted across deterministic shard files."""
+    store = PageArtifactStore(tmp_path / "page-artifacts")
+    records = {
+        "content/a.md": {"uri": "/a/"},
+        "content/b.md": {"uri": "/b/"},
+    }
+
+    store.save(records)
+
+    assert store.load() == records
+
+
+def test_page_artifact_store_prunes_stale_shards(tmp_path):
+    """Saving a smaller record set removes shards no longer in use."""
+    store = PageArtifactStore(tmp_path / "page-artifacts")
+    store.save({"content/a.md": {"uri": "/a/"}})
+    assert list((tmp_path / "page-artifacts").glob("*.json"))
+
+    store.save({})
+
+    assert list((tmp_path / "page-artifacts").glob("*.json")) == []

--- a/tests/unit/health/test_directive_validator.py
+++ b/tests/unit/health/test_directive_validator.py
@@ -332,6 +332,7 @@ Just regular markdown content here.
         # No issues = no results (silence is golden)
         # OR if there are results, none should be errors
         assert all(r.status != CheckStatus.ERROR for r in results)
+        assert validator.last_file_results == {source_file: []}
 
     def test_validate_with_valid_directives(self, tmp_path):
         """Test validation with valid directives."""

--- a/tests/unit/health/test_health_check.py
+++ b/tests/unit/health/test_health_check.py
@@ -335,6 +335,27 @@ class TestHealthCheckHelperMethods:
         assert [result.message for result in report.results] == ["cached broken", "fresh broken"]
         cache.get_cached_validation_results.assert_called_once_with(unchanged.source_path, "Links")
 
+    def test_missing_unchanged_validation_cache_disables_incremental_scope(self, mock_site):
+        """Missing cached unchanged-file findings fall back to full validation."""
+        changed = MagicMock()
+        changed.source_path = Path("content/changed.md")
+        unchanged = MagicMock()
+        unchanged.source_path = Path("content/unchanged.md")
+        mock_site.pages = [changed, unchanged]
+
+        cache = MagicMock()
+        cache.get_cached_validation_results.return_value = None
+        validator = MockValidator("Links", results=[])
+        health_check = HealthCheck(mock_site, auto_register=False)
+
+        scope = health_check._build_validation_scope(
+            validator,
+            cache,
+            files_to_validate={changed.source_path},
+        )
+
+        assert scope is None
+
     def test_run_single_validator_caches_file_results(self, mock_site):
         """Validator-provided per-file results are persisted for changed files."""
         page = MagicMock()
@@ -356,6 +377,35 @@ class TestHealthCheckHelperMethods:
         cache.cache_validation_results.assert_called_once_with(
             page.source_path, "Links", [file_result]
         )
+
+    def test_run_single_validator_caches_full_run_file_results(self, mock_site):
+        """Full validation seeds per-file result cache for future incremental runs."""
+        page1 = MagicMock()
+        page1.source_path = Path("content/one.md")
+        page2 = MagicMock()
+        page2.source_path = Path("content/two.md")
+        mock_site.pages = [page1, page2]
+
+        result1 = CheckResult.error("first broken", code="H101")
+        result2 = CheckResult.warning("second warning", code="H102")
+        validator = MockValidator("Links", results=[result1, result2])
+        validator.last_file_results = {
+            page1.source_path: [result1],
+            page2.source_path: [result2],
+        }
+        cache = MagicMock()
+        health_check = HealthCheck(mock_site, auto_register=False)
+
+        health_check._run_single_validator(
+            validator,
+            build_context=None,
+            cache=cache,
+            files_to_validate=None,
+        )
+
+        assert cache.cache_validation_results.call_count == 2
+        cache.cache_validation_results.assert_any_call(page1.source_path, "Links", [result1])
+        cache.cache_validation_results.assert_any_call(page2.source_path, "Links", [result2])
 
     def test_link_validation_cache_uses_registry_fingerprint_context(self, mock_site):
         """Links cache keys include rendered URL and anchor truth when available."""

--- a/tests/unit/health/validators/test_directives_incremental.py
+++ b/tests/unit/health/validators/test_directives_incremental.py
@@ -6,17 +6,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from bengal.health.scope import ValidationScope, with_validation_scope
 from bengal.health.validators.directives.analysis import DirectiveAnalyzer
-from bengal.orchestration.build_context import BuildContext
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_directive_analyzer_skips_unchanged_pages_in_incremental_mode(tmp_path: Path) -> None:
+def test_directive_analyzer_uses_shared_validation_scope(tmp_path: Path) -> None:
     """
-    When incremental mode is enabled and changed_page_paths is empty, directive analysis should
-    skip all pages (no disk reads / parsing work).
+    Directive analysis scopes through ValidationScope instead of private changed-page skips.
 
     """
     # Arrange: create 2 content files and fake pages pointing at them
@@ -36,13 +35,16 @@ def test_directive_analyzer_skips_unchanged_pages_in_incremental_mode(tmp_path: 
     site = type("S", (), {})()
     site.pages = [page_a, page_b]
 
-    ctx = BuildContext(incremental=True, changed_page_paths=set())
+    ctx = with_validation_scope(
+        None,
+        ValidationScope(incremental=True, files_to_validate=frozenset({a})),
+    )
 
     # Act
     data = DirectiveAnalyzer().analyze(site, build_context=ctx)
 
-    # Assert: nothing processed, everything skipped by no_changes
+    # Assert: only the scoped file is processed.
     stats = data.get("_stats") or {}
-    assert stats.get("pages_processed") == 0
-    skipped = (stats.get("pages_skipped") or {}).get("no_changes")
-    assert skipped == 2
+    assert stats.get("pages_processed") == 1
+    skipped = (stats.get("pages_skipped") or {}).get("unscoped")
+    assert skipped == 1

--- a/tests/unit/orchestration/build/test_completion_policy.py
+++ b/tests/unit/orchestration/build/test_completion_policy.py
@@ -16,14 +16,16 @@ def test_build_options_default_to_complete() -> None:
 
 
 def test_build_input_round_trips_completion_policy() -> None:
-    options = BuildOptions(completion_policy=BuildCompletionPolicy.SERVE_READY)
+    options = BuildOptions(completion_policy=BuildCompletionPolicy.SERVE_READY, quiet=True)
     build_input = BuildInput.from_options(options, Path("/site"))
 
     request = build_input.to_build_request()
     restored = BuildInput.from_build_request(request)
 
     assert request.completion_policy == "serve_ready"
+    assert request.quiet is True
     assert restored.options.completion_policy is BuildCompletionPolicy.SERVE_READY
+    assert restored.options.quiet is True
 
 
 def test_unknown_serialized_completion_policy_falls_back_to_complete() -> None:

--- a/tests/unit/orchestration/build/test_completion_policy.py
+++ b/tests/unit/orchestration/build/test_completion_policy.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 from bengal.orchestration.build.inputs import BuildInput
 from bengal.orchestration.build.options import BuildCompletionPolicy, BuildOptions
-from bengal.server.build_executor import BuildRequest
+from bengal.server.build_executor import BuildRequest, BuildResult
+from bengal.utils.stats_minimal import MinimalStats
 
 
 def test_build_options_default_to_complete() -> None:
@@ -34,3 +35,16 @@ def test_unknown_serialized_completion_policy_falls_back_to_complete() -> None:
     restored = BuildInput.from_build_request(request)
 
     assert restored.options.completion_policy is BuildCompletionPolicy.COMPLETE
+
+
+def test_minimal_stats_preserves_build_result_completion_policy() -> None:
+    result = BuildResult(
+        success=True,
+        pages_built=3,
+        build_time_ms=100.0,
+        completion_policy="serve_ready",
+    )
+
+    stats = MinimalStats.from_build_result(result)
+
+    assert stats.completion_policy == "serve_ready"

--- a/tests/unit/orchestration/build/test_completion_policy.py
+++ b/tests/unit/orchestration/build/test_completion_policy.py
@@ -1,0 +1,34 @@
+"""Tests for build completion policy plumbing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bengal.orchestration.build.inputs import BuildInput
+from bengal.orchestration.build.options import BuildCompletionPolicy, BuildOptions
+from bengal.server.build_executor import BuildRequest
+
+
+def test_build_options_default_to_complete() -> None:
+    options = BuildOptions()
+
+    assert options.completion_policy is BuildCompletionPolicy.COMPLETE
+
+
+def test_build_input_round_trips_completion_policy() -> None:
+    options = BuildOptions(completion_policy=BuildCompletionPolicy.SERVE_READY)
+    build_input = BuildInput.from_options(options, Path("/site"))
+
+    request = build_input.to_build_request()
+    restored = BuildInput.from_build_request(request)
+
+    assert request.completion_policy == "serve_ready"
+    assert restored.options.completion_policy is BuildCompletionPolicy.SERVE_READY
+
+
+def test_unknown_serialized_completion_policy_falls_back_to_complete() -> None:
+    request = BuildRequest(site_root="/site", completion_policy="unknown")
+
+    restored = BuildInput.from_build_request(request)
+
+    assert restored.options.completion_policy is BuildCompletionPolicy.COMPLETE

--- a/tests/unit/orchestration/build/test_finalization.py
+++ b/tests/unit/orchestration/build/test_finalization.py
@@ -107,6 +107,7 @@ class TestPhasePostprocess:
             build_context=ctx,
             incremental=False,
             collector=None,
+            enabled_task_names=None,
         )
 
     def test_updates_postprocess_time_stats(self, tmp_path):
@@ -140,6 +141,32 @@ class TestPhasePostprocess:
         phase_postprocess(orchestrator, cli, parallel=False, ctx=ctx, incremental=True)
 
         assert "asset_audit" in orchestrator.stats.post_render_timings_ms
+
+    def test_can_limit_tasks_and_skip_asset_audit(self, tmp_path):
+        """Serve-ready builds can run only browse-critical postprocess tasks."""
+        orchestrator = MockPhaseContext.create_orchestrator(tmp_path)
+        cli = MockPhaseContext.create_cli()
+        ctx = MagicMock()
+
+        phase_postprocess(
+            orchestrator,
+            cli,
+            parallel=False,
+            ctx=ctx,
+            incremental=False,
+            enabled_task_names={"special pages"},
+            run_asset_audit=False,
+        )
+
+        orchestrator.postprocess.run.assert_called_once_with(
+            parallel=False,
+            progress_manager=None,
+            build_context=ctx,
+            incremental=False,
+            collector=None,
+            enabled_task_names={"special pages"},
+        )
+        assert orchestrator.stats.post_render_timings_ms["asset_audit"] == 0
 
 
 class TestPhaseCacheSave:

--- a/tests/unit/orchestration/build/test_finalization.py
+++ b/tests/unit/orchestration/build/test_finalization.py
@@ -49,6 +49,9 @@ class MockPhaseContext:
 
         orchestrator.stats = MagicMock()
         orchestrator.stats.postprocess_time_ms = 0
+        orchestrator.stats.postprocess_task_timings_ms = {}
+        orchestrator.stats.postprocess_output_timings_ms = {}
+        orchestrator.stats.post_render_timings_ms = {}
         orchestrator.stats.build_time_ms = 0
         orchestrator.stats.health_check_time_ms = 0
         orchestrator.stats.rendering_time_ms = 100
@@ -56,6 +59,15 @@ class MockPhaseContext:
         orchestrator.stats.memory_heap_mb = 0
         orchestrator.stats.total_pages = 0
         orchestrator.stats.total_assets = 0
+        orchestrator.stats.parallel = True
+        orchestrator.stats.incremental = False
+        orchestrator.stats.skipped = False
+        orchestrator.stats.cache_hits = 0
+        orchestrator.stats.cache_misses = 0
+        orchestrator.stats.block_cache_hits = 0
+        orchestrator.stats.block_cache_misses = 0
+        orchestrator.stats.block_cache_site_blocks = 0
+        orchestrator.stats.block_cache_time_saved_ms = 0
 
         orchestrator.logger = MagicMock()
         orchestrator.logger.phase = MagicMock(
@@ -111,6 +123,18 @@ class TestPhasePostprocess:
         phase_postprocess(orchestrator, cli, parallel=False, ctx=ctx, incremental=False)
 
         cli.phase.assert_called_once()
+
+    def test_records_asset_audit_timing(self, tmp_path):
+        """Records post-render timing for the asset audit tail."""
+        orchestrator = MockPhaseContext.create_orchestrator(tmp_path)
+        orchestrator.site.output_dir.mkdir(parents=True)
+        cli = MockPhaseContext.create_cli()
+        ctx = MagicMock()
+        ctx.strict = False
+
+        phase_postprocess(orchestrator, cli, parallel=False, ctx=ctx, incremental=True)
+
+        assert "asset_audit" in orchestrator.stats.post_render_timings_ms
 
 
 class TestPhaseCacheSave:

--- a/tests/unit/orchestration/build/test_finalization.py
+++ b/tests/unit/orchestration/build/test_finalization.py
@@ -16,10 +16,15 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from bengal.cache.build_cache import BuildCache
+from bengal.health.report import CheckResult, HealthReport, ValidatorReport
 from bengal.orchestration.build.artifacts import (
     normalize_build_badge_config,
 )
 from bengal.orchestration.build.finalization import (
+    _health_report_fingerprint,
+    _load_cached_health_report,
+    _store_cached_health_report,
     phase_cache_save,
     phase_collect_stats,
     phase_finalize,
@@ -578,6 +583,9 @@ class TestRunHealthCheck:
             mock_config.return_value = {"enabled": True}
 
             mock_cli = MagicMock()
+            mock_cli.icons.success = "⚡"
+            mock_cli.icons.info = "🔎"
+            mock_cli.icons.warning = "⚠️"
             mock_get_cli.return_value = mock_cli
 
             mock_health = MagicMock()
@@ -659,6 +667,37 @@ class TestRunHealthCheck:
         call_args = mock_health.run.call_args
         assert call_args.kwargs["cache"] is mock_cache
 
+    def test_reuses_cached_health_report_for_matching_incremental_fingerprint(self, tmp_path):
+        """Incremental health can reuse a whole cached report without running validators."""
+        orchestrator = MockPhaseContext.create_orchestrator(tmp_path)
+        report = HealthReport()
+        report.validator_reports.append(
+            ValidatorReport("Directives", [CheckResult.warning("cached", code="H201")])
+        )
+
+        with (
+            patch("bengal.config.defaults.get_feature_config") as mock_config,
+            patch("bengal.health.HealthCheck") as MockHealth,
+            patch("bengal.output.get_cli_output"),
+            patch(
+                "bengal.orchestration.build.finalization._health_report_fingerprint",
+                return_value="fingerprint",
+            ),
+            patch(
+                "bengal.orchestration.build.finalization._load_cached_health_report",
+                return_value=report,
+            ),
+        ):
+            mock_config.return_value = {"enabled": True}
+            mock_health = MagicMock()
+            mock_health.last_stats = None
+            MockHealth.return_value = mock_health
+
+            run_health_check(orchestrator, incremental=True)
+
+        mock_health.run.assert_not_called()
+        assert orchestrator.stats.health_report is report
+
     def test_raises_in_strict_mode_with_errors(self, tmp_path):
         """Raises exception in strict mode with health check errors."""
         orchestrator = MockPhaseContext.create_orchestrator(tmp_path)
@@ -702,6 +741,39 @@ class TestRunHealthCheck:
             run_health_check(orchestrator)
 
         assert orchestrator.stats.health_report is mock_report
+
+    def test_cached_health_report_round_trips(self, tmp_path):
+        """Cached health reports preserve prior findings for reuse."""
+        cache = BuildCache(site_root=tmp_path)
+        report = HealthReport()
+        report.validator_reports.append(
+            ValidatorReport("Links", [CheckResult.error("broken", code="H101")])
+        )
+
+        _store_cached_health_report(cache, "fingerprint", report)
+        loaded = _load_cached_health_report(cache, "fingerprint")
+
+        assert loaded is not None
+        assert loaded.total_errors == 1
+        assert loaded.validator_reports[0].results[0].message == "broken"
+
+    def test_health_report_fingerprint_changes_with_source_fingerprint(self, tmp_path):
+        """Health report reuse is invalidated by source content changes."""
+        source = tmp_path / "content" / "page.md"
+        source.parent.mkdir()
+        source.write_text("# Page\n", encoding="utf-8")
+        site = MagicMock()
+        site.pages = [MagicMock(source_path=source)]
+        site.link_registry = MagicMock(fingerprint="links")
+        cache = BuildCache(site_root=tmp_path)
+        cache.update_file(source)
+
+        first = _health_report_fingerprint(site, cache, {"enabled": True}, None)
+        source.write_text("# Changed\n", encoding="utf-8")
+        cache.update_file(source)
+        second = _health_report_fingerprint(site, cache, {"enabled": True}, None)
+
+        assert first != second
 
     def test_updates_health_check_time_stats(self, tmp_path):
         """Updates health check time statistics."""

--- a/tests/unit/orchestration/build/test_finalization.py
+++ b/tests/unit/orchestration/build/test_finalization.py
@@ -160,6 +160,20 @@ class TestPhaseCacheSave:
 
         orchestrator.logger.info.assert_called_with("cache_saved")
 
+    def test_raises_when_cache_save_fails(self, tmp_path):
+        """Cache persistence failures stop the build instead of being hidden."""
+        from bengal.errors import BengalCacheError
+
+        orchestrator = MockPhaseContext.create_orchestrator(tmp_path)
+        orchestrator.incremental.save_cache.return_value = False
+        phase_context = MagicMock()
+        phase_context.__enter__.return_value = None
+        phase_context.__exit__.return_value = False
+        orchestrator.logger.phase.return_value = phase_context
+
+        with pytest.raises(BengalCacheError):
+            phase_cache_save(orchestrator, [], [])
+
 
 class TestPhaseCollectStats:
     """Tests for phase_collect_stats function."""

--- a/tests/unit/orchestration/build/test_finalization_tasks.py
+++ b/tests/unit/orchestration/build/test_finalization_tasks.py
@@ -1,0 +1,42 @@
+"""Tests for finalization task policy contracts."""
+
+from __future__ import annotations
+
+from bengal.orchestration.build.finalization_tasks import (
+    FinalizationFailurePolicy,
+    FinalizationTaskTier,
+    blocking_finalization_task_names,
+    default_finalization_task_specs,
+)
+from bengal.orchestration.build.options import BuildCompletionPolicy
+
+
+def test_complete_policy_blocks_all_default_tasks() -> None:
+    specs = default_finalization_task_specs()
+
+    assert blocking_finalization_task_names(BuildCompletionPolicy.COMPLETE) == tuple(
+        spec.name for spec in specs
+    )
+
+
+def test_serve_ready_blocks_only_browse_critical_tasks() -> None:
+    assert blocking_finalization_task_names(BuildCompletionPolicy.SERVE_READY) == (
+        "special_pages",
+        "stats",
+    )
+
+
+def test_background_serve_tasks_are_nonfatal_warnings() -> None:
+    background_specs = [
+        spec
+        for spec in default_finalization_task_specs()
+        if not spec.blocks(BuildCompletionPolicy.SERVE_READY)
+    ]
+
+    assert background_specs
+    assert {spec.tier for spec in background_specs} >= {
+        FinalizationTaskTier.ARTIFACTS,
+        FinalizationTaskTier.QUALITY,
+        FinalizationTaskTier.PERSISTENCE,
+    }
+    assert all(spec.failure_policy is FinalizationFailurePolicy.WARN for spec in background_specs)

--- a/tests/unit/orchestration/incremental/test_page_artifact_cache.py
+++ b/tests/unit/orchestration/incremental/test_page_artifact_cache.py
@@ -6,7 +6,9 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
+from bengal.cache import BengalPaths
 from bengal.cache.build_cache import BuildCache
+from bengal.cache.page_artifact_store import PageArtifactStore
 from bengal.orchestration.build_context import AccumulatedPageData
 from bengal.orchestration.incremental.cache_manager import CacheManager
 
@@ -67,6 +69,30 @@ def test_cache_manager_sanitizes_page_artifact_metadata(tmp_path: Path) -> None:
     assert cached["raw_metadata"]["path"] == str(tmp_path / "source.md")
     assert cached["enhanced_metadata"]["updated"] == "2026-05-03T12:00:00"
     assert cached["full_json_data"]["source"] == str(tmp_path / "source.md")
+
+
+def test_cache_manager_saves_page_artifacts_to_shards(tmp_path: Path) -> None:
+    """CacheManager stores bulky page artifacts outside the monolithic cache."""
+    source_path = Path("content/docs.md")
+    site = SimpleNamespace(
+        root_path=tmp_path,
+        pages=[SimpleNamespace(source_path=source_path, toc_items=[])],
+        assets=[],
+        theme=None,
+        config_service=SimpleNamespace(paths=BengalPaths(tmp_path)),
+        url_registry=None,
+    )
+    manager = CacheManager(site)
+    manager.cache = BuildCache(site_root=tmp_path)
+    manager.cache.page_artifacts = {
+        "content/docs.md": _artifact(source_path).full_json_data | {"uri": "/docs/"}
+    }
+
+    assert manager.save([], []) is True
+
+    store = PageArtifactStore(site.config_service.paths.state_dir / "page-artifacts")
+    assert store.load()["content/docs.md"]["uri"] == "/docs/"
+    assert manager.cache.page_artifacts["content/docs.md"]["uri"] == "/docs/"
 
 
 def _artifact(source_path: Path) -> AccumulatedPageData:

--- a/tests/unit/orchestration/incremental/test_page_artifact_cache.py
+++ b/tests/unit/orchestration/incremental/test_page_artifact_cache.py
@@ -46,6 +46,24 @@ def test_cache_manager_prunes_deleted_page_artifacts(tmp_path: Path) -> None:
     manager._store_page_artifacts(build_context)
 
     assert set(manager.cache.page_artifacts) == {"content/docs.md"}
+    assert manager._deleted_page_artifact_keys == {"content/deleted.md"}
+
+
+def test_cache_manager_tracks_dirty_page_artifact_keys(tmp_path: Path) -> None:
+    """CacheManager exposes dirty artifact keys for shard-limited persistence."""
+    source_path = Path("content/docs.md")
+    site = SimpleNamespace(root_path=tmp_path, pages=[SimpleNamespace(source_path=source_path)])
+    manager = CacheManager(site)
+    manager.cache = BuildCache(site_root=tmp_path)
+    manager.cache.page_artifacts = {"content/docs.md": {"uri": "/old/"}}
+    build_context = SimpleNamespace(
+        get_accumulated_page_data=lambda: [_artifact(source_path)],
+        pages_to_build=[SimpleNamespace(source_path=source_path)],
+    )
+
+    manager._store_page_artifacts(build_context)
+
+    assert manager._dirty_page_artifact_keys == {"content/docs.md"}
 
 
 def test_cache_manager_sanitizes_page_artifact_metadata(tmp_path: Path) -> None:

--- a/tests/unit/orchestration/test_build_orchestrator.py
+++ b/tests/unit/orchestration/test_build_orchestrator.py
@@ -231,6 +231,43 @@ class TestBuildOrchestrator:
         mock_orchestrators["taxonomy"].return_value.collect_and_generate.assert_not_called()
         assert mock_health.call_args.kwargs["incremental"] is True
 
+    def test_serve_ready_policy_skips_quality_and_persistence_tail(
+        self, mock_site, mock_orchestrators
+    ):
+        """Serve-ready builds should not block on health or cache persistence."""
+        from bengal.orchestration.build.options import BuildCompletionPolicy
+        from bengal.orchestration.build.results import FilterResult
+
+        orchestrator = BuildOrchestrator(mock_site)
+        mock_inc = mock_orchestrators["incremental"].return_value
+        mock_cache = MagicMock()
+        mock_cache.parsed_content = {}
+        mock_inc.initialize.return_value = mock_cache
+        filter_result = FilterResult(
+            pages_to_build=[Mock()],
+            assets_to_process=[],
+            affected_tags=set(),
+            changed_page_paths=set(),
+            affected_sections=None,
+        )
+
+        with (
+            patch(
+                "bengal.orchestration.build.provenance_filter.phase_incremental_filter_provenance",
+                return_value=filter_result,
+            ),
+            patch("bengal.orchestration.build.finalization.run_health_check") as mock_health,
+        ):
+            options = BuildOptions(
+                incremental=True,
+                force_sequential=False,
+                completion_policy=BuildCompletionPolicy.SERVE_READY,
+            )
+            orchestrator.build(options)
+
+        mock_health.assert_not_called()
+        mock_inc.save_cache.assert_not_called()
+
     def test_section_validation_error_strict(self, mock_site, mock_orchestrators):
         """Test that section validation errors raise exception in strict mode."""
         # Enable strict mode in config

--- a/tests/unit/postprocess/test_output_formats_config.py
+++ b/tests/unit/postprocess/test_output_formats_config.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from bengal.cache.build_cache import BuildCache
 from bengal.orchestration.build_context import AccumulatedPageData
@@ -210,6 +210,73 @@ class TestConfigNormalizationEdgeCases:
 
         assert unchanged_json.read_text(encoding="utf-8") == "old-json"
         assert (output_dir / "changed/index.json").exists()
+
+    def test_incremental_per_page_outputs_skip_noop_when_outputs_exist(
+        self, tmp_path: Path
+    ) -> None:
+        """No-op incremental builds do not regenerate per-page companion files."""
+        output_dir = tmp_path / "public"
+        (output_dir / "page").mkdir(parents=True)
+        (output_dir / "page/index.json").write_text("{}", encoding="utf-8")
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        page = self._create_mock_page(
+            title="Page",
+            url="/page/",
+            content="Page",
+            output_path=output_dir / "page/index.html",
+        )
+        page.source_path = Path("content/page.md")
+        mock_site.pages = [page]
+        build_context = SimpleNamespace(incremental=True, cache=BuildCache(site_root=tmp_path))
+        generator = OutputFormatsGenerator(
+            mock_site, {"enabled": True}, build_context=build_context
+        )
+
+        targets = generator._per_page_target_pages([page], "json")
+
+        assert targets == []
+
+    def test_incremental_missing_json_output_uses_cached_page_artifact(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing unchanged page JSON can be restored without recomputing page JSON."""
+        output_dir = tmp_path / "public"
+        (output_dir / "unchanged").mkdir(parents=True)
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        page = self._create_mock_page(
+            title="Unchanged",
+            url="/unchanged/",
+            content="Unchanged",
+            output_path=output_dir / "unchanged/index.html",
+        )
+        page.source_path = Path("content/unchanged.md")
+        mock_site.pages = [page]
+        cache = BuildCache(site_root=tmp_path)
+        record = _artifact_record("content/unchanged.md")
+        record["json_output_path"] = str(output_dir / "unchanged/index.json")
+        record["full_json_data"] = {"url": "/unchanged/", "title": "Cached"}
+        cache.page_artifacts["content/unchanged.md"] = record
+        build_context = SimpleNamespace(
+            incremental=True,
+            cache=cache,
+            stats=BuildStats(),
+            has_accumulated_page_data=False,
+            get_accumulated_page_data=list,
+        )
+        generator = OutputFormatsGenerator(
+            mock_site,
+            {"enabled": True, "per_page": ["json"], "site_wide": []},
+            build_context=build_context,
+        )
+
+        with patch(
+            "bengal.postprocess.output_formats.json_generator.PageJSONGenerator.page_to_json",
+            side_effect=AssertionError("should use cached artifact"),
+        ):
+            generator.generate()
+
+        content = (output_dir / "unchanged/index.json").read_text(encoding="utf-8")
+        assert '"title":"Cached"' in content
 
     def test_empty_config_uses_all_defaults(self, tmp_path: Path) -> None:
         """Empty config dict should use all defaults."""

--- a/tests/unit/postprocess/test_output_formats_config.py
+++ b/tests/unit/postprocess/test_output_formats_config.py
@@ -674,6 +674,56 @@ class TestConfigNormalizationEdgeCases:
         assert result == output_dir / "index.json"
         assert stats.postprocess_output_timings_ms["site_index_json"] == 0.0
 
+    def test_site_wide_fingerprint_reuses_prior_page_hashes(self, tmp_path: Path) -> None:
+        """Unchanged pages reuse small per-page hashes instead of rehashing artifacts."""
+        output_dir = tmp_path / "public"
+        output_dir.mkdir()
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        page_a = self._create_mock_page(
+            title="A",
+            url="/a/",
+            content="A",
+            output_path=output_dir / "a/index.html",
+        )
+        page_b = self._create_mock_page(
+            title="B",
+            url="/b/",
+            content="B",
+            output_path=output_dir / "b/index.html",
+        )
+        page_a.source_path = Path("content/a.md")
+        page_b.source_path = Path("content/b.md")
+        cache = BuildCache(site_root=tmp_path)
+        cache.output_format_fingerprints["site_index_json:page_hashes"] = '{"content/a.md":"old-a"}'
+        build_context = SimpleNamespace(
+            incremental=True,
+            cache=cache,
+            stats=BuildStats(),
+            pages_to_build=[page_b],
+        )
+        generator = OutputFormatsGenerator(
+            mock_site, {"enabled": True}, build_context=build_context
+        )
+        data = [
+            _accumulated_page_data(Path("content/a.md"), "/a/"),
+            _accumulated_page_data(Path("content/b.md"), "/b/"),
+        ]
+
+        with patch(
+            "bengal.postprocess.output_formats._fingerprint_page_artifact",
+            return_value={"uri": "/b/"},
+        ) as fingerprint_page:
+            fingerprint = generator._site_wide_input_fingerprint(
+                "site_index_json", [page_a, page_b], data, {"json_indent": None}
+            )
+
+        assert fingerprint is not None
+        fingerprint_page.assert_called_once()
+        assert generator._pending_site_wide_page_hashes["site_index_json"]["content/a.md"] == (
+            "old-a"
+        )
+        assert "content/b.md" in generator._pending_site_wide_page_hashes["site_index_json"]
+
     def test_changelog_site_wide_generation_does_not_skip_on_matching_fingerprint(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/postprocess/test_output_formats_config.py
+++ b/tests/unit/postprocess/test_output_formats_config.py
@@ -236,6 +236,76 @@ class TestConfigNormalizationEdgeCases:
 
         assert targets == []
 
+    def test_graph_data_provider_not_called_when_json_outputs_are_unchanged(
+        self, tmp_path: Path
+    ) -> None:
+        """No-op incremental JSON generation does not build graph data first."""
+        output_dir = tmp_path / "public"
+        (output_dir / "page").mkdir(parents=True)
+        (output_dir / "page/index.json").write_text("{}", encoding="utf-8")
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        page = self._create_mock_page(
+            title="Page",
+            url="/page/",
+            content="Page",
+            output_path=output_dir / "page/index.html",
+        )
+        page.source_path = Path("content/page.md")
+        mock_site.pages = [page]
+        build_context = SimpleNamespace(
+            incremental=True,
+            cache=BuildCache(site_root=tmp_path),
+            stats=BuildStats(),
+            has_accumulated_page_data=False,
+            get_accumulated_page_data=list,
+        )
+        provider = Mock(side_effect=AssertionError("graph should stay lazy"))
+        generator = OutputFormatsGenerator(
+            mock_site,
+            {"enabled": True, "per_page": ["json"], "site_wide": []},
+            graph_data_provider=provider,
+            build_context=build_context,
+        )
+
+        generator.generate()
+
+        provider.assert_not_called()
+        assert "graph data" not in build_context.stats.postprocess_task_timings_ms
+
+    def test_graph_data_provider_called_when_json_output_writes(self, tmp_path: Path) -> None:
+        """Changed page JSON still receives graph data when graph connections are enabled."""
+        output_dir = tmp_path / "public"
+        output_dir.mkdir()
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        page = self._create_mock_page(
+            title="Page",
+            url="/page/",
+            content="Page",
+            output_path=output_dir / "page/index.html",
+        )
+        page.source_path = Path("content/page.md")
+        mock_site.pages = [page]
+        build_context = SimpleNamespace(
+            incremental=True,
+            cache=BuildCache(site_root=tmp_path),
+            stats=BuildStats(),
+            pages_to_build=[page],
+            has_accumulated_page_data=False,
+            get_accumulated_page_data=list,
+        )
+        provider = Mock(return_value={"nodes": [], "edges": []})
+        generator = OutputFormatsGenerator(
+            mock_site,
+            {"enabled": True, "per_page": ["json"], "site_wide": []},
+            graph_data_provider=provider,
+            build_context=build_context,
+        )
+
+        generator.generate()
+
+        provider.assert_called_once_with()
+        assert "graph data" in build_context.stats.postprocess_task_timings_ms
+
     def test_incremental_missing_json_output_uses_cached_page_artifact(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/postprocess/test_output_formats_config.py
+++ b/tests/unit/postprocess/test_output_formats_config.py
@@ -168,6 +168,49 @@ class TestConfigNormalizationEdgeCases:
         # llm_txt was not explicitly set, so it should not be added
         # (because we're in simple config mode and json key was present)
 
+    def test_incremental_per_page_outputs_are_changed_page_scoped(self, tmp_path: Path) -> None:
+        """Incremental per-page outputs only regenerate changed or missing companions."""
+        output_dir = tmp_path / "public"
+        output_dir.mkdir()
+
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        unchanged = self._create_mock_page(
+            title="Unchanged",
+            url="/unchanged/",
+            content="Old content",
+            output_path=output_dir / "unchanged/index.html",
+        )
+        unchanged.source_path = Path("content/unchanged.md")
+        changed = self._create_mock_page(
+            title="Changed",
+            url="/changed/",
+            content="New content",
+            output_path=output_dir / "changed/index.html",
+        )
+        changed.source_path = Path("content/changed.md")
+        mock_site.pages = [unchanged, changed]
+
+        (output_dir / "unchanged").mkdir()
+        unchanged_json = output_dir / "unchanged/index.json"
+        unchanged_json.write_text("old-json", encoding="utf-8")
+
+        ctx = Mock()
+        ctx.incremental = True
+        ctx.config_changed = False
+        ctx.pages_to_build = [changed]
+        ctx.changed_page_paths = {changed.source_path}
+        ctx.has_accumulated_page_data = False
+        ctx.get_accumulated_page_data.return_value = []
+        ctx.stats = BuildStats()
+        ctx.cache = None
+
+        config = {"enabled": True, "per_page": ["json"], "site_wide": []}
+        generator = OutputFormatsGenerator(mock_site, config, build_context=ctx)
+        generator.generate()
+
+        assert unchanged_json.read_text(encoding="utf-8") == "old-json"
+        assert (output_dir / "changed/index.json").exists()
+
     def test_empty_config_uses_all_defaults(self, tmp_path: Path) -> None:
         """Empty config dict should use all defaults."""
         output_dir = tmp_path / "public"

--- a/tests/unit/postprocess/test_output_formats_config.py
+++ b/tests/unit/postprocess/test_output_formats_config.py
@@ -493,6 +493,76 @@ class TestConfigNormalizationEdgeCases:
         assert index_path.read_text(encoding="utf-8") == "sentinel"
         assert build_context.stats.postprocess_output_timings_ms["site_index_json"] == 0.0
 
+    def test_incremental_search_backend_skips_when_input_fingerprint_matches(
+        self, tmp_path: Path
+    ) -> None:
+        """Derived search backend artifacts skip when aggregate inputs are unchanged."""
+        output_dir = tmp_path / "public"
+        output_dir.mkdir()
+        index_path = output_dir / "index.json"
+        search_path = output_dir / "search-index.json"
+        index_path.write_text("sentinel", encoding="utf-8")
+        search_path.write_text("search", encoding="utf-8")
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        page = self._create_mock_page(
+            title="Unchanged",
+            url="/unchanged/",
+            content="Unchanged",
+            output_path=output_dir / "unchanged/index.html",
+        )
+        page.source_path = Path("content/unchanged.md")
+        mock_site.pages = [page]
+        cache = BuildCache(site_root=tmp_path)
+        cache.page_artifacts["content/unchanged.md"] = _artifact_record("content/unchanged.md")
+        stats = BuildStats()
+        build_context = SimpleNamespace(
+            incremental=True,
+            cache=cache,
+            stats=stats,
+            has_accumulated_page_data=False,
+            get_accumulated_page_data=list,
+        )
+        generator = OutputFormatsGenerator(
+            mock_site,
+            {"enabled": True, "per_page": [], "site_wide": ["index_json"]},
+            build_context=build_context,
+        )
+        cached_data = generator._merge_cached_page_artifacts([page], [])
+        index_fingerprint = generator._site_wide_input_fingerprint(
+            "site_index_json",
+            [page],
+            cached_data,
+            {
+                "excerpt_length": 200,
+                "json_indent": None,
+                "include_full_content": False,
+            },
+        )
+        assert index_fingerprint is not None
+        search_backend_config = type(
+            "SearchConfig",
+            (),
+            {"enabled": True, "prebuilt_enabled": True, "backend": "lunr", "lunr": {}},
+        )()
+        search_fingerprint = generator._site_wide_input_fingerprint(
+            "site_lunr_index",
+            [page],
+            cached_data,
+            generator._search_backend_fingerprint_options(search_backend_config, [index_path]),
+        )
+        assert search_fingerprint is not None
+        cache.output_format_fingerprints["site_index_json"] = index_fingerprint
+        cache.output_format_fingerprints["site_lunr_index"] = search_fingerprint
+
+        with patch(
+            "bengal.postprocess.search_backends.LunrSearchBackend.generate",
+            side_effect=AssertionError("search backend should skip"),
+        ):
+            generator.generate()
+
+        assert stats.postprocess_output_timings_ms["site_lunr_index"] == 0.0
+        assert search_path.read_text(encoding="utf-8") == "search"
+
     def test_site_wide_generation_skips_when_input_fingerprint_matches(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/postprocess/test_output_formats_llm.py
+++ b/tests/unit/postprocess/test_output_formats_llm.py
@@ -377,6 +377,31 @@ class TestSiteWideLLMFullGeneration:
         assert "## Page 2/3:" in content
         assert "## Page 3/3:" in content
 
+    def test_llm_full_regenerates_when_emitted_metadata_changes(self, tmp_path):
+        """llm-full.txt hash includes metadata that affects emitted content."""
+        output_dir = tmp_path / "public"
+        output_dir.mkdir()
+
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        page = self._create_mock_page(
+            "Original Title",
+            "/test/",
+            "Unchanged plain text",
+            output_dir / "test/index.html",
+        )
+        mock_site.pages = [page]
+
+        config = {"enabled": True, "per_page": [], "site_wide": ["llm_full"]}
+        generator = OutputFormatsGenerator(mock_site, config)
+        generator.generate()
+
+        page.title = "Updated Title"
+        generator.generate()
+
+        content = (output_dir / "llm-full.txt").read_text()
+        assert "Updated Title" in content
+        assert "Original Title" not in content
+
     def test_llm_full_disabled_by_config(self, tmp_path):
         """Test that llm-full.txt is not generated when disabled."""
         output_dir = tmp_path / "public"

--- a/tests/unit/postprocess/test_postprocess_timings.py
+++ b/tests/unit/postprocess/test_postprocess_timings.py
@@ -25,6 +25,39 @@ def test_postprocess_records_sequential_task_timings(monkeypatch) -> None:
     assert "special pages" in stats.postprocess_task_timings_ms
 
 
+def test_postprocess_sequential_failure_emits_failed_line(monkeypatch) -> None:
+    site = SimpleNamespace(
+        config={
+            "output_formats": {"enabled": False},
+            "generate_sitemap": False,
+            "content_signals": {"enabled": False},
+        },
+    )
+    orchestrator = PostprocessOrchestrator(site)
+    emitted: list[tuple[str, str, float]] = []
+    monkeypatch.setattr("bengal.orchestration.postprocess._emit_task_started", lambda _name: None)
+    monkeypatch.setattr(
+        "bengal.orchestration.postprocess._emit_task_finished",
+        lambda name, duration: emitted.append(("finished", name, duration)),
+    )
+    monkeypatch.setattr(
+        "bengal.orchestration.postprocess._emit_task_failed",
+        lambda name, duration: emitted.append(("failed", name, duration)),
+    )
+    monkeypatch.setattr(
+        "bengal.orchestration.postprocess._emit_postprocess_line", lambda _msg: None
+    )
+    monkeypatch.setattr(
+        orchestrator,
+        "_generate_special_pages",
+        lambda _ctx=None: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    orchestrator.run(parallel=False, incremental=True)
+
+    assert [(kind, name) for kind, name, _duration in emitted] == [("failed", "special pages")]
+
+
 def test_postprocess_records_parallel_task_timings(monkeypatch) -> None:
     site = SimpleNamespace(
         config={
@@ -42,3 +75,40 @@ def test_postprocess_records_parallel_task_timings(monkeypatch) -> None:
     orchestrator.run(parallel=True, build_context=ctx, incremental=True)
 
     assert set(stats.postprocess_task_timings_ms) == {"special pages", "sitemap"}
+
+
+def test_postprocess_parallel_failure_emits_failed_line(monkeypatch) -> None:
+    site = SimpleNamespace(
+        config={
+            "output_formats": {"enabled": False},
+            "generate_sitemap": True,
+            "content_signals": {"enabled": False},
+        },
+    )
+    orchestrator = PostprocessOrchestrator(site)
+    emitted: list[tuple[str, str, float]] = []
+    monkeypatch.setattr("bengal.orchestration.postprocess._emit_task_started", lambda _name: None)
+    monkeypatch.setattr(
+        "bengal.orchestration.postprocess._emit_task_finished",
+        lambda name, duration: emitted.append(("finished", name, duration)),
+    )
+    monkeypatch.setattr(
+        "bengal.orchestration.postprocess._emit_task_failed",
+        lambda name, duration: emitted.append(("failed", name, duration)),
+    )
+    monkeypatch.setattr(
+        "bengal.orchestration.postprocess._emit_postprocess_line", lambda _msg: None
+    )
+    monkeypatch.setattr(orchestrator, "_generate_special_pages", lambda _ctx=None: None)
+    monkeypatch.setattr(
+        orchestrator,
+        "_generate_sitemap",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    orchestrator.run(parallel=True, incremental=True)
+
+    emitted_kinds = {(kind, name) for kind, name, _duration in emitted}
+    assert ("finished", "special pages") in emitted_kinds
+    assert ("failed", "sitemap") in emitted_kinds
+    assert ("finished", "sitemap") not in emitted_kinds

--- a/tests/unit/postprocess/test_postprocess_timings.py
+++ b/tests/unit/postprocess/test_postprocess_timings.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bengal.orchestration.build_context import BuildContext
+from bengal.orchestration.postprocess import PostprocessOrchestrator
+from bengal.orchestration.stats import BuildStats
+
+
+def test_postprocess_records_sequential_task_timings(monkeypatch) -> None:
+    site = SimpleNamespace(
+        config={
+            "output_formats": {"enabled": False},
+            "generate_sitemap": False,
+            "content_signals": {"enabled": False},
+        },
+    )
+    stats = BuildStats()
+    ctx = BuildContext(stats=stats)
+    orchestrator = PostprocessOrchestrator(site)
+    monkeypatch.setattr(orchestrator, "_generate_special_pages", lambda _ctx=None: None)
+
+    orchestrator.run(parallel=False, build_context=ctx, incremental=True)
+
+    assert "special pages" in stats.postprocess_task_timings_ms
+
+
+def test_postprocess_records_parallel_task_timings(monkeypatch) -> None:
+    site = SimpleNamespace(
+        config={
+            "output_formats": {"enabled": False},
+            "generate_sitemap": True,
+            "content_signals": {"enabled": False},
+        },
+    )
+    stats = BuildStats()
+    ctx = BuildContext(stats=stats)
+    orchestrator = PostprocessOrchestrator(site)
+    monkeypatch.setattr(orchestrator, "_generate_special_pages", lambda _ctx=None: None)
+    monkeypatch.setattr(orchestrator, "_generate_sitemap", lambda: None)
+
+    orchestrator.run(parallel=True, build_context=ctx, incremental=True)
+
+    assert set(stats.postprocess_task_timings_ms) == {"special pages", "sitemap"}

--- a/tests/unit/rendering/test_asset_audit.py
+++ b/tests/unit/rendering/test_asset_audit.py
@@ -66,3 +66,19 @@ def test_ignores_non_string_baseurl_from_loose_test_doubles(tmp_path) -> None:
     missing = find_missing_local_asset_references(output, baseurl=object())
 
     assert missing == []
+
+
+def test_can_scope_audit_to_changed_html_paths(tmp_path) -> None:
+    output = tmp_path / "public"
+    (output / "docs").mkdir(parents=True)
+    (output / "blog").mkdir(parents=True)
+    (output / "docs" / "index.html").write_text(
+        '<link rel="stylesheet" href="/assets/missing.css">',
+        encoding="utf-8",
+    )
+    changed = output / "blog" / "index.html"
+    changed.write_text("<p>No assets here</p>", encoding="utf-8")
+
+    missing = find_missing_local_asset_references(output, html_paths=[changed])
+
+    assert missing == []

--- a/tests/unit/rendering/test_page_artifact.py
+++ b/tests/unit/rendering/test_page_artifact.py
@@ -1,0 +1,90 @@
+"""Tests for immutable rendering page artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from bengal.orchestration.build_context import AccumulatedPageData, BuildContext
+from bengal.rendering.page_artifact import PageArtifact
+
+
+def test_page_artifact_freezes_and_sanitizes_accumulated_data(tmp_path: Path) -> None:
+    """PageArtifact snapshots mutable accumulated data into a frozen record."""
+    data = _accumulated_page_data()
+    data.raw_metadata["path"] = tmp_path / "source.md"
+    data.full_json_data = {
+        "url": "/docs/",
+        "empty_list": [],
+        "updated": datetime(2026, 5, 3, 12, 0, 0),
+    }
+
+    artifact = PageArtifact.from_accumulated(data, frozenset({"intro"}))
+    data.title = "Mutated"
+    data.raw_metadata["path"] = "changed"
+
+    assert artifact.title == "Docs"
+    assert artifact.anchors == ("intro",)
+    assert artifact.to_cache_record()["raw_metadata"]["path"] == str(tmp_path / "source.md")
+    assert artifact.to_cache_record()["full_json_data"]["empty_list"] == []
+    assert artifact.to_cache_record()["full_json_data"]["updated"] == "2026-05-03T12:00:00"
+    attr = "title"
+    with pytest.raises(FrozenInstanceError):
+        setattr(artifact, attr, "Nope")
+
+
+def test_page_artifact_round_trips_cache_record_to_accumulated() -> None:
+    """Cached artifact records can rehydrate the legacy accumulated shape."""
+    original = PageArtifact.from_accumulated(_accumulated_page_data(), frozenset({"intro"}))
+
+    restored = PageArtifact.from_cache_record(original.to_cache_record()).to_accumulated(
+        AccumulatedPageData
+    )
+
+    assert restored.source_path == Path("content/docs.md")
+    assert restored.title == "Docs"
+    assert restored.tags == ["guide"]
+    assert restored.full_json_data == {"url": "/docs/", "chunks": []}
+
+
+def test_build_context_exposes_frozen_page_artifacts() -> None:
+    """BuildContext keeps the compatibility data and a frozen artifact copy."""
+    ctx = BuildContext(site=SimpleNamespace())
+    data = _accumulated_page_data()
+
+    ctx.accumulate_page_data(data)
+    data.title = "Mutated"
+
+    assert ctx.get_accumulated_page_data()[0].title == "Mutated"
+    artifact = ctx.get_page_artifacts()[0]
+    assert artifact.title == "Docs"
+    assert ctx.get_artifact_for_page(Path("content/docs.md")) == artifact
+
+
+def _accumulated_page_data() -> AccumulatedPageData:
+    return AccumulatedPageData(
+        source_path=Path("content/docs.md"),
+        url="/docs/",
+        uri="/docs/",
+        title="Docs",
+        description="Docs page",
+        date=None,
+        date_iso=None,
+        plain_text="Docs body",
+        excerpt="Docs",
+        content_preview="Docs body",
+        word_count=2,
+        reading_time=1,
+        section="Docs",
+        tags=["guide"],
+        dir="/docs/",
+        enhanced_metadata={"type": "guide"},
+        is_autodoc=False,
+        full_json_data={"url": "/docs/", "chunks": []},
+        json_output_path=Path("public/docs/index.json"),
+        raw_metadata={"description": "Docs page"},
+    )

--- a/tests/unit/server/test_asgi_app.py
+++ b/tests/unit/server/test_asgi_app.py
@@ -153,6 +153,45 @@ async def test_build_in_progress_missing_file_returns_404(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_build_in_progress_missing_deferred_artifact_returns_503(tmp_path: Path) -> None:
+    """Known generated artifacts should say they are still being prepared."""
+    app = create_bengal_dev_app(
+        output_dir=tmp_path,
+        build_in_progress=lambda: True,
+    )
+    sent, send = _make_send_capture()
+
+    await app(
+        scope={"type": "http", "method": "GET", "path": "/index.json"},
+        receive=_noop_receive,
+        send=send,
+    )
+
+    assert sent[0]["status"] == 503
+    assert any(h[0] == b"retry-after" and h[1] == b"1" for h in sent[0]["headers"])
+    assert b"still being prepared" in sent[1]["body"]
+
+
+@pytest.mark.asyncio
+async def test_missing_deferred_artifact_returns_404_when_not_building(tmp_path: Path) -> None:
+    """Deferred artifact handling is only active during a build."""
+    app = create_bengal_dev_app(
+        output_dir=tmp_path,
+        build_in_progress=lambda: False,
+    )
+    sent, send = _make_send_capture()
+
+    await app(
+        scope={"type": "http", "method": "GET", "path": "/docs/v1/search-index.json"},
+        receive=_noop_receive,
+        send=send,
+    )
+
+    assert sent[0]["status"] == 404
+    assert sent[1]["body"] == b"Not Found"
+
+
+@pytest.mark.asyncio
 async def test_build_in_progress_404_html_gets_badge(tmp_path: Path) -> None:
     """When build in progress and 404.html exists, serve it with rebuilding badge."""
     (tmp_path / "404.html").write_text("<html><body>Custom 404</body></html>")

--- a/tests/unit/server/test_buffer_manager.py
+++ b/tests/unit/server/test_buffer_manager.py
@@ -139,6 +139,41 @@ class TestBufferManager:
 
         assert (staging / "keep.html").exists()
 
+    def test_prepare_delta_staging_syncs_changed_files(self, mgr: BufferManager) -> None:
+        active = mgr.active_dir
+        staging = mgr.staging_dir
+        (active / "index.html").write_text("<html>v2</html>")
+        (active / "unchanged.html").write_text("<html>same</html>")
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "index.html").write_text("<html>v1</html>")
+        (staging / "unchanged.html").write_text("<html>same</html>")
+
+        result = mgr.prepare_delta_staging([Path("index.html")])
+
+        assert result == staging
+        assert (staging / "index.html").read_text() == "<html>v2</html>"
+        assert (staging / "unchanged.html").read_text() == "<html>same</html>"
+        assert (active / "index.html").stat().st_ino == (staging / "index.html").stat().st_ino
+
+    def test_prepare_delta_staging_removes_missing_outputs(self, mgr: BufferManager) -> None:
+        active = mgr.active_dir
+        staging = mgr.staging_dir
+        (active / "index.html").write_text("<html>keep</html>")
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "stale.html").write_text("<html>old</html>")
+
+        mgr.prepare_delta_staging([Path("stale.html")])
+
+        assert not (staging / "stale.html").exists()
+
+    def test_prepare_delta_staging_falls_back_when_staging_empty(self, mgr: BufferManager) -> None:
+        active = mgr.active_dir
+        (active / "index.html").write_text("<html>seeded</html>")
+
+        staging = mgr.prepare_delta_staging([Path("index.html")])
+
+        assert (staging / "index.html").read_text() == "<html>seeded</html>"
+
     def test_full_cycle(self, mgr: BufferManager) -> None:
         """Simulate: build to staging, swap, build again to new staging.
 

--- a/tests/unit/server/test_build_executor.py
+++ b/tests/unit/server/test_build_executor.py
@@ -88,6 +88,7 @@ class TestBuildResult:
         assert result.build_time_ms == 1234.5
         assert result.error_message is None
         assert result.changed_outputs == ()
+        assert result.completion_policy == "complete"
 
     def test_creation_with_failure(self) -> None:
         """Test that BuildResult can be created for failure."""
@@ -101,6 +102,7 @@ class TestBuildResult:
         assert result.success is False
         assert result.pages_built == 0
         assert result.error_message == "Build failed: missing config"
+        assert result.completion_policy == "complete"
 
     def test_is_frozen(self) -> None:
         """Test that BuildResult is immutable."""

--- a/tests/unit/server/test_build_trigger.py
+++ b/tests/unit/server/test_build_trigger.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bengal.cache import BuildCache
+from bengal.orchestration.build.options import BuildCompletionPolicy
 from bengal.orchestration.stats import ReloadHint
 from bengal.server.build_trigger import BuildTrigger
 from bengal.server.reload_types import BuildReloadInfo, SerializedOutputRecord
@@ -716,6 +717,7 @@ class TestBuildTriggerIntegration:
         mock_site.build.assert_called_once()
         build_opts = mock_site.build.call_args[1]["options"]
         assert Path("test.md") in build_opts.changed_sources
+        assert build_opts.completion_policy is BuildCompletionPolicy.SERVE_READY
 
 
 class TestBuildTriggerCaching:

--- a/tests/unit/server/test_build_trigger.py
+++ b/tests/unit/server/test_build_trigger.py
@@ -53,6 +53,21 @@ class TestBuildTrigger:
         assert trigger.host == "localhost"
         assert trigger.port == 5173
         assert trigger._executor is mock_executor
+        assert trigger.completion_policy is BuildCompletionPolicy.SERVE_READY
+
+    def test_init_with_completion_policy(
+        self, mock_site: MagicMock, mock_executor: MagicMock
+    ) -> None:
+        """Test BuildTrigger initialization with complete rebuild policy."""
+        trigger = BuildTrigger(
+            site=mock_site,
+            host="localhost",
+            port=5173,
+            executor=mock_executor,
+            completion_policy=BuildCompletionPolicy.COMPLETE,
+        )
+
+        assert trigger.completion_policy is BuildCompletionPolicy.COMPLETE
 
     def test_skips_content_hash_baseline_for_typed_watcher_rebuild(
         self, mock_site: MagicMock, mock_executor: MagicMock
@@ -718,6 +733,48 @@ class TestBuildTriggerIntegration:
         build_opts = mock_site.build.call_args[1]["options"]
         assert Path("test.md") in build_opts.changed_sources
         assert build_opts.completion_policy is BuildCompletionPolicy.SERVE_READY
+
+    @patch("bengal.server.build_trigger.run_pre_build_hooks")
+    @patch("bengal.server.build_trigger.run_post_build_hooks")
+    @patch("bengal.server.build_trigger.show_building_indicator")
+    @patch("bengal.server.build_trigger.get_cli_output")
+    @patch("bengal.server.build_trigger.display_build_stats")
+    @patch("bengal.server.build_trigger.default_reload_controller")
+    @patch("bengal.server.live_reload.notification.send_reload_payload")
+    def test_trigger_build_uses_configured_completion_policy(
+        self,
+        mock_send_reload: MagicMock,
+        mock_controller: MagicMock,
+        mock_display: MagicMock,
+        mock_cli: MagicMock,
+        mock_building: MagicMock,
+        mock_post_hooks: MagicMock,
+        mock_pre_hooks: MagicMock,
+        mock_site: MagicMock,
+        mock_executor: MagicMock,
+    ) -> None:
+        """Watched builds should honor the dev server completion policy."""
+        mock_pre_hooks.return_value = True
+        mock_post_hooks.return_value = True
+
+        mock_stats = MagicMock()
+        mock_stats.total_pages = 5
+        mock_stats.changed_outputs = []
+        mock_site.build.return_value = mock_stats
+
+        trigger = BuildTrigger(
+            site=mock_site,
+            executor=mock_executor,
+            completion_policy=BuildCompletionPolicy.COMPLETE,
+        )
+
+        trigger.trigger_build(
+            changed_paths={Path("test.md")},
+            event_types={"modified"},
+        )
+
+        build_opts = mock_site.build.call_args[1]["options"]
+        assert build_opts.completion_policy is BuildCompletionPolicy.COMPLETE
 
 
 class TestBuildTriggerCaching:

--- a/tests/unit/server/test_build_trigger.py
+++ b/tests/unit/server/test_build_trigger.py
@@ -53,6 +53,17 @@ class TestBuildTrigger:
         assert trigger.port == 5173
         assert trigger._executor is mock_executor
 
+    def test_skips_content_hash_baseline_for_typed_watcher_rebuild(
+        self, mock_site: MagicMock, mock_executor: MagicMock
+    ) -> None:
+        """Normal watcher rebuilds use typed outputs instead of pre-build tree scans."""
+        controller = MagicMock()
+        controller._use_content_hashes = True
+        trigger = BuildTrigger(site=mock_site, executor=mock_executor, controller=controller)
+
+        assert trigger._should_capture_content_hash_baseline(["content/page.md"]) is False
+        assert trigger._should_capture_content_hash_baseline([]) is True
+
     def test_openapi_ref_dependency_triggers_autodoc_regeneration(
         self, mock_executor: MagicMock, tmp_path: Path
     ) -> None:

--- a/tests/unit/server/test_css_only_reload.py
+++ b/tests/unit/server/test_css_only_reload.py
@@ -168,3 +168,89 @@ def test_mixed_change_triggers_full_reload(
     assert call_args[0][1] == "source-change"
 
     trigger.shutdown()
+
+
+def test_static_css_modified_uses_direct_fast_path(
+    mock_site: MagicMock,
+    mock_executor: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Static CSS edits copy directly to output and request CSS reload."""
+    source = tmp_path / "static" / "styles" / "site.css"
+    output = tmp_path / "public" / "styles" / "site.css"
+    source.parent.mkdir(parents=True)
+    output.parent.mkdir(parents=True)
+    source.write_text("body{color:green}")
+    output.write_text("body{color:black}")
+
+    trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+    with (
+        patch.object(trigger, "_handle_reload") as handle_reload,
+        patch.object(trigger, "_clear_html_cache"),
+    ):
+        handled = trigger._try_fast_asset_reload({source}, {"modified"}, {})
+
+    assert handled is True
+    assert output.read_text() == "body{color:green}"
+    handle_reload.assert_called_once()
+    info = handle_reload.call_args.args[0]
+    assert info.reload_hint.value == "css-only"
+    assert info.changed_outputs[0].path == "styles/site.css"
+    assert info.changed_outputs[0].type_value == "css"
+    mock_site.build.assert_not_called()
+
+    trigger.shutdown()
+
+
+def test_static_fast_path_requires_existing_output(
+    mock_site: MagicMock,
+    mock_executor: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """New static files fall back so the normal build owns structural output."""
+    source = tmp_path / "static" / "styles" / "site.css"
+    source.parent.mkdir(parents=True)
+    source.write_text("body{color:green}")
+
+    trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+    with patch.object(trigger, "_handle_reload") as handle_reload:
+        handled = trigger._try_fast_asset_reload({source}, {"modified"}, {})
+
+    assert handled is False
+    handle_reload.assert_not_called()
+
+    trigger.shutdown()
+
+
+def test_site_asset_fast_path_respects_fingerprinted_assets(
+    mock_site: MagicMock,
+    mock_executor: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Default fingerprinted assets fall back to preserve manifest semantics."""
+    source = tmp_path / "assets" / "images" / "logo.svg"
+    output = tmp_path / "public" / "assets" / "images" / "logo.svg"
+    source.parent.mkdir(parents=True)
+    output.parent.mkdir(parents=True)
+    source.write_text("<svg><circle r='2'/></svg>")
+    output.write_text("<svg><circle r='1'/></svg>")
+
+    asset = MagicMock()
+    asset.source_path = source
+    asset.is_css_entry_point.return_value = False
+    asset.is_css_module.return_value = False
+    asset.standalone = False
+    mock_site.assets = [asset]
+
+    trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+    with patch.object(trigger, "_handle_reload") as handle_reload:
+        handled = trigger._try_fast_asset_reload({source}, {"modified"}, {})
+
+    assert handled is False
+    assert output.read_text() == "<svg><circle r='1'/></svg>"
+    handle_reload.assert_not_called()
+
+    trigger.shutdown()

--- a/tests/unit/server/test_dev_server_live_reload.py
+++ b/tests/unit/server/test_dev_server_live_reload.py
@@ -17,6 +17,7 @@ import pytest
 
 from bengal.assets.manifest import AssetManifest
 from bengal.orchestration.build.options import BuildCompletionPolicy
+from bengal.server.build_state import build_state
 from bengal.server.dev_server import DevServer
 from bengal.utils.observability.profile import BuildProfile
 from bengal.utils.stats_minimal import MinimalStats
@@ -109,6 +110,7 @@ class TestDevServerContentHashCacheSeeding:
             thread.join(timeout=2)
 
         assert not thread.is_alive()
+        assert build_state.get_build_in_progress() is False
         build_opts = mock_build.call_args.args[0]
         assert build_opts.completion_policy is BuildCompletionPolicy.COMPLETE
         mock_watcher.start.assert_called_once()

--- a/tests/unit/server/test_dev_server_live_reload.py
+++ b/tests/unit/server/test_dev_server_live_reload.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 import errno
 import socket
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from bengal.assets.manifest import AssetManifest
+from bengal.orchestration.build.options import BuildCompletionPolicy
 from bengal.server.dev_server import DevServer
+from bengal.utils.observability.profile import BuildProfile
+from bengal.utils.stats_minimal import MinimalStats
 
 
 class TestDevServerContentHashCacheSeeding:
@@ -42,6 +45,7 @@ class TestDevServerContentHashCacheSeeding:
             patch.object(DevServer, "_create_server") as mock_create,
             patch.object(DevServer, "_create_watcher") as mock_create_watcher,
             patch.object(DevServer, "_init_reload_controller"),
+            patch.object(DevServer, "_start_background_completion_build") as mock_background,
             patch(
                 "bengal.server.dev_server.PIDManager.get_pid_file", return_value=tmp_path / "pid"
             ),
@@ -70,6 +74,44 @@ class TestDevServerContentHashCacheSeeding:
             assert call_args == list(site.pages), (
                 "seed_content_hash_cache should be called with list(site.pages)"
             )
+            mock_background.assert_called_once_with(
+                ANY,
+                watcher_runner=mock_watcher,
+            )
+            mock_watcher.start.assert_not_called()
+
+    def test_background_completion_runs_complete_policy_then_starts_watcher(
+        self, tmp_path: Path
+    ) -> None:
+        """Background completion should finish deferred work before watching edits."""
+        site = MagicMock()
+        site.root_path = tmp_path
+        site.output_dir = tmp_path / "public"
+        site.output_dir.mkdir()
+        site.config = {}
+        site.pages = []
+        mock_watcher = MagicMock()
+        stats = MinimalStats(total_pages=1, build_time_ms=10.0, incremental=True)
+
+        server = DevServer(site, watch=False, auto_port=False)
+
+        with (
+            patch.object(server, "_run_build_via_executor", return_value=stats) as mock_build,
+            patch.object(server, "_clear_html_cache_after_build"),
+            patch.object(server, "_set_active_palette"),
+            patch.object(server, "_init_reload_controller"),
+            patch("bengal.server.dev_server.display_build_stats"),
+        ):
+            thread = server._start_background_completion_build(
+                BuildProfile.WRITER,
+                watcher_runner=mock_watcher,
+            )
+            thread.join(timeout=2)
+
+        assert not thread.is_alive()
+        build_opts = mock_build.call_args.args[0]
+        assert build_opts.completion_policy is BuildCompletionPolicy.COMPLETE
+        mock_watcher.start.assert_called_once()
 
 
 class TestDevServerServeFirstWatcherOrder:

--- a/tests/unit/server/test_dev_server_live_reload.py
+++ b/tests/unit/server/test_dev_server_live_reload.py
@@ -219,6 +219,50 @@ class TestDevServerServeFirstWatcherOrder:
             mock_watcher.start.assert_called_once()
             mock_build_trigger.seed_content_hash_cache.assert_called_once()
 
+    def test_complete_policy_does_not_serve_cached_output_first(self, tmp_path: Path) -> None:
+        """Complete mode should block on an initial complete build even with cache."""
+        site = MagicMock()
+        site.root_path = tmp_path
+        site.output_dir = tmp_path / "public"
+        site.output_dir.mkdir()
+        site.config = {}
+        site.pages = []
+        stats = MinimalStats(total_pages=1, build_time_ms=10.0, incremental=True)
+
+        with (
+            patch.object(DevServer, "_check_stale_processes"),
+            patch.object(DevServer, "_has_cached_output", return_value=True),
+            patch.object(DevServer, "_prepare_dev_config", return_value=False),
+            patch.object(DevServer, "_run_build_via_executor", return_value=stats) as mock_build,
+            patch.object(DevServer, "_run_validation_build") as mock_validation,
+            patch.object(DevServer, "_create_server") as mock_create,
+            patch.object(DevServer, "_init_reload_controller"),
+            patch(
+                "bengal.server.dev_server.PIDManager.get_pid_file", return_value=tmp_path / "pid"
+            ),
+            patch("bengal.server.dev_server.PIDManager.write_pid_file"),
+            patch("bengal.server.dev_server.ResourceManager") as mock_rm_class,
+        ):
+            mock_backend = MagicMock()
+            mock_backend.port = 5173
+            mock_backend.start.side_effect = KeyboardInterrupt
+            mock_create.return_value = mock_backend
+            mock_rm = MagicMock()
+            mock_rm_class.return_value.__enter__ = MagicMock(return_value=mock_rm)
+            mock_rm_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            server = DevServer(
+                site,
+                watch=False,
+                auto_port=False,
+                completion_policy=BuildCompletionPolicy.COMPLETE,
+            )
+            server.start()
+
+        build_opts = mock_build.call_args.args[0]
+        assert build_opts.completion_policy is BuildCompletionPolicy.COMPLETE
+        mock_validation.assert_not_called()
+
 
 class TestDevServerCachedOutputIntegrity:
     """Tests that serve-first rejects incomplete cached asset trees."""

--- a/tests/unit/server/test_dev_server_live_reload.py
+++ b/tests/unit/server/test_dev_server_live_reload.py
@@ -113,6 +113,7 @@ class TestDevServerContentHashCacheSeeding:
         assert build_state.get_build_in_progress() is False
         build_opts = mock_build.call_args.args[0]
         assert build_opts.completion_policy is BuildCompletionPolicy.COMPLETE
+        assert build_opts.quiet is True
         mock_watcher.start.assert_called_once()
 
     def test_complete_policy_blocks_startup_tail_and_starts_watcher(self, tmp_path: Path) -> None:
@@ -262,6 +263,47 @@ class TestDevServerServeFirstWatcherOrder:
         build_opts = mock_build.call_args.args[0]
         assert build_opts.completion_policy is BuildCompletionPolicy.COMPLETE
         mock_validation.assert_not_called()
+
+
+class TestDevServerRequestLogging:
+    """Tests for serve dashboard request-log filtering."""
+
+    def test_deferred_artifact_requests_are_coalesced(self, tmp_path: Path) -> None:
+        """Deferred artifact polling should not spam scary 503 request lines."""
+        site = MagicMock()
+        site.root_path = tmp_path
+        site.output_dir = tmp_path / "public"
+        site.output_dir.mkdir()
+        site.config = {}
+        cli = MagicMock()
+        cli.icons.success = "✓"
+        cli.icons.info = "·"
+        server = DevServer(site, watch=False, auto_port=False)
+        server._request_callback_holder = [None]
+
+        with (
+            patch("bengal.server.dev_server.get_cli_output", return_value=cli),
+            patch("bengal.utils.dx.collect_hints", return_value=[]),
+        ):
+            server._print_startup_message(5173)
+
+        callback = server._request_callback_holder[0]
+        assert callback is not None
+
+        callback("GET", "/__bengal_reload__", 200, 1.0)
+        callback("GET", "/index.json", 503, 1.0)
+        for _ in range(8):
+            callback("GET", "/docs/page/index.json", 503, 1.0)
+        callback("GET", "/llms.txt", 503, 1.0)
+        callback("GET", "/", 200, 1.0)
+
+        request_calls = cli.http_request.call_args_list
+        assert len(request_calls) == 3
+        assert request_calls[0].args[2] == "PND"
+        assert "generated artifacts still completing" in request_calls[0].args[3]
+        assert request_calls[1].args[2] == "PND"
+        assert "10 requests" in request_calls[1].args[3]
+        assert request_calls[2].args[1:4] == ("GET", "200", "/")
 
 
 class TestDevServerCachedOutputIntegrity:

--- a/tests/unit/server/test_dev_server_live_reload.py
+++ b/tests/unit/server/test_dev_server_live_reload.py
@@ -115,6 +115,55 @@ class TestDevServerContentHashCacheSeeding:
         assert build_opts.completion_policy is BuildCompletionPolicy.COMPLETE
         mock_watcher.start.assert_called_once()
 
+    def test_complete_policy_blocks_startup_tail_and_starts_watcher(self, tmp_path: Path) -> None:
+        """Complete mode should not schedule a serve-ready background tail."""
+        site = MagicMock()
+        site.root_path = tmp_path
+        site.output_dir = tmp_path / "public"
+        site.output_dir.mkdir()
+        site.config = {}
+        site.pages = []
+        mock_watcher = MagicMock()
+        mock_build_trigger = MagicMock()
+        stats = MinimalStats(total_pages=1, build_time_ms=10.0, incremental=True)
+
+        with (
+            patch.object(DevServer, "_check_stale_processes"),
+            patch.object(DevServer, "_has_cached_output", return_value=False),
+            patch.object(DevServer, "_prepare_dev_config", return_value=False),
+            patch.object(DevServer, "_run_build_via_executor", return_value=stats) as mock_build,
+            patch.object(DevServer, "_create_server") as mock_create,
+            patch.object(DevServer, "_create_watcher") as mock_create_watcher,
+            patch.object(DevServer, "_init_reload_controller"),
+            patch.object(DevServer, "_start_background_completion_build") as mock_background,
+            patch(
+                "bengal.server.dev_server.PIDManager.get_pid_file", return_value=tmp_path / "pid"
+            ),
+            patch("bengal.server.dev_server.PIDManager.write_pid_file"),
+            patch("bengal.server.dev_server.ResourceManager") as mock_rm_class,
+        ):
+            mock_create_watcher.return_value = (mock_watcher, mock_build_trigger)
+            mock_backend = MagicMock()
+            mock_backend.port = 5173
+            mock_backend.start.side_effect = KeyboardInterrupt
+            mock_create.return_value = mock_backend
+            mock_rm = MagicMock()
+            mock_rm_class.return_value.__enter__ = MagicMock(return_value=mock_rm)
+            mock_rm_class.return_value.__exit__ = MagicMock(return_value=False)
+
+            server = DevServer(
+                site,
+                watch=True,
+                auto_port=False,
+                completion_policy=BuildCompletionPolicy.COMPLETE,
+            )
+            server.start()
+
+        build_opts = mock_build.call_args.args[0]
+        assert build_opts.completion_policy is BuildCompletionPolicy.COMPLETE
+        mock_background.assert_not_called()
+        mock_watcher.start.assert_called_once()
+
 
 class TestDevServerServeFirstWatcherOrder:
     """Tests that serve-first watcher starts after validation (bug fix)."""

--- a/tests/unit/server/test_reload_controller.py
+++ b/tests/unit/server/test_reload_controller.py
@@ -258,7 +258,7 @@ def test_decide_from_outputs_js_only_triggers_full_reload():
 
 
 def test_decide_from_outputs_xml_sitemap():
-    """XML outputs (sitemap) trigger full reload."""
+    """Aggregate-only postprocess outputs suppress browser reload."""
     ctl = ReloadController(min_notify_interval_ms=0)
 
     outputs = [
@@ -266,8 +266,21 @@ def test_decide_from_outputs_xml_sitemap():
     ]
     decision = ctl.decide_from_outputs(outputs)
 
-    assert decision.action == "reload"
-    assert decision.reason == "content-changed"
+    assert decision.action == "none"
+    assert decision.reason == "aggregate-only"
+
+
+def test_decide_from_outputs_postprocess_html_still_reloads():
+    """Postprocess HTML outputs are visible pages and still reload."""
+    ctl = ReloadController(min_notify_interval_ms=0)
+
+    outputs = [
+        OutputRecord(Path("search/index.html"), OutputType.HTML, "postprocess"),
+    ]
+    decision = ctl.decide_from_outputs(outputs)
+
+    assert decision.action == "reload-page"
+    assert decision.reason == "single-page-content"
 
 
 def test_decide_from_outputs_reload_hint_none_returns_none():

--- a/tests/unit/utils/test_build_stats.py
+++ b/tests/unit/utils/test_build_stats.py
@@ -368,6 +368,35 @@ class TestDisplayFunctions:
 
         reset_cli_output()
 
+    @patch("bengal.orchestration.stats.display.get_cli_output")
+    def test_display_build_stats_uses_recorded_phase_timings(
+        self, mock_cli_class: MagicMock
+    ) -> None:
+        """Build summaries should prefer named phase timings when present."""
+        from bengal.orchestration.stats import BuildStats, display_build_stats
+
+        stats = BuildStats(
+            total_pages=3,
+            regular_pages=3,
+            build_time_ms=1000.0,
+            rendering_time_ms=100.0,
+            postprocess_task_timings_ms={"output formats": 250.0},
+        )
+        stats.record_phase_timing("Discovery", 200.0)
+        stats.record_phase_timing("Rendering", 100.0)
+
+        mock_cli = MagicMock()
+        mock_cli_class.return_value = mock_cli
+
+        display_build_stats(stats)
+
+        ctx = mock_cli.render_write.call_args.kwargs
+        phases = ctx["phases"]
+        assert "Discovery 200 ms" in phases
+        assert "Rendering 100 ms" in phases
+        assert "Slowest post output formats 250 ms" in phases
+        assert "Unaccounted 700 ms" in phases
+
     def test_show_building_indicator_does_nothing(self) -> None:
         """Test show_building_indicator does nothing (header shown elsewhere)."""
         from bengal.orchestration.stats import show_building_indicator

--- a/tests/unit/utils/test_build_stats.py
+++ b/tests/unit/utils/test_build_stats.py
@@ -398,6 +398,23 @@ class TestDisplayFunctions:
         assert "Slowest post output formats 250 ms" in phases
         assert "Unaccounted 700 ms" in phases
 
+    @patch("bengal.orchestration.stats.display.get_cli_output")
+    def test_display_build_stats_labels_serve_ready_as_html_ready(
+        self, mock_cli_class: MagicMock
+    ) -> None:
+        """Serve-ready summaries should not imply full artifact completion."""
+        from bengal.orchestration.stats import BuildStats, display_build_stats
+
+        stats = BuildStats(total_pages=3, regular_pages=3, build_time_ms=1000.0)
+        stats.completion_policy = "serve_ready"
+        mock_cli = MagicMock()
+        mock_cli_class.return_value = mock_cli
+
+        display_build_stats(stats)
+
+        ctx = mock_cli.render_write.call_args.kwargs
+        assert ctx["ready_label"] == "HTML ready"
+
     def test_show_building_indicator_does_nothing(self) -> None:
         """Test show_building_indicator does nothing (header shown elsewhere)."""
         from bengal.orchestration.stats import show_building_indicator

--- a/tests/unit/utils/test_build_stats.py
+++ b/tests/unit/utils/test_build_stats.py
@@ -260,6 +260,7 @@ class TestBuildStatsToDict:
         assert result["build_time_ms"] == 1000.0
         assert "parallel" in result
         assert "incremental" in result
+        assert result["completion_policy"] == "complete"
 
 
 class TestFormatTime:

--- a/tests/unit/utils/test_stats_protocol.py
+++ b/tests/unit/utils/test_stats_protocol.py
@@ -84,6 +84,7 @@ class TestDisplayableStatsProtocol:
         assert hasattr(stats, "rendering_time_ms")
         assert hasattr(stats, "assets_time_ms")
         assert hasattr(stats, "postprocess_time_ms")
+        assert hasattr(stats, "phase_timings_ms")
         assert hasattr(stats, "health_check_time_ms")
 
 


### PR DESCRIPTION
## What changed

This PR splits local dev-server readiness from full deploy-quality build completion.

- Adds cold phase accounting so hidden post-render costs are visible.
- Adds `BuildCompletionPolicy` with `complete` and `serve_ready` contracts.
- Defines finalization task tiers for serve-ready, artifact, quality, and persistence work.
- Makes default `bengal serve` stop blocking first paint on non-browse-critical artifacts, health, cache save, provenance, and inventory.
- Runs deferred artifact/health/cache completion in the background after browse-ready startup.
- Adds retryable deferred artifact responses for generated outputs while background completion is still running.
- Adds `bengal serve --complete` for production-parity local serving.
- Calms serve terminal output: background completion runs quiet, request logs coalesce deferred artifact polling, SSE requests are hidden, and serve-ready summaries say `HTML ready`.

## Why

Cold local `bengal serve` was spending a large amount of time after rendering on work that is important for production output but not required for a writer to open and visually inspect HTML pages. That made the server feel hung after the page render phase had already finished.

The new contract keeps `bengal build` and `bengal serve --complete` deploy-quality, while making default `bengal serve` optimize for local first paint and finish the rest in the background.

## User impact

- Local authors see the HTML site sooner.
- Full generated artifacts, health checks, and caches still complete after startup.
- Users who need full parity before serving can run `bengal serve --complete`.
- The terminal now distinguishes “HTML is ready” from “all artifacts are complete.”

## Steward Notes

- **Server/dev-loop:** protected local first-paint UX, watcher ordering, background completion visibility, request-log clarity, and deferred artifact behavior.
- **Build/orchestration/cache:** kept completion policy explicit and threaded through build request/input/stats contracts without changing `bengal build` semantics.
- **Postprocess/health:** preserved full artifact and health completion under `complete`, while deferring non-browse-critical tail work under `serve_ready`.
- **CLI/docs/tests:** added `--complete`, documented serve-ready versus complete behavior, and fixed cached `--complete` semantics so the flag does not take the early serve-first shortcut.

## Validation

- `uv run pytest -o addopts= -n 0 -q tests/unit/server/test_dev_server_live_reload.py::TestDevServerContentHashCacheSeeding tests/unit/server/test_dev_server_live_reload.py::TestDevServerServeFirstWatcherOrder::test_complete_policy_does_not_serve_cached_output_first tests/unit/server/test_dev_server_live_reload.py::TestDevServerRequestLogging::test_deferred_artifact_requests_are_coalesced tests/unit/server/test_asgi_app.py::test_build_in_progress_missing_deferred_artifact_returns_503 tests/unit/orchestration/build/test_completion_policy.py tests/unit/utils/test_build_stats.py::TestDisplayFunctions::test_display_build_stats_ci_style_is_ascii_safe tests/unit/utils/test_build_stats.py::TestDisplayFunctions::test_display_build_stats_labels_serve_ready_as_html_ready`
- `uv run ruff check bengal/server/dev_server.py bengal/server/build_executor.py bengal/server/asgi_app.py bengal/orchestration/build/inputs.py bengal/orchestration/stats/display.py tests/unit/server/test_dev_server_live_reload.py tests/unit/orchestration/build/test_completion_policy.py tests/unit/utils/test_build_stats.py`
- Additional focused checks were run throughout the stack for finalization policy, postprocess limiting, ASGI deferred artifacts, build trigger completion policy, and serve help output.

## Follow-ups

- Run background validation/completion through staging and atomic swap everywhere.
- Convert background completion from a second full build into a finalization-only continuation from the serve-ready render snapshot.
- Replace the hardcoded deferred artifact filename set with a generated readiness manifest.
- Add a cold serve performance harness for `time_to_bind`, `time_to_first_html_200`, `time_to_serve_ready`, and `time_to_complete`.
