### PR TITLE
perf(provenance): incremental warm-save dependency reverse-map (~180x) + dev-server sendfile crash fix

### DIFF
--- a/bengal/build/contracts/dependency_index.py
+++ b/bengal/build/contracts/dependency_index.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import ItemsView, Iterable, Mapping
 
     from bengal.build.contracts.keys import CacheKey
     from bengal.build.provenance.types import ProvenanceRecord
@@ -73,6 +73,14 @@ class DependencyReadIndex:
         self._entries: dict[tuple[str, str], DependencyIndexEntry] = {}
         for entry in entries or ():
             self._entries[(entry.dependency_kind, entry.dependency_key)] = entry
+
+    def items(self) -> ItemsView[tuple[str, str], DependencyIndexEntry]:
+        """Public read view over ``(dependency_kind, dependency_key) -> entry``.
+
+        Lets callers (e.g. the incremental dependency-index delta in the provenance store)
+        iterate the full reverse map without reaching into the private ``_entries`` field.
+        """
+        return self._entries.items()
 
     def get(self, dependency_kind: str, dependency_key: str) -> DependencyIndexEntry | None:
         """Return the entry for a normalized dependency, if known."""

--- a/bengal/build/provenance/store.py
+++ b/bengal/build/provenance/store.py
@@ -487,7 +487,7 @@ class ProvenanceCache:
         edges: dict[tuple[str, str], set[str]] = {}
         meta: dict[tuple[str, str], tuple[str, str]] = {}
         base_pages: set[str] = set()
-        for (kind, key), entry in base._entries.items():
+        for (kind, key), entry in base.items():
             pages = set(entry.page_keys)
             edges[(kind, key)] = pages
             meta[(kind, key)] = (entry.invalidation_reason, entry.producer)

--- a/bengal/build/provenance/store.py
+++ b/bengal/build/provenance/store.py
@@ -13,6 +13,7 @@ Thread Safety:
 
 from __future__ import annotations
 
+import os
 import threading
 import time
 from collections.abc import Mapping
@@ -21,6 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from bengal.build.contracts.dependency_index import (
+    DependencyIndexEntry,
     DependencyReadIndex,
     build_dependency_read_index,
 )
@@ -37,6 +39,18 @@ from bengal.utils.io.json_compat import load as json_load
 from bengal.utils.observability.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _delta_save_enabled() -> bool:
+    """Whether save() updates the dependency reverse map incrementally (default on).
+
+    Maintaining the reverse map incrementally avoids rebuilding it from every page's record
+    (which, on a 1-page warm edit, cold-reads ~all record files and dominated the build). The
+    incremental result is byte-identical to a full rebuild (asserted by
+    tests/unit/build/provenance/test_delta_dependency_index.py). Set
+    BENGAL_PROVENANCE_DELTA_SAVE=0 to force the full rebuild (rollback lever).
+    """
+    return os.environ.get("BENGAL_PROVENANCE_DELTA_SAVE", "1").lower() not in ("0", "false", "off")
 
 
 @dataclass
@@ -69,6 +83,9 @@ class ProvenanceCache:
     _dependency_index: DependencyReadIndex = field(default_factory=DependencyReadIndex)
     _records: dict[ContentHash, ProvenanceRecord] = field(default_factory=dict)
     _subvenance: dict[ContentHash, set[CacheKey]] = field(default_factory=dict)
+    # Pages whose records were (re)stored this session — used to update the dependency
+    # reverse map incrementally in save() instead of rebuilding it from all records.
+    _dirty_page_keys: set[CacheKey] = field(default_factory=set)
     _loaded: bool = False
     _dirty: bool = False
     _records_dir_created: bool = False
@@ -298,6 +315,7 @@ class ProvenanceCache:
 
             # Store record in memory
             self._records[record.provenance.combined_hash] = record
+            self._dirty_page_keys.add(record.page_path)
 
             # Update subvenance index
             for inp in record.provenance.inputs:
@@ -348,6 +366,7 @@ class ProvenanceCache:
 
                 # Store record in memory
                 self._records[record.provenance.combined_hash] = record
+                self._dirty_page_keys.add(record.page_path)
 
                 # Update subvenance index
                 for inp in record.provenance.inputs:
@@ -419,13 +438,106 @@ class ProvenanceCache:
     def _build_dependency_index(
         self, index_data: dict[CacheKey, ContentHash]
     ) -> DependencyReadIndex:
-        """Build a dependency read index from the current page index snapshot."""
+        """Build a dependency read index from the current page index snapshot.
+
+        Records are content-addressed by ``combined_hash``, so pages with identical inputs
+        (e.g. empty taxonomy pagination pages) share ONE record whose ``page_path`` is an
+        arbitrary sibling. Iterating page-by-page and re-attributing each page's inputs to its
+        OWN key keeps the reverse map complete (every page that consumes an input is listed,
+        not just the dedup winner) and deterministic — which the per-page delta path also
+        produces, so the two stay byte-identical.
+        """
         records: list[ProvenanceRecord] = []
-        for combined_hash in index_data.values():
-            record = self._get_record(combined_hash)
-            if record is not None:
+        record_by_hash: dict[ContentHash, ProvenanceRecord | None] = {}
+        for page_path, combined_hash in index_data.items():
+            if combined_hash not in record_by_hash:
+                record_by_hash[combined_hash] = self._get_record(combined_hash)
+            record = record_by_hash[combined_hash]
+            if record is None:
+                continue
+            if record.page_path == page_path:
                 records.append(record)
+            else:
+                records.append(
+                    ProvenanceRecord(
+                        page_path=page_path,
+                        provenance=record.provenance,
+                        output_hash=record.output_hash,
+                    )
+                )
         return build_dependency_read_index(records)
+
+    def _incremental_dependency_index(
+        self,
+        index_copy: dict[CacheKey, ContentHash],
+        base: DependencyReadIndex,
+        dirty_pages: set[CacheKey],
+        dirty_records: dict[CacheKey, ProvenanceRecord | None],
+    ) -> DependencyReadIndex:
+        """Update the dependency reverse map for changed pages without re-reading all records.
+
+        Produces a result byte-identical to ``_build_dependency_index`` (asserted by tests):
+        edges for changed (dirty) and deleted pages are recomputed from their current records /
+        purged, while every unchanged page's edges are carried over from the loaded prior index
+        — which reflects ALL pages, so the reverse map stays globally complete. Skips the
+        ``config`` kind to match ``build_dependency_read_index``.
+        """
+        skip_kinds = frozenset({"config"})
+        # (kind, key) -> set of page keys, plus per-edge metadata, seeded from the prior index.
+        edges: dict[tuple[str, str], set[str]] = {}
+        meta: dict[tuple[str, str], tuple[str, str]] = {}
+        base_pages: set[str] = set()
+        for (kind, key), entry in base._entries.items():
+            pages = set(entry.page_keys)
+            edges[(kind, key)] = pages
+            meta[(kind, key)] = (entry.invalidation_reason, entry.producer)
+            base_pages |= pages
+
+        # Pages to clear from every edge: dirty pages (edges recomputed below) and pages that
+        # no longer exist in the page index (deletions). Carrying a deleted page's stale edge
+        # would diverge from a full rebuild and over-rebuild forever.
+        current_pages = {str(page) for page in index_copy}
+        reset_pages = {str(page) for page in dirty_pages} | (base_pages - current_pages)
+        if reset_pages:
+            for edge_key in list(edges):
+                remaining = edges[edge_key] - reset_pages
+                if remaining != edges[edge_key]:
+                    if remaining:
+                        edges[edge_key] = remaining
+                    else:
+                        del edges[edge_key]
+                        meta.pop(edge_key, None)
+
+        # Re-add each dirty page's current edges from its in-memory record.
+        for page in dirty_pages:
+            if page not in index_copy:
+                continue
+            record = dirty_records.get(page)
+            if record is None:
+                continue
+            page_key = str(page)
+            for dependency in record.provenance.inputs:
+                if dependency.input_type in skip_kinds:
+                    continue
+                edge_key = (dependency.input_type, str(dependency.path))
+                edges.setdefault(edge_key, set()).add(page_key)
+                meta.setdefault(
+                    edge_key, (f"{dependency.input_type}_dependency_changed", "provenance")
+                )
+
+        entries = [
+            DependencyIndexEntry(
+                dependency_kind=kind,
+                dependency_key=key,
+                page_keys=tuple(pages),
+                output_keys=(),
+                invalidation_reason=meta[(kind, key)][0],
+                producer=meta[(kind, key)][1],
+            )
+            for (kind, key), pages in edges.items()
+            if pages
+        ]
+        return DependencyReadIndex(entries)
 
     def save(
         self,
@@ -447,8 +559,31 @@ class ProvenanceCache:
             self._last_build_time = saved_time
             self._last_build_time_ns = saved_time_ns
             self._dirty = False
+            # Capture state for an incremental dependency-index update (avoids rebuilding the
+            # reverse map from every page's record — a cold-read of ~all records on warm edits).
+            base_dep_index = self._dependency_index
+            dirty_pages = set(self._dirty_page_keys)
+            dirty_records = {
+                page: self._records.get(index_copy[page])
+                for page in dirty_pages
+                if page in index_copy
+            }
+            self._dirty_page_keys = set()
 
-        dependency_index = self._build_dependency_index(index_copy)
+        # Use the incremental update only with a loaded prior index (warm build) and every
+        # dirty page's record available; otherwise fall back to the full rebuild (cold build,
+        # where all records are already in memory, or any uncertainty — never a silent drop).
+        use_delta = (
+            _delta_save_enabled()
+            and not base_dep_index.is_empty
+            and all(dirty_records.get(p) is not None for p in dirty_pages if p in index_copy)
+        )
+        if use_delta:
+            dependency_index = self._incremental_dependency_index(
+                index_copy, base_dep_index, dirty_pages, dirty_records
+            )
+        else:
+            dependency_index = self._build_dependency_index(index_copy)
         with self._lock:
             self._dependency_index = dependency_index
 

--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -228,6 +228,28 @@ def _should_delegate_to_pounce_static(path: str) -> bool:
     return any(raw_path.endswith(ext) for ext in _POUNCE_STATIC_ASSET_EXTENSIONS)
 
 
+def _scope_without_sendfile(scope: dict[str, Any]) -> dict[str, Any]:
+    """Return ``scope`` with Pounce's ``pounce.sendfile`` extension removed.
+
+    Pounce advertises ``pounce.sendfile`` whenever compression is off — and the dev server
+    disables compression so SSE live-reload streams immediately (see
+    ``create_pounce_dev_backend``). But Pounce 0.7.1's zero-copy path (``pounce/_sendfile.py``)
+    runs ``os.sendfile`` in a thread executor and does NOT handle ``EAGAIN``
+    (``BlockingIOError`` errno 35) on the non-blocking socket, so a full send buffer crashes
+    the worker mid-transfer — observed serving CSS on macOS + free-threaded 3.14t. Dropping the
+    extension makes ``StaticFiles`` stream files via chunked ASGI body writes, which respect
+    async backpressure. Local dev asset serving does not need zero-copy.
+
+    Upstream bug: https://github.com/lbliii/pounce/issues/72 — remove this opt-out once Pounce
+    routes file transfers through ``loop.sendfile`` (which handles EAGAIN via the selector).
+    """
+    extensions = scope.get("extensions")
+    if not extensions or "pounce.sendfile" not in extensions:
+        return scope
+    trimmed = {key: value for key, value in extensions.items() if key != "pounce.sendfile"}
+    return {**scope, "extensions": trimmed}
+
+
 async def _serve_pounce_static_asset(
     scope: dict[str, Any],
     receive: Any,
@@ -258,7 +280,7 @@ async def _serve_pounce_static_asset(
         )
         static_asset_handlers[key] = handler
 
-    await handler(scope, receive, send)
+    await handler(_scope_without_sendfile(scope), receive, send)
     return True
 
 

--- a/changelog.d/dev-server-sendfile-eagain.fixed.md
+++ b/changelog.d/dev-server-sendfile-eagain.fixed.md
@@ -1,0 +1,10 @@
+Fixed a dev-server (`bengal serve`) crash where serving a static asset (CSS/JS/font) could
+abort the worker with `BlockingIOError: [Errno 35] Resource temporarily unavailable`. The dev
+server disables compression so live-reload streams immediately, which makes Pounce advertise
+its zero-copy `pounce.sendfile` extension; Pounce 0.7.1's sendfile path runs `os.sendfile` in
+a thread executor without handling `EAGAIN` on the non-blocking socket, so a full send buffer
+crashed the transfer (seen on macOS + free-threaded CPython 3.14t). Bengal now opts out of the
+`pounce.sendfile` extension for dev static serving, falling back to chunked ASGI body writes
+that respect async backpressure. The production-like preview server keeps compression (and so
+never advertised sendfile) and is unaffected. Tracked upstream as
+[lbliii/pounce#72](https://github.com/lbliii/pounce/issues/72).

--- a/changelog.d/incremental-dependency-index.changed.md
+++ b/changelog.d/incremental-dependency-index.changed.md
@@ -1,0 +1,14 @@
+Warm incremental builds now update the provenance dependency reverse-map *incrementally*
+on cache save instead of rebuilding it from every page's record. The old writer cold-read
+~every record file on a one-page edit (≈99% of provenance save), so on a 500-page blog the
+provenance save dropped from ≈2.0s / 511 record reads to ≈11ms / 0 reads — a ~180x cut to
+that phase, the dominant cost of the dev-loop save. The incremental result is byte-identical
+to a full rebuild (gated by `tests/unit/build/provenance/test_delta_dependency_index.py`
+across edit / add / delete / multi-consumer / same-hash / combined scenarios) and falls back
+to the full rebuild on cold builds or any uncertainty. Set `BENGAL_PROVENANCE_DELTA_SAVE=0`
+to force the full rebuild (rollback lever).
+
+This also fixes a latent reverse-map bug: pages with identical inputs (e.g. empty taxonomy
+pagination pages) share one content-addressed record, and the old builder listed only the
+dedup winner — silently dropping the other pages from the reverse map (under-invalidation),
+non-deterministically. The reverse map now lists every page that consumes an input.

--- a/tests/unit/build/provenance/test_delta_dependency_index.py
+++ b/tests/unit/build/provenance/test_delta_dependency_index.py
@@ -1,0 +1,302 @@
+"""Byte-parity gate for the incremental dependency-index writer.
+
+The warm-build optimization (``BENGAL_PROVENANCE_DELTA_SAVE``) updates the dependency
+reverse map incrementally on ``save()`` from the LOADED prior index plus the in-memory
+records of changed pages only — instead of re-reading every page's record from disk (which
+dominated warm 1-page-edit builds). This is only safe if the incremental result is
+**byte-identical** to a full ``_build_dependency_index`` rebuild of the same final state.
+
+These tests assert exactly that across edit / add / delete / multi-consumer / combined
+scenarios, and that the rollback lever (``=0``) forces the full rebuild. If a future change
+breaks the equivalence, CI fails here rather than silently shipping a stale reverse map
+(which would under-rebuild on warm incremental builds — a correctness bug, not a perf one).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from bengal.build.contracts.keys import CacheKey
+from bengal.build.provenance.store import ProvenanceCache
+from bengal.build.provenance.types import ContentHash, Provenance, ProvenanceRecord
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    import pytest
+
+# A shared theme template every page consumes — the multi-consumer edge that must survive a
+# single-page edit. ``config`` inputs are present specifically to prove both paths skip them.
+_SHARED_TEMPLATE = ("template", "templates/page.html", "tmpl-v1")
+_SITE_CONFIG = ("config", "bengal.toml", "cfg-v1")
+
+
+def _rec(page: str, *inputs: tuple[str, str, str]) -> ProvenanceRecord:
+    """Build a record for ``page`` from ``(kind, path, hash)`` inputs."""
+    prov = Provenance()
+    for kind, path, content_hash in inputs:
+        prov = prov.with_input(kind, CacheKey(path), ContentHash(content_hash))
+    return ProvenanceRecord(
+        page_path=CacheKey(page),
+        provenance=prov,
+        output_hash=ContentHash(f"out-{page}"),
+    )
+
+
+def _read_dep_index(cache_dir: Path) -> tuple[str, dict]:
+    """Return (raw JSON text, parsed ``dependencies`` mapping) for byte + semantic compare."""
+    text = (cache_dir / "dependency-index.json").read_text(encoding="utf-8")
+    return text, json.loads(text)["dependencies"]
+
+
+def _full_rebuild(cache_dir: Path, records: Iterable[ProvenanceRecord]) -> tuple[str, dict]:
+    """Ground truth: a from-scratch full rebuild of the final record set.
+
+    A fresh cache has an empty base index, so ``save()`` deterministically takes the full
+    ``_build_dependency_index`` branch — the canonical output the delta must reproduce.
+    """
+    cache = ProvenanceCache(cache_dir=cache_dir)
+    cache.store_batch(list(records))
+    cache.save()
+    return _read_dep_index(cache_dir)
+
+
+class _BranchSpy:
+    """Records which dependency-index branch ``save()`` took (delta vs full rebuild)."""
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.calls: list[str] = []
+        inc = ProvenanceCache._incremental_dependency_index
+        full = ProvenanceCache._build_dependency_index
+
+        def spy_inc(self_: ProvenanceCache, *a: object, **k: object) -> object:
+            self.calls.append("incremental")
+            return inc(self_, *a, **k)  # type: ignore[arg-type]
+
+        def spy_full(self_: ProvenanceCache, *a: object, **k: object) -> object:
+            self.calls.append("full")
+            return full(self_, *a, **k)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(ProvenanceCache, "_incremental_dependency_index", spy_inc)
+        monkeypatch.setattr(ProvenanceCache, "_build_dependency_index", spy_full)
+
+
+def _cold_then_warm(
+    cache_dir: Path,
+    initial: list[ProvenanceRecord],
+    mutate,
+) -> ProvenanceCache:
+    """Cold build (full rebuild) then a warm reopen that applies ``mutate`` and saves (delta).
+
+    Returns the warm cache after ``save()`` so the test can read its on-disk index.
+    """
+    cold = ProvenanceCache(cache_dir=cache_dir)
+    cold.store_batch(initial)
+    cold.save()
+
+    warm = ProvenanceCache(cache_dir=cache_dir)
+    warm._ensure_loaded()  # load the prior index so save() has a non-empty base
+    mutate(warm)
+    warm.save()
+    return warm
+
+
+def _assert_delta_matches_rebuild(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    initial: list[ProvenanceRecord],
+    final: list[ProvenanceRecord],
+    mutate,
+) -> None:
+    """Core gate: warm delta save == from-scratch full rebuild, byte-for-byte."""
+    monkeypatch.setenv("BENGAL_PROVENANCE_DELTA_SAVE", "1")
+    spy = _BranchSpy(monkeypatch)
+
+    _cold_then_warm(tmp_path / "warm", initial, mutate)
+    delta_text, delta_deps = _read_dep_index(tmp_path / "warm")
+
+    # The warm save must have used the incremental branch (not silently fallen back to full).
+    warm_calls = spy.calls[1:]  # calls[0] is the cold build's full rebuild
+    assert warm_calls == ["incremental"], f"warm save did not use delta: {spy.calls}"
+
+    full_text, full_deps = _full_rebuild(tmp_path / "full", final)
+
+    assert delta_deps == full_deps  # semantic: same reverse map
+    assert delta_text == full_text  # byte-identical serialization
+
+
+def test_delta_matches_rebuild_on_edit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Editing one page's content input reproduces the full rebuild exactly."""
+    initial = [
+        _rec("a.md", ("content", "content/a.md", "a-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec("b.md", ("content", "content/b.md", "b-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+    ]
+    edited_a = _rec("a.md", ("content", "content/a.md", "a-v2"), _SHARED_TEMPLATE, _SITE_CONFIG)
+    final = [edited_a, initial[1]]
+    _assert_delta_matches_rebuild(
+        tmp_path, monkeypatch, initial=initial, final=final, mutate=lambda c: c.store(edited_a)
+    )
+
+
+def test_delta_matches_rebuild_on_add(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adding a new page reproduces the full rebuild exactly."""
+    initial = [
+        _rec("a.md", ("content", "content/a.md", "a-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+    ]
+    added = _rec("b.md", ("content", "content/b.md", "b-v1"), _SHARED_TEMPLATE, _SITE_CONFIG)
+    final = [*initial, added]
+    _assert_delta_matches_rebuild(
+        tmp_path, monkeypatch, initial=initial, final=final, mutate=lambda c: c.store(added)
+    )
+
+
+def test_delta_matches_rebuild_on_delete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deleting a page purges its edges, reproducing the full rebuild exactly.
+
+    A pure deletion stores no new record, so the warm cache is marked dirty explicitly — as a
+    real build would when its page set shrinks — and the deleted page is dropped from the index.
+    """
+    initial = [
+        _rec("a.md", ("content", "content/a.md", "a-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec("b.md", ("content", "content/b.md", "b-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec("gone.md", ("content", "content/gone.md", "g-v1"), ("data", "data/only.yaml", "d-v1")),
+    ]
+    final = [initial[0], initial[1]]
+
+    def mutate(cache: ProvenanceCache) -> None:
+        del cache._index[CacheKey("gone.md")]
+        cache._dirty = True
+
+    _assert_delta_matches_rebuild(
+        tmp_path, monkeypatch, initial=initial, final=final, mutate=mutate
+    )
+
+
+def test_delta_preserves_multi_consumer_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Editing one consumer of a shared template keeps the other consumers on that edge.
+
+    This is the failure mode the critique flagged: a naive 'rebuild from changed records only'
+    would drop b/c from the shared-template edge. The delta must carry them over from the base.
+    """
+    initial = [
+        _rec("a.md", ("content", "content/a.md", "a-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec("b.md", ("content", "content/b.md", "b-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec("c.md", ("content", "content/c.md", "c-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+    ]
+    edited_a = _rec("a.md", ("content", "content/a.md", "a-v2"), _SHARED_TEMPLATE, _SITE_CONFIG)
+    final = [edited_a, initial[1], initial[2]]
+
+    _assert_delta_matches_rebuild(
+        tmp_path, monkeypatch, initial=initial, final=final, mutate=lambda c: c.store(edited_a)
+    )
+
+    # Explicit: the shared-template edge still lists all three pages.
+    cache = ProvenanceCache(cache_dir=tmp_path / "warm")
+    cache._ensure_loaded()
+    kind, key, _ = _SHARED_TEMPLATE
+    assert cache._dependency_index.affected_page_keys(kind, key) == ("a.md", "b.md", "c.md")
+
+
+def test_delta_matches_rebuild_on_combined_churn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Edit + add + delete + a newly-introduced shared edge, all in one warm save."""
+    initial = [
+        _rec("a.md", ("content", "content/a.md", "a-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec("b.md", ("content", "content/b.md", "b-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec("old.md", ("content", "content/old.md", "o-v1"), ("partial", "partials/x.html", "p1")),
+    ]
+    edited_a = _rec(
+        "a.md",
+        ("content", "content/a.md", "a-v2"),
+        _SHARED_TEMPLATE,
+        ("partial", "partials/x.html", "p1"),  # a newly references the partial old.md used
+        _SITE_CONFIG,
+    )
+    added = _rec("new.md", ("content", "content/new.md", "n-v1"), _SHARED_TEMPLATE, _SITE_CONFIG)
+    final = [edited_a, initial[1], added]
+
+    def mutate(cache: ProvenanceCache) -> None:
+        cache.store(edited_a)
+        cache.store(added)
+        del cache._index[CacheKey("old.md")]
+
+    _assert_delta_matches_rebuild(
+        tmp_path, monkeypatch, initial=initial, final=final, mutate=mutate
+    )
+
+
+def test_full_rebuild_lists_all_same_hash_pages(tmp_path: Path) -> None:
+    """Pages with identical inputs share one content-addressed record but must all be listed.
+
+    Regression for a latent reverse-map bug: empty taxonomy pagination pages (e.g. tag:x
+    page_1/page_2/page_3) have identical provenance, so they dedup to ONE record whose
+    page_path is an arbitrary sibling. The old builder iterated record hashes and listed only
+    that one page — silently dropping the others from the reverse map (under-invalidation), and
+    non-deterministically (which sibling won depended on store order). The builder must now list
+    every page that consumes the input.
+    """
+    shared = [("taxonomy", "tag:x", "tx-v1"), _SHARED_TEMPLATE]
+    pages = [
+        _rec(".bengal/generated/tags/x/page_1/index.md", *shared),
+        _rec(".bengal/generated/tags/x/page_2/index.md", *shared),
+        _rec(".bengal/generated/tags/x/page_3/index.md", *shared),
+    ]
+    # All three share one combined hash (identical inputs) — the collision that exposed the bug.
+    assert len({r.provenance.combined_hash for r in pages}) == 1
+
+    _, deps = _full_rebuild(tmp_path / "full", pages)
+    assert deps["taxonomy:tag:x"]["page_keys"] == [
+        ".bengal/generated/tags/x/page_1/index.md",
+        ".bengal/generated/tags/x/page_2/index.md",
+        ".bengal/generated/tags/x/page_3/index.md",
+    ]
+
+
+def test_delta_matches_rebuild_with_same_hash_pages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Warm delta reproduces the full rebuild when same-hash pagination pages are present.
+
+    This is the real-build scenario the end-to-end measurement caught: editing a content page
+    leaves the (cache-hit, same-hash) generated taxonomy pages carried over from the base. The
+    delta must keep all of them, byte-identical to a from-scratch rebuild.
+    """
+    shared = [("taxonomy", "tag:x", "tx-v1"), _SHARED_TEMPLATE]
+    initial = [
+        _rec("a.md", ("content", "content/a.md", "a-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec(".bengal/generated/tags/x/page_1/index.md", *shared),
+        _rec(".bengal/generated/tags/x/page_2/index.md", *shared),
+        _rec(".bengal/generated/tags/x/page_3/index.md", *shared),
+    ]
+    edited_a = _rec("a.md", ("content", "content/a.md", "a-v2"), _SHARED_TEMPLATE, _SITE_CONFIG)
+    final = [edited_a, *initial[1:]]
+    _assert_delta_matches_rebuild(
+        tmp_path, monkeypatch, initial=initial, final=final, mutate=lambda c: c.store(edited_a)
+    )
+
+
+def test_rollback_lever_forces_full_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``BENGAL_PROVENANCE_DELTA_SAVE=0`` forces the full rebuild and still matches."""
+    monkeypatch.setenv("BENGAL_PROVENANCE_DELTA_SAVE", "0")
+    spy = _BranchSpy(monkeypatch)
+
+    initial = [
+        _rec("a.md", ("content", "content/a.md", "a-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+        _rec("b.md", ("content", "content/b.md", "b-v1"), _SHARED_TEMPLATE, _SITE_CONFIG),
+    ]
+    edited_a = _rec("a.md", ("content", "content/a.md", "a-v2"), _SHARED_TEMPLATE, _SITE_CONFIG)
+
+    _cold_then_warm(tmp_path / "warm", initial, lambda c: c.store(edited_a))
+
+    assert spy.calls == ["full", "full"], f"flag=0 should never use delta: {spy.calls}"
+    _, delta_off_deps = _read_dep_index(tmp_path / "warm")
+    _, full_deps = _full_rebuild(tmp_path / "full", [edited_a, initial[1]])
+    assert delta_off_deps == full_deps

--- a/tests/unit/server/test_asgi_app.py
+++ b/tests/unit/server/test_asgi_app.py
@@ -218,8 +218,17 @@ async def test_static_asset_range_request_returns_partial_content(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_static_asset_uses_protocol_owned_pounce_sendfile(tmp_path: Path) -> None:
-    """Dev static assets use Pounce's h11-accounted sendfile message."""
+async def test_static_asset_opts_out_of_pounce_sendfile(tmp_path: Path) -> None:
+    """Dev static assets stream via chunked body, NOT Pounce's zero-copy sendfile.
+
+    The dev server disables compression (for SSE), which makes Pounce advertise
+    ``pounce.sendfile``. But Pounce 0.7.1's sendfile path runs ``os.sendfile`` in a thread
+    executor without handling ``EAGAIN`` (``BlockingIOError`` errno 35), so a full socket send
+    buffer crashes the worker mid-transfer (observed serving CSS on macOS + free-threaded
+    3.14t). Bengal drops the ``pounce.sendfile`` extension before delegating so ``StaticFiles``
+    falls back to chunked ASGI body writes, which respect async backpressure. The caller's own
+    scope must not be mutated (other handlers may still rely on the extension).
+    """
     assets = tmp_path / "assets"
     assets.mkdir()
     asset_path = assets / "app.js"
@@ -243,15 +252,11 @@ async def test_static_asset_uses_protocol_owned_pounce_sendfile(tmp_path: Path) 
         send=send,
     )
 
+    # Caller scope untouched; the asset served via chunked body, never a sendfile message.
     assert extensions["pounce.sendfile"] == {"version": 1}
     assert sent[0]["status"] == 200
-    assert sent[1] == {
-        "type": "pounce.response.sendfile",
-        "path": asset_path,
-        "offset": 0,
-        "count": asset_path.stat().st_size,
-        "more_body": False,
-    }
+    assert not any(message.get("type") == "pounce.response.sendfile" for message in sent)
+    assert _body(sent) == b"console.log('ok')"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Two independent, tested changes from the warm-build / dev-loop work:

1. **`perf(provenance)`: incremental dependency reverse-map on warm save.** Warm one-page-edit
   builds rebuilt the dependency reverse-map from *every* page's record, cold-reading ~all
   record files (≈99% of the provenance save). It's now maintained incrementally from the
   loaded prior index + only the changed pages' in-memory records. Byte-identical to a full
   rebuild (release-gated), falls back to the full rebuild on cold builds or any uncertainty,
   and is reversible via `BENGAL_PROVENANCE_DELTA_SAVE=0`.

   This also fixes a **latent reverse-map bug** the parity gate surfaced: pages with identical
   inputs (e.g. empty taxonomy pagination pages) share one content-addressed record, so the old
   builder listed only the dedup winner and silently dropped the rest from the reverse map —
   non-deterministically (cold picked `page_1`, warm picked `page_3`). That's under-invalidation.
   The builder now attributes each page's inputs to its own key, so the map is complete and
   deterministic.

2. **`fix(server)`: opt out of Pounce sendfile in dev to avoid an EAGAIN crash.** `bengal serve`
   disables compression (so live-reload streams immediately), which makes Pounce advertise its
   zero-copy `pounce.sendfile` extension. Pounce 0.7.1's sendfile path runs `os.sendfile` in a
   thread executor without handling `EAGAIN` (`BlockingIOError` errno 35) on the non-blocking
   socket, so a full send buffer crashes the worker mid-transfer when serving a static asset
   (seen serving CSS on macOS + free-threaded 3.14t). Bengal now strips the `pounce.sendfile`
   extension before delegating, falling back to chunked ASGI body writes (proper backpressure).
   The preview server keeps compression and never advertised sendfile, so it is unaffected.
   Tracked upstream as [lbliii/pounce#72](https://github.com/lbliii/pounce/issues/72).

## Performance Evidence

- Benchmark matrix row: warm incremental build, 500-page `blog` archetype, single content-page edit (the dev-loop case)
- Command: `PYTHON_GIL=0 uv run python .context/measure_warm_delta.py` — cold build, edit one page, warm rebuild; isolates the provenance `save()` cost and per-record disk-read count; min-of-3, run with `BENGAL_PROVENANCE_DELTA_SAVE` on vs off
- Python build: CPython 3.14.2t free-threaded (`PYTHON_GIL=0`)
- Machine/OS: Apple Silicon, 5 performance + 6 efficiency cores, macOS (Darwin 25.3.0)
- Baseline commit or saved result: full rebuild (`BENGAL_PROVENANCE_DELTA_SAVE=0`, = prior behavior): provenance `save()` **2052 ms**, **511** record-file disk reads
- Current commit or saved result: incremental delta (`=1`, default): provenance `save()` **11 ms**, **0** record-file disk reads
- Artifact path: `.context/measure_warm_delta.py` (measurement + same-site parity harness); phase ledger key `Cache save` in `BuildStats.to_dict()`
- Interpretation: ~**180x** reduction of the provenance-save phase on a warm one-page edit (the dominant cost of an otherwise-fast warm build), entirely from eliminating the ~500 cold record-file reads. Cold builds are unaffected (they take the full-rebuild path, where all records are already in memory). Output is byte-identical to the full rebuild — verified both by the unit parity gate and by a same-site end-to-end check (delta-on on-disk index == fresh full rebuild, 3/3 runs) — so this is a pure latency win with no behavior change. Two cold builds of identical content still produce a byte-identical `dependency-index.json` (determinism / reproducible-builds invariant preserved).

## Tests

- `tests/unit/build/provenance/test_delta_dependency_index.py` (new): byte-identical parity of the delta vs a from-scratch full rebuild across **edit / add / delete / multi-consumer / same-hash / combined-churn**, plus the `=0` rollback lever. Includes a dedicated regression for the same-hash reverse-map completeness bug.
- `tests/unit/server/test_asgi_app.py`: the existing sendfile test is inverted to assert the safe behavior (chunked body, no `pounce.response.sendfile` message, caller scope unmutated).
- Full `tests/unit/build/provenance/`, `tests/unit/build/contracts/`, incremental/taxonomy orchestration, and `tests/unit/server/` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
