### PR TITLE
fix(incremental): preserve asset manifest on content-only rebuilds (#130)

### DIFF
--- a/bengal/orchestration/asset.py
+++ b/bengal/orchestration/asset.py
@@ -220,8 +220,27 @@ class AssetOrchestrator:
             logger.warning("asset_pipeline_failed", error=str(e))
 
         if not assets:
-            self._write_asset_manifest([])
-            logger.info("asset_processing_skipped", reason="no_assets")
+            # Nothing to process this run (e.g. a content-only incremental build).
+            # The asset phase therefore leaves the output tree unchanged, so the
+            # existing manifest still accurately describes it — preserve it.
+            # Overwriting it with an empty manifest would make
+            # ``inspect_asset_outputs`` report a vacuously "complete" tree (a
+            # present manifest with zero entries → zero missing), blinding the
+            # incremental reprocess safety net on later builds and letting missing
+            # CSS/JS go unrecovered until a full rebuild (#130). When the output
+            # genuinely lost files, the integrity check fires *before* this and
+            # makes ``assets`` non-empty, so the manifest is rebuilt there instead.
+            manifest_path = self.site.output_dir / "asset-manifest.json"
+            if AssetManifest.load(manifest_path) is None:
+                # No prior manifest to preserve — write the empty baseline.
+                self._write_asset_manifest([])
+                logger.info("asset_processing_skipped", reason="no_assets")
+            else:
+                logger.info(
+                    "asset_processing_skipped",
+                    reason="no_assets",
+                    manifest="preserved_existing",
+                )
             return
 
         start_time = time.time()

--- a/changelog.d/incremental-asset-manifest-preserved.fixed.md
+++ b/changelog.d/incremental-asset-manifest-preserved.fixed.md
@@ -1,0 +1,11 @@
+Incremental builds no longer corrupt the asset manifest. When a build had no
+assets to process (e.g. a content-only edit during `bengal serve`), the asset
+phase overwrote `asset-manifest.json` with an empty manifest. A present-but-empty
+manifest makes the output-integrity check (`inspect_asset_outputs`) report a
+vacuously "complete" asset tree (manifest present, zero entries, zero missing),
+which blinded the incremental reprocess safety net on later builds — so if a CSS
+or JS output went missing it was never regenerated until a full rebuild
+(restart). The asset phase now preserves the existing manifest when there is
+nothing to reprocess (the output tree is unchanged, so the manifest is still
+accurate); the empty baseline is only written when no prior manifest exists.
+Adds theme-provided-CSS hot-reload regression coverage. (#130)

--- a/tests/integration/test_css_hot_reload.py
+++ b/tests/integration/test_css_hot_reload.py
@@ -537,3 +537,133 @@ Content modified after CSS directory was cleaned.
             "CSS should be regenerated when output was cleaned. "
             "This tests the provenance filter's CSS entry check."
         )
+
+
+class TestCSSHotReloadThemeProvidedCSS:
+    """Hot-reload CSS coverage for the dogfood case: CSS comes from the *theme*.
+
+    The other tests in this module put a ``style.css`` in the site's own
+    ``assets/css/`` (in-root). The real dogfood site (and most users) have no
+    own CSS — the entry point is the bundled theme's ``style.css``, which lives
+    inside the installed package, *outside* the site root.
+
+    That distinction matters for Issue #130: the incremental asset-discovery
+    cache keys discovered assets by ``source_path.relative_to(root_path)``, so
+    theme assets (outside root) are handled on a different path than in-root
+    assets. These tests assert the theme CSS survives and recovers across
+    content-only incremental rebuilds.
+    """
+
+    @pytest.fixture
+    def theme_site(self, tmp_path: Path) -> Path:
+        """A site that uses the default theme and has NO own CSS."""
+        site_root = tmp_path / "theme_site"
+        site_root.mkdir()
+        (site_root / "bengal.toml").write_text(
+            """
+title = "Theme CSS Hot Reload"
+baseurl = "https://example.com"
+
+[build]
+theme = "default"
+parallel = false
+minify_assets = false
+optimize_assets = false
+fingerprint_assets = false
+incremental = true
+"""
+        )
+        content_dir = site_root / "content"
+        content_dir.mkdir()
+        (content_dir / "index.md").write_text("---\ntitle: Home\n---\n\n# Home\n\nHello.\n")
+        (content_dir / "about.md").write_text("---\ntitle: About\n---\n\n# About\n\nAbout.\n")
+        return site_root
+
+    @staticmethod
+    def _theme_css(output_dir: Path) -> list[Path]:
+        css_dir = output_dir / "assets" / "css"
+        return list(css_dir.glob("style*.css")) if css_dir.exists() else []
+
+    @staticmethod
+    def _manifest_entry_count(output_dir: Path) -> int:
+        import json
+
+        manifest = output_dir / "asset-manifest.json"
+        if not manifest.exists():
+            return 0
+        data = json.loads(manifest.read_text())
+        entries = data.get("entries", data) if isinstance(data, dict) else data
+        return len(entries)
+
+    def test_theme_css_survives_content_only_incremental(self, theme_site: Path) -> None:
+        """Theme CSS and the asset manifest survive a content-only incremental.
+
+        Regression guard for Issue #130: a content-only edit must not drop the
+        theme's ``style.css`` from the output, nor empty the asset manifest
+        (an empty manifest would make the output-integrity check vacuously
+        "complete" and blind the reprocess safety net on later rebuilds).
+        """
+        about_file = theme_site / "content" / "about.md"
+
+        site1 = Site.from_config(theme_site)
+        output_dir = site1.output_dir
+        site1.build(BuildOptions(force_sequential=True, incremental=False))
+
+        assert self._theme_css(output_dir), "full build should emit the theme style.css"
+        entries_full = self._manifest_entry_count(output_dir)
+        assert entries_full >= 1, "full build should record asset-manifest entries"
+
+        # Content-only edit (no CSS touched).
+        about_file.write_text("---\ntitle: About\n---\n\n# About (edited)\n\nEdited.\n")
+        site2 = Site.from_config(theme_site)
+        site2.build(
+            BuildOptions(
+                force_sequential=True,
+                incremental=True,
+                changed_sources={about_file},
+            )
+        )
+
+        assert self._theme_css(output_dir), (
+            "theme style.css must survive a content-only incremental build (Issue #130)"
+        )
+        assert self._manifest_entry_count(output_dir) == entries_full, (
+            "content-only incremental must not empty/shrink the asset manifest (Issue #130)"
+        )
+
+    def test_theme_css_recovered_when_output_cleaned(self, theme_site: Path) -> None:
+        """If the theme CSS goes missing from output, an incremental recovers it.
+
+        This is the dogfood form of Issue #130's "fixed by restart" symptom:
+        when the served output loses ``style.css``, the next incremental build
+        must detect the gap (via the asset-manifest output-integrity check) and
+        regenerate it, rather than serving an unstyled page until a full rebuild.
+        """
+        about_file = theme_site / "content" / "about.md"
+
+        site1 = Site.from_config(theme_site)
+        output_dir = site1.output_dir
+        site1.build(BuildOptions(force_sequential=True, incremental=False))
+
+        css_v1 = self._theme_css(output_dir)
+        assert css_v1, "full build should emit the theme style.css"
+
+        # Simulate the served output losing its CSS.
+        for css in css_v1:
+            css.unlink()
+        assert not self._theme_css(output_dir)
+
+        # Content-only incremental should detect the missing CSS and regenerate.
+        about_file.write_text("---\ntitle: About\n---\n\n# About (edited)\n\nEdited.\n")
+        site2 = Site.from_config(theme_site)
+        site2.build(
+            BuildOptions(
+                force_sequential=True,
+                incremental=True,
+                changed_sources={about_file},
+            )
+        )
+
+        assert self._theme_css(output_dir), (
+            "theme style.css must be regenerated when missing from output (Issue #130)"
+        )

--- a/tests/integration/test_css_hot_reload.py
+++ b/tests/integration/test_css_hot_reload.py
@@ -586,14 +586,22 @@ incremental = true
 
     @staticmethod
     def _manifest_entry_count(output_dir: Path) -> int:
+        """Count the asset entries recorded in ``asset-manifest.json``.
+
+        The manifest schema is ``{"version", "generated_at", "assets": {...}}``;
+        the tracked assets live under the ``assets`` key, so we count that mapping
+        (not the top-level keys, which would be a constant 3 and make the
+        "manifest not emptied" assertion vacuous).
+        """
         import json
 
         manifest = output_dir / "asset-manifest.json"
         if not manifest.exists():
             return 0
         data = json.loads(manifest.read_text())
-        entries = data.get("entries", data) if isinstance(data, dict) else data
-        return len(entries)
+        if not isinstance(data, dict):
+            return 0
+        return len(data.get("assets", {}))
 
     def test_theme_css_survives_content_only_incremental(self, theme_site: Path) -> None:
         """Theme CSS and the asset manifest survive a content-only incremental.


### PR DESCRIPTION
## Summary

Fixes **#130** ("CSS styling breaks during hot reload") — and the investigation behind it.

**Root cause (confirmed).** On a content-only incremental build (the reported scenario: editing markdown during `bengal serve`), the asset phase has nothing to reprocess and called `AssetOrchestrator.process([])`, which **overwrote `asset-manifest.json` with an empty manifest** — a 300-page docs site went from 212 asset entries to 0. An empty-but-present manifest makes the output-integrity check `inspect_asset_outputs` report a **vacuously "complete"** asset tree (manifest present, zero entries, zero missing), which **blinds the incremental reprocess safety net** on later builds: once a CSS/JS output goes missing it is never regenerated until a full rebuild — exactly the "fixed by restart" symptom in the report.

**Fix.** When there are no assets to reprocess, the asset phase leaves the output tree unchanged, so the existing manifest still describes it accurately — **preserve it**. The empty baseline is written only when no prior manifest exists. When output genuinely lost files, the output-integrity check fires *before* the asset phase and makes the asset list non-empty, so the manifest is rebuilt there instead.

**How this was found (credit to the Copilot review).** I first added regression coverage for the theme-provided-CSS case (the dogfood gap — existing tests only used in-root CSS) and concluded the build path was robust. The reviewer flagged that my `_manifest_entry_count` helper counted the manifest's top-level JSON keys (constant 3) instead of the asset entries under the `assets` key. Correcting it turned the "manifest preserved" assertion from vacuous to real — and it **failed (212 → 0)**, exposing the actual bug. The helper fix + the asset-phase fix are both in this PR.

**Note on what was deliberately *not* changed:** the asset-discovery-skip cache (`discovered_assets`) drops theme assets (they're outside the site root), which leaves it empty for theme-only sites and disables that skip path entirely. Populating it would *enable* a reconstruct-from-cache path that is riskier for CSS correctness, so it's left as-is (a minor incremental perf gap, not a correctness bug). A separate, lower-severity issue remains: a *partial* asset incremental (editing one CSS file) still rebuilds the manifest from only the changed assets — worth a follow-up, but not the reported #130 scenario.

Closes #130.

## Proof

- [x] Focused tests: `tests/integration/test_css_hot_reload.py` → 8 passed (incl. 2 new theme-provided-CSS tests that now meaningfully assert the manifest is not emptied and missing theme CSS is recovered).
- [x] Regression suites: 439 unit asset/manifest tests passed; 229 integration + server incremental/asset/hot-reload/buffer tests passed (1 skipped); `ty check bengal/` = 531 (unchanged); ruff/format/pre-commit clean.
- [x] Docs/examples/changelog updated: `changelog.d/incremental-asset-manifest-preserved.fixed.md`.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

## Steward Notes

- Touches `bengal/orchestration/asset.py` (incremental asset path) + a test + a changelog fragment. The fix is conservative: it only changes the no-assets-to-process branch, which a full build never takes (a full build always has assets), so full-build manifest behavior is unchanged. Followed the verify-before-refactoring discipline throughout — the confirmed bug, not the original static hypothesis, drove the fix.
