### PR TITLE
test(bench): native render-profiling harness (Step 0 gate of frozen-render-world RFC)

### DIFF
--- a/benchmarks/PROFILE_RENDER_NATIVE.md
+++ b/benchmarks/PROFILE_RENDER_NATIVE.md
@@ -1,0 +1,124 @@
+<!-- markdownlint-disable MD013 -->
+
+# Native render profiling runbook (Step 0 of the frozen-render-world RFC)
+
+This is the **hard gate** before funding any of `plan/rfc-frozen-render-world.md`'s migration
+phases. The render phase plateaus at ~1.7–1.8x on free-threaded CPython 3.14t with
+**cpu/wall ≈ 4.3** — cores are *busy, not blocked* (so it is not lock contention). Parallel burns
+~2.6x the CPU for the same logical work. The working hypothesis is free-threading's
+**atomic-refcount / cache-coherency traffic** on the shared objects every worker touches per page
+(`Site`, `SiteSnapshot`, nav trees, taxonomy tables, caches, the Kida `Environment`, config dicts).
+
+Cheap microbenchmarks could **not** settle which objects dominate (see the RFC's Validation
+section). The decisive tool is a **native profile on a supported platform**. macOS arm64 cannot do
+`py-spy --native`, so this must run on **Linux**.
+
+## The question this run must answer
+
+> Name the objects/functions whose refcount/coherency traffic dominates cross-thread cost in the
+> 8-worker 1000-page build.
+
+The answer routes the decision:
+
+- **Site / snapshot container graph dominates** → owning per-page data (RFC Phases 1–2) is
+  justified; proceed.
+- **Kida `Environment` / compiled-template objects dominate** → owning per-page data will *not*
+  help (shared by construction, no public instance-immortalization API); pivot to a C/Cython
+  immortalization spike or process/sub-interpreter isolation.
+- **Neither clearly dominates (diffuse coherency/allocator microarch)** → the realistic ceiling is
+  near the P-core count regardless; **do not migrate.**
+
+## 0. Environment
+
+```sh
+# Free-threaded CPython 3.14t, GIL off. Confirm:
+python -c "import sys; print('free-threaded:', not sys._is_gil_enabled())"
+# Linux. py-spy with --native, and perf for hardware counters:
+pip install py-spy           # or: cargo install py-spy
+sudo apt-get install linux-tools-common linux-tools-$(uname -r)   # perf
+# perf may need: sudo sysctl kernel.perf_event_paranoid=1   (or -1)
+# py-spy --native needs ptrace: run as root or grant CAP_SYS_PTRACE.
+```
+
+## 1. Confirm the plateau reproduces on THIS box
+
+The driver `benchmarks/profile_render_native.py` is the build target. First confirm the
+signature (parallel cpu/wall > 1 and a real render speedup vs sequential) before profiling —
+if the box doesn't reproduce it, the profile is meaningless.
+
+```sh
+PYTHON_GIL=0 python benchmarks/profile_render_native.py --pages 1000 --workers 8
+PYTHON_GIL=0 python benchmarks/profile_render_native.py --pages 1000 --sequential
+```
+
+Expect something like (numbers vary by box): parallel `cpu/wall≈3–4`, `render_phase` ~2–3x lower
+than sequential, while parallel `cpu` is ~2–2.6x the sequential `cpu` for identical work. That CPU
+inflation with cores busy is the thing to explain.
+
+## 2. Native sampling profile (py-spy --native)
+
+Pre-generate the site so site-gen is out of the profile, then sample the build with native frames:
+
+```sh
+SITE=/tmp/bengal_profile_site
+PYTHON_GIL=0 python benchmarks/profile_render_native.py --pages 1000 --workers 8 --reuse-dir "$SITE"  # generates + warms
+
+# Flamegraph (SVG) + speedscope (interactive) with C frames included:
+PYTHON_GIL=0 py-spy record --native --rate 1000 --format speedscope \
+  -o render_native.speedscope.json -- \
+  python benchmarks/profile_render_native.py --pages 1000 --workers 8 --reuse-dir "$SITE"
+
+PYTHON_GIL=0 py-spy record --native --rate 1000 -o render_native.svg -- \
+  python benchmarks/profile_render_native.py --pages 1000 --workers 8 --reuse-dir "$SITE"
+```
+
+**What to look for** (the refcount/coherency signature):
+
+- Native frames dominated by reference-count machinery: `_Py_DECREF` / `_Py_MergeZeroLocalRefcount`,
+  `_Py_Dealloc`, `_PyObject_GC_*`, `_PyCriticalSection*`, `_PyMutex_LockSlow`, biased-refcount
+  paths (`_Py_TryIncrefFast`, `_PyObject_SetMaybeWeakref`), and time in the allocator
+  (`_PyObject_Malloc`/`mi_*` if mimalloc). A large share here = coherency tax, not Python-level work.
+- Walk *up* from those native frames to the Python frames that trigger them, and note **which
+  objects** they touch: Site attribute access, `SiteSnapshot`/section graph traversal, the Kida
+  `Environment` / template globals, config dict reads, taxonomy/menu tables, caches.
+- Aggregate by the *owning object* of the hot dereferences. That aggregation is the answer to the
+  question above.
+
+## 3. Hardware-counter confirmation (perf)
+
+Sampling shows *where*; `perf stat` confirms the *mechanism* (cross-core coherency = cache-line
+bouncing shows up as last-level-cache / coherency misses that scale with worker count):
+
+```sh
+# Parallel vs sequential, same work — compare LLC + coherency-related counters per page.
+PYTHON_GIL=0 perf stat -e task-clock,context-switches,cache-references,cache-misses,LLC-loads,LLC-load-misses \
+  python benchmarks/profile_render_native.py --pages 1000 --workers 8 --reuse-dir "$SITE"
+PYTHON_GIL=0 perf stat -e task-clock,context-switches,cache-references,cache-misses,LLC-loads,LLC-load-misses \
+  python benchmarks/profile_render_native.py --pages 1000 --sequential --reuse-dir "$SITE"
+
+# Hot functions across all threads (kernel + user), then annotate the top refcount/alloc symbols:
+PYTHON_GIL=0 perf record -g --call-graph dwarf -- \
+  python benchmarks/profile_render_native.py --pages 1000 --workers 8 --reuse-dir "$SITE"
+perf report --stdio | head -80
+```
+
+If parallel shows **super-linear growth in LLC-load-misses / cache-misses per page** vs sequential
+while task-clock inflates ~2.6x, that corroborates coherency traffic (atomic refcount line bouncing)
+as the mechanism — distinct from lock contention (which `perf` would show as context-switches /
+futex time, and which we already ruled out via cpu/wall≈4.3).
+
+## 4. (Optional) Refcount-attribution probe
+
+To attribute refcount churn to *specific* objects without reading native stacks, a CPython
+**debug build** (`--with-pydebug`) exposes `sys.gettotalrefcount()`; sample it around a fixed render
+batch with 1 vs 8 workers and diff. Or instrument the suspected shared roots: wrap the hot Site /
+snapshot / Environment dereferences and count accesses per page per worker. High per-worker access
+counts on a shared object = a coherency hotspot candidate. (This is a fallback; the native profile
+in §2 is the primary evidence.)
+
+## Recording the result
+
+Write the findings back into `plan/rfc-frozen-render-world.md` under "The hard gate: Step 0":
+the named dominant objects, the perf-counter deltas, and which of the three decision branches the
+evidence selects. Attach `render_native.speedscope.json` / `render_native.svg` / `perf report` output
+as artifacts. Only then is the RFC eligible to move from **Hold** to a funded single-step PoC.

--- a/benchmarks/profile_render_native.py
+++ b/benchmarks/profile_render_native.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 import os
 import random
+import re
 import shutil
 import sys
 import tempfile
@@ -41,16 +42,35 @@ from bengal.orchestration.build.options import BuildOptions
 
 
 def _pin_workers(root: Path, workers: int) -> None:
-    """Pin the render worker count via ``[build] max_workers`` (flows to the scheduler)."""
+    """Pin the render worker count via ``[build] max_workers`` so the run is deterministic.
+
+    Idempotent: OVERWRITES any existing ``max_workers`` (so reruns and reused ``--reuse-dir``
+    sites honor the current ``--workers`` instead of silently keeping a stale value), inserts it
+    under an existing ``[build]`` table, or appends a ``[build]`` table if none exists. The value
+    flows to the render scheduler as ``config_override``.
+    """
     toml = root / "bengal.toml"
     text = toml.read_text(encoding="utf-8")
-    if "max_workers" not in text:
-        text = text.replace("[build]\n", f"[build]\nmax_workers = {workers}\n", 1)
-        toml.write_text(text, encoding="utf-8")
+    line = f"max_workers = {workers}"
+    if re.search(r"^[ \t]*max_workers[ \t]*=.*$", text, re.MULTILINE):
+        text = re.sub(r"^[ \t]*max_workers[ \t]*=.*$", line, text, count=1, flags=re.MULTILINE)
+    elif "[build]\n" in text:
+        text = text.replace("[build]\n", f"[build]\n{line}\n", 1)
+    else:
+        text = text.rstrip("\n") + f"\n\n[build]\n{line}\n"
+    toml.write_text(text, encoding="utf-8")
 
 
 def _build_once(root: Path, *, sequential: bool) -> dict:
-    """Run one cold build and return its cpu/wall signature + phase ledger."""
+    """Run one non-incremental (full re-render) build; return its cpu/wall + phase ledger.
+
+    Clears the output dir and forces ``incremental=False`` so every page is re-rendered. NOTE:
+    persistent caches under ``.bengal/`` (e.g. the Kida bytecode cache) are intentionally NOT
+    cleared — so the FIRST build of a freshly generated site is a true cold start, while later
+    ``--runs`` iterations and a reused ``--reuse-dir`` keep those caches warm (usually what you
+    want when profiling steady-state render rather than first-touch bytecode compilation).
+    Profile the iteration that matches your question.
+    """
     site = Site.from_config(root)
     if site.output_dir.exists():
         shutil.rmtree(site.output_dir)
@@ -89,6 +109,10 @@ def main(argv: list[str] | None = None) -> int:
         help="generate/keep the fixture site here and reuse it if present (keeps it out of the profile)",
     )
     args = parser.parse_args(argv)
+    # A profiler that pins worker count must reject the auto-detect escape hatch: max_workers=0
+    # re-enables CPU-based auto-tuning and makes results box-dependent.
+    if not args.sequential and args.workers < 1:
+        parser.error("--workers must be >= 1 (or pass --sequential for the 1-worker baseline)")
 
     gil_enabled = sys._is_gil_enabled() if hasattr(sys, "_is_gil_enabled") else True
     random.seed(42)
@@ -102,8 +126,11 @@ def main(argv: list[str] | None = None) -> int:
         if root.exists() and root == reuse:
             shutil.rmtree(root)
         create_site(args.archetype, args.pages, root)
-        _pin_workers(root, args.workers)
         owned = reuse is None
+    # Pin AFTER root selection so --workers is honored on reused dirs too (not just freshly
+    # generated ones). Skipped for --sequential, where force_sequential overrides max_workers.
+    if not args.sequential:
+        _pin_workers(root, args.workers)
 
     print(
         f"# profile_render_native  archetype={args.archetype} pages={args.pages} "

--- a/benchmarks/profile_render_native.py
+++ b/benchmarks/profile_render_native.py
@@ -1,0 +1,127 @@
+"""Deterministic single-build driver for NATIVE render profiling.
+
+This is the build target for Step 0 of ``plan/rfc-frozen-render-world.md``: run it under a
+native profiler on Linux to name the objects whose refcount / cache-coherency traffic dominates
+the 8-worker render plateau (measured ~1.7-1.8x with cpu/wall ~4.3 → cores busy, not blocked).
+
+macOS arm64 cannot do ``py-spy --native``, so the *profiling* is a Linux gate — but this driver
+runs anywhere and prints the cpu/wall signature, so you can first confirm the plateau reproduces
+on the target box, then attach the profiler. See ``benchmarks/PROFILE_RENDER_NATIVE.md``.
+
+Usage (the build is the whole program, so a profiler wrapping the process captures the render):
+
+    # confirm the plateau on this box (parallel vs sequential cpu/wall)
+    PYTHON_GIL=0 python benchmarks/profile_render_native.py --pages 1000 --workers 8
+    PYTHON_GIL=0 python benchmarks/profile_render_native.py --pages 1000 --sequential
+
+    # reuse a pre-generated site so site-gen time is not profiled
+    PYTHON_GIL=0 python benchmarks/profile_render_native.py --pages 1000 --workers 8 --reuse-dir /tmp/bengal_profile_site
+
+The phase ledger's ``Rendering`` time and the ``cpu/wall`` ratio are printed so the profile is
+self-documenting (a flat profile with cpu/wall>1 and a low-lock signature confirms the coherency
+hypothesis; the native stacks then name the contended objects).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from benchmark_gil_speedup import create_site
+
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+
+
+def _pin_workers(root: Path, workers: int) -> None:
+    """Pin the render worker count via ``[build] max_workers`` (flows to the scheduler)."""
+    toml = root / "bengal.toml"
+    text = toml.read_text(encoding="utf-8")
+    if "max_workers" not in text:
+        text = text.replace("[build]\n", f"[build]\nmax_workers = {workers}\n", 1)
+        toml.write_text(text, encoding="utf-8")
+
+
+def _build_once(root: Path, *, sequential: bool) -> dict:
+    """Run one cold build and return its cpu/wall signature + phase ledger."""
+    site = Site.from_config(root)
+    if site.output_dir.exists():
+        shutil.rmtree(site.output_dir)
+    site.output_dir.mkdir(parents=True)
+    c0 = os.times()
+    t0 = time.perf_counter()
+    stats = site.build(
+        BuildOptions(force_sequential=sequential, incremental=False, verbose=False, quiet=True)
+    )
+    wall = time.perf_counter() - t0
+    c1 = os.times()
+    cpu = (c1.user - c0.user) + (c1.system - c0.system)
+    sd = stats.to_dict() if hasattr(stats, "to_dict") else {}
+    ledger = sd.get("phase_timings_ms") or {}
+    return {
+        "wall": wall,
+        "cpu": cpu,
+        "cpu_per_wall": cpu / wall if wall else 0.0,
+        "pages": int(sd.get("total_pages", 0)),
+        "render_s": float(ledger.get("Rendering", 0)) / 1000.0,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pages", type=int, default=1000)
+    parser.add_argument(
+        "--workers", type=int, default=8, help="render worker count (ignored with --sequential)"
+    )
+    parser.add_argument("--archetype", default="blog", choices=["blog", "docs"])
+    parser.add_argument("--runs", type=int, default=1)
+    parser.add_argument("--sequential", action="store_true", help="baseline: force 1 worker")
+    parser.add_argument(
+        "--reuse-dir",
+        default=None,
+        help="generate/keep the fixture site here and reuse it if present (keeps it out of the profile)",
+    )
+    args = parser.parse_args(argv)
+
+    gil_enabled = sys._is_gil_enabled() if hasattr(sys, "_is_gil_enabled") else True
+    random.seed(42)
+
+    reuse = Path(args.reuse_dir).resolve() if args.reuse_dir else None
+    if reuse is not None and (reuse / "bengal.toml").exists():
+        root = reuse
+        owned = False
+    else:
+        root = reuse or Path(tempfile.mkdtemp(prefix="profile_render_"))
+        if root.exists() and root == reuse:
+            shutil.rmtree(root)
+        create_site(args.archetype, args.pages, root)
+        _pin_workers(root, args.workers)
+        owned = reuse is None
+
+    print(
+        f"# profile_render_native  archetype={args.archetype} pages={args.pages} "
+        f"workers={'1(seq)' if args.sequential else args.workers} "
+        f"PYTHON_GIL={'1' if gil_enabled else '0'} cores={os.cpu_count()} site={root}"
+    )
+    try:
+        for run in range(args.runs):
+            r = _build_once(root, sequential=args.sequential)
+            print(
+                f"run={run} pages={r['pages']} wall={r['wall']:.2f}s cpu={r['cpu']:.2f}s "
+                f"cpu/wall={r['cpu_per_wall']:.2f} render_phase={r['render_s']:.2f}s"
+            )
+    finally:
+        if owned:
+            shutil.rmtree(root, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/changelog.d/render-native-profiling-harness.added.md
+++ b/changelog.d/render-native-profiling-harness.added.md
@@ -1,0 +1,6 @@
+Added `benchmarks/profile_render_native.py` and `benchmarks/PROFILE_RENDER_NATIVE.md` — a
+deterministic single-build driver and runbook for native profiling of the free-threaded render
+plateau (Step 0 gate of `plan/rfc-frozen-render-world.md`). The driver pins worker count, prints
+the cpu/wall signature + render-phase time so the plateau is confirmable on any box, and is meant
+to be wrapped by `py-spy --native` / `perf` on Linux to name the objects whose refcount/coherency
+traffic dominates the 8-worker build. No production code change.


### PR DESCRIPTION
## What

Adds a native render-profiling harness — the **Step 0 gate** of `plan/rfc-frozen-render-world.md`.

- `benchmarks/profile_render_native.py` — a deterministic single-build driver. Pins the render
  worker count (via `[build] max_workers`), runs one cold build, and prints the `cpu/wall`
  signature + render-phase time. The build *is* the whole program, so a profiler wrapping the
  process captures the render. Verified locally to reproduce the plateau (parallel `cpu/wall`≈3,
  render ~2.5x faster than sequential while burning ~2.2x the CPU for identical work).
- `benchmarks/PROFILE_RENDER_NATIVE.md` — the runbook: exact `py-spy --native` / `perf` commands,
  what refcount/coherency signatures to look for, and the Step-0 **decision tree** (Site/snapshot
  graph dominates → migrate; Kida `Environment` dominates → don't; diffuse → don't).

## Why

The render phase plateaus at ~1.7–1.8x on free-threaded 3.14t with `cpu/wall`≈4.3 (cores busy, not
blocked). Cheap microbenchmarks couldn't settle *which* shared objects' refcount/coherency traffic
dominates. The decisive tool is a native profile — and `py-spy --native` is unsupported on macOS
arm64, so this must run on Linux. This harness makes that run turnkey and its interpretation
unambiguous, so the RFC can move from **Hold** to a funded PoC only once the evidence names the
dominant contended objects.

## Scope

Developer tooling + docs only. No production/runtime code path changes.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable — this PR adds profiling tooling and a runbook; it changes no production code path and has no runtime perf impact of its own. (The harness's purpose is to *produce* the evidence for a future RFC decision; sample local signature: parallel `cpu/wall`≈3.08, render 4.81s→1.95s vs sequential at 200 pages.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
