### PR TITLE
[codex] Build all docs versions on Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,7 +55,12 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            .bengal
+            .bengal/cache
+            .bengal/content_cache
+            .bengal/indexes
+            .bengal/provenance
+            .bengal/version-builds/manifest.json
+            .bengal/worktrees
             site/.bengal
           key: bengal-${{ runner.os }}-${{ steps.bengal-cache.outputs.hash }}
           # No restore-keys - we want exact match for correctness

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -51,12 +54,14 @@ jobs:
       - name: Cache Bengal build state
         uses: actions/cache@v5
         with:
-          path: site/.bengal
+          path: |
+            .bengal
+            site/.bengal
           key: bengal-${{ runner.os }}-${{ steps.bengal-cache.outputs.hash }}
           # No restore-keys - we want exact match for correctness
 
       - name: Build site
-        run: uv run bengal build --source site --environment production --clean-output
+        run: uv run bengal build --source . --all-versions --environment production --clean-output
         env:
           PYTHON_GIL: "0"
 


### PR DESCRIPTION
## Summary

Updates the GitHub Pages workflow so the official Bengal docs dogfood Git tag versioning in CI:

- fetch full history and tags in `actions/checkout`
- cache both root `.bengal` state and `site/.bengal` state
- build from the repository root with `--all-versions`, while still uploading `site/public`

This lets the deployed site build `/docs/` from `main` plus the configured previous release tags.

## Validation

- `uv run bengal cache hash --source site`
- commit hooks, including YAML validation

## Notes

The cache hash step intentionally stays on `--source site` so it emits a clean single-line hash for `$GITHUB_OUTPUT`; the build step uses `--source .` because Git version discovery and worktrees are repo-root concerns.
