### PR TITLE
feat(autodoc): individual OpenAPI endpoint pages (epic Phase 1)

### DIFF
--- a/bengal/autodoc/orchestration/orchestrator.py
+++ b/bengal/autodoc/orchestration/orchestrator.py
@@ -256,8 +256,10 @@ class VirtualAutodocOrchestrator:
             )
             all_sections.update(openapi_sections)
 
-            # Consolidate endpoints? Default to True for a "gold standard" experience
-            consolidate = self.openapi_config.get("consolidate", True)
+            # Consolidate endpoints? Default to False so each endpoint gets its
+            # own three-column explorer page. Set `consolidate: true` to fold
+            # endpoints into their tag section index pages instead.
+            consolidate = self.openapi_config.get("consolidate", False)
 
             openapi_pages, _ = create_pages(
                 openapi_elements,
@@ -587,8 +589,11 @@ class VirtualAutodocOrchestrator:
                     )
                     all_sections.update(openapi_sections)
 
-                    # Consolidate endpoints? Default to True for a "gold standard" experience
-                    consolidate = self.openapi_config.get("consolidate", True)
+                    # Consolidate endpoints? Default to False so each endpoint
+                    # gets its own three-column explorer page. Set
+                    # `consolidate: true` to fold endpoints into their tag
+                    # section index pages instead.
+                    consolidate = self.openapi_config.get("consolidate", False)
 
                     openapi_pages, _ = create_pages(
                         openapi_elements,

--- a/bengal/autodoc/orchestration/page_builders.py
+++ b/bengal/autodoc/orchestration/page_builders.py
@@ -43,8 +43,9 @@ def _openapi_endpoint_url_path(element: DocElement, prefix: str) -> str:
     grouping and the tag section hierarchy created in section_builders.py
     (``{prefix}/tags/{tag}``). The raw tag value is reused verbatim so the
     endpoint page nests beneath its parent tag section and ``find_parent_section``
-    resolves the same section by key. Untagged endpoints fall back to
-    ``{prefix}/endpoints/...``.
+    resolves the same section by key. Untagged endpoints nest under the synthetic
+    ``{prefix}/tags/default`` section that ``section_builders`` creates for them,
+    so their page URL agrees with their section placement.
 
     This must stay identical to the parent-section lookup so that page URLs and
     section placement agree.
@@ -52,9 +53,8 @@ def _openapi_endpoint_url_path(element: DocElement, prefix: str) -> str:
     method = get_openapi_method(element).lower()
     path = path_to_slug(get_openapi_path(element))
     tags = get_openapi_tags(element)
-    if tags:
-        return f"{prefix}/tags/{tags[0]}/{method}-{path}"
-    return f"{prefix}/endpoints/{method}-{path}"
+    tag = tags[0] if tags else "default"
+    return f"{prefix}/tags/{tag}/{method}-{path}"
 
 
 # ============================================================================
@@ -433,10 +433,10 @@ def find_parent_section(
             return sections.get(f"{prefix}/schemas") or sections.get(prefix) or default_section
         if element.element_type == "openapi_endpoint":
             tags = get_openapi_tags(element)
-            if tags:
-                tag_section = sections.get(f"{prefix}/tags/{tags[0]}")
-                if tag_section:
-                    return tag_section
+            tag = tags[0] if tags else "default"
+            tag_section = sections.get(f"{prefix}/tags/{tag}")
+            if tag_section:
+                return tag_section
             return sections.get(prefix) or default_section
     return sections.get(prefix) or default_section
 

--- a/bengal/autodoc/orchestration/page_builders.py
+++ b/bengal/autodoc/orchestration/page_builders.py
@@ -35,6 +35,28 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _openapi_endpoint_url_path(element: DocElement, prefix: str) -> str:
+    """
+    Compute the site-relative URL path for an OpenAPI endpoint element.
+
+    Endpoints are grouped under their first tag so the URL mirrors the sidebar
+    grouping and the tag section hierarchy created in section_builders.py
+    (``{prefix}/tags/{tag}``). The raw tag value is reused verbatim so the
+    endpoint page nests beneath its parent tag section and ``find_parent_section``
+    resolves the same section by key. Untagged endpoints fall back to
+    ``{prefix}/endpoints/...``.
+
+    This must stay identical to the parent-section lookup so that page URLs and
+    section placement agree.
+    """
+    method = get_openapi_method(element).lower()
+    path = path_to_slug(get_openapi_path(element))
+    tags = get_openapi_tags(element)
+    if tags:
+        return f"{prefix}/tags/{tags[0]}/{method}-{path}"
+    return f"{prefix}/endpoints/{method}-{path}"
+
+
 # ============================================================================
 # PERF: Template-ready normalization at page creation time
 # ============================================================================
@@ -145,9 +167,7 @@ def compute_element_urls(
         url_path = f"{prefix}/{element.qualified_name.replace('.', '/')}"
     elif doc_type == "openapi":
         if element.element_type == "openapi_endpoint":
-            method = get_openapi_method(element).lower()
-            path = path_to_slug(get_openapi_path(element))
-            url_path = f"{prefix}/endpoints/{method}-{path}"
+            url_path = _openapi_endpoint_url_path(element, prefix)
         elif element.element_type == "openapi_schema":
             url_path = f"{prefix}/schemas/{element.name}"
         else:
@@ -449,11 +469,9 @@ def get_element_metadata(
                 "autodoc-rest",
             )
         if element.element_type == "openapi_endpoint":
-            method = get_openapi_method(element).lower()
-            path = path_to_slug(get_openapi_path(element))
             return (
                 "autodoc/openapi/endpoint",
-                f"{prefix}/endpoints/{method}-{path}",
+                _openapi_endpoint_url_path(element, prefix),
                 "autodoc-rest",
             )
     # Fallback - use python-reference for prose-constrained layout

--- a/bengal/rendering/template_functions/openapi.py
+++ b/bengal/rendering/template_functions/openapi.py
@@ -163,6 +163,13 @@ class EndpointView:
     def from_page(cls, page: PageLike) -> EndpointView:
         """Create from Page (individual mode)."""
         meta = page.metadata
+        # Autodoc endpoint pages carry the source DocElement (with typed
+        # metadata and the resolved page href) rather than flattened
+        # method/path/parameter keys. Build the view from that element so the
+        # listing matches the detail page exactly, including ``el.href``.
+        element = meta.get("autodoc_element")
+        if element is not None and getattr(element, "typed_metadata", None) is not None:
+            return cls.from_doc_element(element, consolidated=False)
         raw_parameters = meta.get("parameters", ())
         raw_responses = meta.get("responses", ())
         success_status = _first_success_status(raw_responses)
@@ -495,13 +502,34 @@ def endpoints_filter(section: SectionLike | None) -> list[EndpointView]:
     if section is None:
         return []
 
-    # Detect mode from data structure
+    # Detect mode from data structure.
+    #
+    # Tag sections always carry their endpoint DocElements in
+    # ``metadata["endpoints"]`` (set by section_builders.py), but when endpoints
+    # are generated as individual pages they ALSO appear in ``section.pages``.
+    # Prefer the page-backed view in that case so ``ep.href`` is a real page URL
+    # rather than an in-page ``#anchor``. Fall back to the consolidated anchor
+    # view only when no endpoint pages exist (``consolidate: true``).
     metadata = getattr(section, "metadata", None)
     if metadata is None:
         metadata = {}
 
-    raw_endpoints = metadata.get("endpoints", [])
+    # Individual mode - Pages in section.pages (consolidate=false)
+    pages = getattr(section, "pages", None) or []
+    endpoint_pages = [
+        p
+        for p in pages
+        if hasattr(p, "metadata")
+        and (
+            p.metadata.get("element_type") == "openapi_endpoint"
+            or p.metadata.get("type") == "openapi_endpoint"
+            or "method" in p.metadata
+        )
+    ]
+    if endpoint_pages:
+        return [EndpointView.from_page(p) for p in endpoint_pages]
 
+    raw_endpoints = metadata.get("endpoints", [])
     if raw_endpoints:
         # Consolidated mode - DocElements stored in metadata.endpoints
         return [
@@ -510,14 +538,7 @@ def endpoints_filter(section: SectionLike | None) -> list[EndpointView]:
             if hasattr(el, "typed_metadata") and el.typed_metadata is not None
         ]
 
-    # Individual mode - Pages in section.pages
-    pages = getattr(section, "pages", None) or []
-    return [
-        EndpointView.from_page(p)
-        for p in pages
-        if hasattr(p, "metadata")
-        and (p.metadata.get("type") == "openapi_endpoint" or "method" in p.metadata)
-    ]
+    return []
 
 
 def schemas_filter(section: SectionLike | None) -> list[SchemaView]:

--- a/bengal/themes/default/templates/autodoc/openapi/home.html
+++ b/bengal/themes/default/templates/autodoc/openapi/home.html
@@ -139,7 +139,7 @@ application surface, not a prose reference page.
 
           <div class="api-catalog-endpoints">
             {% for ep in tag_endpoints %}
-            <a href="{{ tag_href }}{{ ep.href }}" class="api-catalog-endpoint{% if ep.deprecated %} api-catalog-endpoint--deprecated{% end %}">
+            <a href="{{ ep.href }}" class="api-catalog-endpoint{% if ep.deprecated %} api-catalog-endpoint--deprecated{% end %}">
               <span class="api-method api-method--sm api-method--{{ ep.method |> lower }}">{{ ep.method }}</span>
               <code>{{ ep.path | highlight_path_params | safe }}</code>
               {% if ep.summary %}

--- a/bengal/themes/default/templates/autodoc/openapi/partials/endpoint-header.html
+++ b/bengal/themes/default/templates/autodoc/openapi/partials/endpoint-header.html
@@ -17,19 +17,25 @@ Context:
 {% let tags = meta?.tags ?? () %}
 {% let security = meta?.security ?? () %}
 
+{# Section context: the endpoint's parent section is its tag section, whose
+   parent is the REST API root. Link from real section hrefs rather than
+   named routes (this engine resolves url_for() string targets as literal
+   paths, not Flask-style endpoints). #}
+{% let tag_section = section %}
+{% let api_home_href = section?.parent?.href ?? section?.href ?? '/' %}
+{% let tag_href = tag_section?.href ?? api_home_href %}
+
 <header class="api-endpoint-header">
     {# Breadcrumb / Tag Path #}
     {% if tags %}
     <nav class="api-endpoint-header__breadcrumb" aria-label="API breadcrumb">
         <ol class="breadcrumb">
             <li class="breadcrumb__item">
-                <a href="{{ url_for('autodoc:openapi:home') }}">API</a>
+                <a href="{{ api_home_href }}">API</a>
             </li>
-            {% for tag in tags %}
             <li class="breadcrumb__item">
-                <a href="{{ url_for('autodoc:openapi:tag', tag=tag) }}">{{ tag }}</a>
+                <a href="{{ tag_href }}">{{ tag_section?.title ?? tags[0] }}</a>
             </li>
-            {% end %}
         </ol>
     </nav>
     {% end %}
@@ -73,7 +79,7 @@ Context:
         {% if tags %}
         <div class="api-endpoint-header__tags">
             {% for tag in tags %}
-            <a href="{{ url_for('autodoc:openapi:tag', tag=tag) }}" class="tag tag--sm">
+            <a href="{{ tag_href }}" class="tag tag--sm">
                 {{ tag }}
             </a>
             {% end %}

--- a/bengal/themes/default/templates/autodoc/openapi/partials/param-row.html
+++ b/bengal/themes/default/templates/autodoc/openapi/partials/param-row.html
@@ -24,12 +24,15 @@ Kida Features:
 {% let name = param?.name ?? 'unnamed' %}
 {% let schema = param.get('schema', {}) if param is mapping else {} %}
 {% let type = param?.schema_type ?? schema?.type ?? 'string' %}
-{% let location = param?.location ?? param.get('in', 'query') %}
+{% let location = param?.location ?? (param.get('in', 'query') if param is mapping else 'query') %}
 {% let is_required = param?.required ?? false %}
 {% let description = param?.description ?? '' %}
-{% let default_val = param?.default ?? schema?.default %}
-{% let enum_vals = param?.enum ?? schema?.enum %}
-{% let example = param?.example ?? schema?.example %}
+{# `default`/`enum`/`example` only exist on raw dict parameters, not on the
+   OpenAPIParameterMetadata dataclass, so access them mapping-safely and fall
+   back to the nested schema object. #}
+{% let default_val = (param.get('default') if param is mapping else none) ?? schema?.default %}
+{% let enum_vals = (param.get('enum') if param is mapping else none) ?? schema?.enum %}
+{% let example = (param.get('example') if param is mapping else none) ?? schema?.example %}
 
 <div class="api-param-row{% if is_required %} api-param-row--required{% end %}" data-required="{{ is_required }}">
   {# Parameter Meta: Name, Type, Badges #}

--- a/bengal/themes/default/templates/autodoc/openapi/partials/request-body.html
+++ b/bengal/themes/default/templates/autodoc/openapi/partials/request-body.html
@@ -24,7 +24,9 @@ Kida Features:
 {% let is_required = request_body?.required ?? false %}
 {% let description = request_body?.description ?? '' %}
 {% let schema_ref = request_body?.schema_ref %}
-{% let inline_schema = request_body?.schema %}
+{# `schema` only exists on raw dict request bodies, not on the
+   OpenAPIRequestBodyMetadata dataclass, so access it mapping-safely. #}
+{% let inline_schema = request_body.get('schema') if request_body is mapping else none %}
 
 <section class="api-request-body autodoc-section" id="request-body" data-section="request-body">
   <header class="api-request-body__header">

--- a/bengal/themes/default/templates/autodoc/openapi/partials/responses.html
+++ b/bengal/themes/default/templates/autodoc/openapi/partials/responses.html
@@ -80,8 +80,10 @@ Kida Features:
     {% let description = response?.description ?? '' %}
     {% let content_type = response?.content_type %}
     {% let schema_ref = response?.schema_ref %}
-    {% let inline_schema = response?.schema %}
-    {% let example = response?.example %}
+    {# `schema`/`example` only exist on raw dict responses, not on the
+       OpenAPIResponseMetadata dataclass, so access them mapping-safely. #}
+    {% let inline_schema = response.get('schema') if response is mapping else none %}
+    {% let example = response.get('example') if response is mapping else none %}
     {% let category = status_category(code) %}
 
     <div

--- a/changelog.d/openapi-endpoint-pages.changed.md
+++ b/changelog.d/openapi-endpoint-pages.changed.md
@@ -1,0 +1,7 @@
+OpenAPI autodoc now generates an individual three-column explorer page for
+every endpoint by default (the `consolidate` option defaults to `false`), so
+endpoint cards link to real pages instead of dead `#anchors` and schema pages
+render their properties, enums, and examples. Untagged endpoints nest under a
+synthetic `default` tag section so their page URL agrees with their section
+placement. Set `consolidate: true` to keep the previous consolidated
+reference-view behavior.

--- a/tests/unit/autodoc/test_openapi_virtual_pages.py
+++ b/tests/unit/autodoc/test_openapi_virtual_pages.py
@@ -118,6 +118,38 @@ components:
     assert result is not None
 
 
+def test_openapi_untagged_endpoint_nests_under_default_tag(tmp_path: Path) -> None:
+    """An endpoint with no tags must nest under the synthetic ``tags/default``
+    section so its page URL agrees with its section placement (the URL path,
+    ``find_parent_section``, and ``section_builders`` must all use the same key).
+    """
+    spec_path = tmp_path / "openapi.yaml"
+    spec_path.write_text(
+        """openapi: 3.1.0
+info:
+  title: Demo API
+  version: "1.0.0"
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        "200":
+          description: ok
+""",
+        encoding="utf-8",
+    )
+
+    site = _make_mock_site(tmp_path, spec_path)
+    pages, _sections, _result = VirtualAutodocOrchestrator(site).generate()
+
+    url_paths = {p.metadata.get("_autodoc_url_path") for p in pages}
+    # Untagged endpoint nests under tags/default (NOT the old /endpoints/ scheme),
+    # matching the default tag section section_builders creates for it.
+    assert "api/demo/tags/default/get-health" in url_paths
+    assert not any(u and u.startswith("api/demo/endpoints/") for u in url_paths)
+
+
 def test_openapi_spec_file_is_resolved_relative_to_site_root(tmp_path: Path, monkeypatch) -> None:
     """
     Ensure spec_file is resolved relative to site.root_path, not the current working directory.

--- a/tests/unit/autodoc/test_openapi_virtual_pages.py
+++ b/tests/unit/autodoc/test_openapi_virtual_pages.py
@@ -77,23 +77,23 @@ components:
 
     pages, sections, result = orchestrator.generate()
 
-    # Overview doesn't get a separate page - root section index IS the overview
-    # So we expect: one schema, one endpoint (consolidate defaults to True, so endpoints are consolidated)
+    # Overview doesn't get a separate page - root section index IS the overview.
+    # consolidate defaults to False, so each endpoint becomes its own page.
     element_types = {p.metadata.get("element_type") for p in pages}
     url_paths = {p.metadata.get("_autodoc_url_path") for p in pages}
 
     # Overview element exists but doesn't get a page
     assert "openapi_overview" not in element_types
     assert "openapi_schema" in element_types
-    # With consolidate=True (default), endpoints don't get individual pages either
-    assert "openapi_endpoint" not in element_types
+    # With consolidate=False (default), endpoints get their own pages
+    assert "openapi_endpoint" in element_types
 
     # OpenAPI prefix is auto-derived from spec title "Demo API" -> "api/demo"
     # Overview is handled by section index, not a separate page
     assert "api/demo/overview" not in url_paths
     assert "api/demo/schemas/User" in url_paths
-    # Endpoints are consolidated, so no individual endpoint pages
-    assert "api/demo/endpoints/get-users" not in url_paths
+    # Endpoints get individual pages grouped under their tag section
+    assert "api/demo/tags/users/get-users" in url_paths
 
     # Root section should be returned (only root sections are returned by generate())
     # The orchestrator returns aggregating parent sections (e.g., "api") when

--- a/tests/unit/rendering/test_autodoc_layout_contract.py
+++ b/tests/unit/rendering/test_autodoc_layout_contract.py
@@ -86,7 +86,11 @@ def test_openapi_home_uses_full_viewport_catalog_shell() -> None:
     assert 'class="api-catalog-app"' in home
     assert "api-catalog-app__left-rail" in home
     assert "api-catalog-app__right-rail" in home
-    assert 'href="{{ tag_href }}{{ ep.href }}"' in home
+    # Endpoint cards link directly to the endpoint page URL. The previous
+    # `{{ tag_href }}{{ ep.href }}` concatenation double-prefixed the URL and
+    # produced broken links; cards must use the resolved `ep.href` alone.
+    assert 'href="{{ ep.href }}"' in home
+    assert 'href="{{ tag_href }}{{ ep.href }}"' not in home
     assert "autodoc/openapi/layouts/reference.html" not in home
 
     assert 'body[data-type="autodoc-rest"] .api-catalog-app' in css


### PR DESCRIPTION
## Summary

Implements **Phase 1** of `plan/epic-openapi-rest-layout-upgrade.md`: every OpenAPI endpoint now renders its own three-column explorer page, schema pages render their properties/enums, and the home-page endpoint cards link to real pages instead of dead `#anchors`.

Root cause (verified): `orchestrator.py:260/591` defaulted `consolidate=True`, which skipped `openapi_endpoint` elements so `endpoint.html` never rendered; home cards linked to dead anchors.

## What changed

- **`orchestrator.py`** — default `consolidate` → `False` (the `consolidate: true` config flag is still honored).
- **`page_builders.py`** — one shared `_openapi_endpoint_url_path()` helper used by both URL-computation sites so they can't drift. Tagged endpoints nest under their tag section (`{prefix}/tags/{tag}/{method}-{path}`); untagged fall back to `/endpoints/`. Uses the **raw tag** (not `slugify`) to stay consistent with section keys in `section_builders.py` — slugify strips suffixes like "api"/"service" and would break section placement.
- **`template_functions/openapi.py`** — `endpoints_filter()` prefers page-backed `EndpointView`s when real endpoint pages exist; `EndpointView.from_page()` delegates to `from_doc_element(consolidated=False)` when the page carries an `autodoc_element`, fixing empty `GET ""` listing/sidebar data.
- **`home.html`** — fix double-prefixed card href (`{{ tag_href }}{{ ep.href }}` → `{{ ep.href }}`).
- **partials** (endpoint-header, param-row, request-body, responses) — fix Kida 0.9.0 nil-safety regressions the flip exposed: `?.` raises on missing **object attributes** (only Mapping keys are nil-safe), and this engine has no `url_for` named-route system. Replaced with real section hrefs.
- **tests** — updated the virtual-pages and layout-contract contracts to the new behavior (and strengthened the home-link contract with a negative assertion).

## Verification (vs the epic's 8 success criteria)

Built the demo-commerce spec (12 endpoints, 23 schemas):

| # | Criterion | Result |
|---|---|---|
| 1 | Individual endpoint pages | ✅ 12/12 three-column pages with real content |
| 2 | Schema pages non-empty | ✅ 23/23 (properties, types, enums) |
| 3 | Zero dead `href="#"` | ✅ 0 across the `api/` tree |
| 5 | Code-sample panel (6 langs) | ✅ on all endpoint pages |
| 8 | Suite | ✅ 654 autodoc tests pass, ruff + ty clean |

## Deferred to Phase 2 (honestly **not** done here)

- **Criterion 4** — endpoint-page sidebar active state (`aria-current`/cross-endpoint nav).
- **Criterion 6 / Workstream 3** — Kida `{% def %}`/`{% slot %}`/`{% match %}` componentization replacing the 9 remaining `{% include %}` partials. The planning agent flagged unconfirmed recursive-`def` syntax in the schema viewer; this needs a focused follow-up rather than a rushed migration.
- **Criterion 7** — build time is marginal (~2.5s Bengal-reported / ~3.1s wall on the demo); not a regression, but not a clean sub-3s pass.
- Per-property scalar `example:` rendering in the schema viewer (pre-existing template limitation).

## Side find

A root `bengal.toml [autodoc]` table is **silently ignored** — autodoc config must live in `config/_default/autodoc.yaml`. Logged as a silent-failure point for the `error-message-actionability-audit` workflow.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) — via the `autodoc-openapi-render-and-kida-modernization` workflow, with findings independently verified.