### PR TITLE
[codex] Preserve CSS selector whitespace during minification

### DIFF
--- a/bengal/assets/css_minifier.py
+++ b/bengal/assets/css_minifier.py
@@ -116,6 +116,7 @@ def minify_css(css: str) -> str:
     # Context tracking (O(1) updates instead of O(n) lookbacks)
     paren_depth = 0  # Track function nesting
     current_property = ""  # Current CSS property name
+    in_declaration_value = False  # After a property colon, before ; or }
     in_calc_function = False  # Inside calc/clamp/min/max
     in_multi_value = False  # Inside multi-value property
     in_function_list = False  # Inside filter/transform etc
@@ -136,16 +137,81 @@ def minify_css(css: str) -> str:
 
     def reset_property_context() -> None:
         """Reset context at end of declaration."""
-        nonlocal current_property, in_multi_value, in_function_list, in_slash_prop, in_font
+        nonlocal current_property, in_declaration_value
+        nonlocal in_multi_value, in_function_list, in_slash_prop, in_font
         nonlocal in_calc_function
         current_property = ""
+        in_declaration_value = False
         in_multi_value = False
         in_function_list = False
         in_slash_prop = False
         in_font = False
         in_calc_function = False
 
-    def needs_space_before(next_char: str) -> bool:
+    def starts_selector_component(next_char: str) -> bool:
+        """Return whether a character can start a selector component."""
+        return next_char.isalpha() or next_char in ".#[:*"
+
+    def ends_selector_component(prev_char: str) -> bool:
+        """Return whether a character can end a selector component."""
+        return prev_char.isalnum() or prev_char in ")]_*&"
+
+    def should_preserve_descendant_space(next_char: str, *, property_colon: bool) -> bool:
+        """Preserve source whitespace when removing it would merge selector components."""
+        if in_declaration_value or property_colon:
+            return False
+        if not pending_whitespace or not starts_selector_component(next_char):
+            return False
+        prev = result[-1]
+        return ends_selector_component(prev)
+
+    def colon_starts_declaration(pos: int) -> bool:
+        """Determine whether a colon begins a declaration value, not a pseudo selector."""
+        if paren_depth > 0 or not last_token:
+            return False
+
+        j = pos + 1
+        nested_depth = 0
+        local_string = ""
+
+        while j < length:
+            next_char = css[j]
+
+            if local_string:
+                if next_char == "\\" and j + 1 < length:
+                    j += 2
+                    continue
+                if next_char == local_string:
+                    local_string = ""
+                j += 1
+                continue
+
+            if next_char in {"'", '"'}:
+                local_string = next_char
+                j += 1
+                continue
+
+            if next_char == "/" and j + 1 < length and css[j + 1] == "*":
+                j += 2
+                while j + 1 < length and not (css[j] == "*" and css[j + 1] == "/"):
+                    j += 1
+                j += 2
+                continue
+
+            if next_char in "([":
+                nested_depth += 1
+            elif next_char in ")]":
+                nested_depth = max(0, nested_depth - 1)
+            elif nested_depth == 0 and next_char == "{":
+                return False
+            elif nested_depth == 0 and next_char in ";}":
+                return True
+
+            j += 1
+
+        return True
+
+    def needs_space_before(next_char: str, *, property_colon: bool) -> bool:
         """Determine if space is needed before next character. O(1) complexity."""
         if not result:
             return False
@@ -202,6 +268,11 @@ def minify_css(css: str) -> str:
         if in_font and prev == ")" and next_char.isalpha():
             return True
 
+        # Descendant selectors use a real space combinator. Removing whitespace before
+        # pseudo, attribute, or universal selector starts changes which element matches.
+        if should_preserve_descendant_space(next_char, property_colon=property_colon):
+            return True
+
         # Standard no-space characters
         if prev in _NO_SPACE_CHARS or next_char in _NO_SPACE_CHARS:
             return False
@@ -236,7 +307,7 @@ def minify_css(css: str) -> str:
 
         # Start of string
         if char in {"'", '"'}:
-            if pending_whitespace and needs_space_before(char):
+            if pending_whitespace and needs_space_before(char, property_colon=False):
                 result.append(" ")
             pending_whitespace = False
             in_string = True
@@ -270,10 +341,13 @@ def minify_css(css: str) -> str:
             if paren_depth == 0:
                 in_calc_function = False
 
+        property_colon = char == ":" and colon_starts_declaration(i)
+
         # Track property declarations
-        if char == ":":
+        if property_colon:
             # We just finished a property name
             current_property = last_token
+            in_declaration_value = True
             update_property_context(current_property)
 
         # Reset context at end of declaration
@@ -282,12 +356,15 @@ def minify_css(css: str) -> str:
 
         # Decide whether to emit space
         if pending_whitespace:
-            if needs_space_before(char):
+            if needs_space_before(char, property_colon=property_colon):
                 result.append(" ")
             pending_whitespace = False
 
         # Emit the character
         result.append(char)
+
+        if char == "{" and paren_depth == 0:
+            reset_property_context()
 
         # Track last token (for keyword detection)
         if char.isalnum() or char in "-_":

--- a/changelog.d/css-minifier-selector-whitespace.fixed.md
+++ b/changelog.d/css-minifier-selector-whitespace.fixed.md
@@ -1,0 +1,1 @@
+Preserve descendant selector whitespace before pseudo, attribute, and universal selectors during CSS minification.

--- a/tests/unit/core/test_asset_processing.py
+++ b/tests/unit/core/test_asset_processing.py
@@ -73,6 +73,26 @@ body { color: blue; }
         minified = asset._minified_content
         assert "Bundled" not in minified
 
+    def test_minifies_bundled_css_without_merging_descendant_selectors(self, temp_asset_dir):
+        """Test bundled CSS keeps descendant selector spaces during minification."""
+        css_file = temp_asset_dir / "style.css"
+        css_file.write_text(".unused { color: black; }")
+
+        asset = Asset(source_path=css_file)
+        asset._bundled_content = """
+.docs :where(h1, h2) { color: red; }
+.docs [data-x] { color: blue; }
+.docs * { box-sizing: border-box; }
+.docs:not(.compact) { margin: 0; }
+"""
+        asset.minify()
+
+        minified = asset._minified_content
+        assert ".docs :where(h1, h2){color:red;}" in minified
+        assert ".docs [data-x]{color:blue;}" in minified
+        assert ".docs *{box-sizing:border-box;}" in minified
+        assert ".docs:not(.compact){margin:0;}" in minified
+
     def test_handles_css_nesting_transformation(self, temp_asset_dir):
         """Test that CSS nesting is transformed when lightningcss unavailable."""
         css_file = temp_asset_dir / "nested.css"

--- a/tests/unit/utils/test_css_minifier.py
+++ b/tests/unit/utils/test_css_minifier.py
@@ -17,6 +17,8 @@ Covers:
 
 from __future__ import annotations
 
+import pytest
+
 
 class TestMinifyCssBasics:
     """Test basic minify_css functionality."""
@@ -184,6 +186,54 @@ class TestMinifyCssSelectorHandling:
 
         # Should preserve selector structure
         assert "div.class" in result or "div.class#id" in result
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (".a :where(h1, h2) { color: red; }", ".a :where(h1, h2){color:red;}"),
+            (".a :is(h1, h2) { color: red; }", ".a :is(h1, h2){color:red;}"),
+            (".a :not(pre) > code { color: red; }", ".a :not(pre)>code{color:red;}"),
+            (".a :has(> img) { color: red; }", ".a :has(>img){color:red;}"),
+            (".a :hover { color: red; }", ".a :hover{color:red;}"),
+            (".a ::before { content: ''; }", ".a ::before{content:'';}"),
+            (".a [data-x] { color: red; }", ".a [data-x]{color:red;}"),
+            (".a * { color: red; }", ".a *{color:red;}"),
+            (".a .b { color: red; }", ".a .b{color:red;}"),
+            (".a #b { color: red; }", ".a #b{color:red;}"),
+            (".a button { color: red; }", ".a button{color:red;}"),
+        ],
+    )
+    def test_preserves_descendant_selector_space_before_compound_starts(
+        self,
+        source: str,
+        expected: str,
+    ) -> None:
+        """Test that minification does not turn descendant selectors into same-element selectors."""
+        from bengal.assets.css_minifier import minify_css
+
+        assert minify_css(source) == expected
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (".a:where(h1, h2) { color: red; }", ".a:where(h1, h2){color:red;}"),
+            (".a:is(h1, h2) { color: red; }", ".a:is(h1, h2){color:red;}"),
+            (".a:not(pre) > code { color: red; }", ".a:not(pre)>code{color:red;}"),
+            (".a:has(> img) { color: red; }", ".a:has(>img){color:red;}"),
+            (".a:hover { color: red; }", ".a:hover{color:red;}"),
+            (".a::before { content: ''; }", ".a::before{content:'';}"),
+            (".a[data-x] { color: red; }", ".a[data-x]{color:red;}"),
+        ],
+    )
+    def test_preserves_same_element_selector_compaction(
+        self,
+        source: str,
+        expected: str,
+    ) -> None:
+        """Test that same-element pseudo and attribute selectors stay compact."""
+        from bengal.assets.css_minifier import minify_css
+
+        assert minify_css(source) == expected
 
 
 class TestMinifyCssCalcFunction:


### PR DESCRIPTION
## Summary
- Preserve descendant selector whitespace before pseudo, attribute, and universal selector starts in the CSS minifier.
- Add unit regressions for descendant-vs-same-element selectors.
- Add bundled Asset.minify() coverage and a changelog fragment.

## Proof
- [x] Focused tests: `uv run pytest tests/unit/utils/test_css_minifier.py tests/unit/core/test_asset_processing.py -q`
- [x] `poe proof-pr` or scoped equivalent: scoped pytest plus `uv run ruff check bengal/assets/css_minifier.py tests/unit/utils/test_css_minifier.py tests/unit/core/test_asset_processing.py` and `uv run ruff format --check bengal/assets/css_minifier.py tests/unit/utils/test_css_minifier.py tests/unit/core/test_asset_processing.py`
- [x] Docs/examples/changelog updated or no-impact noted: changelog fragment added; docs/examples no-impact because public behavior is a bug fix to emitted CSS bytes, not a new documented API.

## Root Cause
The minifier treated characters such as colon, bracket, and universal selector starts as globally safe no-space characters. That collapsed valid descendant selectors like `.a :where(...)`, `.a [data-x]`, and `.a *` into same-element selectors.

## Impact
Valid CSS can now survive Bengal pure-Python default asset minification without changing which elements match. Same-element selectors such as `.a:not(...)` and `.a[data-x]` still compact normally.

## Performance Evidence
Required when this PR makes a performance claim, changes a hot path, or changes free-threaded/concurrent behavior.

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: No performance claim. This is a scoped correctness hotfix for CSS selector semantics; the minifier hot path was considered, and broader performance measurement is deferred to the planned token-stream minifier rewrite.

## Steward Notes
- Assets: preserved deterministic pure-Python CSS output and added a changelog fragment.
- Core: kept new behavior in `bengal/assets/`; `bengal/core/asset/asset_core.py` remains a thin delegate.
- Tests: added exact selector regressions and an Asset.minify() proof.