### PR TITLE
fix(dev-server): sync asset manifest across output buffers (#315)

### DIFF
--- a/bengal/server/buffer_manager.py
+++ b/bengal/server/buffer_manager.py
@@ -106,7 +106,12 @@ class BufferManager:
 
         return staging
 
-    def prepare_delta_staging(self, changed_paths: Iterable[Path | str]) -> Path:
+    def prepare_delta_staging(
+        self,
+        changed_paths: Iterable[Path | str],
+        *,
+        always_sync: Iterable[Path | str] = (),
+    ) -> Path:
         """Bring staging up to date by syncing only known changed outputs.
 
         The inactive buffer is usually a complete snapshot from the previous
@@ -115,6 +120,15 @@ class BufferManager:
         enough to make staging a complete base for the next incremental build.
         If staging is empty or a path cannot be made relative safely, this
         falls back to the full hardlink seed.
+
+        ``always_sync`` lists output paths that must be seeded from the active
+        buffer on *every* delta-staging, regardless of ``changed_paths``. These
+        are infrastructure files (notably ``asset-manifest.json``) whose content
+        describes the *currently served* buffer rather than a stable per-file
+        output: a content-only rebuild never rewrites them, so they would never
+        appear in ``changed_paths`` and would otherwise drift a generation behind
+        across swaps — leaving a buffer serving a stale/divergent manifest (#315).
+        Seeding them from active each time keeps both buffers consistent.
         """
         staging = self.staging_dir
         active = self.active_dir
@@ -164,14 +178,57 @@ class BufferManager:
                 shutil.copy2(src_path, dst_path)
             synced += 1
 
+        forced = self._sync_always(always_sync, active, staging)
+
         logger.debug(
             "staging_delta_seeded",
             files=synced,
             removed=removed,
+            forced=forced,
             active=str(active),
             staging=str(staging),
         )
         return staging
+
+    def _sync_always(
+        self,
+        always_sync: Iterable[Path | str],
+        active: Path,
+        staging: Path,
+    ) -> int:
+        """Unconditionally re-seed infrastructure paths from active into staging.
+
+        Mirrors the per-file hardlink/copy used elsewhere. A path absent from the
+        active buffer is removed from staging so the two stay consistent. Unsafe
+        paths are skipped (they cannot escape the buffer root). Returns the number
+        of files synced for logging.
+        """
+        forced = 0
+        for raw_path in always_sync:
+            rel_path = self._normalize_relative_output_path(Path(raw_path), active)
+            if rel_path is None:
+                # Should not happen for the build's own infrastructure paths, but
+                # log it (rather than silently dropping) so an unexpected unsafe
+                # path surfaces instead of manifesting as a mystery stale manifest.
+                logger.debug(
+                    "staging_always_sync_skipped", reason="unsafe_path", path=str(raw_path)
+                )
+                continue
+            src_path = active / rel_path
+            dst_path = staging / rel_path
+            if not src_path.is_file():
+                if dst_path.is_file():
+                    dst_path.unlink()
+                continue
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            if dst_path.exists():
+                dst_path.unlink()
+            try:
+                os.link(src_path, dst_path)
+            except OSError:
+                shutil.copy2(src_path, dst_path)
+            forced += 1
+        return forced
 
     def swap(self) -> int:
         """Atomically swap staging to active.

--- a/bengal/server/build_trigger.py
+++ b/bengal/server/build_trigger.py
@@ -416,8 +416,14 @@ class BuildTrigger:
             swapped = False
             if self._buffer_manager is not None:
                 if use_incremental and self._last_buffer_delta_paths is not None:
+                    # asset-manifest.json describes the currently-served buffer and is
+                    # not rewritten on content-only rebuilds, so it never lands in the
+                    # delta paths — sync it from active every time so the staging buffer
+                    # (and thus the next active buffer) never serves a stale/divergent
+                    # manifest that blinds the asset output-integrity check (#315).
                     staging = self._buffer_manager.prepare_delta_staging(
-                        self._last_buffer_delta_paths
+                        self._last_buffer_delta_paths,
+                        always_sync=("asset-manifest.json",),
                     )
                 else:
                     staging = self._buffer_manager.prepare_staging()

--- a/changelog.d/dev-server-manifest-buffer-sync.fixed.md
+++ b/changelog.d/dev-server-manifest-buffer-sync.fixed.md
@@ -1,0 +1,14 @@
+The dev server no longer lets `asset-manifest.json` drift between its two output
+buffers. The double buffer seeds the next staging buffer from the active one
+using only the previous build's changed outputs, but the asset manifest describes
+the *currently served* buffer and is never rewritten on a content-only rebuild —
+so it never appeared in the changed-output delta and could fall a generation
+behind. A buffer that became active carrying a stale manifest could omit entries
+for assets it actually held (`asset_url` failing to resolve them) and make
+`inspect_asset_outputs` mis-report completeness — the residual dev-server
+mechanism behind #130's intermittent "unstyled, fixed by restart" symptom that
+the build-API fix (#313) did not cover. `prepare_delta_staging` now takes an
+`always_sync` set and the dev server passes `asset-manifest.json`, so the manifest
+is re-seeded from the active buffer on every rebuild and both buffers stay
+consistent. Adds the first dev-server-realistic buffer/swap/delta integration
+harness. (#315)

--- a/tests/integration/test_dev_server_buffer_manifest.py
+++ b/tests/integration/test_dev_server_buffer_manifest.py
@@ -1,0 +1,199 @@
+"""
+Dev-server-realistic regression test for asset-manifest buffer divergence.
+
+GitHub Issue: #315 - Dev-server hot-reload: asset-manifest can diverge between
+double-buffers under delta-staging (residual #130).
+
+The dev server double-buffers output: the ASGI app serves from the *active*
+buffer while the next build writes to a *staging* buffer, then swaps. To avoid
+re-seeding the whole tree each rebuild, ``BufferManager.prepare_delta_staging``
+seeds staging from active using only the *previous* build's changed outputs.
+
+But ``asset-manifest.json`` is special: its content describes the *currently
+served buffer*, and a content-only rebuild never rewrites it — so it never lands
+in the changed-output delta. Without an explicit sync it drifts a generation
+behind across alternating swaps. When a buffer then becomes active carrying a
+stale manifest, it can be missing entries for assets the buffer actually holds
+(``asset_url`` fails to resolve them) and ``inspect_asset_outputs`` mis-reports
+completeness — the residual mechanism behind #130's intermittent "unstyled,
+fixed by restart" symptom that the build-API fix (#313) did not cover.
+
+There was previously no realistic test for the dev-server buffer/swap/delta
+path (the #130 tests use the build API, not ``BufferManager``). This harness
+drives ``BufferManager.for_dev_server`` + ``prepare_staging`` /
+``prepare_delta_staging`` + warm incremental rebuilds + ``swap()`` over many
+cycles, mirroring ``DevServerBuildTrigger``'s real flow, and asserts that after
+every swap the active buffer's manifest stays consistent with the active
+buffer's files.
+
+Verified to fail before the fix (``always_sync`` omitted): an asset added
+mid-session goes missing from the manifest after content-only swaps that land on
+the buffer that never processed the add.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+from bengal.server.buffer_manager import BufferManager
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# Mirror DevServerBuildTrigger: asset-manifest.json is synced from active on
+# every delta-staging so a swapped-in buffer never serves a stale manifest.
+_ALWAYS_SYNC = ("asset-manifest.json",)
+
+
+def _buffer_delta_paths(
+    changed_outputs: Iterable[object], active_root: Path
+) -> tuple[Path, ...] | None:
+    """Normalize an OutputCollector's records to relative output paths.
+
+    Faithfully mirrors ``DevServerBuildTrigger._buffer_delta_paths`` — including its
+    error semantics: an unresolvable or escaping path returns ``None`` (not a
+    partial tuple), which signals ``prepare_delta_staging`` to fall back to a full
+    seed. Matching this is what lets the harness exercise the real fallback path
+    rather than masking it.
+    """
+    paths: list[Path] = []
+    seen: set[Path] = set()
+    for rec in changed_outputs:
+        raw = Path(str(getattr(rec, "path", "")))
+        if raw == Path("."):
+            continue
+        if raw.is_absolute():
+            try:
+                raw = raw.resolve().relative_to(active_root.resolve())
+            except OSError, ValueError:
+                return None
+        if any(part == ".." for part in raw.parts):
+            return None
+        if raw not in seen:
+            seen.add(raw)
+            paths.append(raw)
+    return tuple(paths)
+
+
+def _active_manifest_assets(active_dir: Path) -> dict[str, dict]:
+    manifest = active_dir / "asset-manifest.json"
+    if not manifest.exists():
+        return {}
+    data = json.loads(manifest.read_text())
+    return data.get("assets", {}) if isinstance(data, dict) else {}
+
+
+class TestDevServerBufferManifest:
+    """The active buffer must never serve a stale/divergent asset manifest (#315)."""
+
+    @pytest.fixture
+    def site_root(self, tmp_path: Path) -> Path:
+        """A site with its own JS asset, configured like the dev server (no fingerprint)."""
+        root = tmp_path / "site"
+        root.mkdir()
+        # fingerprint disabled mirrors the dev server (_prepare_dev_config), which
+        # serves stable filenames for hot reload.
+        (root / "bengal.toml").write_text(
+            """
+[site]
+title = "Dev Buffer Manifest"
+
+[build]
+incremental = true
+
+[assets]
+fingerprint = false
+minify = false
+"""
+        )
+        content = root / "content"
+        content.mkdir()
+        (content / "index.md").write_text("---\ntitle: Home\n---\n\n# Home\n")
+        js_dir = root / "assets" / "js"
+        js_dir.mkdir(parents=True)
+        (js_dir / "app.js").write_text("console.log('app');\n")
+        return root
+
+    def test_manifest_stays_consistent_across_buffer_swaps(self, site_root: Path) -> None:
+        """Across many content + asset rebuilds, the active manifest tracks the buffer.
+
+        Adding an asset mid-session and then making content-only edits forces the
+        swaps to alternate buffers, one of which never processed the asset add.
+        Without the manifest sync, that buffer becomes active carrying a manifest
+        that omits the added asset; with the sync, every swap leaves a manifest
+        that lists every site asset and points only to files present in the buffer.
+        """
+        content = site_root / "content" / "index.md"
+        extra_js = site_root / "assets" / "js" / "extra.js"
+
+        staging_dir = site_root / ".bengal" / "staging"
+        out_dir = site_root / "public"
+        mgr = BufferManager.for_dev_server(output_dir=out_dir, staging_dir=staging_dir)
+        mgr.setup()
+
+        site = Site.from_config(site_root)
+        site.dev_mode = True
+
+        # Initial full build writes to the active buffer (dev-server startup).
+        site.output_dir = mgr.active_dir
+        site.build(BuildOptions(force_sequential=True, incremental=False))
+
+        expected_assets = {"js/app.js"}
+        last_delta: tuple[Path, ...] | None = None
+
+        def rebuild(changed: list[Path]) -> None:
+            nonlocal last_delta
+            if last_delta is not None:
+                staging = mgr.prepare_delta_staging(last_delta, always_sync=_ALWAYS_SYNC)
+            else:
+                staging = mgr.prepare_staging()
+            site.output_dir = staging
+            stats = site.build(
+                BuildOptions(
+                    force_sequential=True,
+                    incremental=True,
+                    changed_sources=set(changed),
+                )
+            )
+            mgr.swap()
+            site.output_dir = mgr.active_dir
+            last_delta = _buffer_delta_paths(getattr(stats, "changed_outputs", []), mgr.active_dir)
+
+            assets = _active_manifest_assets(mgr.active_dir)
+            # The active buffer's manifest must list every current site asset...
+            missing = expected_assets - set(assets)
+            assert not missing, (
+                f"gen {mgr.generation}: active buffer serving a divergent manifest "
+                f"missing {sorted(missing)} (asset_url would fail to resolve them and "
+                "the output-integrity check would mis-report completeness — #315)"
+            )
+            # ...and every entry must point to a file present in the active buffer.
+            for logical, entry in assets.items():
+                output = mgr.active_dir / entry["output_path"]
+                assert output.exists(), (
+                    f"gen {mgr.generation}: manifest entry {logical!r} points to "
+                    f"{entry['output_path']} which is missing from the active buffer"
+                )
+
+        steps: list[tuple[str, Path, str]] = [
+            ("content", content, "# edit 1"),
+            ("content", content, "# edit 2"),
+            ("add", extra_js, "console.log('extra');\n"),
+            ("content", content, "# edit 3"),
+            ("content", content, "# edit 4"),
+            ("content", content, "# edit 5"),
+        ]
+        for kind, target, body in steps:
+            if kind == "add":
+                target.write_text(body)
+                expected_assets.add("js/extra.js")
+                rebuild([target])
+            else:
+                target.write_text(f"---\ntitle: Home\n---\n\n{body}\n")
+                rebuild([target])

--- a/tests/unit/server/test_buffer_manager.py
+++ b/tests/unit/server/test_buffer_manager.py
@@ -174,6 +174,86 @@ class TestBufferManager:
 
         assert (staging / "index.html").read_text() == "<html>seeded</html>"
 
+    def test_delta_staging_does_not_sync_unlisted_files(self, mgr: BufferManager) -> None:
+        """A file neither in changed_paths nor always_sync is left untouched.
+
+        This is the divergence mechanism behind #315: asset-manifest.json is never
+        in the delta paths (a content-only rebuild does not rewrite it), so without
+        always_sync it drifts a generation behind in the staging buffer.
+        """
+        active = mgr.active_dir
+        staging = mgr.staging_dir
+        (active / "asset-manifest.json").write_text('{"gen": 2}')
+        (active / "index.html").write_text("<html>v2</html>")
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "asset-manifest.json").write_text('{"gen": 1}')
+        (staging / "index.html").write_text("<html>v1</html>")
+
+        mgr.prepare_delta_staging([Path("index.html")])
+
+        # The manifest was NOT in changed_paths, so plain delta-staging leaves the
+        # staging buffer's stale copy in place — it diverges from active.
+        assert (staging / "asset-manifest.json").read_text() == '{"gen": 1}'
+
+    def test_delta_staging_always_sync_refreshes_manifest(self, mgr: BufferManager) -> None:
+        """always_sync re-seeds the manifest from active even when it is not changed (#315)."""
+        active = mgr.active_dir
+        staging = mgr.staging_dir
+        (active / "asset-manifest.json").write_text('{"gen": 2}')
+        (active / "index.html").write_text("<html>v2</html>")
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "asset-manifest.json").write_text('{"gen": 1}')
+        (staging / "index.html").write_text("<html>v1</html>")
+
+        mgr.prepare_delta_staging([Path("index.html")], always_sync=["asset-manifest.json"])
+
+        # Now the staging buffer carries the active buffer's current manifest, so it
+        # will not serve a stale/divergent manifest after the next swap.
+        assert (staging / "asset-manifest.json").read_text() == '{"gen": 2}'
+        # And it shares active's inode (hardlinked, atomic-write-safe).
+        assert (active / "asset-manifest.json").stat().st_ino == (
+            staging / "asset-manifest.json"
+        ).stat().st_ino
+
+    def test_delta_staging_always_sync_removes_when_absent_in_active(
+        self, mgr: BufferManager
+    ) -> None:
+        """If active lacks an always_sync file, it is removed from staging (stay consistent)."""
+        active = mgr.active_dir
+        staging = mgr.staging_dir
+        (active / "index.html").write_text("<html>v2</html>")
+        staging.mkdir(parents=True, exist_ok=True)
+        (staging / "index.html").write_text("<html>v1</html>")
+        (staging / "asset-manifest.json").write_text('{"gen": 1}')
+
+        mgr.prepare_delta_staging([Path("index.html")], always_sync=["asset-manifest.json"])
+
+        assert not (staging / "asset-manifest.json").exists()
+
+    def test_delta_staging_fallback_full_seed_keeps_manifest_consistent(
+        self, mgr: BufferManager
+    ) -> None:
+        """When delta-staging falls back to a full seed, the manifest is still synced.
+
+        ``prepare_delta_staging`` returns early to ``prepare_staging`` when staging is
+        empty (or a path is unsafe), so ``_sync_always`` is not reached. That is safe
+        because the full hardlink seed copies *every* file — including the manifest —
+        so the buffers stay consistent without the explicit always_sync pass.
+        """
+        active = mgr.active_dir
+        (active / "index.html").write_text("<html>v2</html>")
+        (active / "asset-manifest.json").write_text('{"gen": 2}')
+        # Staging is empty -> prepare_delta_staging falls back to a full seed.
+
+        staging = mgr.prepare_delta_staging(
+            [Path("index.html")], always_sync=["asset-manifest.json"]
+        )
+
+        assert (staging / "asset-manifest.json").read_text() == '{"gen": 2}', (
+            "the full-seed fallback must also leave the staging buffer with the "
+            "active buffer's current manifest"
+        )
+
     def test_full_cycle(self, mgr: BufferManager) -> None:
         """Simulate: build to staging, swap, build again to new staging.
 


### PR DESCRIPTION
## Summary

Fixes #315. Residual dev-server mechanism behind #130. Follow-on to #314 (merged via #319); this PR now targets `main` directly. (Supersedes #320, which GitHub auto-closed when #319's branch was deleted.)

The dev server double-buffers output: the ASGI app serves from the **active** buffer while the next build writes to a **staging** buffer, then swaps. `BufferManager.prepare_delta_staging` seeds staging from active using only the *previous build's changed outputs*.

But `asset-manifest.json` is special — its content describes the **currently served buffer**, and a content-only rebuild never rewrites it, so it never appears in the changed-output delta. Across alternating swaps it could fall a generation behind. A buffer that then became active carrying a stale/divergent manifest could:

- omit entries for assets it actually holds (`asset_url` fails to resolve them), and
- make `inspect_asset_outputs` mis-report completeness, blinding the integrity safety net.

This is the residual dev-server mechanism behind #130's intermittent "unstyled, fixed by restart" symptom that the build-API fix (#313) did not cover. There was previously **no realistic test** for the dev-server buffer/swap/delta path.

## The fix

`prepare_delta_staging` gains an `always_sync` set of infrastructure paths that are re-seeded from the active buffer on **every** delta-staging, regardless of the changed-output delta (`bengal/server/buffer_manager.py::_sync_always`). `DevServerBuildTrigger` passes `always_sync=("asset-manifest.json",)`, so the manifest stays consistent between buffers across swaps.

### Design note (deviates from the issue's proposal)

The issue proposed recording the manifest write in the `OutputCollector`. Adversarial analysis showed that approach is **insufficient and risky**:

- **Insufficient:** a content-only rebuild never *writes* the manifest, so recording it wouldn't keep it in the delta — it would still drift across content-only swaps.
- **Risky:** the manifest would then enter `stats.changed_outputs` and pollute the CSS-only reload-hint classification in three places (`build/__init__.py`, `build_trigger.py`, `reload_controller.py`), flipping CSS hot reloads to full page reloads.

Unconditional sync in `prepare_delta_staging` is both sufficient (independent of whether the manifest changed) and free of the reload-hint regression surface. Composes correctly with #314: in the dev server the staging buffer now carries the *served* manifest, so #314's incremental merge bases off the correct manifest rather than a stale one.

## Verification

- New `tests/integration/test_dev_server_buffer_manifest.py` — the first dev-server-realistic buffer/swap/delta harness: drives `BufferManager.for_dev_server` + `prepare_staging`/`prepare_delta_staging` + warm incremental rebuilds + `swap()` over many cycles (mirroring the real trigger), asserting after every swap that the active buffer's manifest lists every current site asset and points only to files present in that buffer. **Verified to fail without the sync** (an asset added mid-session goes missing from the manifest after a content-only swap at gen 4) and pass with it.
- Focused `BufferManager.always_sync` unit tests in `tests/unit/server/test_buffer_manager.py` (refresh, removal-when-absent, the bug it guards, and that the full-seed fallback also stays consistent), verified non-vacuous.
- Rebased onto `main` after #314 merged (the #314 commit drops out cleanly — patch already upstream).
- Full server + hot-reload regression suites pass; broad sweep 1611 passed.
- `uv run ty check bengal/` = 531 diagnostics (unchanged floor).
- Reviewed by an adversarial multi-agent pass: no correctness/regression bugs (the deliberate "don't record in OutputCollector" decision was confirmed correct). It surfaced that the harness's local `_buffer_delta_paths` mirror diverged from the real impl's `return None` error semantics, which would have masked the fallback path — now corrected so the mirror matches faithfully.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Dev-server correctness fix, not a performance change. Adds one hardlink (copy-on-failure) of asset-manifest.json per dev-server delta-staging — negligible, dev-loop only, never on production builds. No measured perf delta is claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
