### PR TITLE
perf(render): memoize RuntimePage section path — single-thread render -27% (#307)

### DIFF
--- a/bengal/core/page/runtime.py
+++ b/bengal/core/page/runtime.py
@@ -90,6 +90,8 @@ class RuntimePage:
     _init_lock: threading.RLock = field(default_factory=threading.RLock, init=False, repr=False)
     _metadata_view_cache: CascadeView | None = field(default=None, init=False, repr=False)
     _metadata_view_cache_key: tuple[int, str] | None = field(default=None, init=False, repr=False)
+    _section_path_rel_cache: str | None = field(default=None, init=False, repr=False)
+    _section_path_rel_site: int | None = field(default=None, init=False, repr=False)
     _ast_cache: list[ASTNode] | dict[str, Any] | None = field(default=None, repr=False, init=False)
     _html_cache: str | None = field(default=None, repr=False, init=False)
     _plain_text_cache: str | None = field(default=None, repr=False, init=False)
@@ -159,13 +161,7 @@ class RuntimePage:
         if cascade is None or not isinstance(cascade, CascadeSnapshot):
             return self._raw_metadata
 
-        section_path = ""
-        if self._section_path:
-            try:
-                content_dir = self._site.root_path / "content"
-                section_path = str(self._section_path.relative_to(content_dir))
-            except ValueError, AttributeError:
-                section_path = str(self._section_path)
+        section_path = self._relative_section_path()
 
         cache_key = (id(cascade), section_path)
         if self._metadata_view_cache is not None and self._metadata_view_cache_key == cache_key:
@@ -182,6 +178,29 @@ class RuntimePage:
             self._metadata_view_cache = view
             self._metadata_view_cache_key = cache_key
         return view
+
+    def _relative_section_path(self) -> str:
+        """Return the section path relative to ``content/``, memoized per site.
+
+        ``metadata`` is read hundreds of times per page during rendering and the
+        result depends only on the (effectively immutable) section path and the
+        site root, so the ``relative_to`` resolution is cached instead of redone
+        on every access. The ``_section`` setter clears this cache when the
+        section path changes (#307).
+        """
+        if self._section_path is None or self._site is None:
+            return ""
+        site_id = id(self._site)
+        if self._section_path_rel_cache is not None and self._section_path_rel_site == site_id:
+            return self._section_path_rel_cache
+        try:
+            content_dir = self._site.root_path / "content"
+            rel = str(self._section_path.relative_to(content_dir))
+        except ValueError, AttributeError:
+            rel = str(self._section_path)
+        self._section_path_rel_cache = rel
+        self._section_path_rel_site = site_id
+        return rel
 
     @property
     def title(self) -> str:
@@ -538,6 +557,7 @@ class RuntimePage:
 
         self._section_obj_cache_key = None
         self._section_obj_cache = None
+        self._section_path_rel_cache = None
 
     @property
     def section_path(self) -> str | None:

--- a/bengal/core/page/runtime.py
+++ b/bengal/core/page/runtime.py
@@ -558,6 +558,7 @@ class RuntimePage:
         self._section_obj_cache_key = None
         self._section_obj_cache = None
         self._section_path_rel_cache = None
+        self._section_path_rel_site = None
 
     @property
     def section_path(self) -> str | None:

--- a/changelog.d/render-metadata-section-path-memo.changed.md
+++ b/changelog.d/render-metadata-section-path-memo.changed.md
@@ -1,0 +1,8 @@
+Per-page rendering is faster: `RuntimePage.metadata` is read hundreds of times per
+page, and each read previously recomputed the section path relative to `content/`
+via `Path.relative_to` before consulting its cache. The relative section path now is
+memoized per site (invalidated when the section changes), eliminating ~265k
+`Path.relative_to`/`pathlib` calls on a 300-page docs build and cutting single-thread
+render time ~27% (13.4 → 9.7 ms/page, median of 5 sequential builds). Output is
+byte-identical (verified by a timestamp-normalized full-tree comparison: HTML trees
+hash-equal before/after).

--- a/tests/unit/core/page/test_runtime_metadata_memo.py
+++ b/tests/unit/core/page/test_runtime_metadata_memo.py
@@ -1,0 +1,86 @@
+"""Regression tests for RuntimePage.metadata section-path memoization (#307).
+
+``metadata`` is read hundreds of times per page during rendering. The relative
+section path it feeds to the cascade is memoized per site so the ``relative_to``
+resolution is not redone on every access. These tests pin that the memo is
+correct (cache hit returns the same cascade-merged value) and is invalidated when
+the page's section changes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from bengal.core.cascade import CascadeSnapshot
+from tests._testing import make_test_page
+
+pytestmark = pytest.mark.parallel_unsafe
+
+
+def _site_with_cascade(root: Path) -> SimpleNamespace:
+    content = root / "content"
+    snapshot = CascadeSnapshot(
+        _data={
+            "docs": {"layout": "doc-layout"},
+            "blog": {"layout": "blog-layout"},
+        },
+        _content_dir=str(content),
+    )
+    return SimpleNamespace(cascade=snapshot, root_path=root)
+
+
+def _section(root: Path, name: str) -> SimpleNamespace:
+    return SimpleNamespace(path=root / "content" / name, name=name, _path=f"/{name}/")
+
+
+def test_metadata_resolves_cascade_for_section() -> None:
+    root = Path("/site")
+    site = _site_with_cascade(root)
+    page = make_test_page(site=site, section=_section(root, "docs"), metadata={"title": "T"})
+
+    # Cascade value for the "docs" section is surfaced through metadata.
+    assert page.metadata.get("layout") == "doc-layout"
+
+
+def test_section_path_is_memoized_after_first_access() -> None:
+    root = Path("/site")
+    site = _site_with_cascade(root)
+    page = make_test_page(site=site, section=_section(root, "docs"), metadata={"title": "T"})
+
+    assert page._section_path_rel_cache is None
+    # First access computes and memoizes the relative section path.
+    assert page.metadata.get("layout") == "doc-layout"
+    assert page._section_path_rel_cache == "docs"
+    assert page._section_path_rel_site == id(site)
+
+    # Repeated access is a cache hit and returns the same resolved value.
+    for _ in range(5):
+        assert page.metadata.get("layout") == "doc-layout"
+    assert page._section_path_rel_cache == "docs"
+
+
+def test_section_change_invalidates_memo_and_reresolves() -> None:
+    root = Path("/site")
+    site = _site_with_cascade(root)
+    page = make_test_page(site=site, section=_section(root, "docs"), metadata={"title": "T"})
+
+    assert page.metadata.get("layout") == "doc-layout"
+    assert page._section_path_rel_cache == "docs"
+
+    # Reassigning the section must clear the memo so the cascade re-resolves.
+    page._section = _section(root, "blog")
+    assert page._section_path_rel_cache is None
+    assert page.metadata.get("layout") == "blog-layout"
+    assert page._section_path_rel_cache == "blog"
+
+
+def test_no_section_returns_empty_relative_path() -> None:
+    root = Path("/site")
+    site = _site_with_cascade(root)
+    page = make_test_page(site=site, metadata={"title": "T"})
+
+    # With no section path, the helper returns "" and never calls relative_to.
+    assert page._relative_section_path() == ""


### PR DESCRIPTION
## Summary

Saga 1 of the performance epic (#306, #307): make per-page render work cheaper on a single thread — the most reliable lever, not gated on free-threading, and compounding with any parallel speedup.

A single-threaded cProfile of a 300-page `docs` build showed the dominant self-time cost was **`RuntimePage.metadata` recomputing the section path on every access**. `metadata` is read hundreds of times per page (title, nav_title, weight, template lookups, every `page.metadata` access in templates), and before consulting its cascade-view cache it called `Path.relative_to(content_dir)` — allocating a fresh `content_dir` Path each time. That was ~265k `Path.relative_to` calls and ~1M pathlib object constructions on the 300-page build.

The relative section path depends only on the (effectively immutable) section path and the site root, so it is now **memoized per site**, and invalidated by the `_section` setter when the section changes. One surgical change, no behavior change.

The next-largest single-thread cost is `inspect.signature` inside kida's per-page macro wrapping (`kida/template/render_helpers.py`) — an external dependency, noted for a future upstream fix; and per-build file I/O. Those are out of scope here.

Resolves #307 (Saga 1). Part of epic #306.

## Proof

- [x] Focused tests: `uv run pytest tests/unit/core/page/test_runtime_metadata_memo.py -n0 -q` → 4 passed (cascade resolution, memo cache hit, invalidation on section change, empty-section path).
- [x] Domain gates: `uv run ruff check` + `ruff format --check` clean; `uv run ty check bengal/` = 531 diagnostics (floor unchanged — the new helper guards `_site is None`, no new suppressions); 482 metadata/cascade/section/url unit tests pass.
- [x] Full unit suite (`uv run poe proof-pr`): 10291 passed. Two failures under random-order + xdist (`tests/unit/rendering/test_view_transitions.py::...test_meta_tag_present_when_enabled`, `tests/unit/server/test_live_reload.py::...test_serve_asset_from_file_and_cache`) are **pre-existing cross-module order-dependent flakes** — both pass in isolation and pass when their modules run alone on pristine `main` (76 passed); this change adds only per-instance state (no globals), so it cannot be the leak source. Classified per the clean-proof workflow as an unrelated full-suite blocker.
- [x] Byte parity: a timestamp-normalized full-tree comparison of the build before/after this change hashes the **HTML trees equal**; only JSON sidecar `last_modified` build timestamps differ, and those vary run-to-run regardless of this change.

## Performance Evidence

- Benchmark matrix row: docs archetype, 300 pages, single-thread (force_sequential), median of 5 sequential builds
- Command: build the `benchmark_gil_speedup` `docs` site (seed 1234) with parallel=false and read `BuildStats.rendering_time_ms` (harness in PR thread)
- Python build: CPython 3.14.2 free-threaded (3.14.2t)
- Machine/OS: macOS (Darwin 25.3.0), dev machine, idle
- Baseline commit or saved result: origin/main 432083ae5 — render 13.43 ms/page (4041 ms / 301 pages)
- Current commit or saved result: this branch — render 9.73 ms/page (2928 ms / 301 pages)
- Artifact path: not applicable
- Interpretation: -27.5% single-thread render time per page from one targeted memoization; cProfile confirms ~265k Path.relative_to calls eliminated; HTML output byte-identical

## Steward Notes

- Touches `bengal/core/page/runtime.py` (RuntimePage, a Page compatibility surface). Pure caching of a derived value with explicit invalidation; no parser/template/URL logic added to core, no new mutable shared state, no new mixin. Adds a focused regression test under `tests/unit/core/page/`.
