### PR TITLE
fix(docs): clear dogfood site-health blockers (#288)

### DIFF
--- a/bengal/icons/svg.py
+++ b/bengal/icons/svg.py
@@ -187,7 +187,14 @@ ICON_MAP: dict[str, str] = {
     "chevron-left": "chevron-left",
     "chevron-up": "chevron-up",
     "chevron-down": "chevron-down",
-    "external": "arrow-square-out",
+    "external": "external",
+    # Aliases for icons referenced by docs content frontmatter (#288); each
+    # maps a missing name to an existing SVG in the default theme's icon set.
+    "languages": "translate",
+    "python": "file-py",
+    "robot": "sparkle",
+    "stethoscope": "heart",
+    "arrows": "arrow-clockwise",
     "link": "link",
     "search": "magnifying-glass",
     "menu": "list",

--- a/bengal/parsing/backends/patitas/directives/builtins/admonition.py
+++ b/bengal/parsing/backends/patitas/directives/builtins/admonition.py
@@ -62,6 +62,7 @@ ADMONITION_TYPES = frozenset(
         "danger",
         "error",
         "info",
+        "important",
         "example",
         "success",
         "caution",
@@ -78,6 +79,7 @@ TYPE_TO_CSS: dict[str, str] = {
     "danger": "danger",
     "error": "error",
     "info": "info",
+    "important": "info",
     "example": "example",
     "success": "success",
     "seealso": "seealso",
@@ -87,6 +89,7 @@ TYPE_TO_CSS: dict[str, str] = {
 TYPE_TO_ICON: dict[str, str] = {
     "note": "note",
     "info": "info",
+    "important": "info",
     "tip": "tip",
     "warning": "warning",
     "caution": "caution",

--- a/bengal/themes/default/theme.yaml
+++ b/bengal/themes/default/theme.yaml
@@ -55,7 +55,13 @@ icons:
     chevron-left: chevron-left
     chevron-up: chevron-up
     chevron-down: chevron-down
-    external: arrow-square-out
+    external: external
+    # Aliases for icons referenced by docs content frontmatter (#288)
+    languages: translate
+    python: file-py
+    robot: sparkle
+    stethoscope: heart
+    arrows: arrow-clockwise
     link: link
     search: magnifying-glass
     menu: list

--- a/changelog.d/dogfood-health-blockers.fixed.md
+++ b/changelog.d/dogfood-health-blockers.fixed.md
@@ -1,0 +1,20 @@
+Cleared the dogfood-site health blockers that were obscuring REST autodoc QA
+(#288). The `important` admonition (a standard docutils/MyST type) is now
+registered, fixing the H201 "Unknown directive" error and the cascading
+"PosixPath is not JSON serializable" error it triggered. Six icon names
+referenced by docs content (`external`, `languages`, `python`, `robot`,
+`stethoscope`, `arrows`) now resolve: `external` was aliased to a non-existent
+`arrow-square-out` (in both `ICON_MAP` and `theme.yaml`) despite `external.svg`
+existing, and the other five gained aliases to existing theme SVGs. The
+`/docs/content/i18n/` URL collision is resolved by renaming the standalone
+`i18n.md` to `multilingual.md` so it no longer collides with the canonical
+`i18n/` section index. Thirty-one real broken navigation links across the docs
+were corrected (the dominant bug was relative `./sibling` / `.md`-suffixed links
+that don't resolve under pretty URLs — corrected to the `../sibling/` form), and
+the stale `/assets/css/style.css` reference in two self-contained demo HTML files
+was removed. Build health quality rose from 60% (Fair) to 80% (Good); broken
+internal links dropped from 43 to 9 — the remaining nine are illustrative example
+paths inside autodoc'd Python docstrings (e.g. the link-validator module's own
+docstring demonstrates `./sibling.md`) and one shortcode-syntax example, not real
+navigation, and are left as documented false positives. Added guard tests for the
+admonition registry and icon aliases.

--- a/site/assets/experimental/holo-demo.html
+++ b/site/assets/experimental/holo-demo.html
@@ -4,8 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Holographic Card Effects Demo - Bengal</title>
-  <!-- Use Bengal's theme stylesheet -->
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <!-- Self-contained demo: styles are inline below. -->
   <style>
 /* ============================================
    DEMO PAGE LAYOUT

--- a/site/content/docs/about/for-python-teams.md
+++ b/site/content/docs/about/for-python-teams.md
@@ -92,7 +92,7 @@ uv python install 3.14t
 uv run --python=3.14t bengal build
 ```
 
-This works because every layer — Patitas, Rosettes, Kida — was written from scratch for thread safety. No GIL assumptions, no shared mutable state in the hot path. See [Free-Threading](./free-threading) and [Benchmarks](./benchmarks) for details.
+This works because every layer — Patitas, Rosettes, Kida — was written from scratch for thread safety. No GIL assumptions, no shared mutable state in the hot path. See [Free-Threading](../free-threading/) and [Benchmarks](../benchmarks/) for details.
 
 ## AI-Native by Default
 
@@ -117,8 +117,8 @@ bengal serve
 The docs template creates a ready-to-use structure with getting-started, guides, and reference sections. Add your content, configure autodoc, and deploy.
 
 :::{seealso}
-- [Benchmarks](./benchmarks) — measured build times and scaling curves
-- [Free-Threading](./free-threading) — how Bengal uses Python 3.14t
-- [The Bengal Ecosystem](./ecosystem) — the full b-stack architecture
+- [Benchmarks](../benchmarks/) — measured build times and scaling curves
+- [Free-Threading](../free-threading/) — how Bengal uses Python 3.14t
+- [The Bengal Ecosystem](../ecosystem/) — the full b-stack architecture
 - [AI-Native Output](/docs/building/ai-native-output/) — machine-readable output formats
 :::

--- a/site/content/docs/building/ai-native-output.md
+++ b/site/content/docs/building/ai-native-output.md
@@ -124,4 +124,4 @@ content_signals:
   ai_train: false
 ```
 
-See [Output Formats](./output-formats.md) for the full configuration reference and [SEO & Discovery](./seo.md) for the broader discovery strategy.
+See [Output Formats](../output-formats/) for the full configuration reference and [SEO & Discovery](../seo/) for the broader discovery strategy.

--- a/site/content/docs/building/connect-to-ide.md
+++ b/site/content/docs/building/connect-to-ide.md
@@ -71,6 +71,6 @@ enabled = false
 
 ## See Also
 
-- [SEO & Discovery](./seo.md) — Machine discovery, content signals, and related features
-- [Output Formats](./output-formats.md) — JSON, LLM text, and other machine-readable outputs
+- [SEO & Discovery](../seo/) — Machine discovery, content signals, and related features
+- [Output Formats](../output-formats/) — JSON, LLM text, and other machine-readable outputs
 - [Cursor MCP Install Links](https://cursor.com/docs/context/mcp/install-links) — Deeplink format reference

--- a/site/content/docs/building/seo.md
+++ b/site/content/docs/building/seo.md
@@ -45,7 +45,7 @@ Bengal pages can carry structured front matter such as:
 The default theme uses those fields to render metadata such as descriptions, keyword
 tags, canonical URLs, Open Graph tags, Twitter cards, and robots directives.
 
-See [SEO Functions](../reference/template-functions/seo-image-functions/) for the
+See [SEO Functions](../../reference/template-functions/seo-image-functions/) for the
 template helpers that power these tags.
 
 ### Search Engine Discovery
@@ -104,7 +104,7 @@ Bengal can generate machine-friendly output formats such as:
 - `changelog.json` — per-build diff of added, modified, and removed pages
 - `agent.json` — hierarchical site structure for agent discovery
 
-See [Output Formats](./output-formats.md) for configuration details.
+See [Output Formats](../output-formats/) for configuration details.
 
 `llms.txt` is a short Markdown table of contents that tells AI agents what the site
 is and where to find things. It is auto-generated from the site's section hierarchy
@@ -144,7 +144,7 @@ backend.
 
 Bengal can show a "Connect to IDE" button that opens Cursor and adds your docs as an
 MCP server via a one-click install. Requires a hosted Streamable HTTP MCP server —
-Bengal generates the button; you provide the server. See [Connect to IDE](./connect-to-ide.md) for setup.
+Bengal generates the button; you provide the server. See [Connect to IDE](../connect-to-ide/) for setup.
 
 ### Content Signals
 

--- a/site/content/docs/content/multilingual.md
+++ b/site/content/docs/content/multilingual.md
@@ -1,6 +1,6 @@
 ---
 title: Multilingual Sites
-nav_title: i18n
+nav_title: Multilingual Sites
 description: Serve your documentation in multiple languages with proper URL routing and translations
 weight: 60
 icon: globe

--- a/site/content/docs/content/versioning/cross-version-links.md
+++ b/site/content/docs/content/versioning/cross-version-links.md
@@ -196,5 +196,5 @@ For regular content, users expect links to stay within their current version.
 
 ## Next Steps
 
-- [Version Directives](./directives.md) — Mark version-specific content
+- [Version Directives](../directives/) — Mark version-specific content
 - [Versioning Overview](./_index.md) — Full versioning documentation

--- a/site/content/docs/content/versioning/directives.md
+++ b/site/content/docs/content/versioning/directives.md
@@ -308,6 +308,6 @@ Don't annotate every minor change—it creates noise.
 
 ## Next Steps
 
-- [Cross-Version Links](./cross-version-links.md) — Link between versions
-- [Folder Mode](./folder-mode.md) — Set up folder-based versioning
-- [Git Mode](./git-mode.md) — Set up git-based versioning
+- [Cross-Version Links](../cross-version-links/) — Link between versions
+- [Folder Mode](../folder-mode/) — Set up folder-based versioning
+- [Git Mode](../git-mode/) — Set up git-based versioning

--- a/site/content/docs/content/versioning/git-mode.md
+++ b/site/content/docs/content/versioning/git-mode.md
@@ -462,6 +462,6 @@ it is selected.
 
 ## Next Steps
 
-- [Cross-Version Links](./cross-version-links.md) — Link between versions
-- [Version Directives](./directives.md) — Mark version-specific content
-- [Folder Mode](./folder-mode.md) — Alternative: folder-based versioning
+- [Cross-Version Links](../cross-version-links/) — Link between versions
+- [Version Directives](../directives/) — Mark version-specific content
+- [Folder Mode](../folder-mode/) — Alternative: folder-based versioning

--- a/site/content/docs/reference/architecture/design-principles.md
+++ b/site/content/docs/reference/architecture/design-principles.md
@@ -312,6 +312,6 @@ def create_markdown_parser(engine='patitas'):
 ## Related Documentation
 
 - [Architecture Overview](./) - High-level architecture
-- [Orchestration](core/orchestration.md) - Build coordination
+- [Orchestration](../core/orchestration/) - Build coordination
 - [Performance](../../../building/performance/) - Benchmarks and hot paths
-- [Testing](meta/testing.md) - Test strategy
+- [Testing](../meta/testing/) - Test strategy

--- a/site/content/docs/reference/architecture/meta/protocols.md
+++ b/site/content/docs/reference/architecture/meta/protocols.md
@@ -328,6 +328,6 @@ from bengal.protocols import SectionLike, TemplateEngine, HighlightService
 
 ## Related Documentation
 
-- [Extension Points](extension-points.md) — Using protocols for customization
+- [Extension Points](../extension-points/) — Using protocols for customization
 - [Custom Template Engine](/docs/theming/templating/custom-engine/) — Implementing TemplateEngine
-- [Object Model](../core/object-model.md) — PageLike and SectionLike implementations
+- [Object Model](../../core/object-model/) — PageLike and SectionLike implementations

--- a/site/content/docs/reference/architecture/subsystems/analysis.md
+++ b/site/content/docs/reference/architecture/subsystems/analysis.md
@@ -405,4 +405,4 @@ All commands support multiple output formats:
 - **Autodoc Filtering**: API reference pages are excluded by default for cleaner analysis
 - **Multiple Export Formats**: Export results for further analysis or reporting
 
-Refer to [Graph Analysis](../../../content/analysis/graph.md) for usage examples and workflows.
+Refer to [Graph Analysis](../../../../content/analysis/graph/) for usage examples and workflows.

--- a/site/content/docs/reference/architecture/subsystems/debug.md
+++ b/site/content/docs/reference/architecture/subsystems/debug.md
@@ -317,6 +317,6 @@ BENGAL_STRICT_INCREMENTAL=error bengal build
 
 ## Related
 
-- [Orchestration](../core/orchestration.md) - How incremental builds work
-- [Cache](../core/cache.md) - Cache system details
-- [CLI](../tooling/cli.md) - Command-line interface
+- [Orchestration](../../core/orchestration/) - How incremental builds work
+- [Cache](../../core/cache/) - Cache system details
+- [CLI](../../tooling/cli/) - Command-line interface

--- a/site/content/docs/reference/architecture/subsystems/output.md
+++ b/site/content/docs/reference/architecture/subsystems/output.md
@@ -210,5 +210,5 @@ cli.phase("Rendering")  # Suppressed (within 1.5s window)
 
 ## Related
 
-- [CLI](../tooling/cli.md) - Command-line interface
+- [CLI](../../tooling/cli/) - Command-line interface
 - [Performance](../../../../building/performance/) - Benchmarks and hot paths

--- a/site/content/docs/reference/architecture/tooling/cli.md
+++ b/site/content/docs/reference/architecture/tooling/cli.md
@@ -166,7 +166,7 @@ Links: 428
 Orphans: 3
 ```
 
-Refer to [Graph Analysis](../../../content/analysis/graph.md) for details and [Analyze site connectivity](../../../../tutorials/operations/analyze-site-connectivity/) for a guided walkthrough.
+Refer to [Graph Analysis](/docs/content/analysis/graph/) for details and [Analyze site connectivity](../../../../tutorials/operations/analyze-site-connectivity/) for a guided walkthrough.
 
 **Performance Commands**:
 ```bash

--- a/site/content/docs/reference/architecture/tooling/utils.md
+++ b/site/content/docs/reference/architecture/tooling/utils.md
@@ -251,6 +251,6 @@ bengal/utils/
 
 ## Related Documentation
 
-- [Design Principles](../design-principles.md) - Overall design patterns
-- [File Organization](../meta/file-organization.md) - Directory structure
-- [Testing](../meta/testing.md) - Testing strategy
+- [Design Principles](../../design-principles/) - Overall design patterns
+- [File Organization](../../meta/file-organization/) - Directory structure
+- [Testing](../../meta/testing/) - Testing strategy

--- a/site/content/docs/theming/themes/chirpui.md
+++ b/site/content/docs/theming/themes/chirpui.md
@@ -29,7 +29,7 @@ The theme loads Chirp UI through `theme.toml` provider libraries. When the
 package exposes `get_library_contract()`, Bengal uses that contract to emit
 declared CSS and JavaScript under `chirp_ui/`, fingerprint them through the
 normal asset manifest, and render the provider tags from the theme library
-metadata. See [Theme Library Assets](./library-assets/) for the provider
+metadata. See [Theme Library Assets](../library-assets/) for the provider
 contract shape, asset modes, tag attributes, runtime metadata, and strict build
 diagnostics. Bengal does not bundle `chirp-ui` as a hard dependency, so builds
 that use this theme fail fast if the package is missing.

--- a/site/static/demos/holo-cards.html
+++ b/site/static/demos/holo-cards.html
@@ -4,8 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Holographic Card Effects Demo - Bengal</title>
-  <!-- Use Bengal's theme stylesheet -->
-  <link rel="stylesheet" href="/assets/css/style.css">
+  <!-- Self-contained demo: styles are inline below. -->
   <style>
 /* ============================================
    DEMO PAGE LAYOUT

--- a/tests/unit/icons/test_dogfood_icon_aliases.py
+++ b/tests/unit/icons/test_dogfood_icon_aliases.py
@@ -1,0 +1,35 @@
+"""Guard: icon names referenced by docs content must resolve to real SVGs (#288).
+
+These names were reported as "missing icons" on the dogfood build because
+``external`` was aliased to a non-existent ``arrow-square-out`` and the rest had
+no ICON_MAP entry (so they fell through to ``{name}.svg``, which did not exist).
+This test fails if any alias points at an SVG that is not present in the default
+theme — i.e. it discriminates: a broken alias re-breaks it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bengal.icons.svg import ICON_MAP
+
+# Names referenced from dogfood content frontmatter / card directives that were
+# missing before #288.
+DOGFOOD_ICON_NAMES = ["external", "languages", "python", "robot", "stethoscope", "arrows"]
+
+_ICONS_DIR = Path("bengal/themes/default/assets/icons")
+
+
+@pytest.mark.parametrize("name", DOGFOOD_ICON_NAMES)
+def test_dogfood_referenced_icon_resolves_to_existing_svg(name: str) -> None:
+    target = ICON_MAP.get(name, name)
+    svg = _ICONS_DIR / f"{target}.svg"
+    assert svg.exists(), f"icon {name!r} -> {target!r}.svg does not exist in the default theme"
+
+
+def test_external_icon_not_aliased_to_missing_arrow_square_out() -> None:
+    """Regression guard for the specific #288 bug."""
+    assert ICON_MAP.get("external") != "arrow-square-out"
+    assert not (_ICONS_DIR / "arrow-square-out.svg").exists()

--- a/tests/unit/icons/test_dogfood_icon_aliases.py
+++ b/tests/unit/icons/test_dogfood_icon_aliases.py
@@ -29,7 +29,15 @@ def test_dogfood_referenced_icon_resolves_to_existing_svg(name: str) -> None:
     assert svg.exists(), f"icon {name!r} -> {target!r}.svg does not exist in the default theme"
 
 
-def test_external_icon_not_aliased_to_missing_arrow_square_out() -> None:
-    """Regression guard for the specific #288 bug."""
-    assert ICON_MAP.get("external") != "arrow-square-out"
-    assert not (_ICONS_DIR / "arrow-square-out.svg").exists()
+def test_external_icon_resolves_after_alias_fix() -> None:
+    """Regression guard for the specific #288 bug.
+
+    ``external`` was aliased to a non-existent ``arrow-square-out``. Assert the
+    real invariant — its resolved SVG exists — without pinning the target name or
+    asserting any file's absence (which would break if the icon set is later
+    expanded, e.g. an ``arrow-square-out.svg`` is added).
+    """
+    target = ICON_MAP.get("external", "external")
+    assert (_ICONS_DIR / f"{target}.svg").exists(), (
+        f"external -> {target}.svg must exist (regression of the arrow-square-out bug)"
+    )

--- a/tests/unit/rendering/directives/test_admonition_registry.py
+++ b/tests/unit/rendering/directives/test_admonition_registry.py
@@ -1,0 +1,37 @@
+"""Guard: the ``important`` admonition is registered (#288).
+
+The dogfood build reported an H201 "Unknown directive 'important'" error (plus a
+cascading PosixPath-serialization error) because ``important`` — a standard
+docutils/MyST admonition — was not in ADMONITION_TYPES. Registering it propagates
+to the directive registry and the directives health validator.
+"""
+
+from __future__ import annotations
+
+from bengal.parsing.backends.patitas.directives.builtins.admonition import (
+    ADMONITION_TYPES,
+    TYPE_TO_CSS,
+    TYPE_TO_ICON,
+)
+
+_VALID_CSS = {
+    "note",
+    "tip",
+    "warning",
+    "danger",
+    "error",
+    "info",
+    "example",
+    "success",
+    "seealso",
+}
+
+
+def test_important_admonition_is_registered() -> None:
+    assert "important" in ADMONITION_TYPES
+
+
+def test_important_admonition_maps_to_valid_css_and_icon() -> None:
+    # Mapped to an existing CSS class (no orphan selector) and a non-empty icon.
+    assert TYPE_TO_CSS.get("important") in _VALID_CSS
+    assert TYPE_TO_ICON.get("important")


### PR DESCRIPTION
Closes #288.

Clears the dogfood-site health blockers that were obscuring REST autodoc QA. **Build health quality rises 60% (Fair) → 80% (Good); broken internal links drop 43 → 9** (the nine remaining are documented false positives).

## Blockers, and how each was resolved

| Blocker | Resolution |
|---|---|
| Unknown `important` directive (+ cascading `PosixPath is not JSON serializable`) | Registered `important` (standard docutils/MyST admonition) in `ADMONITION_TYPES`/`TYPE_TO_CSS`/`TYPE_TO_ICON` → mapped to `info`. Both errors gone. |
| URL collision `/docs/content/i18n/` | Renamed the standalone `i18n.md` → `multilingual.md` so it no longer collides with the canonical `i18n/` section index. |
| 6 missing icons (`arrows`, `external`, `languages`, `python`, `robot`, `stethoscope`) | `external.svg` existed but `ICON_MAP`+`theme.yaml` aliased `external` → non-existent `arrow-square-out` (the engine bug); the other five had no alias. Added aliases to existing theme SVGs. |
| 43 broken internal links | Fixed **31 real navigation links** (dominant bug: relative `./sibling` / `.md`-suffixed links that don't resolve under pretty URLs → corrected to `../sibling/`). Each target verified to exist. |
| Non-serveable `/assets/css/style.css` | Removed the stale `<link>` from two self-contained demo HTML files (the bundle is fingerprinted `style.<hash>.css`, so that path never exists). |

## Important: false positives, not bugs (verified, not assumed)

The original "43 broken links" were **not** 43 real bugs. Enumerating them via the actual build's link validator showed **9 are illustrative example paths**, not site navigation:
- 8 are anchors generated from **autodoc'd Python docstrings** — e.g. the link-validator module's own docstring demonstrates `./sibling.md`/`../parent.md`; the cards directive docstring shows `/docs/api/`; a role docstring has a typo'd `/getting-starte.html`.
- 1 is a shortcode-syntax example (`{{< ref "docs/guide/intro" >}}`) inside a code fence in `shortcodes.md`.

These have no real targets by design; "fixing" them would mean editing engine source docstrings (or the validator's code-block handling) — out of scope for a dogfood-content cleanup. They are left as **documented residual false positives** (per the issue's "fix or document" acceptance criterion). After this PR, every remaining broken link is one of these nine.

## Editorial flag (non-destructive)

The renamed `multilingual.md` documents an **outdated YAML-translation i18n approach** (`config/_default/i18n.yaml`, `t('nav.home')`) that contradicts Bengal's actual gettext PO/MO implementation (`bengal/i18n/catalog.py`) — which the canonical `i18n/_index.md` section already documents correctly. I renamed rather than deleted (it's author-written content); it's a strong candidate for deletion/merge, but that's a maintainer editorial call.

Also out of scope: a separate `../tokens/foundation.css` asset-audit *notice* (not a health error) originating from theme experimental demo HTML + CSS `@import` paths under `bengal/themes/default/` — pre-existing theme-packaging, unrelated to the named dogfood blockers.

## Verification

- `uv run bengal build --no-incremental` (cache cleared): quality 80% (Good); 0 directive errors; 0 URL collisions; 0 missing icons; broken links = 9 (all the documented false positives above; **0 real content navigation links broken** — verified by re-enumeration).
- `uv run pytest tests/unit -k "admonition or directive or icon"` → 480 passed.
- New discriminating guard tests: `tests/unit/icons/test_dogfood_icon_aliases.py` (icon aliases must resolve to real SVGs; explicit regression guard for the `external`→`arrow-square-out` bug) and `tests/unit/rendering/directives/test_admonition_registry.py` (`important` registered + maps to valid CSS/icon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)