### PR TITLE
[codex] Implement optimization backlog contract suite

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+-
+
+## Proof
+
+- [ ] Focused tests:
+- [ ] `poe proof-pr` or scoped equivalent:
+- [ ] Docs/examples/changelog updated or no-impact noted:
+
+## Performance Evidence
+
+Required when this PR makes a performance claim, changes a hot path, or changes
+free-threaded/concurrent behavior.
+
+- Benchmark matrix row:
+- Command:
+- Python build:
+- Machine/OS:
+- Baseline commit or saved result:
+- Current commit or saved result:
+- Artifact path:
+- Interpretation:
+
+Use `not applicable` for PRs with no performance-sensitive behavior.
+
+## Steward Notes
+
+-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  performance-evidence:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate Performance Evidence section
+        run: python scripts/check_performance_evidence.py --github-event "$GITHUB_EVENT_PATH"
+
   # Detect whether code paths changed — skip tests for docs-only PRs
   detect-changes:
     if: github.event_name == 'pull_request' || github.event_name == 'push'

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,6 +36,23 @@ bengal --version
 
 If this fails with `ModuleNotFoundError` (e.g. `No module named 'bengal'` or `No module named 'kida'`), the install is broken. Reinstall: `pip uninstall bengal` then run `uv sync` from the workspace root (or `pip install -e .` from bengal).
 
+## Canonical Benchmark Matrix
+
+`benchmark_matrix.toml` is the source of truth for which benchmark rows count as
+canonical evidence. It divides runs into smoke, release, and investigation tiers,
+and each row names the command, source paths, metrics, evidence artifacts, and
+change triggers it protects.
+
+Use the matrix before making or reviewing performance claims:
+
+```bash
+uv run pytest tests/unit/benchmarks/test_benchmark_matrix.py -q
+```
+
+Treat the overview below as explanatory. When adding, removing, or renaming a
+benchmark that should guide decisions, update `benchmark_matrix.toml` in the same
+change.
+
 ## Running the Benchmarks
 
 To run the benchmarks, simply run `pytest` from the `benchmarks` directory:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -49,6 +49,14 @@ Use the matrix before making or reviewing performance claims:
 uv run pytest tests/unit/benchmarks/test_benchmark_matrix.py -q
 ```
 
+Run or list matrix rows by tier:
+
+```bash
+uv run python benchmarks/run_matrix.py --tier smoke --dry-run
+uv run python benchmarks/run_matrix.py --tier smoke
+uv run python benchmarks/run_matrix.py --list
+```
+
 Treat the overview below as explanatory. When adding, removing, or renaming a
 benchmark that should guide decisions, update `benchmark_matrix.toml` in the same
 change.

--- a/benchmarks/benchmark_matrix.toml
+++ b/benchmarks/benchmark_matrix.toml
@@ -1,0 +1,201 @@
+version = 1
+updated = "2026-05-22"
+owner = "benchmarks"
+description = "Canonical benchmark matrix for Bengal performance evidence."
+
+[environment]
+python = "Run on Python 3.14+; repeat worker-scaling rows on Python 3.14t when available."
+runner = "uv run"
+baseline_policy = "Save named baselines before release comparisons; never overwrite baseline results without recording the commit and machine."
+artifacts = [
+  "benchmarks/.benchmarks/",
+  "tests/performance/benchmark_results/",
+  ".pytest_cache/",
+]
+
+[tiers.smoke]
+cadence = "Every performance-sensitive PR before review."
+duration = "Less than 10 minutes on a developer laptop."
+purpose = "Catch shape, budget, and obvious hot-path regressions without running the full suite."
+
+[tiers.release]
+cadence = "Before releases and after broad build, render, cache, or concurrency changes."
+duration = "30 to 90 minutes depending on selected scales."
+purpose = "Produce comparable evidence for Bengal's public performance claims."
+
+[tiers.investigation]
+cadence = "When diagnosing a suspected bottleneck or justifying a major redesign."
+duration = "Variable; may require optional external SSGs or larger generated fixtures."
+purpose = "Explain where time, memory, or scaling behavior is coming from."
+
+[[benchmarks]]
+id = "render-output-regression"
+tier = "smoke"
+tags = ["rendering", "assets", "autodoc"]
+purpose = "Guard output shape and fallback asset parsing cost before broader timing runs."
+command = "uv run pytest -o addopts= -n 0 -q tests/performance/test_autodoc_render_regression.py tests/performance/test_asset_fallback_cost.py"
+paths = [
+  "tests/performance/test_autodoc_render_regression.py",
+  "tests/performance/test_asset_fallback_cost.py",
+  "tests/performance/fixtures/autodoc_render_baseline.json",
+]
+metrics = ["rendered bytes", "card counts", "fallback parser invocations", "fallback parser duration"]
+evidence = ["pytest output", ".pytest_cache/render_output_metrics.json", ".pytest_cache/fallback_parser_metrics.json"]
+budget = "Hard budgets live in the tests and baseline fixture."
+triggers = ["autodoc rendering", "theme template output", "asset inventory", "fallback parser behavior"]
+
+[[benchmarks]]
+id = "post-render-budget"
+tier = "smoke"
+tags = ["postprocess", "cache", "incremental", "outputs"]
+purpose = "Measure the post-render tail for cold, no-op, single-page, section-index, and CSS-only changes."
+command = "uv run pytest -o addopts= -n 0 -q -m performance tests/performance/test_post_render_pipeline_budget.py"
+paths = [
+  "tests/performance/test_post_render_pipeline_budget.py",
+  "tests/performance/post_render_harness.py",
+]
+metrics = ["postprocess task time", "post-render finalization time", "changed outputs", "state store sizes"]
+evidence = ["pytest output", ".pytest_cache/post_render_pipeline_metrics.json"]
+budget = "Hard budgets live in tests/performance/test_post_render_pipeline_budget.py."
+triggers = ["postprocess", "artifact inventory", "search/feed/sitemap output", "incremental cache state"]
+
+[[benchmarks]]
+id = "build-incremental-smoke"
+tier = "smoke"
+tags = ["build", "incremental", "cache"]
+purpose = "Keep core full-build, no-op, and edit rebuild paths visible in pytest-benchmark output."
+command = "uv run pytest benchmarks/test_build.py -k 'build_performance or incremental' -v --benchmark-only"
+paths = [
+  "benchmarks/test_build.py",
+  "benchmarks/conftest.py",
+]
+metrics = ["cold build mean", "incremental mean", "no-op mean", "memory deltas"]
+evidence = ["pytest-benchmark table", "saved pytest-benchmark JSON when comparing"]
+budget = "Compare against the latest named baseline for the same machine and Python build."
+triggers = ["build orchestration", "content discovery", "cache invalidation", "provenance"]
+
+[[benchmarks]]
+id = "phase-breakdown-release"
+tier = "release"
+tags = ["build", "rendering", "postprocess", "assets", "cache"]
+purpose = "Produce phase-level timing evidence so regressions have an owning subsystem."
+command = "uv run python tests/performance/benchmark_phase_breakdown.py"
+paths = [
+  "tests/performance/benchmark_phase_breakdown.py",
+  "tests/performance/results_manager.py",
+]
+metrics = ["phase wall time", "phase percentage", "total build time"]
+evidence = ["tests/performance/benchmark_results/phase_breakdown/latest.json"]
+budget = "No hard gate; compare phase deltas to the prior release baseline."
+triggers = ["build lifecycle", "phase ordering", "output writing", "theme or asset behavior"]
+
+[[benchmarks]]
+id = "incremental-scale-release"
+tier = "release"
+tags = ["incremental", "cache", "build", "outputs"]
+purpose = "Validate no-op, single-edit, template-edit, and cache-size behavior at documentation-site scales."
+command = "uv run python tests/performance/benchmark_incremental_scale.py"
+paths = [
+  "tests/performance/benchmark_incremental_scale.py",
+  "tests/performance/benchmark_warm_build_consistency.py",
+  "tests/performance/results_manager.py",
+]
+metrics = ["full build time", "single-page rebuild time", "template rebuild time", "cache bytes per page", "speedup"]
+evidence = ["tests/performance/benchmark_results/incremental_scale/latest.json"]
+budget = "Incremental speedup should stay at or above 15x at the measured scales unless an accepted design note explains the tradeoff."
+triggers = ["incremental invalidation", "cache format", "template dependency tracking", "output artifact tracking"]
+
+[[benchmarks]]
+id = "worker-scaling-release"
+tier = "release"
+tags = ["worker-scaling", "free-threading", "rendering", "postprocess"]
+purpose = "Show whether parallel rendering and postprocess work scale with cores on Python 3.14 and 3.14t."
+command = "uv run python tests/performance/benchmark_worker_scaling.py"
+paths = [
+  "tests/performance/benchmark_worker_scaling.py",
+  "tests/performance/benchmark_parallel.py",
+]
+metrics = ["speedup by worker count", "throughput", "worker count knee", "parallel overhead"]
+evidence = ["tests/performance/benchmark_results/worker_scaling/latest.json", "console summary with Python build"]
+budget = "Parallel paths should not regress below the prior release baseline without a recorded bottleneck or correctness tradeoff."
+triggers = ["concurrency", "executor selection", "shared state", "free-threaded Python behavior"]
+
+[[benchmarks]]
+id = "realistic-scale-release"
+tier = "release"
+tags = ["build", "rendering", "parser", "assets", "postprocess"]
+purpose = "Measure Bengal on realistic content mixes instead of only synthetic minimal pages."
+command = "uv run python tests/performance/benchmark_realistic_scale.py"
+paths = [
+  "tests/performance/benchmark_realistic_scale.py",
+  "tests/performance/benchmark_content_complexity.py",
+  "tests/performance/results_manager.py",
+]
+metrics = ["pages per second", "content complexity slope", "peak memory", "changed output count"]
+evidence = ["tests/performance/benchmark_results/realistic_scale/latest.json"]
+budget = "Compare slope and throughput to the prior release baseline for the same scale."
+triggers = ["parser", "shortcodes", "directives", "template context", "large-site behavior"]
+
+[[benchmarks]]
+id = "parser-render-investigation"
+tier = "investigation"
+tags = ["parser", "rendering", "syntax-highlighting"]
+purpose = "Isolate parse, render, directive, and highlighting hot paths when full-build results move."
+command = "uv run pytest benchmarks/benchmark_render.py benchmarks/test_patitas_performance.py benchmarks/test_directive_performance.py benchmarks/test_highlighting_performance.py -v --benchmark-only"
+paths = [
+  "benchmarks/benchmark_render.py",
+  "benchmarks/test_patitas_performance.py",
+  "benchmarks/test_directive_performance.py",
+  "benchmarks/test_highlighting_performance.py",
+]
+metrics = ["parse time", "render time", "directive expansion time", "highlighting time", "throughput"]
+evidence = ["pytest-benchmark table", "saved pytest-benchmark JSON when comparing"]
+budget = "Use named pytest-benchmark baselines for the same Python and machine."
+triggers = ["parser changes", "renderer changes", "directive cache changes", "syntax highlighting changes"]
+
+[[benchmarks]]
+id = "template-engine-investigation"
+tier = "investigation"
+tags = ["template", "rendering", "worker-scaling"]
+purpose = "Separate Kida/template compilation and render behavior from page orchestration cost."
+command = "uv run pytest benchmarks/test_kida_real_templates.py benchmarks/test_kida_vs_jinja.py benchmarks/bench_render_tiers.py -v --benchmark-only"
+paths = [
+  "benchmarks/test_kida_real_templates.py",
+  "benchmarks/test_kida_vs_jinja.py",
+  "benchmarks/bench_render_tiers.py",
+]
+metrics = ["template render mean", "compile overhead", "concurrent render throughput"]
+evidence = ["pytest-benchmark table", "manual notes for template corpus"]
+budget = "Compare against the named template baseline before changing default theme or template helpers."
+triggers = ["template helpers", "default theme templates", "Kida integration", "render context scoping"]
+
+[[benchmarks]]
+id = "github-pages-ci-investigation"
+tier = "investigation"
+tags = ["build", "worker-scaling", "memory", "ci"]
+purpose = "Evaluate build flags under GitHub Pages-like CPU and memory limits."
+command = "uv run pytest benchmarks/test_github_pages_optimization.py -v --benchmark-only --benchmark-json=benchmarks/.benchmarks/github_pages_results.json"
+paths = [
+  "benchmarks/test_github_pages_optimization.py",
+  "benchmarks/analyze_github_pages_results.py",
+  "benchmarks/GITHUB_PAGES_BENCHMARK_GUIDE.md",
+]
+metrics = ["best flag set by site size", "parallel speedup", "peak memory", "build duration"]
+evidence = ["benchmarks/.benchmarks/github_pages_results.json", "uv run python benchmarks/analyze_github_pages_results.py benchmarks/.benchmarks/github_pages_results.json"]
+budget = "No hard gate; use to choose documented CI recommendations."
+triggers = ["CLI build flags", "CI guidance", "memory-optimized mode", "parallel defaults"]
+
+[[benchmarks]]
+id = "cross-ssg-investigation"
+tier = "investigation"
+tags = ["build", "comparison", "parser"]
+purpose = "Compare Bengal against other SSGs with an explicit external-tool setup and normalized content."
+command = "uv run python tests/performance/benchmark_ssg_comparison.py"
+paths = [
+  "tests/performance/benchmark_ssg_comparison.py",
+  "tests/performance/benchmark_ssg_comparison_tagged.py",
+]
+metrics = ["cold build time by file count", "pages per second", "scaling slope"]
+evidence = ["tests/performance/benchmark_results/ssg_comparison/latest.json", "environment notes for external SSG versions"]
+budget = "No hard gate; use only for external positioning with complete environment metadata."
+triggers = ["public performance claims", "release notes", "SSG comparison docs"]

--- a/benchmarks/run_matrix.py
+++ b/benchmarks/run_matrix.py
@@ -1,0 +1,106 @@
+"""Run benchmark commands from the canonical benchmark matrix."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = ROOT / "benchmarks" / "benchmark_matrix.toml"
+VALID_TIERS = ("smoke", "release", "investigation")
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixEntry:
+    """One executable benchmark matrix row."""
+
+    id: str
+    tier: str
+    command: str
+    purpose: str
+
+
+def load_entries(matrix_path: Path = MATRIX_PATH) -> list[MatrixEntry]:
+    """Load benchmark entries from a matrix TOML file."""
+    matrix = tomllib.loads(matrix_path.read_text(encoding="utf-8"))
+    return [
+        MatrixEntry(
+            id=entry["id"],
+            tier=entry["tier"],
+            command=entry["command"],
+            purpose=entry["purpose"],
+        )
+        for entry in matrix["benchmarks"]
+    ]
+
+
+def select_entries(
+    entries: list[MatrixEntry],
+    *,
+    tier: str | None = None,
+    entry_ids: set[str] | None = None,
+) -> list[MatrixEntry]:
+    """Filter matrix entries by tier and/or id."""
+    selected = entries
+    if tier is not None:
+        selected = [entry for entry in selected if entry.tier == tier]
+    if entry_ids:
+        selected = [entry for entry in selected if entry.id in entry_ids]
+    return selected
+
+
+def run_entries(entries: list[MatrixEntry], *, dry_run: bool = False) -> int:
+    """Run selected benchmark entries in matrix order."""
+    if not entries:
+        print("No benchmark matrix entries selected.", file=sys.stderr)
+        return 2
+
+    for entry in entries:
+        print(f"[{entry.tier}] {entry.id}")
+        print(f"  {entry.command}")
+        if dry_run:
+            continue
+        result = subprocess.run(entry.command, cwd=ROOT, shell=True, check=False)
+        if result.returncode != 0:
+            return result.returncode
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--matrix", type=Path, default=MATRIX_PATH, help="Path to benchmark matrix")
+    parser.add_argument("--tier", choices=VALID_TIERS, help="Run one benchmark tier")
+    parser.add_argument("--id", action="append", dest="ids", help="Run one matrix row id")
+    parser.add_argument(
+        "--list", action="store_true", help="List selected entries without commands"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print commands without executing them"
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the benchmark matrix CLI."""
+    args = build_parser().parse_args(argv)
+    entries = select_entries(
+        load_entries(args.matrix),
+        tier=args.tier,
+        entry_ids=set(args.ids or []),
+    )
+
+    if args.list:
+        for entry in entries:
+            print(f"{entry.tier:13} {entry.id:32} {entry.purpose}")
+        return 0 if entries else 2
+
+    return run_entries(entries, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/run_matrix.py
+++ b/benchmarks/run_matrix.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 import tomllib
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
+from tempfile import NamedTemporaryFile
+from time import perf_counter
 
 ROOT = Path(__file__).resolve().parents[1]
 MATRIX_PATH = ROOT / "benchmarks" / "benchmark_matrix.toml"
@@ -22,6 +26,18 @@ class MatrixEntry:
     tier: str
     command: str
     purpose: str
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixEntryResult:
+    """Execution receipt for one benchmark matrix row."""
+
+    id: str
+    tier: str
+    command: str
+    returncode: int
+    duration_seconds: float
+    skipped: bool = False
 
 
 def load_entries(matrix_path: Path = MATRIX_PATH) -> list[MatrixEntry]:
@@ -53,21 +69,93 @@ def select_entries(
     return selected
 
 
-def run_entries(entries: list[MatrixEntry], *, dry_run: bool = False) -> int:
+def execute_entries(
+    entries: list[MatrixEntry], *, dry_run: bool = False
+) -> tuple[int, list[MatrixEntryResult]]:
     """Run selected benchmark entries in matrix order."""
     if not entries:
         print("No benchmark matrix entries selected.", file=sys.stderr)
-        return 2
+        return 2, []
 
+    results: list[MatrixEntryResult] = []
     for entry in entries:
         print(f"[{entry.tier}] {entry.id}")
         print(f"  {entry.command}")
         if dry_run:
+            results.append(
+                MatrixEntryResult(
+                    id=entry.id,
+                    tier=entry.tier,
+                    command=entry.command,
+                    returncode=0,
+                    duration_seconds=0.0,
+                    skipped=True,
+                )
+            )
             continue
+        started = perf_counter()
         result = subprocess.run(entry.command, cwd=ROOT, shell=True, check=False)
+        duration = perf_counter() - started
+        results.append(
+            MatrixEntryResult(
+                id=entry.id,
+                tier=entry.tier,
+                command=entry.command,
+                returncode=result.returncode,
+                duration_seconds=round(duration, 6),
+            )
+        )
         if result.returncode != 0:
-            return result.returncode
-    return 0
+            return result.returncode, results
+    return 0, results
+
+
+def run_entries(entries: list[MatrixEntry], *, dry_run: bool = False) -> int:
+    """Run selected benchmark entries in matrix order."""
+    exit_code, _results = execute_entries(entries, dry_run=dry_run)
+    return exit_code
+
+
+def write_receipt(
+    receipt_path: Path,
+    *,
+    entries: list[MatrixEntry],
+    results: list[MatrixEntryResult],
+    dry_run: bool,
+    exit_code: int,
+) -> None:
+    """Write a normalized benchmark matrix execution receipt atomically."""
+    payload = {
+        "version": 1,
+        "generated_at": datetime.now(tz=UTC).isoformat(),
+        "dry_run": dry_run,
+        "exit_code": exit_code,
+        "selected_ids": [entry.id for entry in entries],
+        "results": [
+            {
+                "id": result.id,
+                "tier": result.tier,
+                "command": result.command,
+                "returncode": result.returncode,
+                "duration_seconds": result.duration_seconds,
+                "skipped": result.skipped,
+            }
+            for result in results
+        ],
+    }
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=receipt_path.parent,
+        prefix=f".{receipt_path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as tmp:
+        json.dump(payload, tmp, indent=2)
+        tmp.write("\n")
+        tmp_path = Path(tmp.name)
+    tmp_path.replace(receipt_path)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -81,6 +169,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--dry-run", action="store_true", help="Print commands without executing them"
+    )
+    parser.add_argument(
+        "--receipt",
+        type=Path,
+        help="Write a normalized JSON receipt for the selected matrix run",
     )
     return parser
 
@@ -99,7 +192,16 @@ def main(argv: list[str] | None = None) -> int:
             print(f"{entry.tier:13} {entry.id:32} {entry.purpose}")
         return 0 if entries else 2
 
-    return run_entries(entries, dry_run=args.dry_run)
+    exit_code, results = execute_entries(entries, dry_run=args.dry_run)
+    if args.receipt is not None:
+        write_receipt(
+            args.receipt,
+            entries=entries,
+            results=results,
+            dry_run=args.dry_run,
+            exit_code=exit_code,
+        )
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/bengal/build/provenance/filter.py
+++ b/bengal/build/provenance/filter.py
@@ -377,6 +377,16 @@ class ProvenanceFilter:
             page: The page that was built
             output_hash: Hash of the rendered output (optional)
         """
+        record_with_paths = self.build_record(page, output_hash)
+        if record_with_paths is None:
+            return
+        record, input_paths = record_with_paths
+        self.cache.store(record, input_paths)
+
+    def build_record(
+        self, page: PageLike, output_hash: ContentHash | None = None
+    ) -> tuple[ProvenanceRecord, list[str]] | None:
+        """Build a provenance record without persisting it."""
         # OPTIMIZATION: Use already computed provenance if available from filter phase
         page_path = self._get_page_key(page)
 
@@ -400,7 +410,7 @@ class ProvenanceFilter:
                 has_section=getattr(page, "_section", None) is not None,
                 source_path=str(getattr(page, "source_path", None)),
             )
-            return
+            return None
 
         record = ProvenanceRecord(
             page_path=page_path,
@@ -408,7 +418,7 @@ class ProvenanceFilter:
             output_hash=output_hash or ContentHash("_rendered_"),
         )
         input_paths = self._extract_input_paths_for_mtime(record)
-        self.cache.store(record, input_paths)
+        return record, input_paths
 
     def save(self) -> None:
         """Save the provenance cache to disk."""

--- a/bengal/cache/page_artifact_store.py
+++ b/bengal/cache/page_artifact_store.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_MANIFEST_NAME = "manifest.json"
+
 
 class PageArtifactStore:
     """Persist page artifacts in small shards outside the main build cache."""
@@ -20,13 +22,41 @@ class PageArtifactStore:
     def __init__(self, root: Path) -> None:
         self.root = root
 
-    def load(self) -> dict[str, dict[str, Any]]:
-        """Load all page artifact shards."""
+    def load(self, keys: set[str] | None = None) -> dict[str, dict[str, Any]]:
+        """Load page artifact shards, optionally limited to selected keys."""
         if not self.root.exists():
             return {}
 
+        manifest = self._load_manifest()
+        if manifest is not None:
+            if keys is None:
+                shard_names = set(manifest.values())
+                wanted_keys: set[str] | None = None
+            else:
+                shard_names = {manifest[key] for key in keys if key in manifest}
+                wanted_keys = keys
+            return self._load_shards(shard_names, wanted_keys)
+
+        return self._load_legacy_shards(keys)
+
+    def _load_legacy_shards(self, keys: set[str] | None) -> dict[str, dict[str, Any]]:
+        """Load shards by scanning the directory when no manifest exists."""
+        shard_names = {
+            shard_path.stem
+            for shard_path in self.root.glob("*.json")
+            if shard_path.name != _MANIFEST_NAME
+        }
+        return self._load_shards(shard_names, keys)
+
+    def _load_shards(
+        self,
+        shard_names: set[str],
+        keys: set[str] | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        """Load selected shard files."""
         records: dict[str, dict[str, Any]] = {}
-        for shard_path in self.root.glob("*.json"):
+        for shard in sorted(shard_names):
+            shard_path = self.root / f"{shard}.json"
             try:
                 data = json_compat.load(shard_path)
             except Exception as e:
@@ -39,7 +69,7 @@ class PageArtifactStore:
                 continue
             if isinstance(data, dict):
                 for key, value in data.items():
-                    if isinstance(value, dict):
+                    if (keys is None or str(key) in keys) and isinstance(value, dict):
                         records[str(key)] = value
         return records
 
@@ -69,8 +99,10 @@ class PageArtifactStore:
             json_compat.dump(shard_records, shard_path, indent=None)
 
         for shard_path in self.root.glob("*.json"):
-            if shard_path not in live_paths:
+            if shard_path.name != _MANIFEST_NAME and shard_path not in live_paths:
                 shard_path.unlink()
+
+        self._save_manifest(records)
 
         logger.debug(
             "page_artifact_shards_saved",
@@ -97,6 +129,8 @@ class PageArtifactStore:
             elif shard_path.exists():
                 shard_path.unlink()
 
+        self._save_manifest(records)
+
         logger.debug(
             "page_artifact_dirty_shards_saved",
             records=len(records),
@@ -108,3 +142,46 @@ class PageArtifactStore:
 
     def _shard_name(self, key: str) -> str:
         return hashlib.sha256(key.encode("utf-8")).hexdigest()[:2]
+
+    def _manifest_path(self) -> Path:
+        return self.root / _MANIFEST_NAME
+
+    def _load_manifest(self) -> dict[str, str] | None:
+        """Load key-to-shard manifest, returning None for missing/invalid data."""
+        manifest_path = self._manifest_path()
+        try:
+            data = json_compat.load(manifest_path)
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            logger.warning(
+                "page_artifact_manifest_load_failed",
+                path=str(manifest_path),
+                error=str(e),
+                action="falling_back_to_shard_scan",
+            )
+            return None
+
+        if not isinstance(data, dict) or data.get("version") != 1:
+            return None
+        records = data.get("records")
+        if not isinstance(records, dict):
+            return None
+        return {str(key): str(shard) for key, shard in records.items()}
+
+    def _save_manifest(self, records: dict[str, dict[str, Any]]) -> None:
+        """Persist the key-to-shard manifest."""
+        manifest_path = self._manifest_path()
+        if not records:
+            if manifest_path.exists():
+                manifest_path.unlink()
+            return
+
+        json_compat.dump(
+            {
+                "version": 1,
+                "records": {key: self._shard_name(key) for key in sorted(records)},
+            },
+            manifest_path,
+            indent=None,
+        )

--- a/bengal/core/menu.py
+++ b/bengal/core/menu.py
@@ -173,7 +173,9 @@ class MenuItem:
             item.sort_children()  # No-op (already sorted)
         """
         if self._children_dirty:
-            self.children.sort(key=lambda x: x.weight)
+            from bengal.core.utils.sorting import weight_sort_key
+
+            self.children.sort(key=weight_sort_key)
             self._children_dirty = False
 
     def get_sorted_children(self) -> list[MenuItem]:
@@ -516,8 +518,9 @@ class MenuBuilder:
             items_with_parents=sum(1 for i in self.items if i.parent),
         )
 
-        # Create lookup by identifier
-        by_id = {item.identifier: item for item in self.items}
+        # Create lookup by identifier. Items without identifiers can still be roots,
+        # but cannot participate in parent-link validation.
+        by_id = {item.identifier: item for item in self.items if item.identifier is not None}
 
         # Validate parent references
         orphaned_items = [
@@ -539,6 +542,9 @@ class MenuBuilder:
                 items=[(name, parent) for name, parent in orphaned_items[:5]],
             )
 
+        self._validate_parent_links_are_acyclic(by_id)
+        self._clear_existing_hierarchy()
+
         # Build tree
         roots = []
         for item in self.items:
@@ -552,19 +558,19 @@ class MenuBuilder:
             else:
                 roots.append(item)
 
-        # Detect cycles
+        # Detect cycles in the materialized tree as a second line of defense.
         visited: set[str] = set()
-        for root in roots:
-            if self._has_cycle(root, visited, set()):
+        for item in self.items:
+            if item.identifier not in visited and self._has_cycle(item, visited, set()):
                 emit_diagnostic(
                     self,
                     "error",
                     "menu_cycle_detected",
-                    root_item=root.name,
-                    root_identifier=root.identifier,
+                    root_item=item.name,
+                    root_identifier=item.identifier,
                 )
                 raise BengalContentError(
-                    f"Menu has circular reference involving '{root.name}'",
+                    f"Menu has circular reference involving '{item.name}'",
                     code=ErrorCode.C007,
                     suggestion="Check menu configuration for circular parent-child relationships",
                 )
@@ -579,7 +585,9 @@ class MenuBuilder:
             sort_recursive(root)
 
         # Sort roots by weight
-        roots.sort(key=lambda x: x.weight)
+        from bengal.core.utils.sorting import weight_sort_key
+
+        roots.sort(key=weight_sort_key)
 
         emit_diagnostic(
             self,
@@ -591,6 +599,55 @@ class MenuBuilder:
         )
 
         return roots
+
+    def _clear_existing_hierarchy(self) -> None:
+        """Remove previously materialized child links before rebuilding."""
+        for item in self.items:
+            item.children.clear()
+            item._children_dirty = False
+
+    def _validate_parent_links_are_acyclic(self, by_id: dict[str, MenuItem]) -> None:
+        """Validate the flat parent graph before materializing children."""
+        visiting: set[str] = set()
+        visited: set[str] = set()
+
+        def visit(item: MenuItem, path: list[str]) -> None:
+            identifier = item.identifier
+            if identifier is None:
+                return
+            if identifier in visited:
+                return
+            if identifier in visiting:
+                cycle_start = path.index(identifier) if identifier in path else 0
+                cycle = " -> ".join([*path[cycle_start:], identifier])
+                emit_diagnostic(
+                    self,
+                    "error",
+                    "menu_parent_cycle_detected",
+                    cycle=cycle,
+                    item=item.name,
+                    identifier=identifier,
+                )
+                raise BengalContentError(
+                    f"Menu has circular parent reference involving '{item.name}'",
+                    code=ErrorCode.C007,
+                    suggestion=(
+                        "Check menu configuration for circular parent-child relationships "
+                        f"such as: {cycle}"
+                    ),
+                )
+
+            visiting.add(identifier)
+            parent_id = item.parent
+            if parent_id is not None:
+                parent = by_id.get(parent_id)
+                if parent is not None:
+                    visit(parent, [*path, identifier])
+            visiting.discard(identifier)
+            visited.add(identifier)
+
+        for item in self.items:
+            visit(item, [])
 
     def _has_cycle(self, item: MenuItem, visited: set[str], path: set[str]) -> bool:
         """

--- a/bengal/core/output/collector.py
+++ b/bengal/core/output/collector.py
@@ -53,6 +53,7 @@ class BuildOutputCollector:
         """
         self._output_dir = output_dir
         self._outputs: list[OutputRecord] = []
+        self._counts_by_type: dict[OutputType, int] = {}
         self._lock = Lock()
         self._logger = get_logger(__name__)
 
@@ -84,6 +85,9 @@ class BuildOutputCollector:
 
         with self._lock:
             self._outputs.append(record)
+            self._counts_by_type[record.output_type] = (
+                self._counts_by_type.get(record.output_type, 0) + 1
+            )
 
     def get_outputs(
         self,
@@ -130,7 +134,7 @@ class BuildOutputCollector:
         with self._lock:
             if not self._outputs:
                 return False
-            return all(o.output_type == OutputType.CSS for o in self._outputs)
+            return self._counts_by_type.get(OutputType.CSS, 0) == len(self._outputs)
 
     def clear(self) -> None:
         """Clear all recorded outputs.
@@ -139,6 +143,7 @@ class BuildOutputCollector:
         """
         with self._lock:
             self._outputs.clear()
+            self._counts_by_type.clear()
 
     def validate(self, changed_sources: list[str] | None = None) -> None:
         """Validate tracking integrity and emit diagnostics.

--- a/bengal/core/page_cache.py
+++ b/bengal/core/page_cache.py
@@ -26,7 +26,9 @@ class PageCacheManager:
 
     Holds filtered views (regular_pages, generated_pages, listable_pages)
     and O(1) lookup maps (by string path, by Path object). Each cache is
-    built on first access and cleared by invalidate().
+    built on first access and cleared by invalidate(). Cached values also
+    self-invalidate when the page list token changes, which covers same-length
+    list replacement and in-place page reclassification.
 
     Args:
         pages_fn: Callable returning the current list of pages (e.g., lambda: site.pages)
@@ -34,91 +36,128 @@ class PageCacheManager:
 
     __slots__ = (
         "_generated",
+        "_generated_token",
         "_listable",
+        "_listable_token",
         "_lock",
         "_pages_fn",
         "_path_map",
-        "_path_map_version",
+        "_path_map_token",
         "_regular",
+        "_regular_token",
         "_source_path_map",
+        "_source_path_map_token",
     )
 
     def __init__(self, pages_fn: Callable[[], list[PageLike]]) -> None:
         self._pages_fn = pages_fn
         self._regular: list[PageLike] | None = None
+        self._regular_token: tuple[object, ...] | None = None
         self._generated: list[PageLike] | None = None
+        self._generated_token: tuple[object, ...] | None = None
         self._listable: list[PageLike] | None = None
+        self._listable_token: tuple[object, ...] | None = None
         self._path_map: dict[str, PageLike] | None = None
-        self._path_map_version: int = -1
+        self._path_map_token: tuple[object, ...] | None = None
         self._source_path_map: dict[Path, PageLike] | None = None
+        self._source_path_map_token: tuple[object, ...] | None = None
         self._lock = threading.Lock()
+
+    def _regular_view_token(self, pages: list[PageLike]) -> tuple[tuple[int, bool], ...]:
+        """Return token fields that affect regular/generated page views."""
+        return tuple((id(page), bool(page.metadata.get("_generated"))) for page in pages)
+
+    def _listable_view_token(self, pages: list[PageLike]) -> tuple[tuple[int, bool], ...]:
+        """Return token fields that affect listable page views."""
+        return tuple((id(page), bool(page.in_listings)) for page in pages)
+
+    def _path_map_view_token(self, pages: list[PageLike]) -> tuple[tuple[int, Path], ...]:
+        """Return token fields that affect source-path lookup maps."""
+        return tuple((id(page), page.source_path) for page in pages)
 
     @property
     def regular_pages(self) -> list[PageLike]:
         """Regular content pages (excludes generated taxonomy/archive pages)."""
-        if self._regular is not None:
+        pages = self._pages_fn()
+        token = self._regular_view_token(pages)
+        if self._regular is not None and self._regular_token == token:
             return self._regular
         with self._lock:
-            if self._regular is not None:
+            if self._regular is not None and self._regular_token == token:
                 return self._regular
-            self._regular = [p for p in self._pages_fn() if not p.metadata.get("_generated")]
+            self._regular = [p for p in pages if not p.metadata.get("_generated")]
+            self._regular_token = token
         return self._regular
 
     @property
     def generated_pages(self) -> list[PageLike]:
         """Generated pages (taxonomy, archive, pagination)."""
-        if self._generated is not None:
+        pages = self._pages_fn()
+        token = self._regular_view_token(pages)
+        if self._generated is not None and self._generated_token == token:
             return self._generated
         with self._lock:
-            if self._generated is not None:
+            if self._generated is not None and self._generated_token == token:
                 return self._generated
-            self._generated = [p for p in self._pages_fn() if p.metadata.get("_generated")]
+            self._generated = [p for p in pages if p.metadata.get("_generated")]
+            self._generated_token = token
         return self._generated
 
     @property
     def listable_pages(self) -> list[PageLike]:
         """Pages eligible for public listings (excludes hidden/draft)."""
-        if self._listable is not None:
+        pages = self._pages_fn()
+        token = self._listable_view_token(pages)
+        if self._listable is not None and self._listable_token == token:
             return self._listable
         with self._lock:
-            if self._listable is not None:
+            if self._listable is not None and self._listable_token == token:
                 return self._listable
-            self._listable = [p for p in self._pages_fn() if p.in_listings]
+            self._listable = [p for p in pages if p.in_listings]
+            self._listable_token = token
         return self._listable
 
     def get_page_path_map(self) -> dict[str, PageLike]:
         """
         Cached string-keyed page lookup map for O(1) resolution.
 
-        Auto-invalidates when page count changes (covers add/remove in dev server).
+        Auto-invalidates when the page-list token changes.
         """
         pages = self._pages_fn()
-        current_version = len(pages)
-        if self._path_map is None or self._path_map_version != current_version:
+        token = self._path_map_view_token(pages)
+        if self._path_map is None or self._path_map_token != token:
             with self._lock:
-                if self._path_map is None or self._path_map_version != current_version:
+                if self._path_map is None or self._path_map_token != token:
                     self._path_map = {str(p.source_path): p for p in pages}
-                    self._path_map_version = current_version
+                    self._path_map_token = token
         return self._path_map
 
     @property
     def page_by_source_path(self) -> dict[Path, PageLike]:
         """O(1) page lookup by source Path (shared across orchestrators)."""
-        if self._source_path_map is None:
+        pages = self._pages_fn()
+        token = self._path_map_view_token(pages)
+        if self._source_path_map is None or self._source_path_map_token != token:
             with self._lock:
-                if self._source_path_map is None:
-                    self._source_path_map = {p.source_path: p for p in self._pages_fn()}
+                if self._source_path_map is None or self._source_path_map_token != token:
+                    self._source_path_map = {p.source_path: p for p in pages}
+                    self._source_path_map_token = token
         return self._source_path_map
 
     def invalidate(self) -> None:
         """Clear all caches. Call after adding/removing pages or modifying metadata."""
         self._regular = None
+        self._regular_token = None
         self._generated = None
+        self._generated_token = None
         self._listable = None
+        self._listable_token = None
         self._path_map = None
-        self._path_map_version = -1
+        self._path_map_token = None
         self._source_path_map = None
+        self._source_path_map_token = None
 
     def invalidate_regular(self) -> None:
         """Clear only the regular_pages cache."""
         self._regular = None
+        self._regular_token = None

--- a/bengal/core/section/hierarchy.py
+++ b/bengal/core/section/hierarchy.py
@@ -60,12 +60,9 @@ def get_icon(section: Section) -> str | None:
 
 def sorted_subsections(section: Section) -> list[Section]:
     """Get subsections sorted by weight ascending, then title."""
-    from bengal.core.utils.sorting import DEFAULT_WEIGHT
+    from bengal.core.utils.sorting import sorted_by_weight
 
-    return sorted(
-        section.subsections,
-        key=lambda s: (s.metadata.get("weight", DEFAULT_WEIGHT), s.title.lower()),
-    )
+    return sorted_by_weight(section.subsections)
 
 
 def add_subsection(section: Section, child: Section) -> None:

--- a/bengal/errors/reporter.py
+++ b/bengal/errors/reporter.py
@@ -53,14 +53,19 @@ See Also
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 from bengal.errors.utils import get_error_message
 from bengal.output.icons import get_icon_set
-from bengal.utils.observability.terminal import should_use_emoji
 
 if TYPE_CHECKING:
     from bengal.orchestration.stats.models import BuildStats
+
+
+def _should_use_emoji() -> bool:
+    """Check BENGAL_EMOJI without importing terminal infrastructure."""
+    return os.getenv("BENGAL_EMOJI", "").strip() == "1"
 
 
 def format_error_report(stats: BuildStats, verbose: bool = False) -> str:
@@ -82,7 +87,7 @@ def format_error_report(stats: BuildStats, verbose: bool = False) -> str:
     """
     summary = stats.get_error_summary()
 
-    icons = get_icon_set(should_use_emoji())
+    icons = get_icon_set(_should_use_emoji())
 
     # If no errors or warnings, return success message
     if summary["total_errors"] == 0 and summary["total_warnings"] == 0:
@@ -154,7 +159,7 @@ def format_error_summary(stats: BuildStats) -> str:
         Brief summary string
 
     """
-    icons = get_icon_set(should_use_emoji())
+    icons = get_icon_set(_should_use_emoji())
     summary = stats.get_error_summary()
     if summary["total_errors"] == 0 and summary["total_warnings"] == 0:
         return f"{icons.success} Build completed successfully"

--- a/bengal/errors/suggestions.py
+++ b/bengal/errors/suggestions.py
@@ -920,7 +920,7 @@ def identify_none_callable(error: BaseException, template_path: Path | None = No
 
     if template_path and template_path.exists():
         try:
-            from bengal.rendering.errors.context_extractor import (
+            from bengal.errors.template_callables import (
                 scan_template_for_callables,
             )
 

--- a/bengal/errors/template_callables.py
+++ b/bengal/errors/template_callables.py
@@ -1,0 +1,90 @@
+"""Template callable scanning used by error suggestions."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_KNOWN_SAFE_CALLABLES: frozenset[str] = frozenset(
+    {
+        "range",
+        "len",
+        "dict",
+        "list",
+        "str",
+        "int",
+        "float",
+        "bool",
+        "set",
+        "tuple",
+        "enumerate",
+        "zip",
+        "sorted",
+        "reversed",
+        "min",
+        "max",
+        "sum",
+        "abs",
+        "round",
+        "type",
+        "isinstance",
+        "getattr",
+        "hasattr",
+        "callable",
+        "print",
+        "super",
+        "loop",
+        "self",
+        "caller",
+        "if",
+        "else",
+        "elif",
+        "for",
+        "endfor",
+        "endif",
+        "block",
+        "endblock",
+        "macro",
+        "endmacro",
+        "call",
+        "endcall",
+        "include",
+        "import",
+        "from",
+        "extends",
+        "with",
+        "endwith",
+    }
+)
+
+_FUNC_CALL_PATTERN = re.compile(r"\{\{[^}]*\b(\w+)\s*\([^}]*\}\}")
+_FILTER_PATTERN = re.compile(r"\|\s*(\w+)")
+
+
+def scan_template_for_callables(template_path: Path) -> list[str]:
+    """Return likely-None callable suspects from a template file."""
+    try:
+        with open(template_path, encoding="utf-8") as fh:
+            content = fh.read()
+    except OSError:
+        return []
+
+    suspects: list[str] = []
+
+    for match in _FUNC_CALL_PATTERN.finditer(content):
+        func_name = match.group(1)
+        if func_name.lower() not in _KNOWN_SAFE_CALLABLES:
+            suspects.append(f"function '{func_name}'")
+
+    for match in _FILTER_PATTERN.finditer(content):
+        filter_name = match.group(1)
+        if filter_name.lower() not in _KNOWN_SAFE_CALLABLES:
+            suspects.append(f"filter '{filter_name}'")
+
+    return suspects
+
+
+__all__ = ["scan_template_for_callables"]

--- a/bengal/fonts/__init__.py
+++ b/bengal/fonts/__init__.py
@@ -57,6 +57,7 @@ from typing import Any
 from bengal.fonts.downloader import FontVariant, GoogleFontsDownloader
 from bengal.fonts.generator import FontCSSGenerator
 from bengal.fonts.utils import make_font_filename, make_safe_name
+from bengal.utils.io.atomic_write import atomic_write_text
 
 
 def rewrite_font_urls_with_fingerprints(
@@ -128,7 +129,7 @@ def rewrite_font_urls_with_fingerprints(
             css_content = re.sub(pattern, replacement, css_content)
 
     if css_content != original_content:
-        fonts_css_path.write_text(css_content, encoding="utf-8")
+        atomic_write_text(fonts_css_path, css_content, encoding="utf-8")
         return True
 
     return False
@@ -254,7 +255,7 @@ class FontHelper:
                 )
                 return css_path
 
-        css_path.write_text(css_content, encoding="utf-8")
+        atomic_write_text(css_path, css_content, encoding="utf-8")
         cli.detail(
             f"Generated: fonts.css ({total_variants} variants)", indent=1, icon=cli.icons.tree_end
         )

--- a/bengal/fonts/downloader.py
+++ b/bengal/fonts/downloader.py
@@ -504,18 +504,15 @@ class GoogleFontsDownloader:
         ua = user_agent or self.USER_AGENT_WOFF2
         data = urlopen_with_ssl_fallback(url, timeout=30, user_agent=ua, decode=False)
 
-        # Atomic write for safety
-        tmp_path = output_path.with_suffix(".tmp")
         try:
-            tmp_path.write_bytes(data)
-            tmp_path.replace(output_path)
+            from bengal.utils.io.atomic_write import atomic_write_bytes
+
+            atomic_write_bytes(output_path, data)
         except Exception as e:
             logger.debug(
                 "font_downloader_atomic_write_failed",
                 output_path=str(output_path),
                 error=str(e),
                 error_type=type(e).__name__,
-                action="cleaning_up_temp_file",
             )
-            tmp_path.unlink(missing_ok=True)
             raise

--- a/bengal/icons/resolver.py
+++ b/bengal/icons/resolver.py
@@ -20,12 +20,17 @@ Usage:
 from __future__ import annotations
 
 import threading
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from bengal.protocols import SiteConfig
 
 logger = get_logger(__name__)
@@ -33,18 +38,41 @@ logger = get_logger(__name__)
 __all__ = [
     "clear_cache",
     "get_available_icons",
+    "get_scope_key",
     "get_search_paths",
     "initialize",
     "load_icon",
+    "site_context",
 ]
 
-# Module-level state (set during Site initialization)
-# Thread-safe: All state access protected by _icon_lock for concurrent access
+# Legacy default state (set during Site initialization). Scoped rendering paths
+# should use site_context() or pass site=... to avoid cross-site contamination.
+# Thread-safe: All state access protected by _icon_lock for concurrent access.
 _icon_lock = threading.Lock()
 _search_paths: list[Path] = []
 _icon_cache: dict[str, str] = {}
 _not_found_cache: set[str] = set()  # Avoid repeated disk checks
 _initialized: bool = False
+
+
+@dataclass
+class _IconResolverState:
+    """Per-search-path icon resolver cache."""
+
+    search_paths: tuple[Path, ...]
+    icon_cache: dict[str, str] = field(default_factory=dict)
+    not_found_cache: set[str] = field(default_factory=set)
+
+    @property
+    def scope_key(self) -> tuple[str, ...]:
+        return tuple(str(path) for path in self.search_paths)
+
+
+_scoped_states: dict[tuple[str, ...], _IconResolverState] = {}
+_active_state: ContextVar[_IconResolverState | None] = ContextVar(
+    "bengal_icon_resolver_state",
+    default=None,
+)
 
 # Characters that are not allowed in icon names (path traversal prevention)
 _INVALID_CHARS = frozenset("/\\.\x00")
@@ -89,15 +117,46 @@ def initialize(site: SiteConfig, preload: bool = False) -> None:
     global _search_paths, _initialized
     # Compute paths outside lock (expensive I/O)
     paths = _get_icon_search_paths(site)
+    state = _get_or_create_state(paths)
 
     with _icon_lock:
         _search_paths = paths
         _icon_cache.clear()
         _not_found_cache.clear()
+        state.icon_cache.clear()
+        state.not_found_cache.clear()
         _initialized = True
 
     if preload:
+        _preload_state(state)
         _preload_all_icons()
+
+
+def _get_or_create_state(paths: list[Path] | tuple[Path, ...]) -> _IconResolverState:
+    """Return the per-scope resolver state for a search path chain."""
+    search_paths = tuple(paths)
+    key = tuple(str(path) for path in search_paths)
+    with _icon_lock:
+        state = _scoped_states.get(key)
+        if state is None:
+            state = _IconResolverState(search_paths=search_paths)
+            _scoped_states[key] = state
+        return state
+
+
+def _state_for_site(site: SiteConfig) -> _IconResolverState:
+    return _get_or_create_state(_get_icon_search_paths(site))
+
+
+@contextmanager
+def site_context(site: SiteConfig) -> Iterator[None]:
+    """Temporarily scope icon resolution to a site/theme search path chain."""
+    state = _state_for_site(site)
+    token: Token[_IconResolverState | None] = _active_state.set(state)
+    try:
+        yield
+    finally:
+        _active_state.reset(token)
 
 
 def _get_icon_search_paths(site: SiteConfig) -> list[Path]:
@@ -150,7 +209,7 @@ def _get_fallback_path() -> Path:
     return Path(bengal_file).parent / "themes" / "default" / "assets" / "icons"
 
 
-def load_icon(name: str) -> str | None:
+def load_icon(name: str, *, site: SiteConfig | None = None) -> str | None:
     """
     Load icon from first matching path in search chain.
 
@@ -178,7 +237,12 @@ def load_icon(name: str) -> str | None:
         )
         return None
 
-    # Check caches under lock
+    state = _state_for_site(site) if site is not None else _active_state.get()
+
+    if state is not None:
+        return _load_icon_from_state(name, state)
+
+    # Legacy fallback for callers outside an explicit site/build scope.
     with _icon_lock:
         if name in _icon_cache:
             return _icon_cache[name]
@@ -217,6 +281,42 @@ def load_icon(name: str) -> str | None:
     return None
 
 
+def _load_icon_from_state(name: str, state: _IconResolverState) -> str | None:
+    """Load an icon using a site-scoped resolver state."""
+    with _icon_lock:
+        if name in state.icon_cache:
+            return state.icon_cache[name]
+        if name in state.not_found_cache:
+            return None
+        search_paths = state.search_paths
+
+    for icons_dir in search_paths:
+        icon_path = icons_dir / f"{name}.svg"
+        if icon_path.exists():
+            try:
+                content = icon_path.read_text(encoding="utf-8")
+                with _icon_lock:
+                    state.icon_cache[name] = content
+                return content
+            except OSError as e:
+                logger.debug(
+                    "icon_read_error",
+                    icon=name,
+                    path=str(icon_path),
+                    error=str(e),
+                )
+                continue
+
+    logger.debug(
+        "icon_not_found_in_resolver",
+        icon=name,
+        search_paths=[str(p) for p in search_paths],
+    )
+    with _icon_lock:
+        state.not_found_cache.add(name)
+    return None
+
+
 def get_search_paths() -> list[Path]:
     """
     Get current search paths (for error messages).
@@ -227,10 +327,27 @@ def get_search_paths() -> list[Path]:
         Copy of the current search paths list
 
     """
+    state = _active_state.get()
+    if state is not None:
+        return list(state.search_paths)
+
     with _icon_lock:
         if _initialized:
             return _search_paths.copy()
     return [_get_fallback_path()]
+
+
+def get_scope_key(site: SiteConfig | None = None) -> tuple[str, ...]:
+    """Return the active icon resolver scope key for render-cache namespacing."""
+    if site is not None:
+        return _state_for_site(site).scope_key
+    state = _active_state.get()
+    if state is not None:
+        return state.scope_key
+    with _icon_lock:
+        if _initialized:
+            return tuple(str(path) for path in _search_paths)
+    return (str(_get_fallback_path()),)
 
 
 def get_available_icons() -> list[str]:
@@ -249,9 +366,13 @@ def get_available_icons() -> list[str]:
     seen: set[str] = set()
     icons: list[str] = []
 
-    # Copy search paths under lock
-    with _icon_lock:
-        search_paths = _search_paths.copy() if _initialized else [_get_fallback_path()]
+    state = _active_state.get()
+    if state is not None:
+        search_paths = list(state.search_paths)
+    else:
+        # Copy search paths under lock
+        with _icon_lock:
+            search_paths = _search_paths.copy() if _initialized else [_get_fallback_path()]
 
     # Disk I/O outside lock
     for icons_dir in search_paths:
@@ -277,6 +398,9 @@ def clear_cache() -> None:
     with _icon_lock:
         _icon_cache.clear()
         _not_found_cache.clear()
+        for state in _scoped_states.values():
+            state.icon_cache.clear()
+            state.not_found_cache.clear()
 
 
 def _preload_all_icons() -> None:
@@ -317,6 +441,34 @@ def _preload_all_icons() -> None:
     # Batch update cache under lock
     with _icon_lock:
         _icon_cache.update(loaded)
+
+
+def _preload_state(state: _IconResolverState) -> None:
+    """Preload all icons into a site-scoped resolver state."""
+    search_paths = state.search_paths
+    seen: set[str] = set()
+    loaded: dict[str, str] = {}
+
+    for icons_dir in search_paths:
+        if not icons_dir.exists():
+            continue
+        for icon_path in icons_dir.glob("*.svg"):
+            name = icon_path.stem
+            if name in seen:
+                continue
+            try:
+                loaded[name] = icon_path.read_text(encoding="utf-8")
+                seen.add(name)
+            except OSError as e:
+                logger.debug(
+                    "icon_preload_error",
+                    icon=name,
+                    path=str(icon_path),
+                    error=str(e),
+                )
+
+    with _icon_lock:
+        state.icon_cache.update(loaded)
 
 
 def is_initialized() -> bool:

--- a/bengal/icons/svg.py
+++ b/bengal/icons/svg.py
@@ -39,10 +39,14 @@ from __future__ import annotations
 
 import re
 import threading
+from typing import TYPE_CHECKING
 
 from bengal.icons import resolver as icon_resolver
 from bengal.utils.observability.logger import get_logger
 from bengal.utils.primitives.lru_cache import LRUCache
+
+if TYPE_CHECKING:
+    from bengal.protocols import SiteConfig
 
 __all__ = [
     "ICON_MAP",
@@ -66,7 +70,9 @@ _missing_icon_lock = threading.Lock()
 _missing_icon_warnings: dict[str, dict[str, object]] = {}
 
 # Thread-safe LRU cache for SVG icon rendering (replaces @lru_cache for free-threading)
-_svg_icon_cache: LRUCache[tuple[str, int, str, str], str] = LRUCache(maxsize=512, name="svg_icon")
+_svg_icon_cache: LRUCache[tuple[tuple[str, ...], str, int, str, str], str] = LRUCache(
+    maxsize=512, name="svg_icon"
+)
 
 
 def get_icon_svg(name: str) -> str | None:
@@ -99,6 +105,8 @@ def render_svg_icon(
     size: int = 20,
     css_class: str = "",
     aria_label: str = "",
+    *,
+    site: SiteConfig | None = None,
 ) -> str:
     """
     Render an SVG icon for use in directives.
@@ -128,13 +136,14 @@ def render_svg_icon(
             '<svg ...'
 
     """
-    key = (name, size, css_class, aria_label)
+    scope_key = icon_resolver.get_scope_key(site)
+    key = (scope_key, name, size, css_class, aria_label)
 
     def _render_impl() -> str:
         # Map semantic name to actual icon name (e.g., "alert" -> "warning")
         icon_name = ICON_MAP.get(name, name)
 
-        svg_content = icon_resolver.load_icon(icon_name)
+        svg_content = icon_resolver.load_icon(icon_name, site=site)
         if svg_content is None:
             return ""
 

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -280,12 +280,14 @@ class BuildOrchestrator:
         self.stats = BuildStats(parallel=False, incremental=bool(incremental))
         self.stats.strict_mode = strict
         self.stats.completion_policy = options.completion_policy.value
+        self.stats.change_census = build_input.change_census.to_dict()
 
         logger.info(
             "build_start",
             force_sequential=force_sequential,
             incremental=incremental,
             root_path=str(self.site.root_path),
+            change_census=self.stats.change_census,
         )
 
         # Attach a diagnostics collector for core-model events (core must not log).

--- a/bengal/orchestration/build/initialization.py
+++ b/bengal/orchestration/build/initialization.py
@@ -184,9 +184,8 @@ def phase_fonts(
     with orchestrator.logger.phase("fonts"):
         fonts_start = time.time()
         try:
-            import shutil
-
             from bengal.fonts import FontHelper
+            from bengal.utils.io.atomic_write import atomic_write_bytes
 
             # Ensure assets directory exists (source)
             assets_dir = orchestrator.site.root_path / "assets"
@@ -202,15 +201,18 @@ def phase_fonts(
                 output_assets = orchestrator.site.output_dir / "assets"
                 output_assets.mkdir(parents=True, exist_ok=True)
                 output_css = output_assets / "fonts.css"
-                # Only copy if destination doesn't exist or source is newer
-                # (prevents triggering file watcher when nothing changed)
-                if not output_css.exists() or css_path.stat().st_mtime > output_css.stat().st_mtime:
-                    shutil.copy2(css_path, output_css)
+                css_bytes = css_path.read_bytes()
+                output_changed = True
+                if output_css.exists():
+                    output_changed = output_css.read_bytes() != css_bytes
+                if output_changed:
+                    mode = css_path.stat().st_mode & 0o777
+                    atomic_write_bytes(output_css, css_bytes, mode=mode)
                     if collector is not None:
                         from bengal.core.output.types import OutputType
 
                         collector.record(
-                            output_css.relative_to(orchestrator.site.output_dir),
+                            output_css,
                             OutputType.CSS,
                             phase="asset",
                         )

--- a/bengal/orchestration/build/inputs.py
+++ b/bengal/orchestration/build/inputs.py
@@ -7,7 +7,7 @@ enabling serialization, logging, and replay for debugging.
 See Also:
 - plan/analysis-pipeline-inputs-and-vertical-stacks.md
 - bengal.orchestration.build.options: BuildOptions
-- bengal.server.build_executor: BuildRequest (serializable view)
+- bengal.orchestration.build.requests: BuildRequest (serializable view)
 """
 
 from __future__ import annotations
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 from bengal.orchestration.build.options import BuildCompletionPolicy, BuildOptions
 
 if TYPE_CHECKING:
-    from bengal.server.build_executor import BuildRequest
+    from bengal.orchestration.build.requests import BuildRequest
 
 
 _CONTENT_EXTENSIONS = frozenset({".md", ".markdown", ".html", ".txt", ".ipynb"})
@@ -205,7 +205,7 @@ class BuildInput:
 
     def to_build_request(self) -> BuildRequest:
         """Convert to BuildRequest for process-isolated builds."""
-        from bengal.server.build_executor import BuildRequest
+        from bengal.orchestration.build.requests import BuildRequest
 
         return BuildRequest(
             site_root=str(self.site_root),

--- a/bengal/orchestration/build/inputs.py
+++ b/bengal/orchestration/build/inputs.py
@@ -12,7 +12,7 @@ See Also:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,6 +20,77 @@ from bengal.orchestration.build.options import BuildCompletionPolicy, BuildOptio
 
 if TYPE_CHECKING:
     from bengal.server.build_executor import BuildRequest
+
+
+_CONTENT_EXTENSIONS = frozenset({".md", ".markdown", ".html", ".txt", ".ipynb"})
+
+
+@dataclass(frozen=True, slots=True)
+class BuildChangeCensus:
+    """Pre-discovery classification of watcher/build input changes."""
+
+    changed_count: int = 0
+    nav_changed_count: int = 0
+    content_changed_count: int = 0
+    non_content_changed_count: int = 0
+    structural_changed: bool = False
+    no_changes: bool = True
+    single_edit: bool = False
+    single_changed_path: Path | None = None
+
+    @classmethod
+    def empty(cls) -> BuildChangeCensus:
+        """Return a no-change census."""
+        return cls()
+
+    @classmethod
+    def from_changes(
+        cls,
+        *,
+        changed_sources: frozenset[Path],
+        nav_changed_sources: frozenset[Path],
+        structural_changed: bool,
+    ) -> BuildChangeCensus:
+        """Classify changed paths before content discovery runs."""
+        changed_count = len(changed_sources)
+        nav_changed_count = len(nav_changed_sources)
+        content_changed_count = sum(
+            1 for path in changed_sources if path.suffix.lower() in _CONTENT_EXTENSIONS
+        )
+        non_content_changed_count = changed_count - content_changed_count
+        no_changes = changed_count == 0 and nav_changed_count == 0 and not structural_changed
+        single_edit = (
+            changed_count == 1
+            and nav_changed_count == 0
+            and not structural_changed
+            and content_changed_count == 1
+        )
+        single_changed_path = next(iter(changed_sources)) if single_edit else None
+        return cls(
+            changed_count=changed_count,
+            nav_changed_count=nav_changed_count,
+            content_changed_count=content_changed_count,
+            non_content_changed_count=non_content_changed_count,
+            structural_changed=structural_changed,
+            no_changes=no_changes,
+            single_edit=single_edit,
+            single_changed_path=single_changed_path,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable debug/stat payload."""
+        return {
+            "changed_count": self.changed_count,
+            "nav_changed_count": self.nav_changed_count,
+            "content_changed_count": self.content_changed_count,
+            "non_content_changed_count": self.non_content_changed_count,
+            "structural_changed": self.structural_changed,
+            "no_changes": self.no_changes,
+            "single_edit": self.single_edit,
+            "single_changed_path": str(self.single_changed_path)
+            if self.single_changed_path is not None
+            else None,
+        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,6 +120,7 @@ class BuildInput:
     structural_changed: bool = False
     event_types: frozenset[str] = frozenset()
     version_scope: str | None = None
+    change_census: BuildChangeCensus = field(default_factory=BuildChangeCensus.empty)
 
     @classmethod
     def from_options(
@@ -64,25 +136,33 @@ class BuildInput:
         version_scope: str | None = None,
     ) -> BuildInput:
         """Create BuildInput from BuildOptions with optional overrides."""
+        resolved_changed_sources = (
+            changed_sources
+            if changed_sources is not None
+            else frozenset(options.changed_sources or ())
+        )
+        resolved_nav_changed_sources = (
+            nav_changed_sources
+            if nav_changed_sources is not None
+            else frozenset(options.nav_changed_sources or ())
+        )
+        resolved_structural_changed = (
+            structural_changed if structural_changed is not None else options.structural_changed
+        )
         return cls(
             options=options,
             site_root=Path(site_root),
             config_hash=config_hash or "",
-            changed_sources=(
-                changed_sources
-                if changed_sources is not None
-                else frozenset(options.changed_sources or ())
-            ),
-            nav_changed_sources=(
-                nav_changed_sources
-                if nav_changed_sources is not None
-                else frozenset(options.nav_changed_sources or ())
-            ),
-            structural_changed=structural_changed
-            if structural_changed is not None
-            else options.structural_changed,
+            changed_sources=resolved_changed_sources,
+            nav_changed_sources=resolved_nav_changed_sources,
+            structural_changed=resolved_structural_changed,
             event_types=event_types if event_types is not None else frozenset(),
             version_scope=version_scope,
+            change_census=BuildChangeCensus.from_changes(
+                changed_sources=resolved_changed_sources,
+                nav_changed_sources=resolved_nav_changed_sources,
+                structural_changed=resolved_structural_changed,
+            ),
         )
 
     @classmethod
@@ -107,13 +187,20 @@ class BuildInput:
             nav_changed_sources={Path(p) for p in request.nav_changed_paths},
             structural_changed=request.structural_changed,
         )
+        changed_sources = frozenset(Path(p) for p in request.changed_paths)
+        nav_changed_sources = frozenset(Path(p) for p in request.nav_changed_paths)
         return cls(
             options=options,
             site_root=Path(request.site_root),
-            changed_sources=frozenset(Path(p) for p in request.changed_paths),
-            nav_changed_sources=frozenset(Path(p) for p in request.nav_changed_paths),
+            changed_sources=changed_sources,
+            nav_changed_sources=nav_changed_sources,
             structural_changed=request.structural_changed,
             version_scope=request.version_scope,
+            change_census=BuildChangeCensus.from_changes(
+                changed_sources=changed_sources,
+                nav_changed_sources=nav_changed_sources,
+                structural_changed=request.structural_changed,
+            ),
         )
 
     def to_build_request(self) -> BuildRequest:

--- a/bengal/orchestration/build/provenance_filter.py
+++ b/bengal/orchestration/build/provenance_filter.py
@@ -33,6 +33,11 @@ from bengal.orchestration.build.results import (
     RebuildReasonCode,
     SkipReasonCode,
 )
+from bengal.rendering.template_engine.environment import (
+    iter_template_files,
+    resolve_template_dirs,
+    template_name_for_path,
+)
 from bengal.utils.observability.logger import get_logger
 from bengal.utils.primitives.hashing import hash_file
 
@@ -235,51 +240,36 @@ def _detect_changed_templates(
         Set of changed template file paths
     """
     changed: set[Path] = set()
-    templates_dir = site.root_path / "templates"
+    for tpl_file in iter_template_files(site):
+        try:
+            file_changed = cache.is_changed(tpl_file)
+        except OSError:
+            # File error - treat as changed, skip fingerprint update
+            changed.add(tpl_file)
+            continue
 
-    if not templates_dir.exists():
-        return changed
-
-    # Also check theme templates if theme is set
-    theme_templates_dirs = []
-    _theme_path = getattr(site, "theme_path", None)
-    if _theme_path:
-        theme_templates = _theme_path / "templates"
-        if theme_templates.exists():
-            theme_templates_dirs.append(theme_templates)
-
-    # Scan all template directories
-    for tpl_dir in [templates_dir, *theme_templates_dirs]:
-        for tpl_file in tpl_dir.glob("**/*.html"):
+        if file_changed:
+            changed.add(tpl_file)
+            # Store current fingerprint so the next incremental build can use
+            # the mtime/size fast path. Unchanged files already have a valid
+            # fingerprint, and cache.is_changed() refreshes touch-only files.
             try:
-                file_changed = cache.is_changed(tpl_file)
-            except OSError:
-                # File error - treat as changed, skip fingerprint update
-                changed.add(tpl_file)
-                continue
-
-            if file_changed:
-                changed.add(tpl_file)
-                # Store current fingerprint so the next incremental build can use
-                # the mtime/size fast path. Unchanged files already have a valid
-                # fingerprint, and cache.is_changed() refreshes touch-only files.
-                try:
-                    stat = tpl_file.stat()
-                    current_hash = hash_file(tpl_file)
-                    cache.set_file_fingerprint(
-                        tpl_file,
-                        {
-                            "mtime": stat.st_mtime,
-                            "size": stat.st_size,
-                            "hash": current_hash,
-                        },
-                    )
-                except OSError as e:
-                    logger.debug(
-                        "template_fingerprint_update_failed",
-                        file=str(tpl_file),
-                        error=str(e),
-                    )
+                stat = tpl_file.stat()
+                current_hash = hash_file(tpl_file)
+                cache.set_file_fingerprint(
+                    tpl_file,
+                    {
+                        "mtime": stat.st_mtime,
+                        "size": stat.st_size,
+                        "hash": current_hash,
+                    },
+                )
+            except OSError as e:
+                logger.debug(
+                    "template_fingerprint_update_failed",
+                    file=str(tpl_file),
+                    error=str(e),
+                )
 
     if changed:
         logger.debug(
@@ -461,23 +451,16 @@ def _expand_forced_changed(
     changed_templates = _detect_changed_templates(cache, site)
     if changed_templates:
         # Resolve template names relative to template dirs (matches determine_template() format)
-        templates_dir = site.root_path / "templates"
-        _theme_path = getattr(site, "theme_path", None)
-        theme_templates_dir = _theme_path / "templates" if _theme_path else None
+        template_dirs = resolve_template_dirs(site)
 
-        def _template_rel_name(tpl_path: Path) -> str:
-            """Get template name relative to its templates dir (POSIX separators)."""
-            for tpl_dir in (templates_dir, theme_templates_dir):
-                if tpl_dir and tpl_path.is_relative_to(tpl_dir):
-                    return tpl_path.relative_to(tpl_dir).as_posix()
-            return tpl_path.name
-
-        template_names_str = ", ".join(_template_rel_name(t) for t in changed_templates)
+        template_names_str = ", ".join(
+            template_name_for_path(t, template_dirs) for t in changed_templates
+        )
         if cache.template_dependencies:
             # Selective rebuild: only rebuild pages that depend on changed templates
             needs_full_rebuild = False
             for changed_template in changed_templates:
-                template_name = _template_rel_name(changed_template)
+                template_name = template_name_for_path(changed_template, template_dirs)
                 affected = cache.get_pages_for_template(template_name)
                 if affected:
                     for page_path_str in affected:

--- a/bengal/orchestration/build/provenance_filter.py
+++ b/bengal/orchestration/build/provenance_filter.py
@@ -1151,6 +1151,8 @@ def record_all_page_builds(
     if pf is None:
         return
 
+    record_entries = []
+
     # Parallelize when many pages (full rebuild) - provenance computation is I/O bound
     use_parallel = parallel and len(pages) > 50
     if use_parallel:
@@ -1158,13 +1160,24 @@ def record_all_page_builds(
         from bengal.utils.concurrency.work_scope import WorkScope
 
         with WorkScope("provenance", max_workers=max_workers) as scope:
-            results = scope.map(pf.record_build, pages)
+            results = scope.map(pf.build_record, pages)
             for r in results:
                 if r.error:
                     raise r.error
+                if r.value is not None:
+                    record_entries.append(r.value)
     else:
         for page in pages:
-            pf.record_build(page)
+            record_with_paths = pf.build_record(page)
+            if record_with_paths is not None:
+                record_entries.append(record_with_paths)
+
+    if not record_entries:
+        return
+
+    records = [record for record, _input_paths in record_entries]
+    input_paths_map = {record.page_path: input_paths for record, input_paths in record_entries}
+    pf.cache.store_batch(records, input_paths_map)
 
 
 def save_provenance_cache(orchestrator: BuildOrchestrator) -> None:

--- a/bengal/orchestration/build/requests.py
+++ b/bengal/orchestration/build/requests.py
@@ -1,0 +1,33 @@
+"""Serializable build request records shared by server and orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class BuildRequest:
+    """
+    Serializable build request for cross-process execution.
+
+    All fields must be picklable for use with ProcessPoolExecutor.
+    Uses strings instead of Path objects for serialization.
+    """
+
+    site_root: str
+    changed_paths: tuple[str, ...] = field(default_factory=tuple)
+    incremental: bool = True
+    profile: str = "WRITER"
+    nav_changed_paths: tuple[str, ...] = field(default_factory=tuple)
+    structural_changed: bool = False
+    force_sequential: bool = False
+    version_scope: str | None = None
+    memory_optimized: bool = False
+    explain: bool = False
+    dry_run: bool = False
+    profile_templates: bool = False
+    completion_policy: str = "complete"
+    quiet: bool = False
+
+
+__all__ = ["BuildRequest"]

--- a/bengal/orchestration/build/state_ledger.py
+++ b/bengal/orchestration/build/state_ledger.py
@@ -1,0 +1,109 @@
+"""Canonical ledger of durable build-state surfaces.
+
+The ledger is intentionally declarative. It gives build, cache, and benchmark
+work a shared vocabulary for the state files and in-memory summaries that decide
+whether a warm build can skip work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class BuildStateSurface:
+    """Describe one durable or reported build-state surface."""
+
+    id: str
+    owner: str
+    storage: str
+    write_phase: str
+    read_phase: str
+    incremental_role: str
+    proof: tuple[str, ...]
+    participates_in_warm_build: bool = True
+
+
+BUILD_STATE_LEDGER: tuple[BuildStateSurface, ...] = (
+    BuildStateSurface(
+        id="change-census",
+        owner="bengal.orchestration.build.inputs",
+        storage="BuildInput.change_census / BuildStats.change_census",
+        write_phase="pre-discovery",
+        read_phase="build planning and reporting",
+        incremental_role="Explains whether the build started from no changes, targeted changes, or structural changes.",
+        proof=("tests/unit/orchestration/build/test_completion_policy.py",),
+    ),
+    BuildStateSurface(
+        id="provenance",
+        owner="bengal.build.provenance",
+        storage=".bengal/cache/provenance.json",
+        write_phase="post-render",
+        read_phase="incremental filtering",
+        incremental_role="Maps output pages to source, template, and config inputs for rebuild decisions.",
+        proof=(
+            "tests/unit/build/provenance/test_filter.py",
+            "tests/unit/orchestration/build/test_provenance_batch.py",
+        ),
+    ),
+    BuildStateSurface(
+        id="page-artifacts",
+        owner="bengal.cache.page_artifact_store",
+        storage=".bengal/cache/page_artifacts/manifest.json plus shard files",
+        write_phase="post-render",
+        read_phase="incremental warm start",
+        incremental_role="Restores rendered-page artifact metadata without scanning every shard on targeted loads.",
+        proof=(
+            "tests/unit/cache/test_page_artifact_store.py",
+            "tests/unit/orchestration/incremental/test_page_artifact_cache.py",
+        ),
+    ),
+    BuildStateSurface(
+        id="output-collector",
+        owner="bengal.orchestration.build_context",
+        storage="BuildContext output collection and artifact inventory",
+        write_phase="render and postprocess",
+        read_phase="post-render finalization and metrics",
+        incremental_role="Records which artifacts were written, skipped, or need downstream inventory.",
+        proof=(
+            "tests/unit/rendering/test_write_output_rendered_page.py",
+            "tests/performance/test_post_render_pipeline_budget.py",
+        ),
+    ),
+    BuildStateSurface(
+        id="template-fingerprints",
+        owner="bengal.orchestration.incremental.cache_manager",
+        storage=".bengal/cache template fingerprint payload",
+        write_phase="cache refresh",
+        read_phase="incremental filtering",
+        incremental_role="Detects active project/theme template changes and inherited theme changes.",
+        proof=(
+            "tests/unit/rendering/test_template_inheritance_detection.py",
+            "tests/unit/orchestration/build/test_provenance_filter_path_keys.py",
+        ),
+    ),
+    BuildStateSurface(
+        id="render-context-cache",
+        owner="bengal.orchestration.build_context",
+        storage="per-build in-memory BuildContext caches",
+        write_phase="render",
+        read_phase="render",
+        incremental_role="Scopes expensive render-context wrappers to one build and prevents cross-site leakage.",
+        proof=(
+            "tests/unit/rendering/test_engine_globals.py",
+            "tests/unit/rendering/test_thread_safety.py",
+        ),
+        participates_in_warm_build=False,
+    ),
+)
+
+
+def get_state_surface(surface_id: str) -> BuildStateSurface:
+    """Return a build-state surface by id."""
+    for surface in BUILD_STATE_LEDGER:
+        if surface.id == surface_id:
+            return surface
+    raise KeyError(surface_id)
+
+
+__all__ = ["BUILD_STATE_LEDGER", "BuildStateSurface", "get_state_surface"]

--- a/bengal/orchestration/build/state_ledger.py
+++ b/bengal/orchestration/build/state_ledger.py
@@ -106,4 +106,31 @@ def get_state_surface(surface_id: str) -> BuildStateSurface:
     raise KeyError(surface_id)
 
 
-__all__ = ["BUILD_STATE_LEDGER", "BuildStateSurface", "get_state_surface"]
+def warm_build_surfaces() -> tuple[BuildStateSurface, ...]:
+    """Return surfaces that participate in warm-build correctness."""
+    return tuple(surface for surface in BUILD_STATE_LEDGER if surface.participates_in_warm_build)
+
+
+def state_surfaces_by_owner(owner: str) -> tuple[BuildStateSurface, ...]:
+    """Return surfaces owned by a module or package prefix."""
+    owner_prefix = f"{owner}."
+    return tuple(
+        surface
+        for surface in BUILD_STATE_LEDGER
+        if surface.owner == owner or surface.owner.startswith(owner_prefix)
+    )
+
+
+def proof_paths_for_surface(surface_id: str) -> tuple[str, ...]:
+    """Return proof paths attached to one surface."""
+    return get_state_surface(surface_id).proof
+
+
+__all__ = [
+    "BUILD_STATE_LEDGER",
+    "BuildStateSurface",
+    "get_state_surface",
+    "proof_paths_for_surface",
+    "state_surfaces_by_owner",
+    "warm_build_surfaces",
+]

--- a/bengal/orchestration/incremental/cache_manager.py
+++ b/bengal/orchestration/incremental/cache_manager.py
@@ -344,11 +344,13 @@ class CacheManager:
 
         self._store_page_artifacts(build_context)
 
-        # Update template hashes (even if not changed, to track them)
-        theme_templates_dir = self._get_theme_templates_dir()
-        if theme_templates_dir and theme_templates_dir.exists():
-            for template_file in theme_templates_dir.rglob("*.html"):
-                self.cache.update_file(template_file)
+        # Update template hashes (even if not changed) for every render-visible
+        # directory: site overrides, active theme chain, installed/bundled theme,
+        # and default fallback.
+        from bengal.rendering.template_engine.environment import iter_template_files
+
+        for template_file in iter_template_files(self.site):
+            self.cache.update_file(template_file)
 
         # Update data file fingerprints for incremental detection
         # Without this, data files always appear "changed" on incremental builds
@@ -429,34 +431,6 @@ class CacheManager:
         from bengal.cache.page_artifact_store import PageArtifactStore
 
         return PageArtifactStore(self.site.config_service.paths.state_dir / "page-artifacts")
-
-    def _get_theme_templates_dir(self) -> Path | None:
-        """
-        Get the templates directory for the current theme.
-
-        Returns:
-            Path to theme templates or None if not found
-        """
-        # Be defensive: site.theme may be None, a string, or a Mock in tests
-        theme = self.site.theme
-        if not theme or not isinstance(theme, str):
-            return None
-
-        # Check in site's themes directory first
-        site_theme_dir = self.site.root_path / "themes" / theme / "templates"
-        if site_theme_dir.exists():
-            return site_theme_dir
-
-        # Check in Bengal's bundled themes
-        import bengal
-
-        assert bengal.__file__ is not None, "bengal module has no __file__"
-        bengal_dir = Path(bengal.__file__).parent
-        bundled_theme_dir = bengal_dir / "themes" / theme / "templates"
-        if bundled_theme_dir.exists():
-            return bundled_theme_dir
-
-        return None
 
     def _update_data_file_fingerprints(self) -> None:
         """

--- a/bengal/orchestration/incremental/cache_manager.py
+++ b/bengal/orchestration/incremental/cache_manager.py
@@ -432,6 +432,25 @@ class CacheManager:
 
         return PageArtifactStore(self.site.config_service.paths.state_dir / "page-artifacts")
 
+    def _get_theme_templates_dir(self) -> Path | None:
+        """Return the active theme templates directory when it exists."""
+        theme = self.site.theme
+        if not isinstance(theme, str) or not theme:
+            return None
+
+        site_theme_dir = self.site.root_path / "themes" / theme / "templates"
+        if site_theme_dir.exists():
+            return site_theme_dir
+
+        import bengal
+
+        assert bengal.__file__ is not None, "bengal module has no __file__"
+        bundled_theme_dir = Path(bengal.__file__).parent / "themes" / theme / "templates"
+        if bundled_theme_dir.exists():
+            return bundled_theme_dir
+
+        return None
+
     def _update_data_file_fingerprints(self) -> None:
         """
         Update fingerprints for all data files.

--- a/bengal/orchestration/render/orchestrator.py
+++ b/bengal/orchestration/render/orchestrator.py
@@ -238,6 +238,7 @@ class RenderOrchestrator(
 
         # Set build context for template function memoization (RFC: template-function-memoization)
         # This enables site-scoped memoization for functions like get_auto_nav()
+        from bengal.icons import resolver as icon_resolver
         from bengal.rendering.template_functions.memo import set_build_context
 
         set_build_context(build_context)
@@ -299,14 +300,15 @@ class RenderOrchestrator(
         try:
             # Use parallel rendering only when worthwhile (avoid thread overhead for small batches)
             # WorkloadType.MIXED because rendering involves both I/O (templates) and CPU (parsing)
-            if use_parallel:
-                self._render_parallel(
-                    pages, quiet, stats, progress_manager, build_context, changed_sources
-                )
-            else:
-                self._render_sequential(
-                    pages, quiet, stats, progress_manager, build_context, changed_sources
-                )
+            with icon_resolver.site_context(self.site):
+                if use_parallel:
+                    self._render_parallel(
+                        pages, quiet, stats, progress_manager, build_context, changed_sources
+                    )
+                else:
+                    self._render_sequential(
+                        pages, quiet, stats, progress_manager, build_context, changed_sources
+                    )
         finally:
             # Flush write-behind queue and wait for all writes to complete
             if write_behind:

--- a/bengal/orchestration/render/pipeline_runner.py
+++ b/bengal/orchestration/render/pipeline_runner.py
@@ -87,6 +87,9 @@ def process_page_with_pipeline(
         if current_generation is not None:
             _thread_local.pipeline_generation = current_generation
 
+    from bengal.icons import resolver as icon_resolver
+
     _start = time.perf_counter()
-    _thread_local.pipeline.process_page(page)
+    with icon_resolver.site_context(site):
+        _thread_local.pipeline.process_page(page)
     page.render_time_ms = (time.perf_counter() - _start) * 1000

--- a/bengal/orchestration/site_runner.py
+++ b/bengal/orchestration/site_runner.py
@@ -87,7 +87,9 @@ class SiteRunner:
             completion_policy: Initial and watched build completion policy
 
         """
-        from bengal.server.dev_server import DevServer
+        from importlib import import_module
+
+        DevServer = import_module("bengal.server.dev_server").DevServer
 
         server = DevServer(
             self.site,

--- a/bengal/orchestration/stats/models.py
+++ b/bengal/orchestration/stats/models.py
@@ -112,6 +112,7 @@ class BuildStats:
     # Cache bypass statistics
     cache_bypass_hits: int = 0  # Pages that bypassed cache (in changed_sources or is_changed)
     cache_bypass_misses: int = 0  # Pages that used cache (not changed)
+    change_census: dict[str, object] = field(default_factory=dict)
 
     # Block cache statistics - tracks site-wide template block caching (nav, footer, etc.)
     block_cache_hits: int = 0  # Times cached block was reused

--- a/bengal/rendering/context/__init__.py
+++ b/bengal/rendering/context/__init__.py
@@ -410,7 +410,7 @@ def build_page_context(
         page_params.update(metadata["params"])
 
     # Get cached global contexts (site/config/theme/menus are stateless wrappers)
-    global_contexts = _get_global_contexts(site)
+    global_contexts = _get_global_contexts(site, build_context=build_context)
 
     # Use SectionSnapshot directly (no wrapper needed)
     # SectionSnapshot has params property and __bool__ for template compatibility

--- a/bengal/rendering/engines/kida.py
+++ b/bengal/rendering/engines/kida.py
@@ -38,7 +38,6 @@ from bengal.protocols import EngineCapability, TemplateEngineProtocol
 from bengal.protocols.capabilities import has_clear_template_cache
 from bengal.rendering.context.lazy import LazyPageContext
 from bengal.rendering.engines.errors import TemplateError, TemplateNotFoundError
-from bengal.themes.utils import DEFAULT_THEME_PATH, THEMES_ROOT
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -481,49 +480,9 @@ class KidaTemplateEngine:
         1. Site-level custom templates (highest priority)
         2. Theme chain (child themes first, then parent themes)
         """
-        from bengal.core.theme.registry import get_theme_package
-        from bengal.rendering.template_engine.environment import resolve_theme_chain
+        from bengal.rendering.template_engine.environment import resolve_template_dirs
 
-        dirs: list[Path] = []
-
-        # Site-level custom templates (highest priority)
-        custom_templates = self.site.root_path / "templates"
-        if custom_templates.exists():
-            dirs.append(custom_templates)
-
-        # Resolve theme chain (handles theme inheritance)
-        theme_chain = resolve_theme_chain(self.site.theme, self.site)
-
-        for theme_name in theme_chain:
-            # Site-level theme directory
-            site_theme_templates = self.site.root_path / "themes" / theme_name / "templates"
-            if site_theme_templates.exists():
-                dirs.append(site_theme_templates)
-                continue
-
-            # Installed theme directory (via entry point)
-            try:
-                pkg = get_theme_package(theme_name)
-                if pkg:
-                    resolved = pkg.resolve_resource_path("templates")
-                    if resolved and resolved.exists():
-                        dirs.append(resolved)
-                        continue
-            except ImportError, AttributeError, OSError:
-                pass
-
-            # Bundled theme directory
-            bundled_theme_templates = THEMES_ROOT / theme_name / "templates"
-            if bundled_theme_templates.exists():
-                dirs.append(bundled_theme_templates)
-
-        # Ensure default theme exists as ultimate fallback
-        # (resolve_theme_chain filters out 'default' to avoid duplicates)
-        default_templates = DEFAULT_THEME_PATH / "templates"
-        if default_templates not in dirs and default_templates.exists():
-            dirs.append(default_templates)
-
-        return dirs
+        return resolve_template_dirs(self.site)
 
     def _resolve_providers(self) -> tuple:
         """Resolve theme library providers from the theme chain."""

--- a/bengal/rendering/errors/context_extractor.py
+++ b/bengal/rendering/errors/context_extractor.py
@@ -15,78 +15,13 @@ Related Modules:
 
 from __future__ import annotations
 
-import re
 import traceback
-from typing import TYPE_CHECKING, Any
+from typing import Any
+
+from bengal.errors.template_callables import scan_template_for_callables
 
 from .classifier import find_first_code_line
 from .context import TemplateErrorContext
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-# Identifiers that are commonly registered globals/builtins — excluded from
-# the "suspect callables" list so we don't flag obvious safe names like
-# ``len``, ``range``, or Jinja control-flow keywords.
-_KNOWN_SAFE_CALLABLES: frozenset[str] = frozenset(
-    {
-        # Builtins
-        "range",
-        "len",
-        "dict",
-        "list",
-        "str",
-        "int",
-        "float",
-        "bool",
-        "set",
-        "tuple",
-        "enumerate",
-        "zip",
-        "sorted",
-        "reversed",
-        "min",
-        "max",
-        "sum",
-        "abs",
-        "round",
-        "type",
-        "isinstance",
-        "getattr",
-        "hasattr",
-        "callable",
-        "print",
-        "super",
-        # Jinja/template builtins
-        "loop",
-        "self",
-        "caller",
-        # Control flow
-        "if",
-        "else",
-        "elif",
-        "for",
-        "endfor",
-        "endif",
-        "block",
-        "endblock",
-        "macro",
-        "endmacro",
-        "call",
-        "endcall",
-        "include",
-        "import",
-        "from",
-        "extends",
-        "with",
-        "endwith",
-    }
-)
-
-# {{ func( ... }} — function calls inside expression delimiters.
-_FUNC_CALL_PATTERN = re.compile(r"\{\{[^}]*\b(\w+)\s*\([^}]*\}\}")
-# | filter — filter applications anywhere on a line.
-_FILTER_PATTERN = re.compile(r"\|\s*(\w+)")
 
 
 class SourceContextExtractor:
@@ -171,38 +106,6 @@ class SourceContextExtractor:
                 continue
 
         return line_number, filename
-
-
-def scan_template_for_callables(template_path: Path) -> list[str]:
-    """Scan a template file for likely-None callable suspects.
-
-    Returns the list of `function 'name'` / `filter 'name'` strings that
-    appear in the template and are *not* in the known-safe set. Used by
-    the suggestion engine to enrich `TypeError: 'NoneType' is not
-    callable` messages.
-
-    Free function rather than a class method — scanning is a one-shot
-    string operation with no instance state to share.
-    """
-    try:
-        with open(template_path, encoding="utf-8") as fh:
-            content = fh.read()
-    except OSError:
-        return []
-
-    suspects: list[str] = []
-
-    for match in _FUNC_CALL_PATTERN.finditer(content):
-        func_name = match.group(1)
-        if func_name.lower() not in _KNOWN_SAFE_CALLABLES:
-            suspects.append(f"function '{func_name}'")
-
-    for match in _FILTER_PATTERN.finditer(content):
-        filter_name = match.group(1)
-        if filter_name.lower() not in _KNOWN_SAFE_CALLABLES:
-            suspects.append(f"filter '{filter_name}'")
-
-    return suspects
 
 
 __all__ = [

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -976,7 +976,10 @@ class RenderingPipeline:
                         break
 
         # Get cached global contexts (site/config are stateless wrappers)
-        global_contexts = _get_global_contexts(cast("SiteLike", self.site))
+        global_contexts = _get_global_contexts(
+            cast("SiteLike", self.site),
+            build_context=self.build_context,
+        )
 
         context: dict[str, Any] = {
             # Core objects with cached smart wrappers

--- a/bengal/rendering/pipeline/output.py
+++ b/bengal/rendering/pipeline/output.py
@@ -211,7 +211,7 @@ def write_output(
         except UnicodeDecodeError, OSError:
             record_output = True
         if not record_output:
-            _copy_notebook_source(page, output_path=output_path)
+            _copy_notebook_source(page, output_path=output_path, collector=collector)
             _track_and_record(
                 page,
                 site,
@@ -225,7 +225,7 @@ def write_output(
     # Write-behind mode: queue for async write (RFC: rfc-path-to-200-pgs)
     if write_behind is not None:
         write_behind.enqueue(output_path, rendered_html)
-        _copy_notebook_source(page, output_path=output_path)
+        _copy_notebook_source(page, output_path=output_path, collector=collector)
         _track_and_record(
             page,
             site,
@@ -277,7 +277,7 @@ def write_output(
         if fast_writes:
             track_fast_write(output_path)
 
-    _copy_notebook_source(page)
+    _copy_notebook_source(page, collector=collector)
     _track_and_record(
         page,
         site,
@@ -288,7 +288,11 @@ def write_output(
     )
 
 
-def _copy_notebook_source(page: PageLike, output_path: Path | None = None) -> None:
+def _copy_notebook_source(
+    page: PageLike,
+    output_path: Path | None = None,
+    collector: OutputCollector | None = None,
+) -> None:
     """Copy notebook .ipynb to output directory for download link."""
     effective_output_path = output_path or page.output_path
     if not effective_output_path or not getattr(page, "source_path", None):
@@ -297,11 +301,17 @@ def _copy_notebook_source(page: PageLike, output_path: Path | None = None) -> No
     if not str(src).lower().endswith(".ipynb") or not src.exists():
         return
     dest = effective_output_path.parent / f"{src.stem}.ipynb"
-    dest.parent.mkdir(parents=True, exist_ok=True)
     try:
-        import shutil
+        data = src.read_bytes()
+        if dest.exists() and dest.read_bytes() == data:
+            return
 
-        shutil.copy2(src, dest)
+        from bengal.utils.io.atomic_write import atomic_write_bytes
+
+        mode = src.stat().st_mode & 0o777
+        atomic_write_bytes(dest, data, mode=mode)
+        if collector is not None:
+            collector.record(dest, phase="render")
     except OSError as e:
         logger.warning(
             "notebook_copy_failed",

--- a/bengal/rendering/reference_resolution.py
+++ b/bengal/rendering/reference_resolution.py
@@ -1,53 +1,15 @@
-"""URL resolution helpers for rendered internal references."""
+"""Compatibility re-exports for pure internal reference URL helpers."""
 
 from __future__ import annotations
 
-from urllib.parse import urljoin
+from bengal.utils.paths.reference_resolution import (
+    base_url_from_page_url,
+    resolve_internal_link,
+    resolved_path_url_variants,
+)
 
-from bengal.utils.paths.url_normalization import split_url_path
-
-
-def base_url_from_page_url(page_url: str) -> str:
-    """
-    Return the browser-style base URL for resolving links from a page URL.
-
-    Directory-style URLs ending in ``/`` resolve relative links within that
-    directory. File-style URLs resolve relative links against their parent.
-    """
-    if page_url.endswith("/"):
-        return page_url
-    parts = split_url_path(page_url)
-    prefix = "/" if page_url.startswith("/") else ""
-    if len(parts) > 1:
-        return prefix + "/".join(parts[:-1]) + "/"
-    return prefix
-
-
-def resolve_internal_link(page_url: str, link_path: str) -> str:
-    """
-    Resolve an internal link path against a rendered page URL.
-
-    The result is normalized for lookup in Bengal's rendered URL registry:
-    fragments are stripped and markdown source suffixes are converted to clean
-    output URL form.
-    """
-    resolved = urljoin(base_url_from_page_url(page_url), link_path)
-    resolved_path = resolved.split("#")[0] if "#" in resolved else resolved
-
-    if resolved_path.endswith(".md"):
-        if resolved_path.endswith("/_index.md"):
-            resolved_path = resolved_path[:-10] or "/"
-        elif resolved_path.endswith("/index.md"):
-            resolved_path = resolved_path[:-9] or "/"
-        else:
-            resolved_path = resolved_path[:-3]
-
-    return resolved_path
-
-
-def resolved_path_url_variants(resolved: str) -> tuple[str, str, str]:
-    """Return slash variants for URL registry lookup."""
-    stripped = resolved.rstrip("/")
-    if not stripped:
-        return (resolved, "/", "/")
-    return (resolved, stripped, stripped + "/")
+__all__ = [
+    "base_url_from_page_url",
+    "resolve_internal_link",
+    "resolved_path_url_variants",
+]

--- a/bengal/rendering/shortcodes.py
+++ b/bengal/rendering/shortcodes.py
@@ -32,23 +32,20 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Self-closing: {{< name args >}} or {{< name args />}}
-# Paired opening: {{< name args >}} or {{% name args %}}
-# Paired closing: {{< /name >}} or {{% /name %}}
-# Args: [^>]* allows / in paths (e.g. src=/audio/test.mp3)
-# /? = optional slash before > (for {{< name />}})
-SHORTCODE_SELF_CLOSING = re.compile(
-    r"\{\{<\s*([\w/.-]+)(?:\s+([^>]*))?\s*/?\s*>\s*\}\}",
-    re.DOTALL,
-)
-SHORTCODE_OPENING = re.compile(
-    r"\{\{([<%])\s*([\w/.-]+)(?:\s+([^>%]*?))?\s*[>%]\s*\}\}",
-    re.DOTALL,
-)
-SHORTCODE_CLOSING = re.compile(
-    r"\{\{([<%])\s*/\s*([\w/.-]+)\s*[>%]\s*\}\}",
-    re.DOTALL,
-)
+_SHORTCODE_NAME = re.compile(r"([\w/.-]+)(?:\s+(.*))?\Z", re.DOTALL)
+
+
+@dataclass(frozen=True, slots=True)
+class _ShortcodeToken:
+    """A shortcode delimiter found by the single-pass scanner."""
+
+    start: int
+    end: int
+    delim: str
+    name: str
+    args: str
+    closing: bool = False
+    self_closing: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,13 +251,7 @@ def _page_dir(page: PageLike) -> str | None:
 
 def _shortcodes_used_in_content(content: str) -> frozenset[str]:
     """Extract shortcode names used in content ({{< name or {{% name)."""
-    names: set[str] = set()
-    for pattern in (SHORTCODE_OPENING, SHORTCODE_SELF_CLOSING):
-        for m in pattern.finditer(content):
-            name = m.group(2).strip()
-            if name and not name.startswith("/"):
-                names.add(name)
-    return frozenset(names)
+    return frozenset(token.name for token in _scan_shortcode_tokens(content) if not token.closing)
 
 
 def has_shortcode(page: PageLike, name: str) -> bool:
@@ -304,20 +295,82 @@ def _deindent(text: str) -> str:
     return "\n".join(line[min_indent:] if len(line) >= min_indent else line for line in lines)
 
 
-def _find_paired_content(
-    content: str, start: int, open_delim: str, name: str
-) -> tuple[str, int] | None:
-    """Find inner content and end position for paired shortcode."""
-    delim_char = "<" if open_delim == "<" else "%"
-    close_pattern = re.compile(
-        rf"\{{{{[{delim_char}]\s*/\s*{re.escape(name)}\s*[>%]\s*\}}\}}",
-        re.DOTALL,
-    )
-    close_m = close_pattern.search(content, start)
-    if not close_m:
+def _parse_shortcode_token(content: str, start: int, delim: str) -> _ShortcodeToken | None:
+    """Parse a shortcode token that starts at ``start``."""
+    close = ">}}" if delim == "<" else "%}}"
+    body_start = start + 3
+    body_end = content.find(close, body_start)
+    if body_end < 0:
         return None
-    inner = content[start : close_m.start()]
-    return inner, close_m.end()
+
+    raw_body = content[body_start:body_end].strip()
+    end = body_end + len(close)
+    if not raw_body:
+        return None
+
+    closing = raw_body.startswith("/")
+    if closing:
+        raw_body = raw_body[1:].strip()
+
+    self_closing = False
+    if not closing and delim == "<" and raw_body.endswith("/"):
+        self_closing = True
+        raw_body = raw_body[:-1].rstrip()
+
+    match = _SHORTCODE_NAME.match(raw_body)
+    if not match:
+        return None
+
+    return _ShortcodeToken(
+        start=start,
+        end=end,
+        delim=delim,
+        name=match.group(1),
+        args=match.group(2) or "",
+        closing=closing,
+        self_closing=self_closing,
+    )
+
+
+def _scan_shortcode_tokens(content: str) -> list[_ShortcodeToken]:
+    """Scan shortcode delimiters in one pass."""
+    tokens: list[_ShortcodeToken] = []
+    pos = 0
+    length = len(content)
+    while pos < length:
+        start = content.find("{{", pos)
+        if start < 0:
+            break
+        if start + 2 >= length or content[start + 2] not in ("<", "%"):
+            pos = start + 2
+            continue
+        delim = content[start + 2]
+        token = _parse_shortcode_token(content, start, delim)
+        if token is None:
+            pos = start + 2
+            continue
+        tokens.append(token)
+        pos = token.end
+    return tokens
+
+
+def _match_shortcode_pairs(tokens: list[_ShortcodeToken]) -> dict[int, int]:
+    """Match opening and closing shortcode token indexes using a stack."""
+    stack: list[int] = []
+    pairs: dict[int, int] = {}
+    for idx, token in enumerate(tokens):
+        if token.self_closing:
+            continue
+        if token.closing:
+            for stack_pos in range(len(stack) - 1, -1, -1):
+                opener = tokens[stack[stack_pos]]
+                if opener.name == token.name and opener.delim == token.delim:
+                    pairs[stack[stack_pos]] = idx
+                    del stack[stack_pos:]
+                    break
+            continue
+        stack.append(idx)
+    return pairs
 
 
 _MAX_SHORTCODE_DEPTH = 20
@@ -367,78 +420,52 @@ def expand_shortcodes(
         )
         return content
 
+    tokens = _scan_shortcode_tokens(content)
+    if not tokens:
+        return content
+    pairs = _match_shortcode_pairs(tokens)
     result_parts: list[str] = []
     pos = 0
 
-    while True:
-        # Find next shortcode (self-closing or opening)
-        self_m = SHORTCODE_SELF_CLOSING.search(content, pos)
-        open_m = SHORTCODE_OPENING.search(content, pos)
+    def _line_at(offset: int) -> int:
+        return content[:offset].count("\n") + 1
 
-        # Prefer paired over self-closing when both match (e.g. {{< blockquote >}}...{{< /blockquote >}})
-        start, kind, name, args_str, delim = -1, "", "", "", None
-        if open_m:
-            open_end = open_m.end()
-            inner_result = _find_paired_content(content, open_end, open_m.group(1), open_m.group(2))
-            if inner_result is not None:
-                kind, start, name, args_str, delim = (
-                    "paired",
-                    open_m.start(),
-                    open_m.group(2),
-                    open_m.group(3) or "",
-                    open_m.group(1),
-                )
-        if kind != "paired" and self_m and (start < 0 or self_m.start() <= start):
-            kind, start, name, args_str, delim = (
-                "self",
-                self_m.start(),
-                self_m.group(1),
-                self_m.group(2) or "",
-                None,
-            )
+    for idx, token in enumerate(tokens):
+        if token.start < pos or token.closing:
+            continue
 
-        if kind == "":
-            result_parts.append(content[pos:])
-            break
+        pair_idx = pairs.get(idx)
+        is_paired = pair_idx is not None
+        is_self = token.self_closing or (token.delim == "<" and not is_paired)
 
-        params = _parse_args(args_str)
+        if not is_paired and not is_self:
+            continue
 
-        # Emit content before this shortcode
-        result_parts.append(content[pos:start])
+        params = _parse_args(token.args)
+        result_parts.append(content[pos : token.start])
 
-        def _line_at(pos: int) -> int:
-            return content[:pos].count("\n") + 1
-
-        if kind == "self":
-            # Self-closing: {{< name args >}} or {{< name args />}}
-            assert self_m is not None
-            end = self_m.end()
-            fallback = content[start:end]
+        if is_self:
+            fallback = content[token.start : token.end]
             html = _render_shortcode(
                 template_engine,
                 site,
                 page,
-                name,
+                token.name,
                 params,
                 "",
                 fallback,
                 parent_ctx,
                 strict=strict,
                 source_path=page.source_path,
-                line_number=_line_at(start),
+                line_number=_line_at(token.start),
             )
             result_parts.append(html)
-            pos = end
+            pos = token.end
             continue
 
-        # Paired: we have inner_result from above
-        assert open_m is not None
-        assert inner_result is not None
-        open_end = open_m.end()
-        inner, close_end = inner_result
-        fallback = content[start:close_end]
-        inner = _deindent(inner)
-        # Recursive expansion: shortcodes in inner get this shortcode as parent
+        close_token = tokens[pair_idx]
+        inner = _deindent(content[token.end : close_token.start])
+        fallback = content[token.start : close_token.end]
         outer_ctx = ShortcodeContext(params, "", site, page, parent_ctx)
         inner = expand_shortcodes(
             inner,
@@ -449,24 +476,25 @@ def expand_shortcodes(
             parent_ctx=outer_ctx,
             _depth=_depth + 1,
         )
-        # {{% %}} = Markdown notation: parse inner after expansion
-        if delim == "%" and parse_markdown is not None:
+        if token.delim == "%" and parse_markdown is not None:
             inner = parse_markdown(inner)
         html = _render_shortcode(
             template_engine,
             site,
             page,
-            name,
+            token.name,
             params,
             inner,
             fallback,
             parent_ctx,
             strict=strict,
             source_path=page.source_path,
-            line_number=_line_at(start),
+            line_number=_line_at(token.start),
         )
         result_parts.append(html)
-        pos = close_end
+        pos = close_token.end
+
+    result_parts.append(content[pos:])
 
     return "".join(result_parts)
 

--- a/bengal/rendering/template_engine/environment.py
+++ b/bengal/rendering/template_engine/environment.py
@@ -17,11 +17,14 @@ import tomllib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from bengal.protocols import SiteLike
 
 # Imported at module level so tests can patch this target:
 #   bengal.rendering.template_engine.environment.get_theme_package
 from bengal.core.theme import get_theme_package
+from bengal.themes.utils import DEFAULT_THEME_PATH, THEMES_ROOT
 
 
 def resolve_theme_chain(active_theme: str | None, site: SiteLike) -> list[str]:
@@ -64,6 +67,74 @@ def resolve_theme_chain(active_theme: str | None, site: SiteLike) -> list[str]:
     if (active_theme or "default") == "default":
         return chain
     return [t for t in chain if t != "default"]
+
+
+def resolve_template_dirs(site: SiteLike) -> list[Path]:
+    """Return template search directories in render precedence order."""
+    dirs: list[Path] = []
+    root_path = getattr(site, "root_path", None)
+
+    if root_path:
+        custom_templates = root_path / "templates"
+        if custom_templates.exists():
+            dirs.append(custom_templates)
+
+        active_theme = getattr(site, "theme", None)
+        if not isinstance(active_theme, str):
+            active_theme = None
+
+        for theme_name in resolve_theme_chain(active_theme, site):
+            site_theme_templates = root_path / "themes" / theme_name / "templates"
+            if site_theme_templates.exists():
+                dirs.append(site_theme_templates)
+                continue
+
+            try:
+                pkg = get_theme_package(theme_name)
+                if pkg:
+                    resolved = pkg.resolve_resource_path("templates")
+                    if resolved and resolved.exists():
+                        dirs.append(resolved)
+                        continue
+            except ImportError, AttributeError, OSError:
+                pass
+
+            bundled_theme_templates = THEMES_ROOT / theme_name / "templates"
+            if bundled_theme_templates.exists():
+                dirs.append(bundled_theme_templates)
+
+    default_templates = DEFAULT_THEME_PATH / "templates"
+    if default_templates not in dirs and default_templates.exists():
+        dirs.append(default_templates)
+
+    return dirs
+
+
+def template_name_for_path(path: Path, template_dirs: list[Path]) -> str:
+    """Return the cache/template dependency key for a template path."""
+    for template_dir in template_dirs:
+        try:
+            return path.resolve().relative_to(template_dir.resolve()).as_posix()
+        except OSError, ValueError:
+            continue
+    return path.name
+
+
+def iter_template_files(site: SiteLike, pattern: str = "**/*.html") -> tuple[Path, ...]:
+    """Return template files from all render-visible template directories."""
+    files: list[Path] = []
+    seen: set[Path] = set()
+    for template_dir in resolve_template_dirs(site):
+        for template_file in template_dir.glob(pattern):
+            try:
+                key = template_file.resolve()
+            except OSError:
+                key = template_file
+            if key in seen:
+                continue
+            seen.add(key)
+            files.append(template_file)
+    return tuple(files)
 
 
 def read_theme_extends(theme_name: str, site: SiteLike) -> str | None:

--- a/bengal/rendering/template_functions/icons.py
+++ b/bengal/rendering/template_functions/icons.py
@@ -31,55 +31,45 @@ from bengal.utils.primitives.lru_cache import LRUCache
 
 logger = get_logger(__name__)
 
-# Track warned icons to avoid duplicate warnings (reset per build)
-# Thread-safe: protected by _warned_lock for concurrent access
+# Track warned icons to avoid duplicate warnings (reset per build).
+# Thread-safe: protected by _warned_lock for concurrent access.
 _warned_lock = threading.Lock()
-_warned_icons: set[str] = set()
-
-# Site instance for theme config access (set during registration)
-# Thread-safe: protected by _site_lock for concurrent access
-_site_lock = threading.Lock()
-_site_instance: SiteConfig | None = None
+_warned_icons: set[tuple[tuple[str, ...], str]] = set()
 
 
-def _get_mapped_icon_name(name: str) -> str:
+def _get_icon_aliases(site: SiteConfig | None) -> dict[str, str]:
+    """Return a copy of theme-level icon aliases for a site."""
+    if site is None:
+        return {}
+    try:
+        theme_config = site.theme_config
+        if theme_config.config is None:
+            return {}
+        aliases = theme_config.config.get("icons", {}).get("aliases", {})
+        return dict(aliases) if isinstance(aliases, dict) else {}
+    except Exception as e:
+        logger.debug(
+            "icon_alias_load_failed",
+            error=str(e),
+            error_type=type(e).__name__,
+            action="falling_back_to_icon_map",
+        )
+        return {}
+
+
+def _get_mapped_icon_name(name: str, aliases: dict[str, str] | None = None) -> str:
     """
     Get mapped icon name from theme config or ICON_MAP.
 
-    Thread-safe: All site access happens under lock to prevent TOCTOU race.
-    Copies needed values while holding lock, then releases before return.
-
     Args:
         name: Original icon name
+        aliases: Optional site/theme alias mapping
 
     Returns:
         Mapped icon name (may be same as input if no mapping found)
     """
-    # Thread-safe: read _site_instance and extract needed config under lock
-    with _site_lock:
-        site = _site_instance
-        if site is None:
-            # No site instance, use ICON_MAP
-            return ICON_MAP.get(name, name)
-
-        # Extract icon aliases while holding lock
-        try:
-            theme_config = site.theme_config
-            if theme_config.config is not None:
-                icon_aliases = theme_config.config.get("icons", {}).get("aliases", {})
-                if icon_aliases and name in icon_aliases:
-                    return icon_aliases[name]
-        except Exception as e:
-            # Graceful degradation: fall back to ICON_MAP
-            logger.debug(
-                "icon_mapping_failed",
-                icon_name=name,
-                error=str(e),
-                error_type=type(e).__name__,
-                action="falling_back_to_icon_map",
-            )
-
-    # Fall back to ICON_MAP (outside lock, ICON_MAP is module-level constant)
+    if aliases and name in aliases:
+        return aliases[name]
     return ICON_MAP.get(name, name)
 
 
@@ -100,7 +90,7 @@ _RE_CLASS = re.compile(r'\s+class="[^"]*"')
 _RE_SVG_TAG = re.compile(r"<svg\s")
 
 # Thread-safe LRU cache for icon rendering (replaces @lru_cache for free-threading)
-_icon_render_cache: LRUCache[tuple[str, int, str, str], str] = LRUCache(
+_icon_render_cache: LRUCache[tuple[tuple[str, ...], str, int, str, str], str] = LRUCache(
     maxsize=512, name="icon_render"
 )
 
@@ -110,6 +100,8 @@ def _render_icon_cached(
     size: int,
     css_class: str,
     aria_label: str,
+    scope_key: tuple[str, ...],
+    site: SiteConfig | None = None,
 ) -> str:
     """
     Render an icon with LRU caching for repeated calls.
@@ -131,11 +123,11 @@ def _render_icon_cached(
         Rendered SVG HTML string, or empty string if icon not found
 
     """
-    key = (name, size, css_class, aria_label)
+    key = (scope_key, name, size, css_class, aria_label)
 
     def _render_impl() -> str:
         # Load icon via theme-aware resolver
-        svg_content = icon_resolver.load_icon(name)
+        svg_content = icon_resolver.load_icon(name, site=site)
         if svg_content is None:
             return ""
 
@@ -167,7 +159,16 @@ def _render_icon_cached(
     return _icon_render_cache.get_or_set(key, _render_impl)
 
 
-def icon(name: str, size: int = 24, css_class: str = "", aria_label: str = "") -> Markup:
+def _render_icon(
+    name: str,
+    size: int = 24,
+    css_class: str = "",
+    aria_label: str = "",
+    *,
+    site: SiteConfig | None = None,
+    aliases: dict[str, str] | None = None,
+    scope_key: tuple[str, ...] | None = None,
+) -> Markup:
     """
     Render an SVG icon for use in templates.
 
@@ -196,26 +197,69 @@ def icon(name: str, size: int = 24, css_class: str = "", aria_label: str = "") -
     if not name:
         return Markup("")
 
-    # Get icon aliases from theme config (if available)
-    # Thread-safe: copy all needed values under lock to prevent TOCTOU race
-    mapped_name = _get_mapped_icon_name(name)
+    resolved_scope_key = scope_key or icon_resolver.get_scope_key(site)
+    mapped_name = _get_mapped_icon_name(name, aliases)
 
     # Try the mapped name first (uses LRU cache)
-    svg_html = _render_icon_cached(mapped_name, size, css_class, aria_label)
+    svg_html = _render_icon_cached(
+        mapped_name,
+        size,
+        css_class,
+        aria_label,
+        resolved_scope_key,
+        site=site,
+    )
 
     # If mapped name didn't work and it's different from original, try the original
     if not svg_html and mapped_name != name:
-        svg_html = _render_icon_cached(name, size, css_class, aria_label)
+        svg_html = _render_icon_cached(
+            name,
+            size,
+            css_class,
+            aria_label,
+            resolved_scope_key,
+            site=site,
+        )
 
     # Warn if icon not found (deduplicated per icon name, thread-safe)
     if not svg_html:
         with _warned_lock:
-            if name not in _warned_icons:
-                _warned_icons.add(name)
+            warned_key = (resolved_scope_key, name)
+            if warned_key not in _warned_icons:
+                _warned_icons.add(warned_key)
                 warn_missing_icon(name, directive="template-function:icon")
 
     # Return as Markup to prevent Jinja2 auto-escaping
     return Markup(svg_html)
+
+
+def icon(name: str, size: int = 24, css_class: str = "", aria_label: str = "") -> Markup:
+    """Render an SVG icon using the active icon resolver scope."""
+    return _render_icon(name, size=size, css_class=css_class, aria_label=aria_label)
+
+
+def _make_site_icon(site: SiteConfig):
+    """Create a site-scoped icon helper for a template environment."""
+    aliases = _get_icon_aliases(site)
+    scope_key = icon_resolver.get_scope_key(site)
+
+    def site_icon(
+        name: str,
+        size: int = 24,
+        css_class: str = "",
+        aria_label: str = "",
+    ) -> Markup:
+        return _render_icon(
+            name,
+            size=size,
+            css_class=css_class,
+            aria_label=aria_label,
+            site=site,
+            aliases=aliases,
+            scope_key=scope_key,
+        )
+
+    return site_icon
 
 
 def register(env: TemplateEnvironment, site: SiteConfig) -> None:
@@ -225,22 +269,17 @@ def register(env: TemplateEnvironment, site: SiteConfig) -> None:
     Icons are loaded on-demand via the theme-aware resolver, which is
     initialized during Site setup.
 
-    Thread-safe: Site instance assignment protected by lock.
-
     Args:
         env: Jinja2 environment
-        site: Site instance (stored for theme config access)
+        site: Site instance used to scope aliases and icon lookup
 
     """
-    global _site_instance
-    with _site_lock:
-        _site_instance = site
-
-    env.globals["icon"] = icon
-    env.globals["render_icon"] = icon  # Alias
+    site_icon = _make_site_icon(site)
+    env.globals["icon"] = site_icon
+    env.globals["render_icon"] = site_icon  # Alias
 
 
-def get_icon_cache_stats() -> dict[str, int]:
+def get_icon_cache_stats(site: SiteConfig | None = None) -> dict[str, int]:
     """
     Get icon cache statistics for debugging/profiling.
 
@@ -249,8 +288,13 @@ def get_icon_cache_stats() -> dict[str, int]:
 
     """
     stats = _icon_render_cache.stats()
+    if site is not None:
+        with icon_resolver.site_context(site):
+            available_icons = len(icon_resolver.get_available_icons())
+    else:
+        available_icons = len(icon_resolver.get_available_icons())
     return {
-        "available_icons": len(icon_resolver.get_available_icons()),
+        "available_icons": available_icons,
         "cache_hits": stats["hits"],
         "cache_misses": stats["misses"],
         "cache_size": stats["size"],

--- a/bengal/server/build_executor.py
+++ b/bengal/server/build_executor.py
@@ -50,6 +50,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+# Runtime re-export for existing ``bengal.server.build_executor.BuildRequest`` callers.
+from bengal.orchestration.build.requests import BuildRequest  # noqa: TC001
 from bengal.server.reload_types import SerializedOutputRecord
 from bengal.utils.observability.logger import get_logger
 
@@ -69,50 +71,6 @@ def _get_mp_context() -> multiprocessing.context.BaseContext:
     if _mp_context is None:
         _mp_context = multiprocessing.get_context("spawn")
     return _mp_context
-
-
-@dataclass(frozen=True, slots=True)
-class BuildRequest:
-    """
-    Serializable build request for cross-process execution.
-
-    All fields must be picklable for use with ProcessPoolExecutor.
-    Uses strings instead of Path objects for serialization.
-
-    Attributes:
-        site_root: Path to site root directory (as string)
-        changed_paths: Tuple of changed file paths (as strings)
-        incremental: Whether to use incremental build
-        profile: Build profile name (e.g., "WRITER", "PUBLISHER")
-        nav_changed_paths: Paths with navigation-affecting frontmatter changes
-        structural_changed: Whether structural changes (create/delete/move) occurred
-        force_sequential: If True, force sequential processing (bypasses auto-detection)
-        version_scope: RFC: rfc-versioned-docs-pipeline-integration (Phase 3)
-            Focus rebuilds on a single version (e.g., "v2", "latest").
-            If None, all versions are rebuilt on changes.
-        memory_optimized: Use streaming build for memory efficiency
-        explain: Show detailed incremental build decisions
-        dry_run: Preview build without writing files
-        profile_templates: Enable template profiling
-        completion_policy: Serialized BuildCompletionPolicy value
-        quiet: Suppress routine build transcript output
-
-    """
-
-    site_root: str
-    changed_paths: tuple[str, ...] = field(default_factory=tuple)
-    incremental: bool = True
-    profile: str = "WRITER"
-    nav_changed_paths: tuple[str, ...] = field(default_factory=tuple)
-    structural_changed: bool = False
-    force_sequential: bool = False
-    version_scope: str | None = None
-    memory_optimized: bool = False
-    explain: bool = False
-    dry_run: bool = False
-    profile_templates: bool = False
-    completion_policy: str = "complete"
-    quiet: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -1260,28 +1260,15 @@ class BuildTrigger:
         if self._template_dirs is not None:
             return self._template_dirs
 
-        import bengal
-
-        assert bengal.__file__ is not None, "bengal module has no __file__"
-        bengal_dir = Path(bengal.__file__).parent
         root_path = self.site.root_path
 
         if not root_path:
             self._template_dirs = []
             return self._template_dirs
 
-        dirs = [
-            root_path / "templates",
-            root_path / "themes",
-        ]
+        from bengal.rendering.template_engine.environment import resolve_template_dirs
 
-        theme = self.site.theme
-        if theme:
-            bundled = bengal_dir / "themes" / theme / "templates"
-            dirs.append(bundled)
-
-        # Filter to existing directories (cached)
-        self._template_dirs = [d for d in dirs if d.exists()]
+        self._template_dirs = resolve_template_dirs(self.site)
         return self._template_dirs
 
     def _is_template_change(self, changed_paths: set[Path]) -> bool:
@@ -1380,12 +1367,9 @@ class BuildTrigger:
 
     def _template_name_for_path(self, path: Path, template_dirs: list[Path]) -> str:
         """Return the template name used by BuildCache dependency indexes."""
-        for template_dir in template_dirs:
-            try:
-                return to_posix(path.resolve().relative_to(template_dir.resolve()))
-            except OSError, ValueError:
-                continue
-        return path.name
+        from bengal.rendering.template_engine.environment import template_name_for_path
+
+        return template_name_for_path(path, template_dirs)
 
     def _get_template_dependents(
         self,

--- a/bengal/snapshots/handoff.py
+++ b/bengal/snapshots/handoff.py
@@ -1,0 +1,53 @@
+"""Immutable render handoff facts derived from a site snapshot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from bengal.snapshots.types import SiteSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class RenderSnapshotHandoff:
+    """Small immutable summary of snapshot-to-render worker inputs."""
+
+    page_sources: tuple[Path, ...]
+    missing_snapshot_sources: tuple[Path, ...]
+    extra_snapshot_sources: tuple[Path, ...]
+    page_count: int
+    section_count: int
+    template_count: int
+
+    @property
+    def is_complete(self) -> bool:
+        """Return whether live render pages and snapshot pages agree."""
+        return not self.missing_snapshot_sources and not self.extra_snapshot_sources
+
+
+def create_render_snapshot_handoff(
+    snapshot: SiteSnapshot,
+    live_pages: Iterable[Any],
+) -> RenderSnapshotHandoff:
+    """Create immutable facts for the hybrid snapshot-to-render handoff."""
+    snapshot_sources = tuple(page.source_path for page in snapshot.pages)
+    live_sources = tuple(page.source_path for page in live_pages)
+    snapshot_source_set = set(snapshot_sources)
+    live_source_set = set(live_sources)
+
+    return RenderSnapshotHandoff(
+        page_sources=snapshot_sources,
+        missing_snapshot_sources=tuple(
+            source for source in live_sources if source not in snapshot_source_set
+        ),
+        extra_snapshot_sources=tuple(
+            source for source in snapshot_sources if source not in live_source_set
+        ),
+        page_count=snapshot.page_count,
+        section_count=snapshot.section_count,
+        template_count=len(snapshot.schedule.templates),
+    )

--- a/bengal/snapshots/scheduler.py
+++ b/bengal/snapshots/scheduler.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from bengal.snapshots.scout import ScoutThread
     from bengal.snapshots.types import SiteSnapshot
 
+from bengal.snapshots.handoff import create_render_snapshot_handoff
 from bengal.snapshots.utils import (
     ProgressManagerProtocol,
     RenderProgressTracker,
@@ -91,6 +92,7 @@ class WaveScheduler:
         self._strategy = strategy
         self._progress_manager = progress_manager
         self._block_cache = block_cache
+        self.snapshot_handoff = create_render_snapshot_handoff(snapshot, site.pages)
 
         # Create mapping from snapshot pages to actual pages
         self._page_map: dict[Path, PageLike] = {}

--- a/bengal/utils/paths/link_resolution.py
+++ b/bengal/utils/paths/link_resolution.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from bengal.rendering.reference_resolution import (
+from bengal.utils.paths.reference_resolution import (
     base_url_from_page_url,
     resolve_internal_link,
 )
-from bengal.rendering.reference_resolution import (
+from bengal.utils.paths.reference_resolution import (
     resolved_path_url_variants as _resolved_path_url_variants,
 )
 

--- a/bengal/utils/paths/reference_resolution.py
+++ b/bengal/utils/paths/reference_resolution.py
@@ -1,0 +1,60 @@
+"""Pure URL resolution helpers for internal page references."""
+
+from __future__ import annotations
+
+from urllib.parse import urljoin
+
+from bengal.utils.paths.url_normalization import split_url_path
+
+
+def base_url_from_page_url(page_url: str) -> str:
+    """
+    Return the browser-style base URL for resolving links from a page URL.
+
+    Directory-style URLs ending in ``/`` resolve relative links within that
+    directory. File-style URLs resolve relative links against their parent.
+    """
+    if page_url.endswith("/"):
+        return page_url
+    parts = split_url_path(page_url)
+    prefix = "/" if page_url.startswith("/") else ""
+    if len(parts) > 1:
+        return prefix + "/".join(parts[:-1]) + "/"
+    return prefix
+
+
+def resolve_internal_link(page_url: str, link_path: str) -> str:
+    """
+    Resolve an internal link path against a rendered page URL.
+
+    The result is normalized for lookup in Bengal's rendered URL registry:
+    fragments are stripped and markdown source suffixes are converted to clean
+    output URL form.
+    """
+    resolved = urljoin(base_url_from_page_url(page_url), link_path)
+    resolved_path = resolved.split("#")[0] if "#" in resolved else resolved
+
+    if resolved_path.endswith(".md"):
+        if resolved_path.endswith("/_index.md"):
+            resolved_path = resolved_path[:-10] or "/"
+        elif resolved_path.endswith("/index.md"):
+            resolved_path = resolved_path[:-9] or "/"
+        else:
+            resolved_path = resolved_path[:-3]
+
+    return resolved_path
+
+
+def resolved_path_url_variants(resolved: str) -> tuple[str, str, str]:
+    """Return slash variants for URL registry lookup."""
+    stripped = resolved.rstrip("/")
+    if not stripped:
+        return (resolved, "/", "/")
+    return (resolved, stripped, stripped + "/")
+
+
+__all__ = [
+    "base_url_from_page_url",
+    "resolve_internal_link",
+    "resolved_path_url_variants",
+]

--- a/changelog.d/atomic-sidecar-font-writes.fixed.md
+++ b/changelog.d/atomic-sidecar-font-writes.fixed.md
@@ -1,0 +1,1 @@
+Made notebook sidecar and generated font CSS writes atomic and output-collector visible, and routed downloaded font files through the shared atomic write helper.

--- a/changelog.d/build-change-census.added.md
+++ b/changelog.d/build-change-census.added.md
@@ -1,0 +1,1 @@
+Add a pre-discovery build change census for no-op and single-edit rebuilds.

--- a/changelog.d/core-menu-section-sorting.fixed.md
+++ b/changelog.d/core-menu-section-sorting.fixed.md
@@ -1,0 +1,1 @@
+Fix menu hierarchy rebuild idempotence and mixed-type section weight sorting.

--- a/changelog.d/incremental-theme-template-helper.fixed.md
+++ b/changelog.d/incremental-theme-template-helper.fixed.md
@@ -1,0 +1,1 @@
+Restored incremental theme-template directory detection used by warm-build template invalidation.

--- a/changelog.d/page-artifact-manifest.fixed.md
+++ b/changelog.d/page-artifact-manifest.fixed.md
@@ -1,0 +1,1 @@
+Add a manifest for page artifact shards and support targeted artifact loads.

--- a/changelog.d/page-cache-epoch.fixed.md
+++ b/changelog.d/page-cache-epoch.fixed.md
@@ -1,0 +1,1 @@
+Fix stale page lookup caches after same-length page-list replacements.

--- a/changelog.d/provenance-batch-persistence.fixed.md
+++ b/changelog.d/provenance-batch-persistence.fixed.md
@@ -1,0 +1,1 @@
+Batch page provenance persistence after render instead of storing each record individually.

--- a/changelog.d/render-cache-scoping.fixed.md
+++ b/changelog.d/render-cache-scoping.fixed.md
@@ -1,0 +1,1 @@
+Scoped icon resolver caches, rendered icon caches, template icon aliases, and page context wrappers to the active site/build so concurrent or repeated builds cannot reuse stale rendering state from another site.

--- a/changelog.d/shortcode-stack-scanner.fixed.md
+++ b/changelog.d/shortcode-stack-scanner.fixed.md
@@ -1,0 +1,1 @@
+Replaced shortcode pairing with a single-pass stack scanner so nested paired shortcodes, including nested shortcodes with the same name, expand correctly without repeated full-content searches.

--- a/changelog.d/template-invalidation.fixed.md
+++ b/changelog.d/template-invalidation.fixed.md
@@ -1,0 +1,1 @@
+Fix incremental template invalidation for active theme inheritance chains.

--- a/docs/b-stack-changelog-strategy.md
+++ b/docs/b-stack-changelog-strategy.md
@@ -103,6 +103,9 @@ changelog-draft = { cmd = "towncrier build --draft", help = "Preview changelog f
 - **Require a fragment** when the PR changes user-facing code under `src/` (or the repo's published package path).
 - **Allow skipping** for docs-only, chore-only, or internal refactors with no release note: use a **label** (e.g. `skip-changelog`) or documented PR keyword, consistent per repo.
 - **Release:** Run `poe changelog` (or documented equivalent) as part of the version bump / tag checklist so `CHANGELOG.md` updates atomically with the release commit.
+- **Performance claims:** Name the benchmark matrix row, exact command, Python
+  build, machine/OS, baseline, current result, artifact path, and interpretation
+  in the PR before repeating the claim in release notes.
 
 ## Voice (brand)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -425,6 +425,7 @@ benchmark-compare = { cmd = "pytest benchmarks/ tests/performance/ --benchmark-c
 benchmark-save = { cmd = "pytest benchmarks/ tests/performance/ --benchmark-save=baseline -v", help = "Save baseline" }
 benchmark-scenarios = { cmd = "python scripts/generate_benchmark_scenarios.py", help = "Generate cached benchmark scenarios" }
 benchmark-smoke = { cmd = "pytest -o addopts= -n 0 -q tests/unit/benchmarks/test_benchmark_matrix.py tests/performance/test_autodoc_render_regression.py tests/performance/test_asset_fallback_cost.py tests/performance/test_post_render_pipeline_budget.py", help = "Run canonical smoke performance guards without full benchmark timings" }
+benchmark-matrix = { cmd = "python benchmarks/run_matrix.py", help = "Run benchmark rows from benchmarks/benchmark_matrix.toml" }
 
 # Type Checking
 ty = { cmd = "ty check bengal/", help = "Run ty type checker (fast, Rust-based)" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -421,6 +421,7 @@ proof-pr = { sequence = [
 proof-pr-plan = { cmd = "python scripts/proof_pr_plan.py --format json", help = "Print the resolved bounded PR proof path as JSON" }
 output-write-audit = { cmd = "python scripts/check_output_writes.py", help = "Audit direct writes in generated-output and cache-adjacent code" }
 core-surface-audit = { cmd = "python scripts/check_core_surface_usage.py", help = "Audit internal use of core compatibility surfaces marked for retirement" }
+performance-evidence-check = { cmd = "python scripts/check_performance_evidence.py --body-file .github/pull_request_template.md --allow-template", help = "Validate Performance Evidence fields in a PR body markdown file" }
 
 # Benchmarks
 benchmark = { cmd = "pytest benchmarks/ tests/performance/ -v --benchmark-only", help = "Run all benchmarks" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -419,6 +419,7 @@ proof-pr = { sequence = [
     "benchmark-smoke",
 ], help = "Bounded PR proof path: lint, format, types, unit tests, and benchmark smoke guards" }
 proof-pr-plan = { cmd = "python scripts/proof_pr_plan.py --format json", help = "Print the resolved bounded PR proof path as JSON" }
+output-write-audit = { cmd = "python scripts/check_output_writes.py", help = "Audit direct writes in generated-output and cache-adjacent code" }
 
 # Benchmarks
 benchmark = { cmd = "pytest benchmarks/ tests/performance/ -v --benchmark-only", help = "Run all benchmarks" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -418,6 +418,7 @@ proof-pr = { sequence = [
     "test-unit",
     "benchmark-smoke",
 ], help = "Bounded PR proof path: lint, format, types, unit tests, and benchmark smoke guards" }
+proof-pr-plan = { cmd = "python scripts/proof_pr_plan.py --format json", help = "Print the resolved bounded PR proof path as JSON" }
 
 # Benchmarks
 benchmark = { cmd = "pytest benchmarks/ tests/performance/ -v --benchmark-only", help = "Run all benchmarks" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -420,6 +420,7 @@ proof-pr = { sequence = [
 ], help = "Bounded PR proof path: lint, format, types, unit tests, and benchmark smoke guards" }
 proof-pr-plan = { cmd = "python scripts/proof_pr_plan.py --format json", help = "Print the resolved bounded PR proof path as JSON" }
 output-write-audit = { cmd = "python scripts/check_output_writes.py", help = "Audit direct writes in generated-output and cache-adjacent code" }
+core-surface-audit = { cmd = "python scripts/check_core_surface_usage.py", help = "Audit internal use of core compatibility surfaces marked for retirement" }
 
 # Benchmarks
 benchmark = { cmd = "pytest benchmarks/ tests/performance/ -v --benchmark-only", help = "Run all benchmarks" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -411,12 +411,20 @@ test-cov = { cmd = "pytest tests/ --cov=bengal --cov-report=term-missing", help 
 test-parallel = { cmd = "pytest tests/ -n auto -x -q", help = "Run tests in parallel (pytest-xdist)" }
 test-random = { cmd = "pytest tests/ -p randomly --randomly-seed=random -x -q", help = "Run tests in random order" }
 test-verbose = { cmd = "pytest tests/ -v --tb=long", help = "Run tests with verbose output" }
+proof-pr = { sequence = [
+    "lint",
+    "format-check",
+    "ty",
+    "test-unit",
+    "benchmark-smoke",
+], help = "Bounded PR proof path: lint, format, types, unit tests, and benchmark smoke guards" }
 
 # Benchmarks
 benchmark = { cmd = "pytest benchmarks/ tests/performance/ -v --benchmark-only", help = "Run all benchmarks" }
 benchmark-compare = { cmd = "pytest benchmarks/ tests/performance/ --benchmark-compare=baseline -v", help = "Compare to baseline" }
 benchmark-save = { cmd = "pytest benchmarks/ tests/performance/ --benchmark-save=baseline -v", help = "Save baseline" }
 benchmark-scenarios = { cmd = "python scripts/generate_benchmark_scenarios.py", help = "Generate cached benchmark scenarios" }
+benchmark-smoke = { cmd = "pytest -o addopts= -n 0 -q tests/unit/benchmarks/test_benchmark_matrix.py tests/performance/test_autodoc_render_regression.py tests/performance/test_asset_fallback_cost.py tests/performance/test_post_render_pipeline_budget.py", help = "Run canonical smoke performance guards without full benchmark timings" }
 
 # Type Checking
 ty = { cmd = "ty check bengal/", help = "Run ty type checker (fast, Rust-based)" }

--- a/scripts/check_core_surface_usage.py
+++ b/scripts/check_core_surface_usage.py
@@ -1,0 +1,80 @@
+"""Guard internal usage of core compatibility surfaces marked for retirement."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_ROOT = ROOT / "bengal"
+IGNORED_PATHS = {
+    "bengal/core/section/__init__.py",
+}
+RETIRED_COMPAT_ATTRS = {
+    "content_pages": "Use bengal.rendering.section_ergonomics.content_pages() inside Bengal.",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CoreSurfaceUsage:
+    """One internal compatibility-surface usage."""
+
+    path: str
+    line: int
+    attr: str
+    suggestion: str
+
+
+class _CoreSurfaceVisitor(ast.NodeVisitor):
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.usages: list[CoreSurfaceUsage] = []
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr in RETIRED_COMPAT_ATTRS:
+            self.usages.append(
+                CoreSurfaceUsage(
+                    path=self.path,
+                    line=node.lineno,
+                    attr=node.attr,
+                    suggestion=RETIRED_COMPAT_ATTRS[node.attr],
+                )
+            )
+        self.generic_visit(node)
+
+
+def scan_file(path: Path, *, root: Path = ROOT) -> tuple[CoreSurfaceUsage, ...]:
+    """Return retired core-surface usage in one source file."""
+    relative = path.relative_to(root).as_posix()
+    if relative in IGNORED_PATHS:
+        return ()
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+    visitor = _CoreSurfaceVisitor(relative)
+    visitor.visit(tree)
+    return tuple(visitor.usages)
+
+
+def scan_core_surface_usage(root: Path = ROOT) -> tuple[CoreSurfaceUsage, ...]:
+    """Return retired core-surface usage in Bengal production code."""
+    usages: list[CoreSurfaceUsage] = []
+    for path in sorted((root / "bengal").rglob("*.py")):
+        usages.extend(scan_file(path, root=root))
+    return tuple(usages)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(description=__doc__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    _build_parser().parse_args(argv)
+    usages = scan_core_surface_usage()
+    for usage in usages:
+        print(f"{usage.path}:{usage.line}: .{usage.attr} - {usage.suggestion}")
+    return 1 if usages else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_output_writes.py
+++ b/scripts/check_output_writes.py
@@ -1,0 +1,150 @@
+"""Audit direct writes in generated-output and cache-adjacent Bengal code."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCANNED_DIRS = (
+    ROOT / "bengal" / "assets",
+    ROOT / "bengal" / "cache",
+    ROOT / "bengal" / "orchestration",
+    ROOT / "bengal" / "postprocess",
+    ROOT / "bengal" / "rendering",
+)
+DIRECT_WRITE_METHODS = {"write_bytes", "write_text"}
+APPROVED_DIRECT_WRITES = {
+    (
+        "bengal/orchestration/incremental/orchestrator.py",
+        "_write_output",
+        "write_text",
+    ): "test bridge placeholder output; migrate before using for shipped output",
+    (
+        "bengal/rendering/pipeline/write_behind.py",
+        "_atomic_write_fast",
+        "write_text",
+    ): "temp-file write followed by atomic replace",
+    (
+        "bengal/rendering/external_refs/resolver.py",
+        "_fetch",
+        "write_text",
+    ): "external-reference cache write; tracked for atomic-write migration",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DirectWriteFinding:
+    """One direct write call found in a scanned module."""
+
+    path: str
+    line: int
+    function: str
+    method: str
+    receiver: str
+
+    @property
+    def approval_key(self) -> tuple[str, str, str]:
+        return (self.path, self.function, self.method)
+
+
+class _DirectWriteVisitor(ast.NodeVisitor):
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.function_stack: list[str] = []
+        self.findings: list[DirectWriteFinding] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.function_stack.append(node.name)
+        self.generic_visit(node)
+        self.function_stack.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.function_stack.append(node.name)
+        self.generic_visit(node)
+        self.function_stack.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Attribute) and node.func.attr in DIRECT_WRITE_METHODS:
+            self.findings.append(
+                DirectWriteFinding(
+                    path=self.path,
+                    line=node.lineno,
+                    function=self.function_stack[-1] if self.function_stack else "<module>",
+                    method=node.func.attr,
+                    receiver=ast.unparse(node.func.value),
+                )
+            )
+        self.generic_visit(node)
+
+
+def scan_file(path: Path, *, root: Path = ROOT) -> tuple[DirectWriteFinding, ...]:
+    """Return direct write findings for one Python source file."""
+    relative = path.relative_to(root).as_posix()
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+    visitor = _DirectWriteVisitor(relative)
+    visitor.visit(tree)
+    return tuple(visitor.findings)
+
+
+def iter_scanned_files(root: Path = ROOT) -> tuple[Path, ...]:
+    """Return Python files covered by the output-write audit."""
+    files: list[Path] = []
+    for directory in SCANNED_DIRS:
+        if directory.exists():
+            files.extend(sorted(directory.rglob("*.py")))
+    return tuple(files)
+
+
+def scan_direct_writes(root: Path = ROOT) -> tuple[DirectWriteFinding, ...]:
+    """Return all direct write findings in scanned directories."""
+    findings: list[DirectWriteFinding] = []
+    for path in iter_scanned_files(root):
+        findings.extend(scan_file(path, root=root))
+    return tuple(findings)
+
+
+def unapproved_direct_writes(
+    findings: tuple[DirectWriteFinding, ...],
+) -> tuple[DirectWriteFinding, ...]:
+    """Return findings that are not in the explicit approval ledger."""
+    return tuple(
+        finding for finding in findings if finding.approval_key not in APPROVED_DIRECT_WRITES
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--list-approved",
+        action="store_true",
+        help="Print approved direct writes as audit context.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    findings = scan_direct_writes()
+    if args.list_approved:
+        for finding in findings:
+            reason = APPROVED_DIRECT_WRITES.get(finding.approval_key, "UNAPPROVED")
+            print(
+                f"{finding.path}:{finding.line}: "
+                f"{finding.function} {finding.receiver}.{finding.method} - {reason}"
+            )
+        return 0
+
+    unapproved = unapproved_direct_writes(findings)
+    for finding in unapproved:
+        print(
+            f"{finding.path}:{finding.line}: direct {finding.method} in "
+            f"{finding.function}; use atomic_write_* or add an audited approval"
+        )
+    return 1 if unapproved else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_performance_evidence.py
+++ b/scripts/check_performance_evidence.py
@@ -1,0 +1,99 @@
+"""Validate the PR Performance Evidence section."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+PERFORMANCE_SECTION = "Performance Evidence"
+REQUIRED_FIELDS = (
+    "Benchmark matrix row",
+    "Command",
+    "Python build",
+    "Machine/OS",
+    "Baseline commit or saved result",
+    "Current commit or saved result",
+    "Artifact path",
+    "Interpretation",
+)
+
+
+def extract_section(body: str, heading: str = PERFORMANCE_SECTION) -> str:
+    """Return a Markdown section body by level-two heading."""
+    pattern = re.compile(
+        rf"^##\s+{re.escape(heading)}\s*$"
+        r"(?P<section>.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    return match.group("section").strip() if match else ""
+
+
+def field_values(section: str) -> dict[str, str]:
+    """Return field values from the Performance Evidence checklist."""
+    values: dict[str, str] = {}
+    for field in REQUIRED_FIELDS:
+        pattern = re.compile(
+            rf"^[ \t]*-[ \t]*{re.escape(field)}:[ \t]*(?P<value>.*)$",
+            re.MULTILINE,
+        )
+        match = pattern.search(section)
+        if match:
+            values[field] = match.group("value").strip()
+    return values
+
+
+def missing_evidence_fields(body: str, *, allow_template: bool = False) -> tuple[str, ...]:
+    """Return missing evidence fields, or an empty tuple when the section is valid."""
+    section = extract_section(body)
+    if not section:
+        return (PERFORMANCE_SECTION,)
+    values = field_values(section)
+    if allow_template:
+        return tuple(field for field in REQUIRED_FIELDS if field not in values)
+    if any(value.lower() == "not applicable" for value in values.values()):
+        return ()
+
+    return tuple(field for field in REQUIRED_FIELDS if not values.get(field))
+
+
+def body_from_github_event(path: Path) -> str:
+    """Read a pull-request body from a GitHub event payload."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    pull_request = payload.get("pull_request", {})
+    body = pull_request.get("body") or ""
+    if not isinstance(body, str):
+        return ""
+    return body
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--body-file", type=Path, help="Markdown file containing a PR body")
+    source.add_argument("--github-event", type=Path, help="GitHub event JSON payload")
+    parser.add_argument(
+        "--allow-template",
+        action="store_true",
+        help="Only require that the Performance Evidence fields are present.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    body = (
+        body_from_github_event(args.github_event)
+        if args.github_event is not None
+        else args.body_file.read_text(encoding="utf-8")
+    )
+    missing = missing_evidence_fields(body, allow_template=args.allow_template)
+    for field in missing:
+        print(f"Missing Performance Evidence field: {field}")
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/proof_pr_plan.py
+++ b/scripts/proof_pr_plan.py
@@ -1,0 +1,94 @@
+"""Print the canonical bounded PR proof plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True, slots=True)
+class ProofPlanStep:
+    """One resolved task in the bounded PR proof path."""
+
+    name: str
+    command: str
+    help: str
+
+
+def _load_poe_tasks(root: Path) -> dict[str, Any]:
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    return pyproject["tool"]["poe"]["tasks"]
+
+
+def _task_sequence(task: Any, *, task_name: str) -> tuple[str, ...]:
+    if not isinstance(task, dict):
+        raise TypeError(f"{task_name} must be a table in [tool.poe.tasks]")
+    sequence = task.get("sequence")
+    if not isinstance(sequence, list) or not all(isinstance(item, str) for item in sequence):
+        raise TypeError(f"{task_name} must define a string sequence")
+    return tuple(sequence)
+
+
+def _task_command(task: Any, *, task_name: str) -> str:
+    if not isinstance(task, dict):
+        raise TypeError(f"{task_name} must be a table in [tool.poe.tasks]")
+    command = task.get("cmd")
+    if not isinstance(command, str) or not command:
+        raise TypeError(f"{task_name} must define a non-empty cmd")
+    return command
+
+
+def _task_help(task: Any, *, task_name: str) -> str:
+    if not isinstance(task, dict):
+        raise TypeError(f"{task_name} must be a table in [tool.poe.tasks]")
+    help_text = task.get("help", "")
+    if not isinstance(help_text, str):
+        raise TypeError(f"{task_name} help must be a string")
+    return help_text
+
+
+def proof_pr_plan(root: Path = ROOT) -> tuple[ProofPlanStep, ...]:
+    """Return the resolved bounded PR proof plan from pyproject tasks."""
+    tasks = _load_poe_tasks(root)
+    sequence = _task_sequence(tasks["proof-pr"], task_name="proof-pr")
+    return tuple(
+        ProofPlanStep(
+            name=task_name,
+            command=_task_command(tasks[task_name], task_name=task_name),
+            help=_task_help(tasks[task_name], task_name=task_name),
+        )
+        for task_name in sequence
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    plan = proof_pr_plan()
+    if args.format == "json":
+        print(json.dumps([asdict(step) for step in plan], indent=2))
+        return 0
+
+    for index, step in enumerate(plan, start=1):
+        print(f"{index}. {step.name}: {step.command}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -2,6 +2,19 @@
 
 This directory contains performance benchmarks for Bengal SSG to validate performance claims and track improvements.
 
+## Incremental Correctness Contract
+
+`incremental_contract.toml` names the canonical warm-build cases that must remain
+correct as the build pipeline changes: no-op, single content edit, template edit,
+asset edit, sidecar edit, and config edit. Each row records the expected behavior,
+state surfaces involved, and proof paths that should move with related changes.
+
+Validate the contract metadata with:
+
+```bash
+uv run pytest tests/unit/performance/test_incremental_contract.py -q
+```
+
 ## Available Benchmarks
 
 ### 1. SSG Comparison (`benchmark_ssg_comparison.py`) ⭐ NEW

--- a/tests/performance/incremental_contract.py
+++ b/tests/performance/incremental_contract.py
@@ -1,0 +1,64 @@
+"""Reusable loader for incremental correctness contract cases."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = ROOT / "tests" / "performance" / "incremental_contract.toml"
+
+
+@dataclass(frozen=True, slots=True)
+class IncrementalContractCase:
+    """One warm-build correctness case from the canonical contract."""
+
+    id: str
+    change: str
+    expected: str
+    proof_paths: tuple[str, ...]
+    state_surfaces: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class IncrementalContract:
+    """Parsed incremental correctness contract."""
+
+    version: int
+    updated: str
+    owner: str
+    description: str
+    invariants: dict[str, str]
+    cases: tuple[IncrementalContractCase, ...]
+
+    def case(self, case_id: str) -> IncrementalContractCase:
+        """Return one contract case by id."""
+        for case in self.cases:
+            if case.id == case_id:
+                return case
+        raise KeyError(case_id)
+
+
+def _as_case(payload: dict[str, Any]) -> IncrementalContractCase:
+    return IncrementalContractCase(
+        id=payload["id"],
+        change=payload["change"],
+        expected=payload["expected"],
+        proof_paths=tuple(payload["proof_paths"]),
+        state_surfaces=tuple(payload["state_surfaces"]),
+    )
+
+
+def load_incremental_contract(path: Path = CONTRACT_PATH) -> IncrementalContract:
+    """Load the canonical incremental correctness contract."""
+    payload = tomllib.loads(path.read_text(encoding="utf-8"))
+    return IncrementalContract(
+        version=payload["version"],
+        updated=str(payload["updated"]),
+        owner=payload["owner"],
+        description=payload["description"],
+        invariants=dict(payload["invariants"]),
+        cases=tuple(_as_case(case) for case in payload["cases"]),
+    )

--- a/tests/performance/incremental_contract.toml
+++ b/tests/performance/incremental_contract.toml
@@ -1,0 +1,71 @@
+version = 1
+updated = "2026-05-22"
+owner = "tests/performance"
+description = "Canonical incremental correctness cases that warm-build changes must preserve."
+
+[invariants]
+outputs = "Changed output accounting must match files written or intentionally skipped."
+caches = "Cache/provenance/artifact state must explain rebuild decisions without stale page data."
+parity = "Warm builds must produce the same user-visible artifacts as clean cold builds."
+diagnostics = "A changed source should leave enough stats or logs to explain why work did or did not run."
+
+[[cases]]
+id = "no-op"
+change = "No source, template, config, asset, or cache input changes."
+expected = "No pages render, no outputs are rewritten, and caches stay readable."
+proof_paths = [
+  "tests/performance/benchmark_warm_build_consistency.py",
+  "tests/performance/test_post_render_pipeline_budget.py",
+]
+state_surfaces = ["change census", "provenance", "page artifacts", "output collector"]
+
+[[cases]]
+id = "single-content-edit"
+change = "One content page changes without navigation or taxonomy fallout."
+expected = "The edited page and its required derived outputs update; unrelated pages remain unchanged."
+proof_paths = [
+  "benchmarks/test_build.py",
+  "tests/performance/benchmark_incremental.py",
+  "tests/performance/test_post_render_pipeline_budget.py",
+]
+state_surfaces = ["change census", "provenance", "page cache", "output collector"]
+
+[[cases]]
+id = "template-edit"
+change = "An active theme or project template changes."
+expected = "Pages depending on the template rebuild, including inherited-theme templates."
+proof_paths = [
+  "tests/unit/rendering/test_template_inheritance_detection.py",
+  "tests/unit/orchestration/build/test_provenance_filter_path_keys.py",
+  "tests/performance/benchmark_incremental_scale.py",
+]
+state_surfaces = ["template path keys", "provenance", "cache invalidation"]
+
+[[cases]]
+id = "asset-edit"
+change = "A tracked asset or CSS-only source changes."
+expected = "Asset outputs and dependent post-render outputs update without forcing unrelated page renders."
+proof_paths = [
+  "tests/performance/test_asset_fallback_cost.py",
+  "tests/performance/test_post_render_pipeline_budget.py",
+]
+state_surfaces = ["tracked assets", "artifact inventory", "output collector"]
+
+[[cases]]
+id = "sidecar-edit"
+change = "A notebook or page sidecar changes while rendered HTML is unchanged."
+expected = "The sidecar output is written atomically, recorded as changed, and skipped on identical reruns."
+proof_paths = [
+  "tests/unit/rendering/test_write_output_rendered_page.py",
+]
+state_surfaces = ["output collector", "sidecar bytes", "rendered page output"]
+
+[[cases]]
+id = "config-edit"
+change = "A build-affecting config file changes."
+expected = "The build chooses a full or structurally broad rebuild and records why."
+proof_paths = [
+  "benchmarks/test_build.py",
+  "tests/unit/orchestration/build/test_completion_policy.py",
+]
+state_surfaces = ["change census", "build options", "provenance"]

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -82,6 +82,7 @@ class TestLRUCacheThreadSafety:
                         size=20 + (i % 3),
                         css_class=f"class_{i % 2}",
                         aria_label="",
+                        scope_key=(),
                     )
                     with lock:
                         results.append(result)

--- a/tests/unit/benchmarks/test_benchmark_matrix.py
+++ b/tests/unit/benchmarks/test_benchmark_matrix.py
@@ -1,0 +1,98 @@
+"""Schema checks for the canonical benchmark matrix."""
+
+from __future__ import annotations
+
+import shlex
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MATRIX_PATH = ROOT / "benchmarks" / "benchmark_matrix.toml"
+
+REQUIRED_ENTRY_FIELDS = {
+    "id",
+    "tier",
+    "tags",
+    "purpose",
+    "command",
+    "paths",
+    "metrics",
+    "evidence",
+    "budget",
+    "triggers",
+}
+REQUIRED_TAGS = {
+    "assets",
+    "build",
+    "cache",
+    "incremental",
+    "parser",
+    "postprocess",
+    "rendering",
+    "worker-scaling",
+}
+
+
+def _load_matrix() -> dict:
+    return tomllib.loads(MATRIX_PATH.read_text(encoding="utf-8"))
+
+
+def test_benchmark_matrix_entries_have_canonical_shape() -> None:
+    matrix = _load_matrix()
+    tiers = set(matrix["tiers"])
+    entries = matrix["benchmarks"]
+
+    assert matrix["version"] >= 1
+    assert tiers == {"smoke", "release", "investigation"}
+    assert entries
+
+    seen_ids: set[str] = set()
+    for entry in entries:
+        missing_fields = REQUIRED_ENTRY_FIELDS.difference(entry)
+        assert not missing_fields, f"{entry.get('id', '<missing>')} missing {missing_fields}"
+        assert entry["id"] not in seen_ids
+        assert entry["tier"] in tiers
+        assert entry["command"].startswith("uv run ")
+        assert entry["paths"]
+        assert entry["tags"]
+        assert entry["metrics"]
+        assert entry["evidence"]
+
+        seen_ids.add(entry["id"])
+
+
+def test_benchmark_matrix_references_existing_sources() -> None:
+    matrix = _load_matrix()
+
+    for entry in matrix["benchmarks"]:
+        for source_path in entry["paths"]:
+            path = ROOT / source_path
+            assert path.exists(), f"{entry['id']} references missing path: {source_path}"
+            assert "/output/" not in source_path, (
+                f"{entry['id']} must not depend on generated output"
+            )
+            assert source_path.startswith(("benchmarks/", "tests/performance/"))
+
+
+def test_benchmark_matrix_commands_reference_tracked_paths() -> None:
+    matrix = _load_matrix()
+
+    for entry in matrix["benchmarks"]:
+        tokens = shlex.split(entry["command"])
+        command_paths = [
+            token
+            for token in tokens
+            if token.startswith(("benchmarks/", "tests/performance/")) and "::" not in token
+        ]
+        assert command_paths, f"{entry['id']} command should name at least one benchmark path"
+        for command_path in command_paths:
+            assert (ROOT / command_path).exists(), (
+                f"{entry['id']} command references missing path: {command_path}"
+            )
+
+
+def test_benchmark_matrix_covers_required_hot_paths() -> None:
+    matrix = _load_matrix()
+    covered_tags = {tag for entry in matrix["benchmarks"] for tag in entry["tags"]}
+
+    assert REQUIRED_TAGS.issubset(covered_tags)

--- a/tests/unit/benchmarks/test_benchmark_matrix.py
+++ b/tests/unit/benchmarks/test_benchmark_matrix.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import shlex
 import tomllib
 from pathlib import Path
+
+from benchmarks.run_matrix import (
+    MatrixEntry,
+    execute_entries,
+    load_entries,
+    write_receipt,
+)
 
 ROOT = Path(__file__).resolve().parents[3]
 MATRIX_PATH = ROOT / "benchmarks" / "benchmark_matrix.toml"
@@ -96,3 +104,55 @@ def test_benchmark_matrix_covers_required_hot_paths() -> None:
     covered_tags = {tag for entry in matrix["benchmarks"] for tag in entry["tags"]}
 
     assert REQUIRED_TAGS.issubset(covered_tags)
+
+
+def test_matrix_runner_dry_run_returns_normalized_results() -> None:
+    entry = MatrixEntry(
+        id="render-output-regression",
+        tier="smoke",
+        command="uv run pytest tests/performance/test_autodoc_render_regression.py",
+        purpose="Guard render output shape.",
+    )
+
+    exit_code, results = execute_entries([entry], dry_run=True)
+
+    assert exit_code == 0
+    assert len(results) == 1
+    assert results[0].id == entry.id
+    assert results[0].returncode == 0
+    assert results[0].duration_seconds == 0.0
+    assert results[0].skipped is True
+
+
+def test_matrix_runner_writes_receipt(tmp_path: Path) -> None:
+    entry = MatrixEntry(
+        id="post-render-budget",
+        tier="smoke",
+        command="uv run pytest tests/performance/test_post_render_pipeline_budget.py",
+        purpose="Guard post-render budget.",
+    )
+    exit_code, results = execute_entries([entry], dry_run=True)
+    receipt_path = tmp_path / "matrix" / "receipt.json"
+
+    write_receipt(
+        receipt_path,
+        entries=[entry],
+        results=results,
+        dry_run=True,
+        exit_code=exit_code,
+    )
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+
+    assert receipt["version"] == 1
+    assert receipt["dry_run"] is True
+    assert receipt["exit_code"] == 0
+    assert receipt["selected_ids"] == [entry.id]
+    assert receipt["results"][0]["id"] == entry.id
+
+
+def test_matrix_runner_loads_canonical_rows() -> None:
+    entries = load_entries(MATRIX_PATH)
+
+    assert entries
+    assert {entry.tier for entry in entries} == {"smoke", "release", "investigation"}

--- a/tests/unit/benchmarks/test_run_matrix.py
+++ b/tests/unit/benchmarks/test_run_matrix.py
@@ -1,0 +1,68 @@
+"""Tests for the benchmark matrix runner."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from benchmarks import run_matrix
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_load_entries_reads_canonical_matrix() -> None:
+    entries = run_matrix.load_entries()
+
+    assert any(entry.id == "render-output-regression" for entry in entries)
+    assert {entry.tier for entry in entries} == {"smoke", "release", "investigation"}
+
+
+def test_select_entries_filters_by_tier_and_id() -> None:
+    entries = [
+        run_matrix.MatrixEntry("a", "smoke", "echo a", "A"),
+        run_matrix.MatrixEntry("b", "release", "echo b", "B"),
+        run_matrix.MatrixEntry("c", "smoke", "echo c", "C"),
+    ]
+
+    assert [entry.id for entry in run_matrix.select_entries(entries, tier="smoke")] == ["a", "c"]
+    assert [
+        entry.id for entry in run_matrix.select_entries(entries, tier="smoke", entry_ids={"c"})
+    ] == ["c"]
+
+
+def test_run_entries_dry_run_does_not_execute(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_run(*args, **kwargs):
+        calls.append("called")
+        raise AssertionError("dry run should not execute commands")
+
+    monkeypatch.setattr(run_matrix.subprocess, "run", fake_run)
+
+    exit_code = run_matrix.run_entries(
+        [run_matrix.MatrixEntry("a", "smoke", "echo a", "A")],
+        dry_run=True,
+    )
+
+    assert exit_code == 0
+    assert calls == []
+
+
+def test_run_entries_stops_on_failure(monkeypatch) -> None:
+    commands: list[str] = []
+
+    def fake_run(command: str, *, cwd: Path, shell: bool, check: bool):
+        commands.append(command)
+        return type("Result", (), {"returncode": 7})()
+
+    monkeypatch.setattr(run_matrix.subprocess, "run", fake_run)
+
+    exit_code = run_matrix.run_entries(
+        [
+            run_matrix.MatrixEntry("a", "smoke", "echo a", "A"),
+            run_matrix.MatrixEntry("b", "smoke", "echo b", "B"),
+        ]
+    )
+
+    assert exit_code == 7
+    assert commands == ["echo a"]

--- a/tests/unit/cache/test_page_artifact_store.py
+++ b/tests/unit/cache/test_page_artifact_store.py
@@ -18,6 +18,7 @@ def test_page_artifact_store_round_trips_records(tmp_path):
     store.save(records)
 
     assert store.load() == records
+    assert (store.root / "manifest.json").exists()
 
 
 def test_page_artifact_store_prunes_stale_shards(tmp_path):
@@ -66,6 +67,32 @@ def test_page_artifact_store_dirty_save_deletes_empty_shard(tmp_path):
     store.save({}, dirty_keys=set(), deleted_keys={"content/a.md"})
 
     assert not shard_path.exists()
+    assert not (store.root / "manifest.json").exists()
+
+
+def test_page_artifact_store_loads_selected_keys_from_manifest(tmp_path):
+    """Targeted loads only return requested records from manifest-backed shards."""
+    store = PageArtifactStore(tmp_path / "page-artifacts")
+    records = {
+        "content/a.md": {"uri": "/a/"},
+        "content/b.md": {"uri": "/b/"},
+    }
+    store.save(records)
+
+    assert store.load(keys={"content/b.md"}) == {"content/b.md": {"uri": "/b/"}}
+
+
+def test_page_artifact_store_falls_back_without_manifest(tmp_path):
+    """Legacy shard directories without a manifest still load."""
+    store = PageArtifactStore(tmp_path / "page-artifacts")
+    store.root.mkdir(parents=True)
+    shard = store._shard_name("content/a.md")
+    (store.root / f"{shard}.json").write_text(
+        '{"content/a.md": {"uri": "/a/"}}',
+        encoding="utf-8",
+    )
+
+    assert store.load() == {"content/a.md": {"uri": "/a/"}}
 
 
 def _key_in_different_shard(store: PageArtifactStore, key: str) -> str:

--- a/tests/unit/core/output/test_collector.py
+++ b/tests/unit/core/output/test_collector.py
@@ -193,6 +193,20 @@ class TestBuildOutputCollector:
         collector.clear()
         assert len(collector) == 0
         assert collector.get_outputs() == []
+        assert collector.css_only() is False
+
+    def test_css_only_uses_updated_type_counts_after_clear(self) -> None:
+        """css_only() stays correct when records are cleared and reused."""
+        collector = BuildOutputCollector()
+        collector.record(Path("index.html"), OutputType.HTML, phase="render")
+        collector.record(Path("style.css"), OutputType.CSS, phase="asset")
+
+        assert collector.css_only() is False
+
+        collector.clear()
+        collector.record(Path("reset.css"), OutputType.CSS, phase="asset")
+
+        assert collector.css_only() is True
 
     def test_len(self) -> None:
         """__len__ returns count of recorded outputs."""

--- a/tests/unit/core/test_menu_cycles.py
+++ b/tests/unit/core/test_menu_cycles.py
@@ -7,32 +7,52 @@ from bengal.errors import BengalContentError
 class TestMenuCircularDependencies:
     def test_menu_parent_child_cycle_raises(self):
         builder = MenuBuilder()
-        # Build a cycle via identifiers: p -> c -> p
         builder.add_from_config(
             [
-                {"name": "Parent", "url": "/parent", "identifier": "p"},
+                {"name": "Parent", "url": "/parent", "parent": "c", "identifier": "p"},
                 {"name": "Child", "url": "/child", "parent": "p", "identifier": "c"},
             ]
         )
-        # Inject the cycle by marking parent of "p" as "c" via an additional child that uses
-        # the same identifier. Since MenuBuilder uses identifier as key, simulate by building then
-        # manually linking children to force a cycle.
-        builder.build_hierarchy()
-        # Find nodes
-        by_id = {item.identifier: item for item in builder.items}
-        p = by_id["p"]
-        c = by_id["c"]
-        # Force a cycle
-        if c not in p.children:
-            p.children.append(c)
-        c.children.append(p)
-
-        # Now the cycle should be detected by the cycle checker when rebuilding
-        with pytest.raises(BengalContentError):
-            builder.build_hierarchy()
 
         with pytest.raises(BengalContentError):
             builder.build_hierarchy()
+
+    def test_rootless_parent_cycle_raises(self):
+        builder = MenuBuilder()
+        builder.add_from_config(
+            [
+                {"name": "A", "url": "/a", "parent": "b", "identifier": "a"},
+                {"name": "B", "url": "/b", "parent": "a", "identifier": "b"},
+            ]
+        )
+
+        with pytest.raises(BengalContentError):
+            builder.build_hierarchy()
+
+    def test_self_parent_cycle_raises(self):
+        builder = MenuBuilder()
+        builder.add_from_config(
+            [{"name": "Self", "url": "/self", "parent": "self", "identifier": "self"}]
+        )
+
+        with pytest.raises(BengalContentError):
+            builder.build_hierarchy()
+
+    def test_repeated_build_hierarchy_is_idempotent(self):
+        builder = MenuBuilder()
+        builder.add_from_config(
+            [
+                {"name": "Root", "url": "/", "identifier": "root"},
+                {"name": "Child", "url": "/child", "parent": "root", "identifier": "child"},
+            ]
+        )
+
+        first_roots = builder.build_hierarchy()
+        second_roots = builder.build_hierarchy()
+
+        assert first_roots == second_roots
+        assert len(second_roots) == 1
+        assert [child.identifier for child in second_roots[0].children] == ["child"]
 
     def test_valid_tree_builds(self):
         builder = MenuBuilder()
@@ -58,13 +78,9 @@ class TestCycleDetectionEdgeCases:
     def test_self_referencing_item(self):
         """Test that a self-referencing item is detected as a cycle."""
         builder = MenuBuilder()
-        builder.add_from_config([{"name": "Self", "url": "/self", "identifier": "self"}])
-        builder.build_hierarchy()
-
-        # Manually create self-reference
-        by_id = {item.identifier: item for item in builder.items}
-        self_item = by_id["self"]
-        self_item.children.append(self_item)
+        builder.add_from_config(
+            [{"name": "Self", "url": "/self", "parent": "self", "identifier": "self"}]
+        )
 
         with pytest.raises(BengalContentError):
             builder.build_hierarchy()
@@ -74,16 +90,11 @@ class TestCycleDetectionEdgeCases:
         builder = MenuBuilder()
         builder.add_from_config(
             [
-                {"name": "A", "url": "/a", "identifier": "a"},
+                {"name": "A", "url": "/a", "parent": "c", "identifier": "a"},
                 {"name": "B", "url": "/b", "parent": "a", "identifier": "b"},
                 {"name": "C", "url": "/c", "parent": "b", "identifier": "c"},
             ]
         )
-        builder.build_hierarchy()
-
-        # Create cycle: C → A
-        by_id = {item.identifier: item for item in builder.items}
-        by_id["c"].children.append(by_id["a"])
 
         with pytest.raises(BengalContentError):
             builder.build_hierarchy()

--- a/tests/unit/core/test_page_cache.py
+++ b/tests/unit/core/test_page_cache.py
@@ -14,12 +14,17 @@ from unittest.mock import MagicMock
 from bengal.core.page_cache import PageCacheManager
 
 
-def _make_mock_page(source_path: Path | str) -> MagicMock:
+def _make_mock_page(
+    source_path: Path | str,
+    *,
+    generated: bool = False,
+    in_listings: bool = True,
+) -> MagicMock:
     """Create mock page with source_path."""
     p = MagicMock()
     p.source_path = Path(source_path) if isinstance(source_path, str) else source_path
-    p.metadata = {}
-    p.in_listings = True
+    p.metadata = {"_generated": True} if generated else {}
+    p.in_listings = in_listings
     return p
 
 
@@ -85,3 +90,49 @@ class TestGetPagePathMapPathKeys:
         # Lookup with absolute path string - misses (map key is relative)
         resolved = path_map.get(str(tax_member.source_path))
         assert resolved is None  # Current behavior: format mismatch = miss
+
+    def test_same_length_page_replacement_rebuilds_path_map(self) -> None:
+        """Replacing pages without changing count should not reuse stale maps."""
+        pages = [_make_mock_page("content/old.md")]
+        cache = PageCacheManager(pages_fn=lambda: pages)
+
+        first_map = cache.get_page_path_map()
+        assert first_map["content/old.md"] is pages[0]
+
+        pages[:] = [_make_mock_page("content/new.md")]
+        second_map = cache.get_page_path_map()
+
+        assert "content/old.md" not in second_map
+        assert second_map["content/new.md"] is pages[0]
+        assert second_map is not first_map
+
+    def test_same_length_page_replacement_rebuilds_source_path_map(self) -> None:
+        """Path-keyed lookup maps track same-length page-list replacements."""
+        pages = [_make_mock_page("content/old.md")]
+        cache = PageCacheManager(pages_fn=lambda: pages)
+
+        first_map = cache.page_by_source_path
+        assert first_map[Path("content/old.md")] is pages[0]
+
+        pages[:] = [_make_mock_page("content/new.md")]
+        second_map = cache.page_by_source_path
+
+        assert Path("content/old.md") not in second_map
+        assert second_map[Path("content/new.md")] is pages[0]
+        assert second_map is not first_map
+
+    def test_metadata_reclassification_rebuilds_filtered_views(self) -> None:
+        """Generated/listable views refresh when page classification changes."""
+        page = _make_mock_page("content/page.md")
+        cache = PageCacheManager(pages_fn=lambda: [page])
+
+        assert cache.regular_pages == [page]
+        assert cache.generated_pages == []
+        assert cache.listable_pages == [page]
+
+        page.metadata["_generated"] = True
+        page.in_listings = False
+
+        assert cache.regular_pages == []
+        assert cache.generated_pages == [page]
+        assert cache.listable_pages == []

--- a/tests/unit/core/test_section_sorting.py
+++ b/tests/unit/core/test_section_sorting.py
@@ -334,6 +334,35 @@ class TestSectionSortedSubsectionsProperty:
         assert sorted_subs[0] == sub2
         assert sorted_subs[1] == sub1
 
+    def test_sorted_subsections_normalizes_mixed_weight_values(self, tmp_path):
+        """String, numeric, malformed, and missing weights stay sortable."""
+        section = Section(name="docs", path=tmp_path / "docs")
+
+        numeric = Section(
+            name="numeric",
+            path=tmp_path / "docs/numeric",
+            metadata={"title": "Numeric", "weight": 2},
+        )
+        string = Section(
+            name="string",
+            path=tmp_path / "docs/string",
+            metadata={"title": "String", "weight": "10"},
+        )
+        malformed = Section(
+            name="malformed",
+            path=tmp_path / "docs/malformed",
+            metadata={"title": "Malformed", "weight": "later"},
+        )
+        missing = Section(
+            name="missing",
+            path=tmp_path / "docs/missing",
+            metadata={"title": "Missing"},
+        )
+
+        section.subsections = [missing, string, malformed, numeric]
+
+        assert section.sorted_subsections == [numeric, string, malformed, missing]
+
 
 class TestSectionSortChildrenByWeight:
     """Test Section.sort_children_by_weight() method."""

--- a/tests/unit/core/test_surface_budget.py
+++ b/tests/unit/core/test_surface_budget.py
@@ -1,0 +1,48 @@
+"""Regression guards for core compatibility surface budgets."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from bengal.core.section import Section
+
+ROOT = Path(__file__).resolve().parents[3]
+SECTION_SOURCE = ROOT / "bengal" / "core" / "section" / "__init__.py"
+
+SECTION_ERGONOMICS_SHIMS = {
+    "content_pages",
+    "recent_pages",
+    "pages_with_tag",
+    "featured_posts",
+    "post_count",
+    "post_count_recursive",
+    "word_count",
+    "total_reading_time",
+    "aggregate_content",
+    "apply_section_template",
+    "has_nav_children",
+    "icon",
+}
+
+
+def test_section_ergonomics_compatibility_shim_budget_does_not_grow() -> None:
+    """Section may keep known shims, but new ergonomics belong outside core."""
+    source = SECTION_SOURCE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    shim_methods: set[str] = set()
+    section_class = next(
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Section"
+    )
+    for node in section_class.body:
+        if isinstance(node, ast.FunctionDef):
+            method_source = ast.get_source_segment(source, node) or ""
+            if "from bengal.rendering.section_ergonomics import" in method_source:
+                shim_methods.add(node.name)
+
+    assert shim_methods == SECTION_ERGONOMICS_SHIMS
+
+
+def test_section_does_not_restore_sections_alias() -> None:
+    """The old sections -> subsections alias should stay retired."""
+    assert "sections" not in vars(Section)

--- a/tests/unit/core/test_surface_retirement.py
+++ b/tests/unit/core/test_surface_retirement.py
@@ -1,0 +1,32 @@
+"""Retirement guards for core compatibility surfaces."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.check_core_surface_usage import scan_core_surface_usage, scan_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_bengal_internal_code_avoids_retired_section_content_pages() -> None:
+    assert scan_core_surface_usage() == ()
+
+
+def test_core_surface_usage_scan_flags_new_internal_call(tmp_path: Path) -> None:
+    candidate = tmp_path / "candidate.py"
+    candidate.write_text(
+        """
+def render(section):
+    return section.content_pages
+""",
+        encoding="utf-8",
+    )
+
+    usages = scan_file(candidate, root=tmp_path)
+
+    assert len(usages) == 1
+    assert usages[0].path == "candidate.py"
+    assert usages[0].attr == "content_pages"
+    assert "section_ergonomics.content_pages" in usages[0].suggestion

--- a/tests/unit/fonts/test_atomic_outputs.py
+++ b/tests/unit/fonts/test_atomic_outputs.py
@@ -1,0 +1,95 @@
+"""Font output writes use the shared atomic writer."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+from bengal import fonts as fonts_module
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_rewrite_font_urls_uses_atomic_write(tmp_path: Path, monkeypatch) -> None:
+    css_path = tmp_path / "fonts.css"
+    css_path.write_text("@font-face { src: url('fonts/inter-400.woff2'); }", encoding="utf-8")
+    writes: list[tuple[Path, str]] = []
+
+    def fake_atomic_write_text(path: Path, content: str, **kwargs) -> None:
+        writes.append((path, content))
+        path.write_text(content, encoding=kwargs.get("encoding", "utf-8"))
+
+    monkeypatch.setattr(fonts_module, "atomic_write_text", fake_atomic_write_text)
+
+    updated = fonts_module.rewrite_font_urls_with_fingerprints(
+        css_path,
+        {
+            "assets": {
+                "fonts/inter-400.woff2": {
+                    "output_path": "assets/fonts/inter-400.abc123.woff2",
+                }
+            }
+        },
+    )
+
+    assert updated is True
+    assert writes == [(css_path, "@font-face { src: url('fonts/inter-400.abc123.woff2'); }")]
+
+
+def test_font_helper_process_uses_atomic_write_for_fonts_css(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    helper = fonts_module.FontHelper({"primary": "Inter:400"})
+    helper.downloader = SimpleNamespace(download_font=lambda **kwargs: ["variant"])
+    helper.generator = SimpleNamespace(generate=lambda variants: "/* fonts */\n")
+    writes: list[tuple[Path, str]] = []
+
+    class FakeCli:
+        icons = SimpleNamespace(tree_end="tree")
+
+        def section(self, message: str) -> None:
+            pass
+
+        def detail(self, message: str, **kwargs) -> None:
+            pass
+
+    def fake_atomic_write_text(path: Path, content: str, **kwargs) -> None:
+        writes.append((path, content))
+        path.write_text(content, encoding=kwargs.get("encoding", "utf-8"))
+
+    monkeypatch.setattr("bengal.output.get_cli_output", lambda: FakeCli())
+    monkeypatch.setattr(fonts_module, "atomic_write_text", fake_atomic_write_text)
+
+    css_path = helper.process(tmp_path)
+
+    assert css_path == tmp_path / "fonts.css"
+    assert writes == [(tmp_path / "fonts.css", "/* fonts */\n")]
+
+
+def test_font_helper_process_skips_atomic_write_when_css_is_unchanged(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    (tmp_path / "fonts.css").write_text("/* fonts */\n", encoding="utf-8")
+    helper = fonts_module.FontHelper({"primary": "Inter:400"})
+    helper.downloader = SimpleNamespace(download_font=lambda **kwargs: ["variant"])
+    helper.generator = SimpleNamespace(generate=lambda variants: "/* fonts */\n")
+
+    class FakeCli:
+        icons = SimpleNamespace(tree_end="tree")
+
+        def section(self, message: str) -> None:
+            pass
+
+        def detail(self, message: str, **kwargs) -> None:
+            pass
+
+    def fail_atomic_write_text(path: Path, content: str, **kwargs) -> None:
+        raise AssertionError("unchanged fonts.css should not be rewritten")
+
+    monkeypatch.setattr("bengal.output.get_cli_output", lambda: FakeCli())
+    monkeypatch.setattr(fonts_module, "atomic_write_text", fail_atomic_write_text)
+
+    assert helper.process(tmp_path) == tmp_path / "fonts.css"

--- a/tests/unit/icons/test_resolver.py
+++ b/tests/unit/icons/test_resolver.py
@@ -6,6 +6,7 @@ Tests the theme-aware icon resolution system.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -147,6 +148,101 @@ class TestIconCaching:
         # Should get new version
         content2 = icon_resolver.load_icon("reload")
         assert "<!-- v2 -->" in content2
+
+
+class TestScopedIconCaching:
+    """Site-scoped icon caches do not leak across theme roots."""
+
+    def _site(self, root_path: Path, aliases: dict[str, str] | None = None):
+        theme_config = SimpleNamespace(
+            icons=SimpleNamespace(extend_defaults=False),
+            config={"icons": {"aliases": aliases or {}}},
+        )
+        return SimpleNamespace(
+            root_path=root_path,
+            theme="custom",
+            theme_config=theme_config,
+        )
+
+    def test_site_context_keeps_same_icon_name_isolated(self, tmp_path: Path, monkeypatch) -> None:
+        """The active site context chooses the matching theme icon cache."""
+        site1 = self._site(tmp_path / "site1")
+        site2 = self._site(tmp_path / "site2")
+        for site, marker in [(site1, "site-one"), (site2, "site-two")]:
+            icons_dir = site.root_path / "theme" / "assets" / "icons"
+            icons_dir.mkdir(parents=True)
+            (icons_dir / "shared.svg").write_text(
+                f"<svg><!-- {marker} --></svg>",
+                encoding="utf-8",
+            )
+
+        monkeypatch.setattr(
+            "bengal.services.theme.get_theme_assets_chain",
+            lambda root_path, theme: [root_path / "theme" / "assets"],
+        )
+
+        with icon_resolver.site_context(site1):
+            assert "<!-- site-one -->" in icon_resolver.load_icon("shared")
+
+        with icon_resolver.site_context(site2):
+            assert "<!-- site-two -->" in icon_resolver.load_icon("shared")
+
+    def test_render_svg_cache_is_scoped_by_site(self, tmp_path: Path, monkeypatch) -> None:
+        """Rendered SVG cache keys include the active icon resolver scope."""
+        from bengal.icons.svg import render_svg_icon
+
+        site1 = self._site(tmp_path / "site1")
+        site2 = self._site(tmp_path / "site2")
+        for site, marker in [(site1, "site-one"), (site2, "site-two")]:
+            icons_dir = site.root_path / "theme" / "assets" / "icons"
+            icons_dir.mkdir(parents=True)
+            (icons_dir / "shared.svg").write_text(
+                f"<svg><!-- {marker} --></svg>",
+                encoding="utf-8",
+            )
+
+        monkeypatch.setattr(
+            "bengal.services.theme.get_theme_assets_chain",
+            lambda root_path, theme: [root_path / "theme" / "assets"],
+        )
+
+        with icon_resolver.site_context(site1):
+            first = render_svg_icon("shared", size=16)
+        with icon_resolver.site_context(site2):
+            second = render_svg_icon("shared", size=16)
+
+        assert "<!-- site-one -->" in first
+        assert "<!-- site-two -->" in second
+
+    def test_template_icon_aliases_are_site_scoped(self, tmp_path: Path, monkeypatch) -> None:
+        """Registered template helpers capture each site's aliases and icon scope."""
+        from bengal.rendering.template_functions.icons import register
+
+        site1 = self._site(tmp_path / "site1", aliases={"docs": "one"})
+        site2 = self._site(tmp_path / "site2", aliases={"docs": "two"})
+        for site, icon_name, marker in [
+            (site1, "one", "site-one"),
+            (site2, "two", "site-two"),
+        ]:
+            icons_dir = site.root_path / "theme" / "assets" / "icons"
+            icons_dir.mkdir(parents=True)
+            (icons_dir / f"{icon_name}.svg").write_text(
+                f"<svg><!-- {marker} --></svg>",
+                encoding="utf-8",
+            )
+
+        monkeypatch.setattr(
+            "bengal.services.theme.get_theme_assets_chain",
+            lambda root_path, theme: [root_path / "theme" / "assets"],
+        )
+
+        env1 = SimpleNamespace(globals={})
+        env2 = SimpleNamespace(globals={})
+        register(env1, site1)
+        register(env2, site2)
+
+        assert "<!-- site-one -->" in str(env1.globals["icon"]("docs"))
+        assert "<!-- site-two -->" in str(env2.globals["icon"]("docs"))
 
 
 class TestMissingIconWarningAggregation:

--- a/tests/unit/icons/test_resolver.py
+++ b/tests/unit/icons/test_resolver.py
@@ -6,15 +6,21 @@ Tests the theme-aware icon resolution system.
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from bengal.icons import resolver as icon_resolver
 from bengal.icons.svg import clear_icon_cache, flush_missing_icon_warnings, warn_missing_icon
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+pytestmark = pytest.mark.parallel_unsafe
 
 
 class TestIconResolutionOrder:
@@ -186,6 +192,48 @@ class TestScopedIconCaching:
 
         with icon_resolver.site_context(site2):
             assert "<!-- site-two -->" in icon_resolver.load_icon("shared")
+
+    def test_site_context_is_thread_local_for_same_icon_name(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ) -> None:
+        """Concurrent site contexts keep per-site icon caches isolated."""
+        site1 = self._site(tmp_path / "site1")
+        site2 = self._site(tmp_path / "site2")
+        for site, marker in [(site1, "site-one"), (site2, "site-two")]:
+            icons_dir = site.root_path / "theme" / "assets" / "icons"
+            icons_dir.mkdir(parents=True)
+            (icons_dir / "shared.svg").write_text(
+                f"<svg><!-- {marker} --></svg>",
+                encoding="utf-8",
+            )
+
+        monkeypatch.setattr(
+            "bengal.services.theme.get_theme_assets_chain",
+            lambda root_path, theme: [root_path / "theme" / "assets"],
+        )
+
+        barrier = threading.Barrier(2)
+
+        def load_many(site, marker: str) -> list[str]:
+            loaded: list[str] = []
+            with icon_resolver.site_context(site):
+                barrier.wait(timeout=10)
+                for _ in range(50):
+                    content = icon_resolver.load_icon("shared")
+                    assert content is not None
+                    loaded.append(content)
+            assert all(marker in content for content in loaded)
+            return loaded
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(load_many, site1, "site-one"),
+                executor.submit(load_many, site2, "site-two"),
+            ]
+
+        assert sum(len(future.result()) for future in futures) == 100
 
     def test_render_svg_cache_is_scoped_by_site(self, tmp_path: Path, monkeypatch) -> None:
         """Rendered SVG cache keys include the active icon resolver scope."""

--- a/tests/unit/orchestration/build/test_build_request_boundary.py
+++ b/tests/unit/orchestration/build/test_build_request_boundary.py
@@ -1,0 +1,28 @@
+"""BuildRequest lives in orchestration and is re-exported by server."""
+
+from __future__ import annotations
+
+import pickle
+
+from bengal.orchestration.build.requests import BuildRequest
+from bengal.server.build_executor import BuildRequest as ServerBuildRequest
+
+
+def test_build_request_is_owned_by_orchestration() -> None:
+    request = BuildRequest(site_root="/site", changed_paths=("content/page.md",))
+
+    assert request.site_root == "/site"
+    assert request.changed_paths == ("content/page.md",)
+    assert request.incremental is True
+
+
+def test_server_build_request_reexport_preserves_compatibility() -> None:
+    assert ServerBuildRequest is BuildRequest
+
+
+def test_build_request_stays_picklable() -> None:
+    request = BuildRequest(site_root="/site", completion_policy="serve_ready")
+
+    restored = pickle.loads(pickle.dumps(request))
+
+    assert restored == request

--- a/tests/unit/orchestration/build/test_completion_policy.py
+++ b/tests/unit/orchestration/build/test_completion_policy.py
@@ -48,3 +48,46 @@ def test_minimal_stats_preserves_build_result_completion_policy() -> None:
     stats = MinimalStats.from_build_result(result)
 
     assert stats.completion_policy == "serve_ready"
+
+
+def test_build_input_records_no_change_census() -> None:
+    build_input = BuildInput.from_options(BuildOptions(incremental=True), Path("/site"))
+
+    assert build_input.change_census.no_changes is True
+    assert build_input.change_census.single_edit is False
+    assert build_input.change_census.to_dict()["changed_count"] == 0
+
+
+def test_build_input_records_single_content_edit_census() -> None:
+    changed = frozenset({Path("/site/content/docs/page.md")})
+    build_input = BuildInput.from_options(
+        BuildOptions(incremental=True),
+        Path("/site"),
+        changed_sources=changed,
+    )
+
+    assert build_input.change_census.no_changes is False
+    assert build_input.change_census.single_edit is True
+    assert build_input.change_census.content_changed_count == 1
+    assert build_input.change_census.non_content_changed_count == 0
+    assert build_input.change_census.single_changed_path == Path("/site/content/docs/page.md")
+
+
+def test_build_input_rejects_nav_or_structural_change_as_single_edit() -> None:
+    changed = frozenset({Path("/site/content/docs/page.md")})
+
+    nav_input = BuildInput.from_options(
+        BuildOptions(incremental=True),
+        Path("/site"),
+        changed_sources=changed,
+        nav_changed_sources=changed,
+    )
+    structural_input = BuildInput.from_options(
+        BuildOptions(incremental=True),
+        Path("/site"),
+        changed_sources=changed,
+        structural_changed=True,
+    )
+
+    assert nav_input.change_census.single_edit is False
+    assert structural_input.change_census.single_edit is False

--- a/tests/unit/orchestration/build/test_font_outputs.py
+++ b/tests/unit/orchestration/build/test_font_outputs.py
@@ -1,0 +1,70 @@
+"""Focused tests for font output writes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from bengal.core.output import BuildOutputCollector, OutputType
+from bengal.orchestration.build.initialization import phase_fonts
+
+
+def _orchestrator(tmp_path: Path):
+    orchestrator = MagicMock()
+    orchestrator.site = MagicMock()
+    orchestrator.site.root_path = tmp_path
+    orchestrator.site.output_dir = tmp_path / "public"
+    orchestrator.site.output_dir.mkdir(parents=True)
+    orchestrator.site.config = {"fonts": {"google": ["Outfit"]}}
+    orchestrator.stats = MagicMock()
+    orchestrator.stats.fonts_time_ms = 0
+    orchestrator._last_build_options = None
+    return orchestrator
+
+
+def test_fonts_css_copy_is_atomic_and_collector_visible(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path)
+    cli = MagicMock()
+    collector = BuildOutputCollector(output_dir=orchestrator.site.output_dir)
+
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    fonts_css = assets_dir / "fonts.css"
+    fonts_css.write_text("/* fonts */", encoding="utf-8")
+
+    with patch("bengal.fonts.FontHelper") as MockFontHelper:
+        mock_font_helper = MagicMock()
+        MockFontHelper.return_value = mock_font_helper
+        mock_font_helper.process.return_value = fonts_css
+
+        phase_fonts(orchestrator, cli, collector=collector)
+
+    output_css = orchestrator.site.output_dir / "assets" / "fonts.css"
+    assert output_css.read_text(encoding="utf-8") == "/* fonts */"
+    outputs = collector.get_outputs()
+    assert len(outputs) == 1
+    assert outputs[0].path == Path("assets/fonts.css")
+    assert outputs[0].output_type == OutputType.CSS
+
+
+def test_unchanged_fonts_css_is_not_recorded(tmp_path: Path) -> None:
+    orchestrator = _orchestrator(tmp_path)
+    cli = MagicMock()
+    collector = BuildOutputCollector(output_dir=orchestrator.site.output_dir)
+
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    fonts_css = assets_dir / "fonts.css"
+    fonts_css.write_text("/* fonts */", encoding="utf-8")
+    output_css = orchestrator.site.output_dir / "assets" / "fonts.css"
+    output_css.parent.mkdir(parents=True)
+    output_css.write_text("/* fonts */", encoding="utf-8")
+
+    with patch("bengal.fonts.FontHelper") as MockFontHelper:
+        mock_font_helper = MagicMock()
+        MockFontHelper.return_value = mock_font_helper
+        mock_font_helper.process.return_value = fonts_css
+
+        phase_fonts(orchestrator, cli, collector=collector)
+
+    assert collector.get_outputs() == []

--- a/tests/unit/orchestration/build/test_provenance_batch.py
+++ b/tests/unit/orchestration/build/test_provenance_batch.py
@@ -1,0 +1,69 @@
+"""Tests for batched provenance recording after rendering."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from bengal.build.provenance.filter import ProvenanceFilter
+from bengal.build.provenance.store import ProvenanceCache
+from bengal.orchestration.build.provenance_filter import (
+    record_all_page_builds,
+    record_page_build,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _page(root: Path, name: str = "page.md") -> MagicMock:
+    source_path = root / "content" / name
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text("# Page\n", encoding="utf-8")
+
+    page = MagicMock()
+    page.source_path = source_path
+    page.metadata = {}
+    page.virtual = False
+    page._section = None
+    return page
+
+
+def _filter(tmp_path: Path) -> ProvenanceFilter:
+    site = MagicMock()
+    site.root_path = tmp_path
+    site.config = {}
+    site.get_section_by_path.return_value = None
+    cache = ProvenanceCache(tmp_path / ".bengal" / "provenance")
+    return ProvenanceFilter(site=site, cache=cache)
+
+
+def test_record_all_page_builds_uses_store_batch(tmp_path: Path) -> None:
+    provenance_filter = _filter(tmp_path)
+    provenance_filter.cache.store = MagicMock()
+    provenance_filter.cache.store_batch = MagicMock()
+    orchestrator = MagicMock()
+    orchestrator._provenance_filter = provenance_filter
+    page = _page(tmp_path)
+
+    record_all_page_builds(orchestrator, [page], parallel=False)
+
+    provenance_filter.cache.store.assert_not_called()
+    provenance_filter.cache.store_batch.assert_called_once()
+    records, input_paths_map = provenance_filter.cache.store_batch.call_args.args
+    assert len(records) == 1
+    assert records[0].page_path in input_paths_map
+
+
+def test_record_page_build_keeps_single_record_path(tmp_path: Path) -> None:
+    provenance_filter = _filter(tmp_path)
+    provenance_filter.cache.store = MagicMock()
+    provenance_filter.cache.store_batch = MagicMock()
+    orchestrator = MagicMock()
+    orchestrator._provenance_filter = provenance_filter
+    page = _page(tmp_path)
+
+    record_page_build(orchestrator, page)
+
+    provenance_filter.cache.store.assert_called_once()
+    provenance_filter.cache.store_batch.assert_not_called()

--- a/tests/unit/orchestration/build/test_provenance_filter_path_keys.py
+++ b/tests/unit/orchestration/build/test_provenance_filter_path_keys.py
@@ -58,6 +58,7 @@ def mock_site(tmp_path: Path):
     """Site mock with root_path."""
     site = MagicMock()
     site.root_path = tmp_path
+    site.theme = None
     site.theme_path = None
     return site
 
@@ -162,8 +163,30 @@ class TestDetectChangedTemplatesPathKeys:
         changed = _detect_changed_templates(mock_cache, mock_site)
 
         assert tpl_file not in changed
-        mock_cache.is_changed.assert_called_once_with(tpl_file)
+        mock_cache.is_changed.assert_any_call(tpl_file)
         mock_cache.set_file_fingerprint.assert_not_called()
+
+    def test_detects_active_parent_theme_template_changes(
+        self, mock_cache: MagicMock, mock_site: MagicMock, tmp_path: Path
+    ) -> None:
+        """Template invalidation scans the full active theme chain."""
+        themes_dir = tmp_path / "themes"
+        parent_templates = themes_dir / "parent" / "templates"
+        parent_templates.mkdir(parents=True)
+        (themes_dir / "parent" / "theme.toml").write_text('name = "parent"\n')
+        parent_template = parent_templates / "base.html"
+        parent_template.write_text("<html>v2</html>")
+
+        child_templates = themes_dir / "child" / "templates"
+        child_templates.mkdir(parents=True)
+        (themes_dir / "child" / "theme.toml").write_text('name = "child"\nextends = "parent"\n')
+        mock_site.theme = "child"
+
+        mock_cache.is_changed = MagicMock(side_effect=lambda path: Path(path) == parent_template)
+
+        changed = _detect_changed_templates(mock_cache, mock_site)
+
+        assert parent_template in changed
 
 
 class TestGetTaxonomyTermPagesForMemberPathKeys:

--- a/tests/unit/orchestration/build/test_state_ledger.py
+++ b/tests/unit/orchestration/build/test_state_ledger.py
@@ -1,0 +1,51 @@
+"""Tests for the build-state ledger contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bengal.orchestration.build.state_ledger import BUILD_STATE_LEDGER, get_state_surface
+
+ROOT = Path(__file__).resolve().parents[4]
+REQUIRED_SURFACES = {
+    "change-census",
+    "provenance",
+    "page-artifacts",
+    "output-collector",
+    "template-fingerprints",
+    "render-context-cache",
+}
+
+
+def test_build_state_ledger_names_required_surfaces() -> None:
+    surface_ids = {surface.id for surface in BUILD_STATE_LEDGER}
+
+    assert REQUIRED_SURFACES.issubset(surface_ids)
+    assert len(surface_ids) == len(BUILD_STATE_LEDGER)
+
+
+def test_build_state_ledger_proofs_exist() -> None:
+    for surface in BUILD_STATE_LEDGER:
+        assert surface.owner.startswith("bengal.")
+        assert surface.storage
+        assert surface.write_phase
+        assert surface.read_phase
+        assert surface.incremental_role
+        assert surface.proof
+        for proof_path in surface.proof:
+            assert (ROOT / proof_path).exists(), (
+                f"{surface.id} references missing proof path: {proof_path}"
+            )
+
+
+def test_get_state_surface_returns_by_id() -> None:
+    surface = get_state_surface("provenance")
+
+    assert surface.owner == "bengal.build.provenance"
+
+
+def test_get_state_surface_rejects_unknown_id() -> None:
+    with pytest.raises(KeyError):
+        get_state_surface("unknown")

--- a/tests/unit/orchestration/build/test_state_ledger.py
+++ b/tests/unit/orchestration/build/test_state_ledger.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
-from bengal.orchestration.build.state_ledger import BUILD_STATE_LEDGER, get_state_surface
+from bengal.orchestration.build.state_ledger import (
+    BUILD_STATE_LEDGER,
+    get_state_surface,
+    proof_paths_for_surface,
+    state_surfaces_by_owner,
+    warm_build_surfaces,
+)
 
 ROOT = Path(__file__).resolve().parents[4]
 REQUIRED_SURFACES = {
@@ -49,3 +55,30 @@ def test_get_state_surface_returns_by_id() -> None:
 def test_get_state_surface_rejects_unknown_id() -> None:
     with pytest.raises(KeyError):
         get_state_surface("unknown")
+
+
+def test_warm_build_surfaces_excludes_in_memory_render_cache() -> None:
+    surface_ids = {surface.id for surface in warm_build_surfaces()}
+
+    assert "provenance" in surface_ids
+    assert "page-artifacts" in surface_ids
+    assert "render-context-cache" not in surface_ids
+
+
+def test_state_surfaces_by_owner_matches_exact_and_package_prefixes() -> None:
+    exact = state_surfaces_by_owner("bengal.build.provenance")
+    package = state_surfaces_by_owner("bengal.orchestration")
+
+    assert [surface.id for surface in exact] == ["provenance"]
+    assert {surface.id for surface in package} >= {
+        "change-census",
+        "render-context-cache",
+        "template-fingerprints",
+    }
+
+
+def test_proof_paths_for_surface_reuses_canonical_lookup() -> None:
+    assert proof_paths_for_surface("provenance") == get_state_surface("provenance").proof
+
+    with pytest.raises(KeyError):
+        proof_paths_for_surface("missing")

--- a/tests/unit/orchestration/test_render_orchestrator.py
+++ b/tests/unit/orchestration/test_render_orchestrator.py
@@ -21,6 +21,7 @@ def mock_site():
     site = Mock()
     site.root_path = Path("/fake/site")
     site.output_dir = Path("/fake/site/public")
+    site.theme = None
     site.config = {}
     site.pages = []
     site.data = Mock()

--- a/tests/unit/performance/test_incremental_contract.py
+++ b/tests/unit/performance/test_incremental_contract.py
@@ -1,0 +1,51 @@
+"""Schema checks for the incremental correctness contract."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+CONTRACT_PATH = ROOT / "tests" / "performance" / "incremental_contract.toml"
+
+REQUIRED_CASES = {
+    "no-op",
+    "single-content-edit",
+    "template-edit",
+    "asset-edit",
+    "sidecar-edit",
+    "config-edit",
+}
+REQUIRED_CASE_FIELDS = {
+    "id",
+    "change",
+    "expected",
+    "proof_paths",
+    "state_surfaces",
+}
+
+
+def _load_contract() -> dict:
+    return tomllib.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def test_incremental_contract_covers_required_cases() -> None:
+    contract = _load_contract()
+    case_ids = {case["id"] for case in contract["cases"]}
+
+    assert contract["version"] >= 1
+    assert REQUIRED_CASES.issubset(case_ids)
+
+
+def test_incremental_contract_cases_have_proof_and_state_surfaces() -> None:
+    contract = _load_contract()
+
+    for case in contract["cases"]:
+        missing_fields = REQUIRED_CASE_FIELDS.difference(case)
+        assert not missing_fields, f"{case.get('id', '<missing>')} missing {missing_fields}"
+        assert case["proof_paths"], f"{case['id']} needs proof paths"
+        assert case["state_surfaces"], f"{case['id']} needs state surfaces"
+        for proof_path in case["proof_paths"]:
+            assert (ROOT / proof_path).exists(), (
+                f"{case['id']} references missing proof path: {proof_path}"
+            )

--- a/tests/unit/performance/test_incremental_contract.py
+++ b/tests/unit/performance/test_incremental_contract.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
-import tomllib
+from dataclasses import fields
 from pathlib import Path
 
+import pytest
+
+from tests.performance.incremental_contract import (
+    CONTRACT_PATH,
+    IncrementalContract,
+    load_incremental_contract,
+)
+
 ROOT = Path(__file__).resolve().parents[3]
-CONTRACT_PATH = ROOT / "tests" / "performance" / "incremental_contract.toml"
 
 REQUIRED_CASES = {
     "no-op",
@@ -25,27 +32,40 @@ REQUIRED_CASE_FIELDS = {
 }
 
 
-def _load_contract() -> dict:
-    return tomllib.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+@pytest.fixture(scope="module")
+def incremental_contract() -> IncrementalContract:
+    return load_incremental_contract(CONTRACT_PATH)
 
 
-def test_incremental_contract_covers_required_cases() -> None:
-    contract = _load_contract()
-    case_ids = {case["id"] for case in contract["cases"]}
+def test_incremental_contract_covers_required_cases(incremental_contract) -> None:
+    case_ids = {case.id for case in incremental_contract.cases}
 
-    assert contract["version"] >= 1
+    assert incremental_contract.version >= 1
     assert REQUIRED_CASES.issubset(case_ids)
 
 
-def test_incremental_contract_cases_have_proof_and_state_surfaces() -> None:
-    contract = _load_contract()
+def test_incremental_contract_cases_have_proof_and_state_surfaces(
+    incremental_contract,
+) -> None:
+    raw_cases = load_incremental_contract(CONTRACT_PATH).cases
 
-    for case in contract["cases"]:
-        missing_fields = REQUIRED_CASE_FIELDS.difference(case)
-        assert not missing_fields, f"{case.get('id', '<missing>')} missing {missing_fields}"
-        assert case["proof_paths"], f"{case['id']} needs proof paths"
-        assert case["state_surfaces"], f"{case['id']} needs state surfaces"
-        for proof_path in case["proof_paths"]:
+    for case in raw_cases:
+        assert not REQUIRED_CASE_FIELDS.difference(field.name for field in fields(case))
+        assert case.proof_paths, f"{case.id} needs proof paths"
+        assert case.state_surfaces, f"{case.id} needs state surfaces"
+        for proof_path in case.proof_paths:
             assert (ROOT / proof_path).exists(), (
-                f"{case['id']} references missing proof path: {proof_path}"
+                f"{case.id} references missing proof path: {proof_path}"
             )
+
+
+def test_incremental_contract_case_lookup_uses_canonical_fixture(
+    incremental_contract,
+) -> None:
+    case = incremental_contract.case("template-edit")
+
+    assert "template" in case.change.lower()
+    assert "provenance" in case.state_surfaces
+
+    with pytest.raises(KeyError):
+        incremental_contract.case("missing")

--- a/tests/unit/rendering/test_engine_globals.py
+++ b/tests/unit/rendering/test_engine_globals.py
@@ -10,6 +10,7 @@ Related RFC: plan/drafted/rfc-engine-agnostic-context-layer.md
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -200,6 +201,26 @@ class TestGetEngineGlobalsCaching:
         # Different sites should have different wrappers
         assert result1["site"] is not result2["site"]
         assert result1["config"] is not result2["config"]
+
+    def test_page_context_cache_is_build_scoped(self, mock_site):
+        """Page context wrappers are reused within a build, not across builds."""
+        from bengal.orchestration.build_context import BuildContext
+        from bengal.rendering.context import build_page_context
+
+        page = SimpleNamespace(
+            metadata={},
+            title="Page",
+            source_path=Path("/tmp/test-site/content/page.md"),
+        )
+        first_build = BuildContext(site=mock_site)
+        second_build = BuildContext(site=mock_site)
+
+        first_context = build_page_context(page, mock_site, build_context=first_build)
+        first_again = build_page_context(page, mock_site, build_context=first_build)
+        second_context = build_page_context(page, mock_site, build_context=second_build)
+
+        assert first_context["site"] is first_again["site"]
+        assert first_context["site"] is not second_context["site"]
 
 
 class TestGetEngineGlobalsThreadSafety:

--- a/tests/unit/rendering/test_shortcodes.py
+++ b/tests/unit/rendering/test_shortcodes.py
@@ -222,6 +222,51 @@ class TestExpandShortcodes:
         result = expand_shortcodes(content, engine, page, site)
         assert '<img src="cat.jpg" class="thumbnails">' in result
 
+    def test_nested_same_name_shortcodes_pair_with_stack(self) -> None:
+        """Nested shortcodes with the same name pair with their own closers."""
+        engine = MagicMock()
+        engine.template_exists.return_value = True
+
+        def render_shortcode(template_name: str, context: dict) -> str:
+            shortcode = context["shortcode"]
+            return f'<div data-id="{shortcode.Get("id")}">{shortcode.Inner}</div>'
+
+        engine.render_template.side_effect = render_shortcode
+        page = MagicMock()
+        page.source_path = "test.md"
+        site = MagicMock()
+        site.config = {}
+        site.xref_index = {}
+        content = (
+            '{{< box id="outer" >}}'
+            "before "
+            '{{< box id="inner" >}}inside{{< /box >}}'
+            " after"
+            "{{< /box >}}"
+        )
+
+        result = expand_shortcodes(content, engine, page, site)
+
+        assert '<div data-id="outer">' in result
+        assert '<div data-id="inner">inside</div>' in result
+        assert " after</div>" in result
+
+    def test_unclosed_markdown_shortcode_is_unchanged(self) -> None:
+        """Unclosed {{% %}} shortcodes remain literal content."""
+        engine = MagicMock()
+        engine.template_exists.return_value = True
+        page = MagicMock()
+        page.source_path = "test.md"
+        site = MagicMock()
+        site.config = {}
+        site.xref_index = {}
+        content = "Before {{% note %}}missing close"
+
+        result = expand_shortcodes(content, engine, page, site)
+
+        assert result == content
+        engine.render_template.assert_not_called()
+
     def test_shortcodes_used_in_content(self) -> None:
         """_shortcodes_used_in_content extracts shortcode names."""
         content = "{{< audio src=x >}} {{% blockquote %}}x{{% /blockquote %}}"

--- a/tests/unit/rendering/test_template_inheritance_detection.py
+++ b/tests/unit/rendering/test_template_inheritance_detection.py
@@ -49,6 +49,40 @@ class TestThemeChainResolution:
         if len(chain) > 1:
             assert chain[1] == "parent"
 
+    def test_resolve_template_dirs_includes_site_theme_chain(self, tmp_path):
+        """Template directory discovery follows the active theme inheritance chain."""
+        from bengal.rendering.template_engine.environment import (
+            resolve_template_dirs,
+            template_name_for_path,
+        )
+
+        site = MagicMock()
+        site.root_path = tmp_path
+        site.theme = "child"
+
+        site_templates = tmp_path / "templates"
+        site_templates.mkdir()
+
+        themes_dir = tmp_path / "themes"
+        parent_templates = themes_dir / "parent" / "templates"
+        parent_templates.mkdir(parents=True)
+        (themes_dir / "parent" / "theme.toml").write_text('name = "parent"\n')
+        parent_base = parent_templates / "base.html"
+        parent_base.write_text("<html>{% block content %}{% endblock %}</html>")
+
+        child_templates = themes_dir / "child" / "templates"
+        child_templates.mkdir(parents=True)
+        (themes_dir / "child" / "theme.toml").write_text('name = "child"\nextends = "parent"\n')
+
+        with patch(
+            "bengal.rendering.template_engine.environment.get_theme_package",
+            return_value=None,
+        ):
+            dirs = resolve_template_dirs(site)
+
+        assert dirs[:3] == [site_templates, child_templates, parent_templates]
+        assert template_name_for_path(parent_base, dirs) == "base.html"
+
 
 class TestParentTemplateChanges:
     """Test detection of changes to parent templates."""

--- a/tests/unit/rendering/test_write_output_rendered_page.py
+++ b/tests/unit/rendering/test_write_output_rendered_page.py
@@ -141,8 +141,31 @@ class TestWriteOutputRenderedPage:
 
         write_output(page, site, collector=collector)
 
-        assert collector.get_outputs() == []
+        outputs = collector.get_outputs()
+        assert len(outputs) == 1
+        assert str(outputs[0].path) == "same/analysis.ipynb"
         assert (out.parent / "analysis.ipynb").read_text(encoding="utf-8") == '{"cells":[]}'
+
+    def test_does_not_record_unchanged_notebook_sidecar(self, tmp_path):
+        """Notebook sidecars are recorded only when sidecar bytes change."""
+        src = tmp_path / "content" / "analysis.ipynb"
+        src.parent.mkdir(parents=True)
+        src.write_text('{"cells":[]}', encoding="utf-8")
+        out = tmp_path / "same" / "index.html"
+        out.parent.mkdir(parents=True)
+        out.write_text("<p>same</p>", encoding="utf-8")
+        (out.parent / "analysis.ipynb").write_text('{"cells":[]}', encoding="utf-8")
+        page = _make_page(
+            source_path=src,
+            output_path=out,
+            rendered_html="<p>same</p>",
+        )
+        site = _make_site(tmp_path)
+        collector = BuildOutputCollector(output_dir=tmp_path)
+
+        write_output(page, site, collector=collector)
+
+        assert collector.get_outputs() == []
 
     def test_full_rebuild_can_skip_existing_output_compare(self, tmp_path):
         """Full rebuilds can record outputs without reading old HTML first."""

--- a/tests/unit/server/test_build_trigger.py
+++ b/tests/unit/server/test_build_trigger.py
@@ -412,6 +412,29 @@ class TestBuildTrigger:
 
         assert trigger._is_template_change({template_file}) is True
 
+    def test_parent_theme_template_change_without_dependency_data_is_detected(
+        self, mock_site: MagicMock, mock_executor: MagicMock, tmp_path: Path
+    ) -> None:
+        """Dev-server template change checks use the active theme chain."""
+        mock_site.root_path = tmp_path
+        mock_site.theme = "child"
+
+        themes_dir = tmp_path / "themes"
+        parent_templates = themes_dir / "parent" / "templates"
+        parent_templates.mkdir(parents=True)
+        (themes_dir / "parent" / "theme.toml").write_text('name = "parent"\n')
+        template_file = parent_templates / "base.html"
+        template_file.write_text("<html></html>")
+
+        child_templates = themes_dir / "child" / "templates"
+        child_templates.mkdir(parents=True)
+        (themes_dir / "child" / "theme.toml").write_text('name = "child"\nextends = "parent"\n')
+        mock_site._cache = BuildCache(site_root=tmp_path)
+
+        trigger = BuildTrigger(site=mock_site, executor=mock_executor)
+
+        assert trigger._is_template_change({template_file}) is True
+
     @patch("bengal.server.build_trigger.logger")
     def test_template_change_logs_missing_dependency_data(
         self,

--- a/tests/unit/snapshots/test_render_handoff.py
+++ b/tests/unit/snapshots/test_render_handoff.py
@@ -1,0 +1,58 @@
+"""Tests for immutable render snapshot handoff facts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from bengal.snapshots.handoff import create_render_snapshot_handoff
+
+
+def _page(path: str) -> SimpleNamespace:
+    return SimpleNamespace(source_path=Path(path))
+
+
+def _snapshot(
+    *,
+    pages: tuple[SimpleNamespace, ...],
+    templates: dict[str, object] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        pages=pages,
+        page_count=len(pages),
+        section_count=1,
+        schedule=SimpleNamespace(templates=templates or {}),
+    )
+
+
+def test_render_snapshot_handoff_is_complete_when_live_pages_match() -> None:
+    snapshot = _snapshot(
+        pages=(_page("content/a.md"), _page("content/b.md")),
+        templates={"page.html": object()},
+    )
+
+    handoff = create_render_snapshot_handoff(
+        snapshot,
+        [_page("content/a.md"), _page("content/b.md")],
+    )
+
+    assert handoff.is_complete is True
+    assert handoff.page_sources == (Path("content/a.md"), Path("content/b.md"))
+    assert handoff.missing_snapshot_sources == ()
+    assert handoff.extra_snapshot_sources == ()
+    assert handoff.page_count == 2
+    assert handoff.section_count == 1
+    assert handoff.template_count == 1
+
+
+def test_render_snapshot_handoff_records_hybrid_mismatches() -> None:
+    snapshot = _snapshot(pages=(_page("content/a.md"), _page("content/stale.md")))
+
+    handoff = create_render_snapshot_handoff(
+        snapshot,
+        [_page("content/a.md"), _page("content/new.md")],
+    )
+
+    assert handoff.is_complete is False
+    assert handoff.missing_snapshot_sources == (Path("content/new.md"),)
+    assert handoff.extra_snapshot_sources == (Path("content/stale.md"),)

--- a/tests/unit/snapshots/test_render_handoff.py
+++ b/tests/unit/snapshots/test_render_handoff.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from bengal.snapshots.handoff import create_render_snapshot_handoff
+
+pytestmark = pytest.mark.parallel_unsafe
 
 
 def _page(path: str) -> SimpleNamespace:
@@ -56,3 +61,27 @@ def test_render_snapshot_handoff_records_hybrid_mismatches() -> None:
     assert handoff.is_complete is False
     assert handoff.missing_snapshot_sources == (Path("content/new.md"),)
     assert handoff.extra_snapshot_sources == (Path("content/stale.md"),)
+
+
+def test_render_snapshot_handoff_parallel_reads_are_stable() -> None:
+    snapshot = _snapshot(
+        pages=tuple(_page(f"content/page-{index}.md") for index in range(50)),
+        templates={"page.html": object(), "docs.html": object()},
+    )
+    handoff = create_render_snapshot_handoff(snapshot, list(snapshot.pages))
+
+    def read_handoff(_index: int) -> tuple[bool, tuple[Path, ...], int, int, int]:
+        return (
+            handoff.is_complete,
+            handoff.page_sources,
+            handoff.page_count,
+            handoff.section_count,
+            handoff.template_count,
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = tuple(executor.map(read_handoff, range(200)))
+
+    assert len(set(results)) == 1
+    assert results[0][0] is True
+    assert len(results[0][1]) == 50

--- a/tests/unit/test_output_write_audit.py
+++ b/tests/unit/test_output_write_audit.py
@@ -1,0 +1,51 @@
+"""Guards for direct writes in output and cache surfaces."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from scripts.check_output_writes import (
+    APPROVED_DIRECT_WRITES,
+    scan_direct_writes,
+    scan_file,
+    unapproved_direct_writes,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_output_write_audit_has_no_unapproved_current_writes() -> None:
+    findings = scan_direct_writes()
+
+    assert findings
+    assert not unapproved_direct_writes(findings)
+
+
+def test_output_write_audit_approval_keys_match_current_findings() -> None:
+    findings = scan_direct_writes()
+    approval_keys = {finding.approval_key for finding in findings}
+
+    assert approval_keys == set(APPROVED_DIRECT_WRITES)
+
+
+def test_output_write_audit_flags_new_direct_write(tmp_path: Path) -> None:
+    source = tmp_path / "candidate.py"
+    source.write_text(
+        """
+from pathlib import Path
+
+
+def write(path: Path) -> None:
+    path.write_text("unsafe")
+""",
+        encoding="utf-8",
+    )
+
+    findings = scan_file(source, root=tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].path == "candidate.py"
+    assert findings[0].function == "write"
+    assert findings[0].method == "write_text"
+    assert unapproved_direct_writes(findings) == findings

--- a/tests/unit/test_performance_evidence_check.py
+++ b/tests/unit/test_performance_evidence_check.py
@@ -1,0 +1,49 @@
+"""Tests for PR performance evidence validation."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.check_performance_evidence import (
+    REQUIRED_FIELDS,
+    body_from_github_event,
+    missing_evidence_fields,
+)
+
+
+def _body(field_values: dict[str, str]) -> str:
+    lines = ["## Summary", "", "-", "", "## Performance Evidence", ""]
+    lines.extend(f"- {field}: {field_values.get(field, '')}" for field in REQUIRED_FIELDS)
+    lines.extend(["", "## Steward Notes", "", "-"])
+    return "\n".join(lines)
+
+
+def test_performance_evidence_accepts_complete_receipts() -> None:
+    values = {field: f"value for {field}" for field in REQUIRED_FIELDS}
+
+    assert missing_evidence_fields(_body(values)) == ()
+
+
+def test_performance_evidence_accepts_explicit_not_applicable() -> None:
+    assert missing_evidence_fields(_body({"Benchmark matrix row": "not applicable"})) == ()
+
+
+def test_performance_evidence_rejects_blank_template_values() -> None:
+    assert missing_evidence_fields(_body({})) == REQUIRED_FIELDS
+
+
+def test_performance_evidence_template_mode_requires_field_labels() -> None:
+    assert missing_evidence_fields(_body({}), allow_template=True) == ()
+    assert missing_evidence_fields("## Performance Evidence\n", allow_template=True) == (
+        "Performance Evidence",
+    )
+
+
+def test_performance_evidence_reads_github_event(tmp_path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"body": _body({"Command": "not applicable"})}}),
+        encoding="utf-8",
+    )
+
+    assert missing_evidence_fields(body_from_github_event(event_path)) == ()

--- a/tests/unit/test_pr_proof_task.py
+++ b/tests/unit/test_pr_proof_task.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
+from scripts.proof_pr_plan import proof_pr_plan
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -35,3 +37,17 @@ def test_benchmark_smoke_task_uses_canonical_fast_guards() -> None:
     assert "tests/performance/test_autodoc_render_regression.py" in command
     assert "tests/performance/test_asset_fallback_cost.py" in command
     assert "tests/performance/test_post_render_pipeline_budget.py" in command
+
+
+def test_proof_pr_plan_resolves_sequence_to_commands() -> None:
+    plan = proof_pr_plan(ROOT)
+
+    assert [step.name for step in plan] == [
+        "lint",
+        "format-check",
+        "ty",
+        "test-unit",
+        "benchmark-smoke",
+    ]
+    assert all(step.command for step in plan)
+    assert plan[-1].command == _poe_tasks()["benchmark-smoke"]["cmd"]

--- a/tests/unit/test_pr_proof_task.py
+++ b/tests/unit/test_pr_proof_task.py
@@ -1,0 +1,37 @@
+"""Guards for the bounded PR proof task."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _poe_tasks() -> dict:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return pyproject["tool"]["poe"]["tasks"]
+
+
+def test_pr_proof_task_runs_checks_before_smoke_benchmarks() -> None:
+    tasks = _poe_tasks()
+    proof = tasks["proof-pr"]
+
+    assert proof["sequence"] == [
+        "lint",
+        "format-check",
+        "ty",
+        "test-unit",
+        "benchmark-smoke",
+    ]
+
+
+def test_benchmark_smoke_task_uses_canonical_fast_guards() -> None:
+    task = _poe_tasks()["benchmark-smoke"]
+    command = task["cmd"]
+
+    assert "-o addopts= -n 0 -q" in command
+    assert "tests/unit/benchmarks/test_benchmark_matrix.py" in command
+    assert "tests/performance/test_autodoc_render_regression.py" in command
+    assert "tests/performance/test_asset_fallback_cost.py" in command
+    assert "tests/performance/test_post_render_pipeline_budget.py" in command

--- a/tests/unit/test_pr_template_contract.py
+++ b/tests/unit/test_pr_template_contract.py
@@ -1,0 +1,34 @@
+"""Guards for PR evidence template requirements."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE = ROOT / ".github" / "pull_request_template.md"
+
+REQUIRED_PERFORMANCE_FIELDS = [
+    "Benchmark matrix row",
+    "Command",
+    "Python build",
+    "Machine/OS",
+    "Baseline commit or saved result",
+    "Current commit or saved result",
+    "Artifact path",
+    "Interpretation",
+]
+
+
+def test_pr_template_requires_performance_evidence_receipts() -> None:
+    content = TEMPLATE.read_text(encoding="utf-8")
+
+    assert "## Performance Evidence" in content
+    for field in REQUIRED_PERFORMANCE_FIELDS:
+        assert f"- {field}:" in content
+
+
+def test_pr_template_mentions_not_applicable_escape_hatch() -> None:
+    content = TEMPLATE.read_text(encoding="utf-8")
+
+    assert "not applicable" in content
+    assert "performance-sensitive behavior" in content


### PR DESCRIPTION
## Summary

- Adds the optimization backlog cleanup series as focused commits across build boundaries, proof automation, benchmark receipts, output-write auditing, render snapshot handoff facts, core-surface retirement guards, incremental fixtures, threaded stress coverage, and performance-evidence CI.
- Converts several steward expectations into machine-checkable scripts and tests so future refactors can move with clearer proof.
- Keeps public compatibility surfaces in place while adding internal guardrails against new dependence on retiring shims.

## Proof

- [x] Focused tests: `uv run pytest tests/unit/orchestration/build/test_build_request_boundary.py tests/unit/orchestration/build/test_state_ledger.py tests/unit/test_pr_proof_task.py tests/unit/benchmarks/test_benchmark_matrix.py tests/unit/test_output_write_audit.py tests/unit/snapshots/test_render_handoff.py tests/unit/core/test_surface_retirement.py tests/unit/performance/test_incremental_contract.py tests/unit/test_performance_evidence_check.py -q` (`36 passed`)
- [x] `poe proof-pr` or scoped equivalent: scoped equivalent plus `uv run ruff check ...`, `uv run ruff format --check ...`, `python scripts/check_cycles.py`, and `python scripts/check_dependencies.py`
- [x] Docs/examples/changelog updated or no-impact noted: no user-facing runtime behavior change; governance is covered by PR template/CI and script tasks.

## Performance Evidence

Required when this PR makes a performance claim, changes a hot path, or changes
free-threaded/concurrent behavior.

- Benchmark matrix row: `benchmark-smoke` / smoke matrix dry-run receipt path
- Command: `uv run python benchmarks/run_matrix.py --tier smoke --dry-run --receipt /private/tmp/bengal-benchmark-matrix-receipt.json`; focused proof command listed above
- Python build: Python 3.14.2 local uv environment
- Machine/OS: local macOS developer workstation
- Baseline commit or saved result: `origin/main` comparison not measured; this PR makes no speedup claim
- Current commit or saved result: `e1ce2a3d1` plus dry-run receipt and focused test/audit outputs
- Artifact path: `/private/tmp/bengal-benchmark-matrix-receipt.json`
- Interpretation: establishes benchmark/proof receipt plumbing and threaded handoff stability; no timing improvement is claimed.

Use `not applicable` for PRs with no performance-sensitive behavior.

## Steward Notes

- Build/orchestration: `BuildRequest` is owned by orchestration and server keeps a compatibility re-export.
- Rendering/snapshots: handoff facts are frozen and tested under concurrent reads.
- Core: compatibility shims remain available, while internal use of `Section.content_pages` is guarded.
- Performance/CI: benchmark matrix receipts and PR performance-evidence validation are now machine-checkable.
