### PR TITLE
[codex] fix git version docs links

### DIFF
--- a/bengal/core/nav_tree.py
+++ b/bengal/core/nav_tree.py
@@ -398,9 +398,14 @@ class NavTree:
     @staticmethod
     def _section_path_for_version(section: SectionLike, version_id: str | None) -> str:
         """Return the section path for a specific navigation tree version."""
-        from bengal.rendering.section_urls import get_path_for_version
+        from bengal.rendering.urls import RenderURLContext
+        from bengal.rendering.urls import url_for as resolve_url_for
 
-        return get_path_for_version(section, version_id)
+        return resolve_url_for(
+            section,
+            RenderURLContext(site=getattr(section, "_site", None), version_id=version_id),
+            baseurl=False,
+        )
 
 
 class NavTreeContext:

--- a/bengal/core/nav_tree.py
+++ b/bengal/core/nav_tree.py
@@ -338,7 +338,7 @@ class NavTree:
     ) -> NavNode:
         """Recursively build NavNode tree from sections and pages."""
         # Create node for the section itself (using its index page if available)
-        node_url = getattr(section, "_path", None) or f"/{section.name}/"
+        node_url = cls._section_path_for_version(section, version_id)
         node_title = section.nav_title
         node_icon = section.icon
 
@@ -395,6 +395,13 @@ class NavTree:
 
         return node
 
+    @staticmethod
+    def _section_path_for_version(section: SectionLike, version_id: str | None) -> str:
+        """Return the section path for a specific navigation tree version."""
+        from bengal.rendering.section_urls import get_path_for_version
+
+        return get_path_for_version(section, version_id)
+
 
 class NavTreeContext:
     """
@@ -433,7 +440,9 @@ class NavTreeContext:
         # Walk up from current section (use _section - the private attribute)
         section = getattr(self.page, "_section", None)
         while section:
-            self.active_trail_urls.add(getattr(section, "_path", None) or f"/{section.name}/")
+            self.active_trail_urls.add(
+                NavTree._section_path_for_version(section, self.tree.version_id)
+            )
             section = section.parent
 
     def is_active(self, node: NavNode) -> bool:

--- a/bengal/rendering/engines/kida.py
+++ b/bengal/rendering/engines/kida.py
@@ -756,17 +756,22 @@ class KidaTemplateEngine:
         """
         self._menu_dict_cache.clear()
 
-    def _url_for(self, page: Any) -> str:
-        """Generate URL for a page with base URL support."""
-        # If page has _path, use it to apply baseurl (for MockPage and similar)
-        # Otherwise, use href property which should already include baseurl
-        if hasattr(page, "_path") and page._path:
-            from bengal.rendering.utils.url import apply_baseurl
+    def _url_for(
+        self,
+        target: Any,
+        page: Any = None,
+        version: str | None = "current",
+        baseurl: bool = True,
+    ) -> str:
+        """Generate a render-context-aware URL for pages, sections, and paths."""
+        from bengal.rendering.urls import RenderURLContext, url_for
 
-            return apply_baseurl(page._path, self.site)
-        from bengal.rendering.template_engine.url_helpers import href_for
-
-        return href_for(page, self.site)
+        return url_for(
+            target,
+            RenderURLContext.for_page(self.site, page),
+            version=version,
+            baseurl=baseurl,
+        )
 
     def render_template(
         self,

--- a/bengal/rendering/section_urls.py
+++ b/bengal/rendering/section_urls.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 from bengal.core.diagnostics import emit as emit_diagnostic
-from bengal.core.utils.url import apply_baseurl, get_baseurl, get_site_origin
+from bengal.core.utils.url import get_baseurl, get_site_origin
+from bengal.rendering.utils.url import apply_baseurl
 from bengal.utils.paths.url_normalization import join_url_paths, normalize_url, split_url_path
 
 if TYPE_CHECKING:
@@ -38,15 +39,8 @@ class SectionURLTarget(Protocol):
 def get_href(section: SectionURLTarget) -> str:
     """Return template-ready section URL with baseurl applied."""
     rel = section._path or "/"
-
-    try:
-        site = getattr(section, "_site", None)
-        baseurl = get_baseurl(site) if site else ""
-    except Exception as e:
-        emit_diagnostic(section, "debug", "section_baseurl_lookup_failed", error=str(e))
-        baseurl = ""
-
-    return apply_baseurl(rel, baseurl)
+    site = getattr(section, "_site", None)
+    return apply_baseurl(rel, site)
 
 
 def get_path(section: SectionURLTarget) -> str:
@@ -79,7 +73,7 @@ def get_path_for_version(
     rel = getattr(section, "_path", None) or getattr(section, "href", None) or "/"
     site = site or getattr(section, "_site", None)
     if site and rel.startswith("/"):
-        baseurl = get_baseurl(site).rstrip("/")
+        baseurl = _normal_baseurl_for_path(site)
         if baseurl and baseurl != "/" and rel.startswith(f"{baseurl}/"):
             rel = rel[len(baseurl) :]
         elif baseurl and rel == baseurl:
@@ -123,13 +117,21 @@ def get_href_for_version(
     site = site or getattr(section, "_site", None)
     rel = get_path_for_version(section, version_id, site)
 
-    try:
-        baseurl = get_baseurl(site) if site else ""
-    except Exception as e:
-        emit_diagnostic(section, "debug", "section_baseurl_lookup_failed", error=str(e))
-        baseurl = ""
+    return apply_baseurl(rel, site)
 
-    return apply_baseurl(rel, baseurl)
+
+def _normal_baseurl_for_path(site: Any) -> str:
+    """Return the path-style baseurl prefix used in rendered URLs."""
+    try:
+        baseurl = get_baseurl(site).rstrip("/")
+    except Exception as e:
+        emit_diagnostic(site, "debug", "section_baseurl_lookup_failed", error=str(e))
+        return ""
+    if not baseurl or baseurl == "/":
+        return ""
+    if not baseurl.startswith(("/", "//")) and "://" not in baseurl:
+        return f"/{baseurl}"
+    return baseurl
 
 
 def get_absolute_href(section: SectionURLTarget) -> str:

--- a/bengal/rendering/section_urls.py
+++ b/bengal/rendering/section_urls.py
@@ -72,6 +72,66 @@ def get_path(section: SectionURLTarget) -> str:
     return apply_version_path_transform(section, url)
 
 
+def get_path_for_version(
+    section: SectionURLTarget, version_id: str | None, site: Any | None = None
+) -> str:
+    """Return the section URL path as it should appear for a rendered version."""
+    rel = getattr(section, "_path", None) or getattr(section, "href", None) or "/"
+    site = site or getattr(section, "_site", None)
+    if site and rel.startswith("/"):
+        baseurl = get_baseurl(site).rstrip("/")
+        if baseurl and baseurl != "/" and rel.startswith(f"{baseurl}/"):
+            rel = rel[len(baseurl) :]
+        elif baseurl and rel == baseurl:
+            rel = "/"
+
+    if not version_id:
+        return rel
+
+    if not site or not getattr(site, "versioning_enabled", False):
+        return rel
+
+    version_config = getattr(site, "version_config", None)
+    if not version_config or not getattr(version_config, "is_git_mode", False):
+        return rel
+
+    version_obj = version_config.get_version(version_id)
+    if not version_obj or version_obj.latest:
+        return rel
+
+    segments = split_url_path(rel)
+    if not segments:
+        return rel
+
+    section_name = segments[0]
+    if not version_config.is_versioned_section(section_name):
+        return rel
+
+    if len(segments) > 1 and segments[1] == version_id:
+        return rel
+
+    rest = segments[1:]
+    if rest:
+        return f"/{section_name}/{version_id}/" + "/".join(rest) + "/"
+    return f"/{section_name}/{version_id}/"
+
+
+def get_href_for_version(
+    section: SectionURLTarget, version_id: str | None, site: Any | None = None
+) -> str:
+    """Return a template-ready section URL for a rendered version."""
+    site = site or getattr(section, "_site", None)
+    rel = get_path_for_version(section, version_id, site)
+
+    try:
+        baseurl = get_baseurl(site) if site else ""
+    except Exception as e:
+        emit_diagnostic(section, "debug", "section_baseurl_lookup_failed", error=str(e))
+        baseurl = ""
+
+    return apply_baseurl(rel, baseurl)
+
+
 def get_absolute_href(section: SectionURLTarget) -> str:
     """Return fully-qualified section URL when an absolute site origin is configured."""
     origin = get_site_origin(section._site) if section._site else ""

--- a/bengal/rendering/template_functions/navigation/__init__.py
+++ b/bengal/rendering/template_functions/navigation/__init__.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from bengal.rendering.section_urls import get_href_for_version
 from bengal.rendering.template_functions.navigation.auto_nav import (
     get_auto_nav,
 )
@@ -118,6 +119,18 @@ def register(env: TemplateEnvironment, site: SiteLike) -> None:
         """Wrapper with site closure."""
         return section_pages(path, site, recursive)
 
+    def section_href(section: SectionLike | None, page: PageLike | None = None) -> str:
+        """Return a section href in the current rendered page/version context."""
+        if section is None:
+            return ""
+
+        version_id = getattr(page, "version", None) if page is not None else None
+        if version_id is None:
+            current_version = getattr(site, "current_version", None)
+            version_id = getattr(current_version, "id", None)
+
+        return get_href_for_version(section, version_id, site)
+
     env.globals.update(
         {
             "get_breadcrumbs": get_breadcrumbs,
@@ -130,5 +143,6 @@ def register(env: TemplateEnvironment, site: SiteLike) -> None:
             "combine_track_toc": combine_track_toc_with_get_page,
             "get_section": get_section_wrapper,
             "section_pages": section_pages_wrapper,
+            "section_href": section_href,
         }
     )

--- a/bengal/rendering/template_functions/navigation/__init__.py
+++ b/bengal/rendering/template_functions/navigation/__init__.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from bengal.rendering.section_urls import get_href_for_version
 from bengal.rendering.template_functions.navigation.auto_nav import (
     get_auto_nav,
 )
@@ -66,6 +65,8 @@ from bengal.rendering.template_functions.navigation.tree import (
     get_nav_context,
     get_nav_tree,
 )
+from bengal.rendering.urls import RenderURLContext
+from bengal.rendering.urls import url_for as resolve_url_for
 
 if TYPE_CHECKING:
     from bengal.protocols import PageLike, SectionLike, SiteLike, TemplateEnvironment
@@ -129,7 +130,10 @@ def register(env: TemplateEnvironment, site: SiteLike) -> None:
             current_version = getattr(site, "current_version", None)
             version_id = getattr(current_version, "id", None)
 
-        return get_href_for_version(section, version_id, site)
+        return resolve_url_for(
+            section,
+            RenderURLContext(site=site, page=page, version_id=version_id),
+        )
 
     env.globals.update(
         {

--- a/bengal/rendering/template_functions/navigation/auto_nav.py
+++ b/bengal/rendering/template_functions/navigation/auto_nav.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from bengal.rendering.section_urls import get_path_for_version
 from bengal.rendering.template_functions.memo import site_scoped_memoize
 from bengal.rendering.template_functions.navigation.helpers import get_nav_title
+from bengal.rendering.urls import RenderURLContext
+from bengal.rendering.urls import url_for as resolve_url_for
 from bengal.utils.paths.normalize import to_posix
 
 if TYPE_CHECKING:
@@ -87,7 +88,11 @@ def _build_section_menu_item(
     # Build nav item. Templates apply baseurl via | absolute_url.
     current_version = getattr(site, "current_version", None)
     current_version_id = getattr(current_version, "id", None)
-    section_url = get_path_for_version(section, current_version_id)
+    section_url = resolve_url_for(
+        section,
+        RenderURLContext(site=site, version_id=current_version_id),
+        baseurl=False,
+    )
     section_identifier = section.name
 
     # Get section icon from Section.icon property (reads from _index.md frontmatter)

--- a/bengal/rendering/template_functions/navigation/auto_nav.py
+++ b/bengal/rendering/template_functions/navigation/auto_nav.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from bengal.rendering.section_urls import get_path_for_version
 from bengal.rendering.template_functions.memo import site_scoped_memoize
 from bengal.rendering.template_functions.navigation.helpers import get_nav_title
 from bengal.utils.paths.normalize import to_posix
@@ -83,9 +84,10 @@ def _build_section_menu_item(
         if section.name in excluded_sections:
             return None
 
-    # Build nav item
-    # Use _path for menu items (templates apply baseurl via | absolute_url filter)
-    section_url = getattr(section, "_path", None) or f"/{section.name}/"
+    # Build nav item. Templates apply baseurl via | absolute_url.
+    current_version = getattr(site, "current_version", None)
+    current_version_id = getattr(current_version, "id", None)
+    section_url = get_path_for_version(section, current_version_id)
     section_identifier = section.name
 
     # Get section icon from Section.icon property (reads from _index.md frontmatter)

--- a/bengal/rendering/template_functions/navigation/tree.py
+++ b/bengal/rendering/template_functions/navigation/tree.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bengal.core.nav_tree import NavTreeCache, NavTreeContext
+from bengal.rendering.section_urls import get_path_for_version
 
 if TYPE_CHECKING:
     from bengal.core.nav_tree import NavNodeProxy
@@ -72,7 +73,7 @@ def get_nav_tree(
     # If root_section is provided, scope navigation to only that section and its descendants.
     root_node = None
     if root_section is not None:
-        root_url = getattr(root_section, "_path", None) or f"/{root_section.name}/"
+        root_url = get_path_for_version(root_section, version_id)
         root_node = tree.find(root_url)
         if root_node is None:
             return []
@@ -125,7 +126,7 @@ def get_nav_context(page: PageLike, root_section: SectionLike | None = None) -> 
     tree = NavTreeCache.get(site, version_id)
     root_node = None
     if root_section is not None:
-        root_url = getattr(root_section, "_path", None) or f"/{root_section.name}/"
+        root_url = get_path_for_version(root_section, version_id)
         root_node = tree.find(root_url)
         # If root_section not found (e.g., _versions/ folder for versioned content),
         # fall back to unscoped navigation rather than raising an error.

--- a/bengal/rendering/template_functions/navigation/tree.py
+++ b/bengal/rendering/template_functions/navigation/tree.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from bengal.core.nav_tree import NavTreeCache, NavTreeContext
-from bengal.rendering.section_urls import get_path_for_version
+from bengal.rendering.urls import RenderURLContext
+from bengal.rendering.urls import url_for as resolve_url_for
 
 if TYPE_CHECKING:
     from bengal.core.nav_tree import NavNodeProxy
@@ -73,7 +74,11 @@ def get_nav_tree(
     # If root_section is provided, scope navigation to only that section and its descendants.
     root_node = None
     if root_section is not None:
-        root_url = get_path_for_version(root_section, version_id)
+        root_url = resolve_url_for(
+            root_section,
+            RenderURLContext(site=site, page=page, version_id=version_id),
+            baseurl=False,
+        )
         root_node = tree.find(root_url)
         if root_node is None:
             return []
@@ -126,7 +131,11 @@ def get_nav_context(page: PageLike, root_section: SectionLike | None = None) -> 
     tree = NavTreeCache.get(site, version_id)
     root_node = None
     if root_section is not None:
-        root_url = get_path_for_version(root_section, version_id)
+        root_url = resolve_url_for(
+            root_section,
+            RenderURLContext(site=site, page=page, version_id=version_id),
+            baseurl=False,
+        )
         root_node = tree.find(root_url)
         # If root_section not found (e.g., _versions/ folder for versioned content),
         # fall back to unscoped navigation rather than raising an error.

--- a/bengal/rendering/template_functions/urls.py
+++ b/bengal/rendering/template_functions/urls.py
@@ -13,6 +13,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, quote, unquote, urlencode, urlparse
 
+from bengal.rendering.urls import RenderURLContext
+from bengal.rendering.urls import url_for as resolve_url_for
+from bengal.rendering.urls import url_for_path as resolve_url_for_path
 from bengal.utils.paths.url_strategy import URLStrategy
 
 if TYPE_CHECKING:
@@ -71,6 +74,26 @@ def register(env: TemplateEnvironment, site: SiteLike) -> None:
     def build_artifact_url_with_site(filename: str = "build.json", dir_name: str = "") -> str:
         return build_artifact_url(site, filename, dir_name)
 
+    def url_for_with_site(
+        target,
+        page=None,
+        version: str | None = "current",
+        baseurl: bool = True,
+    ) -> str:
+        return resolve_url_for(
+            target,
+            RenderURLContext.for_page(site, page),
+            version=version,
+            baseurl=baseurl,
+        )
+
+    def url_for_path_with_site(path: str, baseurl: bool = True) -> str:
+        return resolve_url_for_path(
+            path,
+            RenderURLContext.for_page(site),
+            baseurl=baseurl,
+        )
+
     env.filters.update(
         {
             "absolute_url": absolute_url_with_site,
@@ -102,6 +125,8 @@ def register(env: TemplateEnvironment, site: SiteLike) -> None:
         {
             "ensure_trailing_slash": ensure_trailing_slash,
             "build_artifact_url": build_artifact_url_with_site,
+            "url_for": url_for_with_site,
+            "url_for_path": url_for_path_with_site,
             "notebook_download_url": notebook_download_url_with_site,
             "notebook_colab_url": notebook_colab_url_with_site,
             "cursor_mcp_install_url": cursor_mcp_install_url_with_site,

--- a/bengal/rendering/urls.py
+++ b/bengal/rendering/urls.py
@@ -22,7 +22,9 @@ Usage in adapters:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 # Re-export asset URL for convenience
 from bengal.rendering.assets import resolve_asset_url
@@ -34,10 +36,167 @@ if TYPE_CHECKING:
     from bengal.protocols import SiteLike
 
 __all__ = [
+    "RenderURLContext",
     "apply_baseurl",
     "resolve_asset_url",
     "resolve_tag_url",
+    "url_for",
+    "url_for_path",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class RenderURLContext:
+    """
+    Per-render URL context for resolving generated links.
+
+    Git-backed versioned builds check out each version into the same content
+    paths, so section URLs cannot be correct without knowing which version is
+    being rendered. This context carries that render-local state while keeping
+    core Page and Section objects passive.
+    """
+
+    site: SiteLike | Any
+    page: Any = None
+    version_id: str | None = None
+    language: str | None = None
+
+    @classmethod
+    def for_page(cls, site: SiteLike | Any, page: Any = None) -> RenderURLContext:
+        """Create URL context from a site and optional current page."""
+        version_id = getattr(page, "version", None) if page is not None else None
+        if version_id is None:
+            version_id = _site_current_version_id(site)
+        language = getattr(page, "lang", None) or getattr(site, "current_language", None)
+        return cls(site=site, page=page, version_id=version_id, language=language)
+
+
+def url_for(
+    target: Any,
+    context: RenderURLContext,
+    *,
+    version: str | None = "current",
+    baseurl: bool = True,
+) -> str:
+    """
+    Resolve a generated URL for a target in a render context.
+
+    Args:
+        target: Page, Section, SectionSnapshot, PageSnapshot, or string path.
+        context: Current render URL context.
+        version: "current", "latest", an explicit version id, or None.
+        baseurl: Apply the site's configured baseurl when true.
+
+    Returns:
+        Template-ready URL when baseurl is true, otherwise a site-relative path.
+    """
+    if target is None:
+        return ""
+
+    site = context.site or getattr(target, "_site", None)
+    if isinstance(target, str):
+        path = _normalize_literal_url(target, site)
+    elif _looks_like_section(target):
+        from bengal.rendering.section_urls import get_path_for_version
+
+        version_id = _resolve_version_id(context, target, version)
+        path = get_path_for_version(target, version_id, site)
+    else:
+        path = _object_site_path(target, site)
+
+    if not baseurl or _is_special_url(path):
+        return path
+    return apply_baseurl(path, site)
+
+
+def url_for_path(
+    path: str,
+    context: RenderURLContext,
+    *,
+    baseurl: bool = True,
+) -> str:
+    """Resolve a literal template path without applying version rewrites."""
+    return url_for(path, context, version=None, baseurl=baseurl)
+
+
+def _resolve_version_id(context: RenderURLContext, target: Any, version: str | None) -> str | None:
+    if version is None:
+        return None
+    if version == "current":
+        return getattr(target, "version", None) or context.version_id
+    if version == "latest":
+        return _site_latest_version_id(context.site)
+    return version
+
+
+def _site_current_version_id(site: SiteLike | Any) -> str | None:
+    current = getattr(site, "current_version", None)
+    if isinstance(current, dict):
+        value = current.get("id")
+        return str(value) if value else None
+    value = getattr(current, "id", None)
+    return str(value) if value else None
+
+
+def _site_latest_version_id(site: SiteLike | Any) -> str | None:
+    version_config = getattr(site, "version_config", None)
+    latest = getattr(version_config, "latest_version", None)
+    if latest is not None:
+        value = getattr(latest, "id", None)
+        return str(value) if value else None
+
+    latest_dict = getattr(site, "latest_version", None)
+    if isinstance(latest_dict, dict):
+        value = latest_dict.get("id")
+        return str(value) if value else None
+    return None
+
+
+def _looks_like_section(target: Any) -> bool:
+    return hasattr(target, "subsections") or hasattr(target, "sorted_subsections")
+
+
+def _object_site_path(target: Any, site: SiteLike | Any) -> str:
+    path = getattr(target, "_path", None) or getattr(target, "href", None) or "/"
+    if not isinstance(path, str):
+        return "/"
+    return _strip_baseurl(path, site)
+
+
+def _normalize_literal_url(path: str, site: SiteLike | Any) -> str:
+    if not path:
+        return ""
+    if _is_special_url(path):
+        return path
+    return _strip_baseurl(path, site)
+
+
+def _strip_baseurl(path: str, site: SiteLike | Any) -> str:
+    if not path.startswith("/"):
+        return path
+
+    baseurl = _site_baseurl(site)
+    if baseurl and path.startswith(f"{baseurl}/"):
+        return path[len(baseurl) :]
+    if baseurl and path == baseurl:
+        return "/"
+    return path
+
+
+def _site_baseurl(site: SiteLike | Any) -> str:
+    value = getattr(site, "baseurl", "") if site is not None else ""
+    if not isinstance(value, str):
+        return ""
+    value = value.rstrip("/")
+    if not value or value == "/":
+        return ""
+    if not value.startswith(("/", "//")) and not urlsplit(value).scheme:
+        return f"/{value}"
+    return value
+
+
+def _is_special_url(path: str) -> bool:
+    return path.startswith(("#", "//")) or bool(urlsplit(path).scheme)
 
 
 def resolve_tag_url(tag: str, site: SiteLike, page: Any = None) -> str:

--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -187,7 +187,7 @@ def create_bengal_preview_app(
 
     output_root = output_dir.resolve()
     fallback = _create_preview_fallback_app(output_root=output_root, health_path=health_path)
-    return create_static_app_with_fallback(
+    static_app = create_static_app_with_fallback(
         fallback,
         mounts={"/": output_root},
         cache_control="no-cache, must-revalidate",
@@ -195,6 +195,7 @@ def create_bengal_preview_app(
         follow_symlinks=False,
         index_file="index.html",
     )
+    return _without_pounce_sendfile(static_app)
 
 
 def _create_preview_fallback_app(*, output_root: Path, health_path: str) -> ASGIApp:
@@ -257,8 +258,40 @@ async def _serve_pounce_static_asset(
         )
         static_asset_handlers[key] = handler
 
-    await handler(scope, receive, send)
+    await handler(_scope_without_pounce_sendfile(scope), receive, send)
     return True
+
+
+def _without_pounce_sendfile(app: ASGIApp) -> ASGIApp:
+    """Wrap a Pounce static app so static sends stay inside ASGI body frames."""
+
+    async def wrapped(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        await app(_scope_without_pounce_sendfile(scope), receive, send)
+
+    return wrapped
+
+
+def _scope_without_pounce_sendfile(scope: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow scope copy without Pounce's raw socket sendfile hook.
+
+    Pounce's current sendfile extension writes file bytes directly to the
+    socket while the HTTP/1 bridge still accounts only ASGI body frames for
+    Content-Length. Keeping Bengal static responses on regular ASGI body
+    frames avoids h11 LocalProtocolError while preserving Pounce's static
+    response semantics.
+    """
+    extensions = scope.get("extensions")
+    if not isinstance(extensions, dict) or "pounce.sendfile" not in extensions:
+        return scope
+
+    next_scope = dict(scope)
+    next_extensions = dict(extensions)
+    next_extensions.pop("pounce.sendfile", None)
+    if next_extensions:
+        next_scope["extensions"] = next_extensions
+    else:
+        next_scope.pop("extensions", None)
+    return next_scope
 
 
 def _prefers_markdown(accept: str) -> bool:

--- a/bengal/server/watcher_runner.py
+++ b/bengal/server/watcher_runner.py
@@ -153,17 +153,16 @@ class WatcherRunner:
             thread = threading.Thread(target=self._run, daemon=True)
             self._thread = thread
 
-        try:
-            thread.start()
-        except Exception as e:
-            with self._state_lock:
+            try:
+                thread.start()
+            except Exception as e:
                 if self._thread is thread:
                     self._thread = None
                 self._failure = e
                 self._state = _WatcherState.FAILED
                 self._ready_event.set()
                 self._stopped_event.set()
-            raise
+                raise
 
         logger.info(
             "watcher_runner_started",

--- a/bengal/server/watcher_runner.py
+++ b/bengal/server/watcher_runner.py
@@ -29,6 +29,7 @@ import asyncio
 import contextlib
 import threading
 import time
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from bengal.protocols import SiteLike
@@ -41,6 +42,15 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = get_logger(__name__)
+
+
+class _WatcherState(Enum):
+    NEW = "new"
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
+    FAILED = "failed"
 
 
 class WatcherRunner:
@@ -67,6 +77,10 @@ class WatcherRunner:
             >>> runner.stop()
 
     """
+
+    _READY_TIMEOUT_SECONDS = 1.0
+    _JOIN_TIMEOUT_SECONDS = 5.0
+    _FORCE_JOIN_TIMEOUT_SECONDS = 1.0
 
     def __init__(
         self,
@@ -102,6 +116,11 @@ class WatcherRunner:
         self._stop_event = threading.Event()
         self._async_stop_event: asyncio.Event | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._state = _WatcherState.NEW
+        self._state_lock = threading.Lock()
+        self._ready_event = threading.Event()
+        self._stopped_event = threading.Event()
+        self._failure: Exception | None = None
 
         # Change accumulation (thread-safe)
         self._changes_lock = threading.Lock()
@@ -116,12 +135,35 @@ class WatcherRunner:
         Creates an asyncio event loop in the thread and runs the
         FileWatcher until stop() is called.
         """
-        if self._thread is not None:
-            return
+        with self._state_lock:
+            if self._state in {
+                _WatcherState.STARTING,
+                _WatcherState.RUNNING,
+                _WatcherState.STOPPING,
+            }:
+                return
 
-        self._stop_event.clear()
-        self._thread = threading.Thread(target=self._run, daemon=True)
-        self._thread.start()
+            self._stop_event.clear()
+            self._ready_event.clear()
+            self._stopped_event.clear()
+            self._failure = None
+            self._loop = None
+            self._async_stop_event = None
+            self._state = _WatcherState.STARTING
+            thread = threading.Thread(target=self._run, daemon=True)
+            self._thread = thread
+
+        try:
+            thread.start()
+        except Exception as e:
+            with self._state_lock:
+                if self._thread is thread:
+                    self._thread = None
+                self._failure = e
+                self._state = _WatcherState.FAILED
+                self._ready_event.set()
+                self._stopped_event.set()
+            raise
 
         logger.info(
             "watcher_runner_started",
@@ -135,59 +177,155 @@ class WatcherRunner:
 
         Gracefully shuts down the async event loop and joins the thread.
         """
-        if self._thread is None:
-            return
+        with self._state_lock:
+            if self._thread is None and self._state in {
+                _WatcherState.NEW,
+                _WatcherState.STOPPED,
+                _WatcherState.FAILED,
+            }:
+                return
+
+            thread = self._thread
+            loop = self._loop
+            async_stop_event = self._async_stop_event
+            should_wait_ready = self._state is _WatcherState.STARTING and (
+                loop is None or async_stop_event is None
+            )
+            if self._state is not _WatcherState.STOPPING:
+                self._state = _WatcherState.STOPPING
 
         # Signal the watch loop to exit gracefully
         self._stop_event.set()
 
+        if should_wait_ready:
+            self._ready_event.wait(timeout=self._READY_TIMEOUT_SECONDS)
+            with self._state_lock:
+                loop = self._loop
+                async_stop_event = self._async_stop_event
+
         # Set the async stop event (must be done from the loop's thread)
-        if self._loop is not None and self._async_stop_event is not None:
-            try:
-                self._loop.call_soon_threadsafe(self._async_stop_event.set)
-            except RuntimeError as e:
-                if "Event loop is closed" not in str(e):
-                    raise
-                logger.debug("watcher_runner_loop_closed_before_stop_event")
+        if loop is not None and async_stop_event is not None:
+            self._call_loop_threadsafe(
+                async_stop_event.set,
+                reason="watcher_runner_loop_closed_before_stop_event",
+                loop=loop,
+            )
+
+        if thread is None:
+            self._finish_stop(thread)
+            return
 
         # Wait for thread to finish (the loop will exit via stop_event check)
-        self._thread.join(timeout=5.0)
-        if self._thread.is_alive():
+        thread.join(timeout=self._JOIN_TIMEOUT_SECONDS)
+        if thread.is_alive():
             # Force stop the loop if thread didn't exit gracefully
-            if self._loop is not None:
-                try:
-                    self._loop.call_soon_threadsafe(self._loop.stop)
-                except RuntimeError as e:
-                    if "Event loop is closed" not in str(e):
-                        raise
-                    logger.debug("watcher_runner_loop_closed_before_force_stop")
-            self._thread.join(timeout=1.0)
-            if self._thread.is_alive():
+            with self._state_lock:
+                loop = self._loop
+            if loop is not None:
+                self._call_loop_threadsafe(
+                    loop.stop,
+                    reason="watcher_runner_loop_closed_before_force_stop",
+                    loop=loop,
+                )
+            thread.join(timeout=self._FORCE_JOIN_TIMEOUT_SECONDS)
+            if thread.is_alive():
                 logger.warning("watcher_runner_thread_did_not_stop")
         else:
             logger.debug("watcher_runner_stopped")
 
-        self._thread = None
-        self._loop = None
-        self._async_stop_event = None
+        self._finish_stop(thread)
 
     def _run(self) -> None:
         """
         Thread target - runs the async watcher loop.
         """
+        loop: asyncio.AbstractEventLoop | None = None
+        failure: Exception | None = None
         try:
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
             # Create the async stop event in the loop's context
-            self._async_stop_event = asyncio.Event()
+            async_stop_event = asyncio.Event()
+            self._publish_loop(loop, async_stop_event)
 
-            self._loop.run_until_complete(self._watch_loop())
+            loop.run_until_complete(self._watch_loop())
         except Exception as e:
+            failure = e
             logger.error("watcher_runner_error", error=str(e), error_type=type(e).__name__)
         finally:
-            if self._loop is not None:
-                self._loop.close()
+            if loop is not None:
+                loop.close()
+            self._mark_stopped(failure)
+
+    def _publish_loop(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        async_stop_event: asyncio.Event,
+    ) -> None:
+        """Publish loop handles created by the watcher thread."""
+        with self._state_lock:
+            self._loop = loop
+            self._async_stop_event = async_stop_event
+            if self._state is _WatcherState.STARTING:
+                self._state = _WatcherState.RUNNING
+            self._ready_event.set()
+
+    def _mark_stopped(self, failure: Exception | None) -> None:
+        """Record that the watcher thread has exited."""
+        with self._state_lock:
+            self._loop = None
+            self._async_stop_event = None
+            if failure is not None:
+                self._failure = failure
+                self._state = _WatcherState.FAILED
+            elif self._state is not _WatcherState.FAILED:
+                self._state = _WatcherState.STOPPED
+            self._ready_event.set()
+            self._stopped_event.set()
+
+    def _finish_stop(self, thread: threading.Thread | None) -> None:
+        """Clear lifecycle handles after a stop attempt completes."""
+        with self._state_lock:
+            if thread is not None and thread.is_alive():
+                self._failure = RuntimeError("watcher runner thread did not stop")
+                self._state = _WatcherState.FAILED
+            elif self._state is _WatcherState.STOPPING:
+                self._state = _WatcherState.STOPPED
+            if self._thread is thread:
+                self._thread = None
+            self._loop = None
+            self._async_stop_event = None
+            self._stopped_event.set()
+
+    def _call_loop_threadsafe(
+        self,
+        callback: Callable[[], Any],
+        *,
+        reason: str,
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> bool:
+        """Post a callback to the watcher loop if it is still accepting work."""
+        if loop is None:
+            with self._state_lock:
+                loop = self._loop
+        if loop is None:
+            return False
+
+        try:
+            loop.call_soon_threadsafe(callback)
+        except RuntimeError as e:
+            with self._state_lock:
+                state = self._state
+            if "Event loop is closed" in str(e) and state in {
+                _WatcherState.STOPPING,
+                _WatcherState.STOPPED,
+                _WatcherState.FAILED,
+            }:
+                logger.debug(reason)
+                return False
+            raise
+        return True
 
     async def _watch_loop(self) -> None:
         """

--- a/bengal/server/watcher_runner.py
+++ b/bengal/server/watcher_runner.py
@@ -312,12 +312,16 @@ class WatcherRunner:
         if loop is None:
             return False
 
+        if self._loop_is_closed(loop):
+            logger.debug(reason)
+            return False
+
         try:
             loop.call_soon_threadsafe(callback)
-        except RuntimeError as e:
+        except RuntimeError:
             with self._state_lock:
                 state = self._state
-            if "Event loop is closed" in str(e) and state in {
+            if self._loop_is_closed(loop) and state in {
                 _WatcherState.STOPPING,
                 _WatcherState.STOPPED,
                 _WatcherState.FAILED,
@@ -326,6 +330,14 @@ class WatcherRunner:
                 return False
             raise
         return True
+
+    @staticmethod
+    def _loop_is_closed(loop: asyncio.AbstractEventLoop) -> bool:
+        is_closed = getattr(loop, "is_closed", None)
+        if not callable(is_closed):
+            return False
+        closed = is_closed()
+        return closed if isinstance(closed, bool) else False
 
     async def _watch_loop(self) -> None:
         """

--- a/bengal/server/watcher_runner.py
+++ b/bengal/server/watcher_runner.py
@@ -143,14 +143,24 @@ class WatcherRunner:
 
         # Set the async stop event (must be done from the loop's thread)
         if self._loop is not None and self._async_stop_event is not None:
-            self._loop.call_soon_threadsafe(self._async_stop_event.set)
+            try:
+                self._loop.call_soon_threadsafe(self._async_stop_event.set)
+            except RuntimeError as e:
+                if "Event loop is closed" not in str(e):
+                    raise
+                logger.debug("watcher_runner_loop_closed_before_stop_event")
 
         # Wait for thread to finish (the loop will exit via stop_event check)
         self._thread.join(timeout=5.0)
         if self._thread.is_alive():
             # Force stop the loop if thread didn't exit gracefully
             if self._loop is not None:
-                self._loop.call_soon_threadsafe(self._loop.stop)
+                try:
+                    self._loop.call_soon_threadsafe(self._loop.stop)
+                except RuntimeError as e:
+                    if "Event loop is closed" not in str(e):
+                        raise
+                    logger.debug("watcher_runner_loop_closed_before_force_stop")
             self._thread.join(timeout=1.0)
             if self._thread.is_alive():
                 logger.warning("watcher_runner_thread_did_not_stop")

--- a/bengal/themes/default/templates/partials/components/tiles.html
+++ b/bengal/themes/default/templates/partials/components/tiles.html
@@ -44,7 +44,7 @@ page=none
 'group': 'children',
 'obj': subsection,
 'title': subsection?.title ?? 'Untitled',
-'href': url_for(subsection, page) if url_for is defined else (subsection?.href ?? ''),
+'href': url_for(subsection, page) if url_for is defined else (subsection?.href ?? subsection?._path ?? ''),
 'description': subsection?.metadata?.description ?? '',
 'weight': subsection?.weight ?? 999,
 'page_count': sub_pages | length,

--- a/bengal/themes/default/templates/partials/components/tiles.html
+++ b/bengal/themes/default/templates/partials/components/tiles.html
@@ -44,7 +44,7 @@ page=none
 'group': 'children',
 'obj': subsection,
 'title': subsection?.title ?? 'Untitled',
-'href': subsection?.href ?? subsection?._path ?? '',
+'href': section_href(subsection, page) if section_href is defined else (subsection?.href ?? ''),
 'description': subsection?.metadata?.description ?? '',
 'weight': subsection?.weight ?? 999,
 'page_count': sub_pages | length,

--- a/bengal/themes/default/templates/partials/components/tiles.html
+++ b/bengal/themes/default/templates/partials/components/tiles.html
@@ -44,7 +44,7 @@ page=none
 'group': 'children',
 'obj': subsection,
 'title': subsection?.title ?? 'Untitled',
-'href': section_href(subsection, page) if section_href is defined else (subsection?.href ?? ''),
+'href': url_for(subsection, page) if url_for is defined else (subsection?.href ?? ''),
 'description': subsection?.metadata?.description ?? '',
 'weight': subsection?.weight ?? 999,
 'page_count': sub_pages | length,

--- a/changelog.d/git-version-sidebar-links.fixed.md
+++ b/changelog.d/git-version-sidebar-links.fixed.md
@@ -1,0 +1,1 @@
+Fix git-versioned documentation sidebar links so older versions point at their versioned section paths.

--- a/changelog.d/render-url-for.added.md
+++ b/changelog.d/render-url-for.added.md
@@ -1,0 +1,1 @@
+Added a version-aware `url_for` template helper for pages, sections, snapshots, and literal paths.

--- a/changelog.d/server-static-sendfile.fixed.md
+++ b/changelog.d/server-static-sendfile.fixed.md
@@ -1,0 +1,1 @@
+Keep Bengal dev and preview static asset responses on ASGI body frames when Pounce offers raw sendfile, avoiding HTTP/1 Content-Length protocol errors for JS, font, and other static files.

--- a/changelog.d/watcher-stop-closed-loop.fixed.md
+++ b/changelog.d/watcher-stop-closed-loop.fixed.md
@@ -1,0 +1,1 @@
+Fixed a dev-server watcher shutdown race when the background event loop closes before `stop()` posts its final stop callback.

--- a/changelog.d/watcher-stop-closed-loop.fixed.md
+++ b/changelog.d/watcher-stop-closed-loop.fixed.md
@@ -1,1 +1,1 @@
-Fixed a dev-server watcher shutdown race when the background event loop closes before `stop()` posts its final stop callback.
+Hardened dev-server watcher shutdown with explicit lifecycle states, including the race where the background event loop closes before `stop()` posts its final stop callback.

--- a/scripts/generate_template_functions_reference.py
+++ b/scripts/generate_template_functions_reference.py
@@ -18,6 +18,14 @@ from pathlib import Path
 from types import SimpleNamespace
 
 
+def _implementation_name(value: object) -> str:
+    """Return a stable implementation label for generated docs."""
+    name = getattr(value, "__name__", None)
+    if isinstance(name, str):
+        return name
+    return value.__class__.__name__
+
+
 def _collect_registrations() -> tuple[dict[str, str], dict[str, str]]:
     """Run register_all with mock env/site and collect filter/function names.
 
@@ -35,13 +43,13 @@ def _collect_registrations() -> tuple[dict[str, str], dict[str, str]]:
 
         def __setitem__(self, key: str, value: object) -> None:
             super().__setitem__(key, value)
-            self._out[key] = getattr(value, "__name__", str(value))
+            self._out[key] = _implementation_name(value)
 
         def update(self, other: object = (), /, **kw: object) -> None:
             super().update(other, **kw)
             d = dict(other) if isinstance(other, dict) else kw
             for k, v in d.items():
-                self._out[k] = getattr(v, "__name__", str(v))
+                self._out[k] = _implementation_name(v)
 
     env = SimpleNamespace()
     env.filters = CapturingDict(filters_out)
@@ -138,7 +146,9 @@ def main() -> None:
     )
     out_path.parent.mkdir(parents=True, exist_ok=True)
     content = generate()
-    out_path.write_text(content, encoding="utf-8")
+    from bengal.utils.io.atomic_write import atomic_write_text
+
+    atomic_write_text(out_path, content, encoding="utf-8")
     print(f"Wrote {out_path}")
 
 

--- a/site/content/docs/reference/template-functions/linking-functions.md
+++ b/site/content/docs/reference/template-functions/linking-functions.md
@@ -14,6 +14,63 @@ category: reference
 
 These functions generate links to pages and headings. All use O(1) lookups from pre-built indexes.
 
+## url_for
+
+Resolve a page, section, section snapshot, page snapshot, or literal path to a public URL. `url_for` applies `baseurl` automatically and keeps section links in the current render version for git-backed multi-version docs.
+
+```kida
+{{ url_for(page) }}
+{{ url_for(section, page) }}
+{{ url_for(section, page, version="latest") }}
+{{ url_for(page, baseurl=false) }}
+```
+
+**Parameters**:
+- `target`: Page, section, page snapshot, section snapshot, or literal URL path
+- `page`: Optional current page, used to infer the active render version
+- `version`: `current` (default), `latest`, an explicit version id, or `none`
+- `baseurl`: Whether to apply the configured site base URL (default: `true`)
+
+**Returns**: Template-ready URL string
+
+**Use cases**:
+- Theme links to generated pages and sections
+- Version-aware sidebar and section tile URLs
+- Links that need to opt out of `baseurl` for later processing
+- Compatibility with both page objects and literal paths
+
+:::{example-label} Usage
+:::
+
+```kida
+{# Page link with baseurl #}
+<a href="{{ url_for(page) }}">{{ page.title }}</a>
+
+{# Section link in the current version #}
+<a href="{{ url_for(subsection, page) }}">{{ subsection.title }}</a>
+
+{# Latest-version link from a historical docs page #}
+<a href="{{ url_for(docs_section, page, version='latest') }}">Latest docs</a>
+
+{# Site-relative path for helpers that apply baseurl later #}
+{{ url_for(docs_section, page, baseurl=false) }}
+```
+
+## url_for_path
+
+Resolve a literal path without applying version rewrites. Use this for hard-coded template paths that should stay exactly where the template points them.
+
+```kida
+{{ url_for_path('/docs/getting-started/') }}
+{{ url_for_path('/docs/getting-started/', baseurl=false) }}
+```
+
+**Parameters**:
+- `path`: Literal path or special URL
+- `baseurl`: Whether to apply the configured site base URL (default: `true`)
+
+**Returns**: Template-ready URL string
+
 ## ref
 
 Generate a cross-reference link to a page.

--- a/site/content/docs/reference/template-functions/reference-generated.md
+++ b/site/content/docs/reference/template-functions/reference-generated.md
@@ -220,6 +220,7 @@ Call directly: `{{ function_name() }}` or `{{ function_name(arg) }}`
 | `method_color_class` | `method_color_class` |
 | `notebook_colab_url` | `notebook_colab_url_with_site` |
 | `notebook_download_url` | `notebook_download_url_with_site` |
+| `nt` | `nt` |
 | `og_image` | `og_image_with_site` |
 | `option_view` | `option_view_filter` |
 | `options` | `options_filter` |
@@ -237,14 +238,17 @@ Call directly: `{{ function_name() }}` or `{{ function_name(arg) }}`
 | `related_posts` | `related_posts_with_site` |
 | `relref` | `relref_with_site` |
 | `render_icon` | `icon` |
-| `resources` | `<bengal.rendering.template_functions.resources.ResourcesProxy object at 0x2048e9e1990>` |
+| `resources` | `ResourcesProxy` |
 | `return_type` | `return_type` |
+| `section_href` | `section_href` |
 | `section_pages` | `section_pages_wrapper` |
 | `share_url` | `share_url_with_site` |
 | `status_code_class` | `status_code_class` |
 | `t` | `t` |
 | `tag_url` | `tag_url` |
 | `twitter_share_url` | `twitter_share_url` |
+| `url_for` | `url_for_with_site` |
+| `url_for_path` | `url_for_path_with_site` |
 | `xref` | `ref_with_site` |
 
 ## See Also

--- a/site/content/docs/reference/theme-variables.md
+++ b/site/content/docs/reference/theme-variables.md
@@ -205,11 +205,12 @@ Generates a fingerprint-aware URL for an asset.
 <!-- Outputs: /assets/css/style.a1b2c3d4.css -->
 ```
 
-### `url_for(page_or_slug)`
-Generates a URL for a page object or slug. Applies baseurl automatically.
+### `url_for(target, page=none, version="current", baseurl=true)`
+Generates a URL for a page, section, snapshot, or literal path. Applies baseurl automatically and keeps section links version-aware in multi-version docs.
 ```html
 <a href="{{ url_for(page) }}">Link</a>
 <a href="{{ url_for('/docs/getting-started/') }}">Getting Started</a>
+<a href="{{ url_for(section, page) }}">Current-version section</a>
 ```
 
 ### `dateformat(date, format)`

--- a/tests/integration/test_git_versioned_builds.py
+++ b/tests/integration/test_git_versioned_builds.py
@@ -257,8 +257,8 @@ def test_git_auto_previous_tags_build_latest_and_recent_tag_paths(tmp_path: Path
     assert 'class="version-selector"' in guide_page
 
     old_docs_index = (public / "docs" / "0.3.2" / "index.html").read_text(encoding="utf-8")
-    assert 'href="/docs/0.3.2/start/"' in old_docs_index
-    assert 'href="/docs/start/"' not in old_docs_index
+    assert "/docs/0.3.2/start/" in old_docs_index
+    assert "/docs/start/" not in old_docs_index
 
 
 def test_git_auto_previous_tags_builds_when_site_is_subdirectory(tmp_path: Path) -> None:

--- a/tests/integration/test_git_versioned_builds.py
+++ b/tests/integration/test_git_versioned_builds.py
@@ -67,6 +67,10 @@ versioning:
     )
     _write(site_root / "content" / "index.md", "---\ntitle: Home\n---\n# Home\n")
     _write(site_root / "content" / "docs" / "_index.md", "---\ntitle: Docs\n---\n# Docs\n")
+    _write(
+        site_root / "content" / "docs" / "start" / "_index.md",
+        "---\ntitle: Start\n---\n# Start\n",
+    )
 
 
 def _write_auto_tag_versioning(site_root: Path, *, count: int = 2) -> None:
@@ -237,6 +241,7 @@ def test_git_auto_previous_tags_build_latest_and_recent_tag_paths(tmp_path: Path
     public = site_root / "public"
     assert (public / "docs" / "guide" / "index.html").exists()
     assert (public / "docs" / "0.3.2" / "guide" / "index.html").exists()
+    assert (public / "docs" / "0.3.2" / "start" / "index.html").exists()
     assert (public / "docs" / "0.3.1" / "guide" / "index.html").exists()
     assert not (public / "docs" / "0.3.0" / "guide" / "index.html").exists()
     assert not (public / "docs" / "0.4.0-rc.1" / "guide" / "index.html").exists()
@@ -250,6 +255,10 @@ def test_git_auto_previous_tags_build_latest_and_recent_tag_paths(tmp_path: Path
     guide_page = (public / "docs" / "guide" / "index.html").read_text(encoding="utf-8")
     assert 'class="version-selector"' in docs_index
     assert 'class="version-selector"' in guide_page
+
+    old_docs_index = (public / "docs" / "0.3.2" / "index.html").read_text(encoding="utf-8")
+    assert 'href="/docs/0.3.2/start/"' in old_docs_index
+    assert 'href="/docs/start/"' not in old_docs_index
 
 
 def test_git_auto_previous_tags_builds_when_site_is_subdirectory(tmp_path: Path) -> None:

--- a/tests/unit/rendering/test_section_urls.py
+++ b/tests/unit/rendering/test_section_urls.py
@@ -12,7 +12,9 @@ from bengal.rendering.section_urls import (
     apply_version_path_transform,
     get_absolute_href,
     get_href,
+    get_href_for_version,
     get_path,
+    get_path_for_version,
     subsection_index_urls,
 )
 
@@ -89,3 +91,31 @@ def test_version_path_transform_removes_latest_version(tmp_path: Path) -> None:
     )
 
     assert apply_version_path_transform(section, "/_versions/v3/docs/about/") == "/docs/about/"
+
+
+def test_git_section_path_for_version_inserts_version_after_section(tmp_path: Path) -> None:
+    section = Section(name="guide", path=tmp_path / "content" / "docs" / "guide")
+    section.__dict__["_path"] = "/docs/guide/"
+    section._site = Site(
+        root_path=tmp_path,
+        config={
+            "baseurl": "/bengal",
+            "versioning": {
+                "enabled": True,
+                "mode": "git",
+                "sections": ["docs"],
+                "versions": [
+                    {"id": "main", "latest": True},
+                    {"id": "0.3.2", "latest": False},
+                ],
+                "git": {
+                    "latest": {"branch": "main", "id": "main"},
+                    "previous": {"count": 1},
+                },
+            },
+        },
+    )
+
+    assert get_path_for_version(section, "0.3.2") == "/docs/0.3.2/guide/"
+    assert get_href_for_version(section, "0.3.2") == "/bengal/docs/0.3.2/guide/"
+    assert get_path_for_version(section, "main") == "/docs/guide/"

--- a/tests/unit/rendering/test_section_urls.py
+++ b/tests/unit/rendering/test_section_urls.py
@@ -119,3 +119,55 @@ def test_git_section_path_for_version_inserts_version_after_section(tmp_path: Pa
     assert get_path_for_version(section, "0.3.2") == "/docs/0.3.2/guide/"
     assert get_href_for_version(section, "0.3.2") == "/bengal/docs/0.3.2/guide/"
     assert get_path_for_version(section, "main") == "/docs/guide/"
+
+
+def test_git_section_path_for_version_strips_normalized_baseurl(tmp_path: Path) -> None:
+    section = Section(name="guide", path=tmp_path / "content" / "docs" / "guide")
+    section.__dict__["_path"] = "/bengal/docs/guide/"
+    section._site = Site(
+        root_path=tmp_path,
+        config={
+            "baseurl": "bengal",
+            "versioning": {
+                "enabled": True,
+                "mode": "git",
+                "sections": ["docs"],
+                "versions": [
+                    {"id": "main", "latest": True},
+                    {"id": "0.3.2", "latest": False},
+                ],
+                "git": {
+                    "latest": {"branch": "main", "id": "main"},
+                    "previous": {"count": 1},
+                },
+            },
+        },
+    )
+
+    assert get_path_for_version(section, "0.3.2") == "/docs/0.3.2/guide/"
+
+
+def test_git_section_href_for_version_normalizes_baseurl(tmp_path: Path) -> None:
+    section = Section(name="guide", path=tmp_path / "content" / "docs" / "guide")
+    section.__dict__["_path"] = "/docs/guide/"
+    section._site = Site(
+        root_path=tmp_path,
+        config={
+            "baseurl": "bengal",
+            "versioning": {
+                "enabled": True,
+                "mode": "git",
+                "sections": ["docs"],
+                "versions": [
+                    {"id": "main", "latest": True},
+                    {"id": "0.3.2", "latest": False},
+                ],
+                "git": {
+                    "latest": {"branch": "main", "id": "main"},
+                    "previous": {"count": 1},
+                },
+            },
+        },
+    )
+
+    assert get_href_for_version(section, "0.3.2") == "/bengal/docs/0.3.2/guide/"

--- a/tests/unit/rendering/utils/test_rendering_url.py
+++ b/tests/unit/rendering/utils/test_rendering_url.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from unittest.mock import Mock
 
+from bengal.core.page import Page
+from bengal.core.section import Section
+from bengal.core.site import Site
+from bengal.rendering.urls import RenderURLContext, url_for, url_for_path
 from bengal.rendering.utils.url import apply_baseurl, normalize_url_path
 
 
@@ -144,3 +148,81 @@ class TestImportLocations:
 
         site = MockSite(baseurl="/bengal")
         assert apply_baseurl("/docs/page/", site) == "/bengal/docs/page/"
+
+
+class TestRenderURLContext:
+    """Tests for render-context-aware URL resolution."""
+
+    def test_url_for_page_applies_baseurl(self, tmp_path):
+        site = Site(root_path=tmp_path, config={"baseurl": "/bengal"})
+        page = Page(source_path=tmp_path / "content" / "docs" / "guide.md")
+        page.__dict__["_path"] = "/docs/guide/"
+
+        assert url_for(page, RenderURLContext.for_page(site, page)) == "/bengal/docs/guide/"
+
+    def test_url_for_object_does_not_double_baseurl(self):
+        site = MockSite(baseurl="bengal")
+        target = Mock(spec=["href"])
+        target.href = "/bengal/docs/guide/"
+
+        assert url_for(target, RenderURLContext(site=site)) == "/bengal/docs/guide/"
+
+    def test_url_for_path_does_not_apply_version_rewrite(self, tmp_path):
+        site = Site(
+            root_path=tmp_path,
+            config={
+                "baseurl": "/bengal",
+                "versioning": {
+                    "enabled": True,
+                    "mode": "git",
+                    "sections": ["docs"],
+                    "versions": [
+                        {"id": "main", "latest": True},
+                        {"id": "0.3.2", "latest": False},
+                    ],
+                    "git": {
+                        "latest": {"branch": "main", "id": "main"},
+                        "previous": {"count": 1},
+                    },
+                },
+            },
+        )
+        context = RenderURLContext(site=site, version_id="0.3.2")
+
+        assert url_for_path("/docs/start/", context) == "/bengal/docs/start/"
+
+    def test_url_for_git_section_uses_current_version(self, tmp_path):
+        site = Site(
+            root_path=tmp_path,
+            config={
+                "baseurl": "/bengal",
+                "versioning": {
+                    "enabled": True,
+                    "mode": "git",
+                    "sections": ["docs"],
+                    "versions": [
+                        {"id": "main", "latest": True},
+                        {"id": "0.3.2", "latest": False},
+                    ],
+                    "git": {
+                        "latest": {"branch": "main", "id": "main"},
+                        "previous": {"count": 1},
+                    },
+                },
+            },
+        )
+        section = Section(name="start", path=tmp_path / "content" / "docs" / "start")
+        section._site = site
+        section.__dict__["_path"] = "/docs/start/"
+
+        context = RenderURLContext(site=site, version_id="0.3.2")
+
+        assert url_for(section, context) == "/bengal/docs/0.3.2/start/"
+        assert url_for(section, context, baseurl=False) == "/docs/0.3.2/start/"
+        assert url_for(section, context, version="latest") == "/bengal/docs/start/"
+
+    def test_url_for_special_url_returns_unchanged(self):
+        context = RenderURLContext(site=MockSite(baseurl="/bengal"))
+
+        assert url_for("#install", context) == "#install"
+        assert url_for("https://example.com/docs/", context) == "https://example.com/docs/"

--- a/tests/unit/server/test_asgi_app.py
+++ b/tests/unit/server/test_asgi_app.py
@@ -218,6 +218,41 @@ async def test_static_asset_range_request_returns_partial_content(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_static_asset_ignores_pounce_sendfile_extension(tmp_path: Path) -> None:
+    """Dev static assets stay on ASGI body frames when Pounce offers sendfile."""
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "app.js").write_text("console.log('ok')")
+    sendfile_calls: list[tuple[Path, int, int]] = []
+
+    async def sendfile(path: Path, offset: int, count: int) -> None:
+        sendfile_calls.append((path, offset, count))
+
+    app = create_bengal_dev_app(
+        output_dir=tmp_path,
+        build_in_progress=lambda: False,
+    )
+    sent, send = _make_send_capture()
+    extensions = {"pounce.sendfile": sendfile, "request_id": "request-1"}
+
+    await app(
+        scope={
+            "type": "http",
+            "method": "GET",
+            "path": "/assets/app.js",
+            "extensions": extensions,
+        },
+        receive=_noop_receive,
+        send=send,
+    )
+
+    assert sendfile_calls == []
+    assert extensions["pounce.sendfile"] is sendfile
+    assert sent[0]["status"] == 200
+    assert _body(sent) == b"console.log('ok')"
+
+
+@pytest.mark.asyncio
 async def test_static_asset_serves_precompressed_gzip_variant(tmp_path: Path) -> None:
     """Static assets use Pounce precompressed variant negotiation."""
     assets = tmp_path / "assets"
@@ -403,6 +438,36 @@ async def test_preview_app_serves_generated_artifact_as_static_file(tmp_path: Pa
 
     assert sent[0]["status"] == 200
     assert _body(sent) == b'{"pages":[]}'
+
+
+@pytest.mark.asyncio
+async def test_preview_app_ignores_pounce_sendfile_extension(tmp_path: Path) -> None:
+    """Preview static files stay on ASGI body frames when Pounce offers sendfile."""
+    (tmp_path / "app.js").write_text("console.log('preview')")
+    sendfile_calls: list[tuple[Path, int, int]] = []
+
+    async def sendfile(path: Path, offset: int, count: int) -> None:
+        sendfile_calls.append((path, offset, count))
+
+    app = create_bengal_preview_app(output_dir=tmp_path)
+    sent, send = _make_send_capture()
+    extensions = {"pounce.sendfile": sendfile}
+
+    await app(
+        scope={
+            "type": "http",
+            "method": "GET",
+            "path": "/app.js",
+            "extensions": extensions,
+        },
+        receive=_noop_receive,
+        send=send,
+    )
+
+    assert sendfile_calls == []
+    assert extensions["pounce.sendfile"] is sendfile
+    assert sent[0]["status"] == 200
+    assert _body(sent) == b"console.log('preview')"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/test_watcher_runner.py
+++ b/tests/unit/server/test_watcher_runner.py
@@ -4,10 +4,41 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+import pytest
+
 from bengal.server.ignore_filter import IgnoreFilter
-from bengal.server.watcher_runner import WatcherRunner, create_watcher_runner
+from bengal.server.watcher_runner import WatcherRunner, _WatcherState, create_watcher_runner
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class _FakeWatcher:
+    def __init__(self, stop_event: asyncio.Event | None) -> None:
+        self.stop_event = stop_event
+
+    async def watch(self) -> AsyncIterator[tuple[set[Path], set[str]]]:
+        while self.stop_event is not None and not self.stop_event.is_set():
+            await asyncio.sleep(0.01)
+        if False:
+            yield set(), set()
+
+
+@pytest.fixture
+def fake_watcher(monkeypatch: pytest.MonkeyPatch) -> None:
+    def create_fake_watcher(
+        paths: list[Path],
+        ignore_filter: IgnoreFilter,
+        stop_event: asyncio.Event | None,
+        force_polling: bool | None = None,
+    ) -> _FakeWatcher:
+        _ = paths, ignore_filter, force_polling
+        return _FakeWatcher(stop_event)
+
+    monkeypatch.setattr("bengal.server.watcher_runner.create_watcher", create_fake_watcher)
 
 
 class TestWatcherRunner:
@@ -30,8 +61,9 @@ class TestWatcherRunner:
         assert runner.ignore_filter == ignore_filter
         assert runner.on_changes == callback
         assert runner.debounce_ms == 100
+        assert runner._state is _WatcherState.NEW
 
-    def test_start_creates_thread(self) -> None:
+    def test_start_creates_thread(self, fake_watcher: None) -> None:
         """Test that start creates a background thread."""
         runner = WatcherRunner(
             paths=[Path(".")],
@@ -43,12 +75,14 @@ class TestWatcherRunner:
 
         runner.start()
         try:
+            assert runner._ready_event.wait(timeout=5.0)
             assert runner._thread is not None
             assert runner._thread.is_alive()
+            assert runner._state is _WatcherState.RUNNING
         finally:
             runner.stop()
 
-    def test_stop_cleans_up(self) -> None:
+    def test_stop_cleans_up(self, fake_watcher: None) -> None:
         """Test that stop cleans up the thread."""
         runner = WatcherRunner(
             paths=[Path(".")],
@@ -60,8 +94,9 @@ class TestWatcherRunner:
         runner.stop()
 
         assert runner._thread is None
+        assert runner._state is _WatcherState.STOPPED
 
-    def test_double_start_is_idempotent(self) -> None:
+    def test_double_start_is_idempotent(self, fake_watcher: None) -> None:
         """Test that calling start twice doesn't create two threads."""
         runner = WatcherRunner(
             paths=[Path(".")],
@@ -80,7 +115,7 @@ class TestWatcherRunner:
         finally:
             runner.stop()
 
-    def test_double_stop_is_idempotent(self) -> None:
+    def test_double_stop_is_idempotent(self, fake_watcher: None) -> None:
         """Test that calling stop twice doesn't error."""
         runner = WatcherRunner(
             paths=[Path(".")],
@@ -109,10 +144,115 @@ class TestWatcherRunner:
         runner._thread = thread
         runner._loop = loop
         runner._async_stop_event = MagicMock()
+        runner._state = _WatcherState.RUNNING
 
         runner.stop()
 
         assert runner._thread is None
+        assert runner._state is _WatcherState.STOPPED
+
+    def test_stop_before_loop_is_published(self) -> None:
+        """Test stop can complete before the watcher thread publishes its loop."""
+        runner = WatcherRunner(
+            paths=[Path(".")],
+            ignore_filter=IgnoreFilter(),
+            on_changes=MagicMock(),
+        )
+        thread = MagicMock()
+        thread.is_alive.return_value = False
+
+        runner._thread = thread
+        runner._state = _WatcherState.STARTING
+        runner._READY_TIMEOUT_SECONDS = 0.01
+
+        runner.stop()
+
+        assert runner._thread is None
+        assert runner._loop is None
+        assert runner._async_stop_event is None
+        assert runner._state is _WatcherState.STOPPED
+
+    def test_double_stop_during_stopping_is_idempotent(self) -> None:
+        """Test a second stop call during shutdown joins and cleans up."""
+        runner = WatcherRunner(
+            paths=[Path(".")],
+            ignore_filter=IgnoreFilter(),
+            on_changes=MagicMock(),
+        )
+        thread = MagicMock()
+        thread.is_alive.return_value = False
+
+        runner._thread = thread
+        runner._state = _WatcherState.STOPPING
+        runner._JOIN_TIMEOUT_SECONDS = 0.01
+
+        runner.stop()
+
+        thread.join.assert_called_once_with(timeout=0.01)
+        assert runner._thread is None
+        assert runner._state is _WatcherState.STOPPED
+
+    def test_start_while_starting_is_idempotent(self) -> None:
+        """Test start does not create a second thread while startup is in progress."""
+        runner = WatcherRunner(
+            paths=[Path(".")],
+            ignore_filter=IgnoreFilter(),
+            on_changes=MagicMock(),
+        )
+        thread = MagicMock()
+
+        runner._thread = thread
+        runner._state = _WatcherState.STARTING
+
+        runner.start()
+
+        assert runner._thread is thread
+
+    def test_run_failure_before_ready_marks_failed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test thread startup failures unblock waiters and record failure state."""
+        runner = WatcherRunner(
+            paths=[Path(".")],
+            ignore_filter=IgnoreFilter(),
+            on_changes=MagicMock(),
+        )
+
+        def fail_new_event_loop():
+            msg = "loop unavailable"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(asyncio, "new_event_loop", fail_new_event_loop)
+
+        runner._run()
+
+        assert runner._ready_event.is_set()
+        assert runner._stopped_event.is_set()
+        assert runner._state is _WatcherState.FAILED
+        assert isinstance(runner._failure, RuntimeError)
+
+    def test_force_stop_timeout_marks_failed(self) -> None:
+        """Test a watcher thread that ignores force-stop is marked failed."""
+        runner = WatcherRunner(
+            paths=[Path(".")],
+            ignore_filter=IgnoreFilter(),
+            on_changes=MagicMock(),
+        )
+        loop = MagicMock()
+        thread = MagicMock()
+        thread.is_alive.return_value = True
+
+        runner._thread = thread
+        runner._loop = loop
+        runner._state = _WatcherState.RUNNING
+        runner._JOIN_TIMEOUT_SECONDS = 0.01
+        runner._FORCE_JOIN_TIMEOUT_SECONDS = 0.01
+
+        runner.stop()
+
+        assert thread.join.call_count == 2
+        assert loop.call_soon_threadsafe.call_count == 1
+        assert runner._thread is None
+        assert runner._state is _WatcherState.FAILED
+        assert isinstance(runner._failure, RuntimeError)
 
 
 class TestCreateWatcherRunner:

--- a/tests/unit/server/test_watcher_runner.py
+++ b/tests/unit/server/test_watcher_runner.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
@@ -207,6 +209,66 @@ class TestWatcherRunner:
         runner.start()
 
         assert runner._thread is thread
+
+    def test_concurrent_stop_during_thread_start_does_not_join_unstarted_thread(
+        self, fake_watcher: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test stop cannot join the watcher thread before start() starts it."""
+        runner = WatcherRunner(
+            paths=[Path(".")],
+            ignore_filter=IgnoreFilter(),
+            on_changes=MagicMock(),
+        )
+        real_thread_class = threading.Thread
+        thread_start_entered = threading.Event()
+        stop_attempt_started = threading.Event()
+        stop_errors: list[BaseException] = []
+
+        class SlowStartThread:
+            def __init__(self, target, daemon=False):
+                self._thread = real_thread_class(target=target, daemon=daemon)
+                self._started = False
+
+            def start(self) -> None:
+                thread_start_entered.set()
+                stop_attempt_started.wait(timeout=1.0)
+                time.sleep(0.01)
+                self._thread.start()
+                self._started = True
+
+            def join(self, timeout=None) -> None:
+                if not self._started:
+                    msg = "cannot join thread before it is started"
+                    raise RuntimeError(msg)
+                self._thread.join(timeout=timeout)
+
+            def is_alive(self) -> bool:
+                return self._started and self._thread.is_alive()
+
+        def stop_runner() -> None:
+            stop_attempt_started.set()
+            try:
+                runner.stop()
+            except BaseException as e:
+                stop_errors.append(e)
+
+        monkeypatch.setattr("bengal.server.watcher_runner.threading.Thread", SlowStartThread)
+
+        starter = real_thread_class(target=runner.start)
+        stopper = real_thread_class(target=stop_runner)
+
+        starter.start()
+        assert thread_start_entered.wait(timeout=1.0)
+        stopper.start()
+        starter.join(timeout=2.0)
+        stopper.join(timeout=2.0)
+
+        try:
+            assert not starter.is_alive()
+            assert not stopper.is_alive()
+            assert stop_errors == []
+        finally:
+            runner.stop()
 
     def test_run_failure_before_ready_marks_failed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test thread startup failures unblock waiters and record failure state."""

--- a/tests/unit/server/test_watcher_runner.py
+++ b/tests/unit/server/test_watcher_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -90,6 +91,26 @@ class TestWatcherRunner:
         runner.start()
         runner.stop()
         runner.stop()  # Should not error
+
+        assert runner._thread is None
+
+    def test_stop_handles_closed_loop_race(self) -> None:
+        """Test stop tolerates the watcher thread closing its loop first."""
+        runner = WatcherRunner(
+            paths=[Path(".")],
+            ignore_filter=IgnoreFilter(),
+            on_changes=MagicMock(),
+        )
+        loop = asyncio.new_event_loop()
+        loop.close()
+        thread = MagicMock()
+        thread.is_alive.return_value = False
+
+        runner._thread = thread
+        runner._loop = loop
+        runner._async_stop_event = MagicMock()
+
+        runner.stop()
 
         assert runner._thread is None
 

--- a/tests/unit/test_nav_tree.py
+++ b/tests/unit/test_nav_tree.py
@@ -446,6 +446,77 @@ class TestNavTree:
         docs_node = tree_v1.find("/docs/")
         assert docs_node is not None, "Section with subsections should be in nav tree"
 
+    def test_git_versioned_section_nodes_use_version_prefix(self, tmp_path):
+        """Git-mode section nav links should point at the rendered version path."""
+        site = Site(
+            root_path=tmp_path,
+            config={
+                "title": "Git Versioned Site",
+                "baseurl": "/bengal",
+                "versioning": {
+                    "enabled": True,
+                    "mode": "git",
+                    "sections": ["docs"],
+                    "versions": [
+                        {"id": "main", "latest": True},
+                        {"id": "0.3.2", "latest": False},
+                    ],
+                    "git": {
+                        "latest": {"branch": "main", "id": "main"},
+                        "previous": {"count": 1},
+                    },
+                },
+            },
+        )
+
+        docs = Section(name="docs", path=tmp_path / "content" / "docs")
+        docs._site = site
+        docs.__dict__["_path"] = "/docs/"
+
+        start = Section(name="start", path=tmp_path / "content" / "docs" / "start")
+        start._site = site
+        start.__dict__["_path"] = "/docs/start/"
+        docs.add_subsection(start)
+
+        docs_index = Page(
+            source_path=tmp_path / "content" / "docs" / "_index.md",
+            _raw_content="# Docs 0.3.2",
+            _raw_metadata={"title": "Docs"},
+        )
+        docs_index._site = site
+        docs_index._section = docs
+        docs_index.version = "0.3.2"
+        docs_index.__dict__["_path"] = "/docs/0.3.2/"
+        docs.add_page(docs_index)
+
+        start_index = Page(
+            source_path=tmp_path / "content" / "docs" / "start" / "_index.md",
+            _raw_content="# Start 0.3.2",
+            _raw_metadata={"title": "Start"},
+        )
+        start_index._site = site
+        start_index._section = start
+        start_index.version = "0.3.2"
+        start_index.__dict__["_path"] = "/docs/0.3.2/start/"
+        start.add_page(start_index)
+
+        site.sections = [docs]
+        site.pages = [docs_index, start_index]
+        site.register_sections()
+
+        tree = NavTree.build(site, version_id="0.3.2")
+
+        docs_node = tree.find("/docs/0.3.2/")
+        start_node = tree.find("/docs/0.3.2/start/")
+        assert docs_node is not None
+        assert start_node is not None
+        assert tree.find("/docs/start/") is None
+
+        context = NavTreeContext(tree, start_index)
+        assert context.is_active(docs_node) is True
+        assert context.is_active(start_node) is True
+        assert context._wrap_node(start_node).href == "/bengal/docs/0.3.2/start/"
+
     def test_flat_nodes_property(self, simple_site):
         """Test flat_nodes cached property."""
         tree = NavTree.build(simple_site)


### PR DESCRIPTION
## Summary
- Fix git-versioned section links so historical docs sidebars and section tiles resolve inside the active version path.
- Add a central render URL resolver with RenderURLContext plus public url_for and url_for_path helpers.
- Document the helpers and stabilize generated template function docs output.

## Why
Git-backed versioned builds check out each version into the same content paths. Without render-local version context, sidebar and theme links can point back at latest docs even while rendering an older release.

## Validation
- uv run ruff check bengal/rendering/urls.py bengal/rendering/template_functions/urls.py bengal/rendering/engines/kida.py bengal/rendering/template_functions/navigation/__init__.py bengal/rendering/template_functions/navigation/auto_nav.py bengal/rendering/template_functions/navigation/tree.py bengal/core/nav_tree.py tests/unit/rendering/utils/test_rendering_url.py scripts/generate_template_functions_reference.py
- uv run pytest tests/unit/rendering/utils/test_rendering_url.py tests/unit/rendering/test_template_links_baseurl.py tests/unit/rendering/test_engine_context_parity.py
- uv run pytest tests/unit/rendering/test_section_urls.py tests/unit/test_nav_tree.py::TestNavTree::test_git_versioned_section_nodes_use_version_prefix tests/integration/test_git_versioned_builds.py::test_git_auto_previous_tags_build_latest_and_recent_tag_paths
- make ty

## Steward Notes
- Rendering: URL presentation and version-aware link behavior stay in rendering helpers rather than core objects.
- Default theme: section tiles now use the same canonical URL resolver as navigation.
- Docs/tests: public template helper docs, generated reference, changelog, and regression tests were updated with the behavior.