### PR TITLE
refactor(core): delete vestigial rendering forwarders from page.computed

### DIFF
--- a/bengal/core/page/computed.py
+++ b/bengal/core/page/computed.py
@@ -6,9 +6,7 @@ accessing them through mixin self-reference.
 
 Key Functions:
 - compute_word_count: Word count from source markdown
-- compute_meta_description: Compatibility wrapper for rendering-side descriptions
 - compute_reading_time: Estimated reading time in minutes
-- compute_excerpt: Compatibility wrapper for rendering-side excerpts
 - compute_age_days: Days since publication
 - compute_age_months: Months since publication
 - get_primary_author: Primary Author object
@@ -16,10 +14,14 @@ Key Functions:
 - get_series_info: Series object for multi-part content
 - get_series_neighbor: Navigate between pages in a series
 
+Content-derived rendering helpers (excerpts, meta descriptions) live in
+``bengal.rendering.page_content``; ``Page.excerpt`` and ``Page.meta_description``
+delegate there directly.
+
 Performance:
 Page class uses @cached_property wrappers that call these pure functions,
-ensuring expensive operations (HTML stripping, word counting, truncation)
-are only performed once per page.
+ensuring expensive operations (word counting, series resolution) are only
+performed once per page.
 
 Related Modules:
 - bengal.rendering.pipeline: Content rendering that populates page.content
@@ -63,27 +65,6 @@ def compute_word_count(raw_content: str) -> int:
     return len(raw_content.split())
 
 
-def compute_meta_description(metadata: Mapping[str, Any], raw_content: str) -> str:
-    """Generate SEO-friendly meta description.
-
-    .. deprecated::
-        Content-derived descriptions belong in
-        ``bengal.rendering.page_content``. This wrapper remains so older
-        imports of ``bengal.core.page.computed.compute_meta_description`` keep
-        working.
-
-    Args:
-        metadata: Page metadata dict
-        raw_content: Raw markdown source string
-
-    Returns:
-        Meta description text (max 160 chars)
-    """
-    from bengal.rendering.page_content import compute_meta_description as render_description
-
-    return render_description(metadata, raw_content)
-
-
 def compute_reading_time(word_count: int) -> int:
     """Calculate reading time in minutes.
 
@@ -96,25 +77,6 @@ def compute_reading_time(word_count: int) -> int:
         Reading time in minutes (minimum 1)
     """
     return max(1, round(word_count / 200))
-
-
-def compute_excerpt(raw_content: str) -> str:
-    """Extract content excerpt as rendered HTML.
-
-    .. deprecated::
-        Rendering excerpts belongs in ``bengal.rendering.page_content``.
-        This wrapper remains so older imports of
-        ``bengal.core.page.computed.compute_excerpt`` keep working.
-
-    Args:
-        raw_content: Raw markdown source string
-
-    Returns:
-        Excerpt as HTML (safe to render in templates)
-    """
-    from bengal.rendering.page_content import compute_excerpt as render_excerpt
-
-    return render_excerpt(raw_content)
 
 
 def compute_age_days(date: datetime | None) -> int:

--- a/tests/unit/core/test_computed_functions.py
+++ b/tests/unit/core/test_computed_functions.py
@@ -3,7 +3,7 @@ Tests for computed free functions in bengal.core.page.computed.
 
 These test the functions directly (not through Page property wrappers),
 verifying correctness of age calculations, author parsing, series parsing,
-series navigation, and the legacy content-derived rendering wrappers.
+and series navigation.
 
 Completes Track 4b of the free-threading migration epic.
 """
@@ -17,8 +17,6 @@ from typing import Any
 from bengal.core.page.computed import (
     compute_age_days,
     compute_age_months,
-    compute_excerpt,
-    compute_meta_description,
     compute_reading_time,
     compute_word_count,
     get_all_authors,
@@ -49,34 +47,6 @@ class TestComputeWordCount:
 
 
 # -----------------------------------------------------------------------
-# compute_meta_description
-# -----------------------------------------------------------------------
-
-
-class TestComputeMetaDescription:
-    """Direct tests for the compute_meta_description compatibility wrapper."""
-
-    def test_explicit_description_preferred(self):
-        result = compute_meta_description(
-            {"description": "Explicit desc"},
-            "Some long content",
-        )
-        assert result == "Explicit desc"
-
-    def test_generated_from_content(self):
-        result = compute_meta_description({}, "Short content here.")
-        assert result == "Short content here."
-
-    def test_empty_content_no_description(self):
-        assert compute_meta_description({}, "") == ""
-
-    def test_max_160_chars(self):
-        long = "This is a sentence. " * 30
-        result = compute_meta_description({}, long)
-        assert len(result) <= 160
-
-
-# -----------------------------------------------------------------------
 # compute_reading_time
 # -----------------------------------------------------------------------
 
@@ -94,63 +64,6 @@ class TestComputeReadingTime:
     def test_rounds(self):
         assert compute_reading_time(250) == 1  # 1.25 -> 1
         assert compute_reading_time(350) == 2  # 1.75 -> 2
-
-
-# -----------------------------------------------------------------------
-# compute_excerpt
-# -----------------------------------------------------------------------
-
-
-class TestComputeExcerpt:
-    """Direct tests for the compute_excerpt compatibility wrapper.
-
-    The rendering-side helper returns rendered HTML, strips leading h1, and
-    truncates at ~250 chars before rendering. The core wrapper preserves the
-    older import path without owning that rendering behavior.
-    """
-
-    def test_short_content_renders_markdown(self):
-        result = compute_excerpt("Hello world.")
-        assert "Hello world" in result
-        assert "<" in result  # Rendered to HTML (e.g. <p>)
-
-    def test_empty_string(self):
-        assert compute_excerpt("") == ""
-
-    def test_strips_leading_h1(self):
-        result = compute_excerpt("# My Title\n\nFirst paragraph here.")
-        assert "First paragraph" in result
-        assert "My Title" not in result
-
-    def test_renders_markdown(self):
-        result = compute_excerpt("This has **bold** and *italic*.")
-        assert "bold" in result
-        assert "<strong>" in result or "**" not in result  # Rendered
-
-    def test_does_not_cut_mid_markdown(self):
-        """Excerpt should not end with orphaned ** or other markdown syntax."""
-        content = (
-            "Bengal is a powerful static site generator. "
-            "Key Features: Fast Builds, Asset Optimization, **SEO** friendly."
-        )
-        result = compute_excerpt(content)
-        from bengal.core.utils.text import strip_html
-
-        plain = strip_html(result)
-        assert not plain.endswith("**"), "Should not end with orphaned **"
-
-    def test_headers_in_content(self):
-        """Headers in content are rendered and available for card excerpt."""
-        content = (
-            "Intro paragraph here.\n\n"
-            "## Key Features\n\n"
-            "### Fast Builds\n"
-            "- Parallel processing\n"
-            "- Asset Optimization\n"
-            "**SEO** friendly."
-        )
-        result = compute_excerpt(content)
-        assert "Key Features" in result or "Intro" in result
 
 
 # -----------------------------------------------------------------------

--- a/tests/unit/rendering/test_page_content.py
+++ b/tests/unit/rendering/test_page_content.py
@@ -87,10 +87,6 @@ def test_excerpt_fallback_renders_markdown_without_leading_h1() -> None:
     assert "<strong>" in excerpt
 
 
-def test_compute_excerpt_handles_empty_source() -> None:
-    assert compute_excerpt("") == ""
-
-
 def test_ast_cache_helpers_handle_document_dict() -> None:
     ast_cache = {
         "type": "document",
@@ -111,3 +107,87 @@ def test_page_private_content_shims_delegate_to_rendering_helpers() -> None:
     assert page._extract_links_from_ast() == ["/guide/"]
     assert page._extract_text_from_ast() == ""
     assert page._strip_html_to_text("<p>Hello</p>") == strip_html_to_text("<p>Hello</p>")
+
+
+# -----------------------------------------------------------------------
+# compute_meta_description
+# -----------------------------------------------------------------------
+
+
+class TestComputeMetaDescription:
+    """Direct tests for compute_meta_description (raw-content path)."""
+
+    def test_explicit_description_preferred(self):
+        result = compute_meta_description(
+            {"description": "Explicit desc"},
+            "Some long content",
+        )
+        assert result == "Explicit desc"
+
+    def test_generated_from_content(self):
+        result = compute_meta_description({}, "Short content here.")
+        assert result == "Short content here."
+
+    def test_empty_content_no_description(self):
+        assert compute_meta_description({}, "") == ""
+
+    def test_max_160_chars(self):
+        long = "This is a sentence. " * 30
+        result = compute_meta_description({}, long)
+        assert len(result) <= 160
+
+
+# -----------------------------------------------------------------------
+# compute_excerpt
+# -----------------------------------------------------------------------
+
+
+class TestComputeExcerpt:
+    """Direct tests for compute_excerpt (raw-content path).
+
+    The helper returns rendered HTML, strips a leading h1, and truncates at
+    ~250 chars before rendering.
+    """
+
+    def test_short_content_renders_markdown(self):
+        result = compute_excerpt("Hello world.")
+        assert "Hello world" in result
+        assert "<" in result  # Rendered to HTML (e.g. <p>)
+
+    def test_empty_string(self):
+        assert compute_excerpt("") == ""
+
+    def test_strips_leading_h1(self):
+        result = compute_excerpt("# My Title\n\nFirst paragraph here.")
+        assert "First paragraph" in result
+        assert "My Title" not in result
+
+    def test_renders_markdown(self):
+        result = compute_excerpt("This has **bold** and *italic*.")
+        assert "bold" in result
+        assert "<strong>" in result or "**" not in result  # Rendered
+
+    def test_does_not_cut_mid_markdown(self):
+        """Excerpt should not end with orphaned ** or other markdown syntax."""
+        content = (
+            "Bengal is a powerful static site generator. "
+            "Key Features: Fast Builds, Asset Optimization, **SEO** friendly."
+        )
+        result = compute_excerpt(content)
+        from bengal.core.utils.text import strip_html
+
+        plain = strip_html(result)
+        assert not plain.endswith("**"), "Should not end with orphaned **"
+
+    def test_headers_in_content(self):
+        """Headers in content are rendered and available for card excerpt."""
+        content = (
+            "Intro paragraph here.\n\n"
+            "## Key Features\n\n"
+            "### Fast Builds\n"
+            "- Parallel processing\n"
+            "- Asset Optimization\n"
+            "**SEO** friendly."
+        )
+        result = compute_excerpt(content)
+        assert "Key Features" in result or "Intro" in result


### PR DESCRIPTION
## Summary

Deletes two **vestigial forwarders** from `bengal/core/page/computed.py`:

- `compute_excerpt` (`computed.py:101`)
- `compute_meta_description` (`computed.py:66`)

Both were deprecated re-exports whose entire body forwarded to `bengal.rendering.page_content` with no added logic. The live `Page.excerpt` / `Page.meta_description` properties already call the rendering helpers **directly** (`runtime.py:669,681`), so the wrappers had **zero production callers** — their only importer was a single test module. Their own docstrings labeled them `.. deprecated::`.

Per the greenfield-design test (`CLAUDE.md` / `plan/epic-delete-forwarding-wrappers.md`), these are textbook forwarder residue left behind by a past `page_content` extraction. Removing them keeps rendering-derived behavior out of core.

## Changes

- Delete both functions + their docstring entries from `page.computed`; refresh the module docstring's stale Performance examples (HTML stripping / truncation no longer live here).
- **Move** their behavioral tests — which carried unique coverage (`max-160-chars`, mid-markdown truncation, headers-in-content) not duplicated elsewhere — from `tests/unit/core/test_computed_functions.py` to `tests/unit/rendering/test_page_content.py`, importing the canonical functions from `bengal.rendering.page_content`. Tests now live on the correct side of the boundary.

## Verification

- No production migration needed (`Page` properties already bypass the wrappers).
- No remaining references to the deleted symbols anywhere in the tree.
- Full unit suite green: **2997 passed, 3 skipped** (pre-existing skips), incl. boundary guards `test_no_core_mixins.py` and `test_surface_retirement.py`.
- ruff, ty, dependency-layer, and circular-import pre-commit hooks all pass.

## Provenance

Surfaced by a `core-boundary-audit` dynamic workflow (37 agents): 11 candidates → 2 confirmed, 9 verified as false positives (e.g. `page.params`/`props`, the `section_ergonomics` content-stat shims — all correctly defended as genuine facets / allow-listed shims). Both confirmed findings were judged 3/3 by independent adversarial verifiers and re-verified by hand before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)