### PR TITLE
fix(incremental): merge asset manifest on partial asset rebuilds (#314)

### DIFF
--- a/bengal/assets/manifest.py
+++ b/bengal/assets/manifest.py
@@ -248,6 +248,20 @@ class AssetManifest:
             provenance=provenance,
         )
 
+    def add_entry(self, entry: AssetManifestEntry) -> None:
+        """
+        Insert a fully-formed entry as-is, keyed by its logical path.
+
+        Unlike :meth:`set_entry`, this preserves the entry's existing metadata
+        (output path, fingerprint, size, timestamp, provenance) without
+        re-deriving it. Used by incremental builds to carry forward prior
+        manifest entries for assets that were not reprocessed this run.
+
+        Args:
+            entry: A previously-built manifest entry to retain verbatim.
+        """
+        self._entries[to_posix(entry.logical_path)] = entry
+
     def get(self, logical_path: str) -> AssetManifestEntry | None:
         """
         Retrieve the entry for a logical path.

--- a/bengal/orchestration/asset.py
+++ b/bengal/orchestration/asset.py
@@ -833,8 +833,38 @@ class AssetOrchestrator:
     def _write_asset_manifest(self, assets: list[Asset]) -> None:
         """
         Persist an asset-manifest.json file mapping logical assets to final outputs.
+
+        On an **incremental** build, ``assets`` holds only the subset reprocessed
+        this run. Rebuilding the manifest from just that subset would drop every
+        unchanged entry, shrinking the manifest and making ``inspect_asset_outputs``
+        report a vacuously "complete" tree — which blinds the incremental reprocess
+        safety net on later builds (#130 / #314). So for incremental builds we
+        *merge*: carry forward prior entries whose output file still exists, then
+        overlay this run's freshly-processed assets below (current entries win on a
+        logical-path collision). Full builds process the complete asset set, so they
+        rebuild from scratch — orphan-free, matching prior full-build semantics.
         """
+        manifest_path = self.site.output_dir / "asset-manifest.json"
         manifest = AssetManifest()
+
+        build_state = self.site.build_state
+        if build_state is not None and build_state.incremental:
+            prior = AssetManifest.load(manifest_path)
+            if prior is not None:
+                for entry in prior.entries.values():
+                    output_abs = self.site.output_dir / entry.output_path
+                    try:
+                        output_exists = output_abs.exists()
+                    except OSError:
+                        output_exists = False
+                    # Only retain entries whose output is still on disk. A deleted
+                    # asset whose output was cleaned drops out here; one whose
+                    # output lingers is retained but still accurately describes a
+                    # real file (harmless to the integrity check; the next full
+                    # build prunes it).
+                    if output_exists:
+                        manifest.add_entry(entry)
+
         for asset in assets:
             final_path = getattr(asset, "output_path", None)
             if not isinstance(final_path, Path):
@@ -863,6 +893,5 @@ class AssetOrchestrator:
                 provenance=asset.manifest_provenance,
             )
 
-        manifest_path = self.site.output_dir / "asset-manifest.json"
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
         manifest.write(manifest_path)

--- a/changelog.d/incremental-asset-manifest-partial-merge.fixed.md
+++ b/changelog.d/incremental-asset-manifest-partial-merge.fixed.md
@@ -1,0 +1,11 @@
+Incremental builds no longer shrink the asset manifest when only some assets are
+reprocessed. `_write_asset_manifest` rebuilt `asset-manifest.json` from just the
+assets processed that run, so editing a single asset (a *partial* asset
+incremental) dropped every unchanged entry — leaving a manifest with one entry.
+That re-introduced the #130 failure class: a small-but-complete manifest makes
+`inspect_asset_outputs` report a vacuously "complete" tree, blinding the
+incremental reprocess safety net so a later missing CSS/JS output goes
+unrecovered until a full rebuild. Incremental builds now *merge* — prior entries
+whose output file still exists are carried forward, then the run's freshly
+processed assets are overlaid (current entries win). Full builds still rebuild
+from scratch, so they stay orphan-free. (#314)

--- a/tests/integration/test_asset_manifest_incremental_merge.py
+++ b/tests/integration/test_asset_manifest_incremental_merge.py
@@ -1,0 +1,174 @@
+"""
+Regression tests for asset-manifest preservation on *partial* incremental builds.
+
+GitHub Issue: #314 - Incremental asset manifest shrinks on partial asset rebuilds
+(follow-on to #130).
+
+#313 fixed the *content-only* case where ``AssetOrchestrator.process([])`` wiped
+``asset-manifest.json`` to an empty manifest. But ``_write_asset_manifest`` still
+rebuilt the manifest from **only the assets reprocessed this run**, so editing a
+single asset (a *partial* incremental) rebuilt the manifest with just that one
+entry and dropped every unchanged entry.
+
+A shrunk manifest re-introduces the #130 failure class: ``inspect_asset_outputs``
+reports a vacuously "complete" tree (few entries, all present, zero missing),
+blinding the incremental reprocess safety net — a missing CSS/JS output then goes
+unrecovered until a full rebuild.
+
+The fix merges instead of rebuilding on incremental builds: prior entries whose
+output file still exists are carried forward, then this run's freshly-processed
+assets are overlaid. Full builds still rebuild from scratch (orphan-free).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _manifest(output_dir: Path) -> dict[str, dict]:
+    """Return the ``assets`` mapping of ``asset-manifest.json`` (empty if absent)."""
+    manifest = output_dir / "asset-manifest.json"
+    if not manifest.exists():
+        return {}
+    data = json.loads(manifest.read_text())
+    return data.get("assets", {}) if isinstance(data, dict) else {}
+
+
+class TestAssetManifestPartialIncrementalMerge:
+    """Editing one asset must not drop the manifest's other entries (#314)."""
+
+    @pytest.fixture
+    def site_with_standalone_assets(self, tmp_path: Path) -> Path:
+        """A default-theme site with several own *standalone* (non-bundled) assets.
+
+        Standalone image assets are fingerprinted and copied individually, so
+        editing one yields a true *partial* asset incremental (``process()`` runs
+        on a single-asset subset) rather than a re-bundle or a forced full
+        reprocess — which is exactly the path #314 regresses.
+        """
+        site_root = tmp_path / "site"
+        site_root.mkdir()
+        (site_root / "bengal.toml").write_text(
+            """
+[site]
+title = "Asset Manifest Merge"
+
+[build]
+incremental = true
+
+[assets]
+fingerprint = true
+minify = false
+"""
+        )
+        content = site_root / "content"
+        content.mkdir()
+        (content / "index.md").write_text("---\ntitle: Home\n---\n\n# Home\n")
+
+        img_dir = site_root / "assets" / "img"
+        img_dir.mkdir(parents=True)
+        for name in ("alpha", "beta", "gamma"):
+            (img_dir / f"{name}.svg").write_text(
+                f'<svg xmlns="http://www.w3.org/2000/svg" id="{name}"><rect/></svg>\n'
+            )
+        return site_root
+
+    def test_partial_asset_incremental_preserves_full_manifest(
+        self, site_with_standalone_assets: Path
+    ) -> None:
+        """Editing one asset keeps the manifest complete and refreshes only that entry."""
+        site_root = site_with_standalone_assets
+        alpha = site_root / "assets" / "img" / "alpha.svg"
+
+        # Build 1: full build.
+        site1 = Site.from_config(site_root)
+        output_dir = site1.output_dir
+        site1.build(BuildOptions(force_sequential=True, incremental=False))
+
+        full = _manifest(output_dir)
+        # Sanity: the three own assets plus theme assets are all recorded.
+        assert {"img/alpha.svg", "img/beta.svg", "img/gamma.svg"} <= set(full), (
+            "full build should record all standalone asset entries"
+        )
+        assert len(full) > 3, "full build should also record the theme's assets"
+        alpha_fp_v1 = full["img/alpha.svg"]["fingerprint"]
+        beta_entry_v1 = full["img/beta.svg"]
+
+        # Edit ONLY alpha.svg -> a true partial asset incremental.
+        alpha.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg" id="alpha2"><rect width="9"/></svg>\n'
+        )
+        site2 = Site.from_config(site_root)
+        site2.build(
+            BuildOptions(
+                force_sequential=True,
+                incremental=True,
+                changed_sources={alpha},
+            )
+        )
+
+        partial = _manifest(output_dir)
+
+        # Core #314 guard: the manifest must NOT shrink to just the reprocessed asset.
+        assert len(partial) == len(full), (
+            "partial asset incremental must preserve every manifest entry, not "
+            f"shrink to the reprocessed subset (had {len(full)}, got {len(partial)}). "
+            "A shrunk manifest re-introduces the #130 vacuous-complete blindness."
+        )
+
+        # Unchanged asset entry is carried forward verbatim.
+        assert partial.get("img/beta.svg") == beta_entry_v1, (
+            "an unchanged asset's manifest entry must be carried forward unchanged"
+        )
+
+        # Edited asset entry is refreshed (new fingerprint, output present).
+        assert "img/alpha.svg" in partial, "edited asset must remain in the manifest"
+        alpha_fp_v2 = partial["img/alpha.svg"]["fingerprint"]
+        assert alpha_fp_v2 != alpha_fp_v1, (
+            "edited asset's manifest entry must be refreshed with its new fingerprint"
+        )
+        assert (output_dir / partial["img/alpha.svg"]["output_path"]).exists(), (
+            "edited asset's new fingerprinted output must exist on disk"
+        )
+
+    def test_full_rebuild_after_incremental_is_orphan_free(
+        self, site_with_standalone_assets: Path
+    ) -> None:
+        """A full rebuild rebuilds from scratch — same entry set as the first full build.
+
+        Guards that the incremental merge does not leak orphan entries into the
+        full-build path (the merge is gated to incremental builds only).
+        """
+        site_root = site_with_standalone_assets
+        alpha = site_root / "assets" / "img" / "alpha.svg"
+
+        site1 = Site.from_config(site_root)
+        output_dir = site1.output_dir
+        site1.build(BuildOptions(force_sequential=True, incremental=False))
+        full_v1 = set(_manifest(output_dir))
+
+        # Partial incremental (merges/carries forward).
+        alpha.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg" id="a2"><rect width="3"/></svg>\n'
+        )
+        site2 = Site.from_config(site_root)
+        site2.build(BuildOptions(force_sequential=True, incremental=True, changed_sources={alpha}))
+
+        # A subsequent full build rebuilds from scratch.
+        site3 = Site.from_config(site_root)
+        site3.build(BuildOptions(force_sequential=True, incremental=False))
+        full_v2 = set(_manifest(output_dir))
+
+        assert full_v2 == full_v1, (
+            "full rebuild after an incremental must yield the same manifest entry set "
+            "(the merge is incremental-only and must not leak orphans into full builds)"
+        )

--- a/tests/unit/orchestration/test_asset_manifest_merge.py
+++ b/tests/unit/orchestration/test_asset_manifest_merge.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for the incremental asset-manifest merge in ``_write_asset_manifest`` (#314).
+
+These exercise the merge/carry-forward/prune logic directly, without a full build,
+so they isolate the three behaviors independently of the asset-output-integrity
+safety net (which, in an end-to-end build, would force a full reprocess and mask
+the prune branch):
+
+1. Incremental builds carry forward prior entries whose output still exists.
+2. Prior entries whose output file is gone are pruned (the output-exists filter).
+3. The reprocessed asset's entry is overlaid (current wins on a logical collision).
+4. Full (non-incremental) builds ignore the prior manifest and rebuild from scratch.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from bengal.assets.manifest import AssetManifest
+from bengal.core.asset import Asset
+from bengal.core.site import Site
+from bengal.orchestration.asset import AssetOrchestrator
+from bengal.orchestration.build_state import BuildState
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _site(tmp_path: Path) -> Site:
+    root = tmp_path / "site"
+    root.mkdir()
+    (root / "bengal.toml").write_text('[site]\ntitle = "Merge Unit"\n')
+    (root / "content").mkdir()
+    (root / "content" / "index.md").write_text("---\ntitle: H\n---\n# H\n")
+    return Site.from_config(root)
+
+
+def _write_prior_manifest(output_dir: Path, entries: dict[str, str]) -> None:
+    """Write a prior manifest mapping logical_path -> output_path (relative)."""
+    manifest = AssetManifest()
+    for logical, output in entries.items():
+        manifest.set_entry(
+            logical,
+            output,
+            fingerprint="old",
+            size_bytes=3,
+            updated_at=time.time(),
+        )
+    manifest.write(output_dir / "asset-manifest.json")
+
+
+def _new_asset(output_dir: Path, logical: str, output_rel: str, tmp_path: Path) -> Asset:
+    """A freshly-processed asset whose output file exists on disk."""
+    out_file = output_dir / output_rel
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    out_file.write_text("new")
+    src = tmp_path / "src" / logical
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("src")
+    from pathlib import Path as _P
+
+    return Asset(
+        source_path=src,
+        output_path=out_file,
+        fingerprint="new",
+        logical_path=_P(logical),
+    )
+
+
+def test_incremental_merge_carries_forward_prunes_and_overlays(tmp_path: Path) -> None:
+    site = _site(tmp_path)
+    out = site.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    site.set_build_state(BuildState(incremental=True))
+
+    # Prior manifest: one entry whose output exists, one whose output is gone.
+    (out / "assets").mkdir(parents=True, exist_ok=True)
+    (out / "assets" / "keep.css").write_text("keep")
+    _write_prior_manifest(
+        out,
+        {
+            "css/keep.css": "assets/keep.css",  # output present -> carried forward
+            "css/gone.css": "assets/gone.css",  # output absent -> pruned
+        },
+    )
+
+    orch = AssetOrchestrator(site)
+    new_asset = _new_asset(out, "js/new.js", "assets/new.js", tmp_path)
+    orch._write_asset_manifest([new_asset])
+
+    merged = AssetManifest.load(out / "asset-manifest.json")
+    assert merged is not None
+    entries = merged.entries
+    assert "css/keep.css" in entries, "entry whose output exists must be carried forward"
+    assert "css/gone.css" not in entries, "entry whose output is gone must be pruned"
+    assert "js/new.js" in entries, "the reprocessed asset must be overlaid into the manifest"
+    # Carried-forward entry keeps its prior metadata; overlaid entry is fresh.
+    assert entries["css/keep.css"].fingerprint == "old"
+    assert entries["js/new.js"].fingerprint == "new"
+
+
+def test_incremental_overlay_wins_on_logical_collision(tmp_path: Path) -> None:
+    """A reprocessed asset replaces its own prior entry (refreshed fingerprint)."""
+    site = _site(tmp_path)
+    out = site.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    site.set_build_state(BuildState(incremental=True))
+
+    (out / "assets").mkdir(parents=True, exist_ok=True)
+    (out / "assets" / "app.js").write_text("v1")
+    _write_prior_manifest(out, {"js/app.js": "assets/app.js"})
+
+    orch = AssetOrchestrator(site)
+    reprocessed = _new_asset(out, "js/app.js", "assets/app.js", tmp_path)
+    orch._write_asset_manifest([reprocessed])
+
+    merged = AssetManifest.load(out / "asset-manifest.json")
+    assert merged is not None
+    assert merged.entries["js/app.js"].fingerprint == "new", (
+        "the reprocessed asset's entry must win over the carried-forward prior entry"
+    )
+
+
+def test_full_build_rebuilds_from_scratch_ignoring_prior(tmp_path: Path) -> None:
+    """Non-incremental builds do not carry forward prior entries."""
+    site = _site(tmp_path)
+    out = site.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    site.set_build_state(BuildState(incremental=False))
+
+    (out / "assets").mkdir(parents=True, exist_ok=True)
+    (out / "assets" / "keep.css").write_text("keep")
+    _write_prior_manifest(out, {"css/keep.css": "assets/keep.css"})
+
+    orch = AssetOrchestrator(site)
+    new_asset = _new_asset(out, "js/new.js", "assets/new.js", tmp_path)
+    orch._write_asset_manifest([new_asset])
+
+    merged = AssetManifest.load(out / "asset-manifest.json")
+    assert merged is not None
+    assert set(merged.entries) == {"js/new.js"}, (
+        "a full build rebuilds the manifest from only this run's assets, even though "
+        "the prior entry's output still exists on disk"
+    )


### PR DESCRIPTION
## Summary

Fixes #314. Follow-on to #130 / #313.

#313 fixed the **content-only** incremental case where `AssetOrchestrator.process([])` wiped `asset-manifest.json` to an empty manifest. But `_write_asset_manifest` still rebuilt the manifest from **only the assets reprocessed this run**, so a **partial** asset incremental — editing a single asset while others are unchanged — rebuilt the manifest with just that one entry and dropped every unchanged entry.

A shrunk manifest re-introduces the #130 failure class: `inspect_asset_outputs` reports a vacuously "complete" tree (few entries, all present, zero missing), which blinds the incremental reprocess safety net — a later missing CSS/JS output then goes unrecovered until a full rebuild.

## The fix

Incremental builds now **merge** instead of rebuild (`bengal/orchestration/asset.py::_write_asset_manifest`):

1. Carry forward prior manifest entries whose output file still exists (`AssetManifest.add_entry`).
2. Overlay this run's freshly-processed assets — current entries win on a logical-path collision, so an edited asset's entry is refreshed with its new fingerprint.

The merge is gated on `build_state.incremental`, so **full builds still rebuild from scratch** and stay orphan-free (matching prior full-build semantics).

A deleted asset whose output was cleaned drops out via the output-exists filter; one whose output lingers is retained but still accurately describes a real file on disk (harmless to the integrity check, since the danger is *missing* entries, not present-and-valid ones; the next full build prunes it).

## Verification

- New `tests/integration/test_asset_manifest_incremental_merge.py`, verified to **fail on pre-fix code** (manifest shrinks 215 -> 1) and pass after. Asserts: no shrink, an unchanged asset's entry is carried forward verbatim, the edited asset's entry is refreshed (new fingerprint, output present), and a full rebuild after an incremental yields the same entry set (no orphan leakage).
- New `tests/unit/orchestration/test_asset_manifest_merge.py` exercises the merge/carry-forward/**prune**/overlay logic in `_write_asset_manifest` directly (the prune branch is masked end-to-end by the output-integrity safety net, which regenerates a missing output — verified — so it is tested in isolation here).
- Full asset/manifest/incremental/hot-reload regression suites pass; broad sweep 1611 passed.
- `uv run ty check bengal/` = 531 diagnostics (unchanged floor).
- Reviewed by an adversarial multi-agent pass: no correctness/regression bugs; the test additions above close coverage gaps it surfaced.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Correctness fix, not a performance change. The incremental path now does one extra AssetManifest.load plus an O(entries) output-exists scan in _write_asset_manifest; negligible relative to asset processing and only on incremental builds. No measured perf delta is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
