### PR TITLE
feat(autodoc): render advanced OpenAPI schema constructs (#285)

### DIFF
--- a/bengal/rendering/template_functions/openapi.py
+++ b/bengal/rendering/template_functions/openapi.py
@@ -257,6 +257,13 @@ class SchemaView:
             "example": example,
             "description": el.description,
         }
+        # Surface advanced constructs (composition, constraints, flags, ...) for
+        # the recursive viewer, but only when actually present so simple-schema
+        # display_schema stays byte-identical and render baselines do not move.
+        if isinstance(raw_schema, Mapping):
+            for key in _ADVANCED_DISPLAY_KEYS:
+                if key in raw_schema and key not in display_schema:
+                    display_schema[key] = raw_schema[key]
 
         # Smart href: anchor if no page, page URL otherwise
         if consolidated or not el.href:
@@ -342,6 +349,255 @@ def _schema_enum(raw_schema: Any) -> tuple[Any, ...] | None:
                 if child_enum:
                     return child_enum
     return None
+
+
+# =============================================================================
+# Advanced schema normalization (composition, constraints, flags, examples)
+# =============================================================================
+#
+# These helpers turn a raw (already $ref-resolved) OpenAPI schema object into
+# small, template-friendly structures. They are registered as filters so the
+# recursive schema viewer can render advanced constructs uniformly on both the
+# top-level normalized schema and nested raw property schemas. Each one returns
+# an empty/None result when its construct is absent so templates can guard with
+# a cheap ``{% if %}`` and emit nothing for simple schemas (keeping their output
+# byte-identical).
+
+
+def _is_sequence(value: Any) -> bool:
+    """True for list/tuple-like sequences, excluding strings and bytes."""
+    return isinstance(value, Sequence) and not isinstance(value, str | bytes)
+
+
+def _branch_label(branch: Any) -> str | None:
+    """Derive a readable label for a composition branch.
+
+    The extractor inlines ``$ref`` targets before this runs, so the original
+    schema name is gone. Recover a stable label from (in order): an explicit
+    ``title``; a discriminator-style ``type`` property whose single ``enum``
+    value names the variant; or a bare ``$ref`` left behind at a cycle.
+    """
+    if not isinstance(branch, Mapping):
+        return None
+    title = branch.get("title")
+    if title:
+        return str(title)
+    props = branch.get("properties")
+    if isinstance(props, Mapping):
+        type_prop = props.get("type")
+        if isinstance(type_prop, Mapping):
+            enum = type_prop.get("enum")
+            if _is_sequence(enum) and len(enum) == 1:
+                return str(enum[0])
+    ref = branch.get("$ref")
+    if isinstance(ref, str):
+        return ref.rsplit("/", 1)[-1]
+    return None
+
+
+def _schema_discriminator(schema: Any) -> dict[str, Any] | None:
+    """Normalize an OpenAPI ``discriminator`` into ``{property_name, mapping}``.
+
+    ``mapping`` is a tuple of ``{value, target, ref}`` rows; ``target`` is the
+    schema name pulled from the ref string (the ref itself is preserved as
+    ``ref``). Returns ``None`` when no usable discriminator is present.
+    """
+    if not isinstance(schema, Mapping):
+        return None
+    disc = schema.get("discriminator")
+    if not isinstance(disc, Mapping):
+        return None
+    property_name = disc.get("propertyName")
+    if not property_name:
+        return None
+    raw_mapping = disc.get("mapping")
+    mapping: tuple[dict[str, str], ...] = ()
+    if isinstance(raw_mapping, Mapping):
+        mapping = tuple(
+            {"value": str(value), "target": str(ref).rsplit("/", 1)[-1], "ref": str(ref)}
+            for value, ref in raw_mapping.items()
+        )
+    return {"property_name": str(property_name), "mapping": mapping}
+
+
+def schema_composition(schema: Any) -> dict[str, Any] | None:
+    """Normalize ``oneOf``/``anyOf``/``allOf`` composition for rendering.
+
+    Returns ``{kind, branches, discriminator}`` or ``None`` when the schema is
+    not composed. ``branches`` is a tuple of ``{label, schema_type, schema}``
+    where ``schema`` is the resolved branch object (templates can recurse into
+    it) and ``label`` is derived via :func:`_branch_label`. ``discriminator`` is
+    populated for ``oneOf``/``anyOf`` polymorphism when present, else ``None``.
+    """
+    if not isinstance(schema, Mapping):
+        return None
+    for kind in ("oneOf", "anyOf", "allOf"):
+        raw_branches = schema.get(kind)
+        if not (_is_sequence(raw_branches) and raw_branches):
+            continue
+        branches = tuple(
+            {
+                "label": _branch_label(branch) or f"Variant {index + 1}",
+                "schema_type": _schema_type(branch),
+                "schema": branch,
+            }
+            for index, branch in enumerate(raw_branches)
+        )
+        return {
+            "kind": kind,
+            "branches": branches,
+            "discriminator": _schema_discriminator(schema),
+        }
+    return None
+
+
+# (schema key, display label) for validation constraints, in render order.
+_CONSTRAINT_SPECS: tuple[tuple[str, str], ...] = (
+    ("format", "format"),
+    ("pattern", "pattern"),
+    ("minimum", "min"),
+    ("maximum", "max"),
+    ("exclusiveMinimum", "exclusive min"),
+    ("exclusiveMaximum", "exclusive max"),
+    ("multipleOf", "multiple of"),
+    ("minLength", "min length"),
+    ("maxLength", "max length"),
+    ("minItems", "min items"),
+    ("maxItems", "max items"),
+    ("uniqueItems", "unique items"),
+    ("minProperties", "min properties"),
+    ("maxProperties", "max properties"),
+)
+
+
+def schema_constraints(schema: Any) -> dict[str, str]:
+    """Return present validation constraints as an ordered ``label -> value`` map.
+
+    Only keys actually set on the schema are included, so a property with no
+    constraints yields an empty dict (cheap ``{% if constraints %}`` guard).
+    Boolean-style constraints (``uniqueItems``) map to an empty string when true
+    and are omitted when false, so templates can render the label alone.
+    """
+    if not isinstance(schema, Mapping):
+        return {}
+    constraints: dict[str, str] = {}
+    for key, label in _CONSTRAINT_SPECS:
+        if key not in schema:
+            continue
+        value = schema[key]
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            if value:
+                constraints[label] = ""
+            continue
+        constraints[label] = str(value)
+    return constraints
+
+
+def schema_flags(schema: Any) -> dict[str, bool]:
+    """Return the boolean schema flags that are set to true.
+
+    Recognized flags: ``nullable`` (OpenAPI 3.0 ``nullable: true`` or 3.1
+    ``type: [..., 'null']``), ``readOnly``, ``writeOnly``, ``deprecated``.
+    Returns only true entries so templates iterate/guard cheaply.
+    """
+    flags: dict[str, bool] = {}
+    if not isinstance(schema, Mapping):
+        return flags
+    schema_type = schema.get("type")
+    nullable = bool(schema.get("nullable")) or (_is_sequence(schema_type) and "null" in schema_type)
+    if nullable:
+        flags["nullable"] = True
+    if schema.get("readOnly"):
+        flags["readOnly"] = True
+    if schema.get("writeOnly"):
+        flags["writeOnly"] = True
+    if schema.get("deprecated"):
+        flags["deprecated"] = True
+    return flags
+
+
+def schema_additional_properties(schema: Any) -> dict[str, Any] | None:
+    """Normalize ``additionalProperties`` for map-type schemas.
+
+    Returns ``{allowed: bool}`` for the boolean form, ``{value_schema,
+    schema_type}`` when it is a schema object (typed map), or ``None`` when the
+    key is absent.
+    """
+    if not isinstance(schema, Mapping) or "additionalProperties" not in schema:
+        return None
+    value = schema["additionalProperties"]
+    if isinstance(value, bool):
+        return {"allowed": value}
+    if isinstance(value, Mapping):
+        return {"value_schema": value, "schema_type": _schema_type(value)}
+    return {"allowed": True}
+
+
+def schema_examples(schema: Any) -> tuple[dict[str, Any], ...]:
+    """Normalize schema examples into a tuple of ``{name, summary, value}``.
+
+    Honors a singular ``example`` and an ``examples`` collection. ``examples``
+    may be an OpenAPI media-type-style map (each value optionally
+    ``{summary, value}``) or a JSON-Schema-style bare list of values. Returns an
+    empty tuple when no example is present.
+    """
+    if not isinstance(schema, Mapping):
+        return ()
+    out: list[dict[str, Any]] = []
+    if schema.get("example") is not None:
+        out.append({"name": "", "summary": "", "value": schema["example"]})
+    examples = schema.get("examples")
+    if isinstance(examples, Mapping):
+        for name, item in examples.items():
+            if isinstance(item, Mapping) and ("value" in item or "summary" in item):
+                out.append(
+                    {
+                        "name": str(name),
+                        "summary": str(item.get("summary", "")),
+                        "value": item.get("value"),
+                    }
+                )
+            else:
+                out.append({"name": str(name), "summary": "", "value": item})
+    elif _is_sequence(examples):
+        out.extend({"name": "", "summary": "", "value": item} for item in examples)
+    return tuple(out)
+
+
+def schema_ref(schema: Any) -> str | None:
+    """Return the schema name from an unresolved ``$ref`` leaf, else ``None``.
+
+    The extractor resolves ``$ref`` targets inline but, on detecting a cycle,
+    leaves a bare ``{"$ref": ...}`` object at the cycle point. Surfacing it lets
+    the viewer render a compact "circular reference" indicator instead of an
+    empty object box.
+    """
+    if isinstance(schema, Mapping):
+        ref = schema.get("$ref")
+        if isinstance(ref, str):
+            return ref.rsplit("/", 1)[-1]
+    return None
+
+
+# Raw schema keys merged into ``display_schema`` (only when present) so the
+# recursive viewer's filters see the same advanced constructs at the top level
+# that nested raw property schemas already carry. Merging only-when-present
+# keeps simple-schema display_schema byte-identical.
+_ADVANCED_DISPLAY_KEYS: tuple[str, ...] = (
+    "oneOf",
+    "anyOf",
+    "allOf",
+    "discriminator",
+    "additionalProperties",
+    "examples",
+    "nullable",
+    "readOnly",
+    "writeOnly",
+    "deprecated",
+    *(key for key, _label in _CONSTRAINT_SPECS),
+)
 
 
 def _generate_anchor_id(method: str, path: str) -> str:
@@ -634,6 +890,12 @@ def register(env: TemplateEnvironment, site: SiteLike) -> None:
             "endpoints": endpoints_filter,
             "schemas": schemas_filter,
             "schema_view": schema_view_filter,
+            "schema_composition": schema_composition,
+            "schema_constraints": schema_constraints,
+            "schema_flags": schema_flags,
+            "schema_additional_properties": schema_additional_properties,
+            "schema_examples": schema_examples,
+            "schema_ref": schema_ref,
         }
     )
 
@@ -699,6 +961,25 @@ def generate_code_sample(
     )
 
 
+def _first_example_value(examples: Any) -> Any:
+    """Return the first example's value from an examples collection.
+
+    Handles both the OpenAPI media-type form (a map of Example Objects, each
+    ``{summary?, value?, ...}``) and the JSON-Schema 3.1 form (a bare list of
+    values). Returns ``{}`` when there is nothing usable, so a malformed
+    ``examples`` (e.g. a list where a map was expected) never crashes a build.
+    """
+    if isinstance(examples, Mapping):
+        first = next(iter(examples.values()), {})
+    elif _is_sequence(examples) and examples:
+        first = examples[0]
+    else:
+        return {}
+    if isinstance(first, Mapping):
+        return _get_value(first, "value", {})
+    return first
+
+
 def _build_example_body(request_body: Any) -> Any:
     """Build an example request body from schema."""
     if not request_body:
@@ -715,10 +996,7 @@ def _build_example_body(request_body: Any) -> Any:
         return request_body["example"]
     examples = request_body.get("examples")
     if examples:
-        first_example = next(iter(examples.values()), {})
-        if isinstance(first_example, Mapping):
-            return first_example.get("value", {})
-        return first_example
+        return _first_example_value(examples)
 
     if "content" in request_body and isinstance(request_body["content"], Mapping):
         media = _select_json_media(request_body["content"])
@@ -727,10 +1005,7 @@ def _build_example_body(request_body: Any) -> Any:
                 return media["example"]
             examples = media.get("examples")
             if examples:
-                first_example = next(iter(examples.values()), {})
-                if isinstance(first_example, Mapping):
-                    return first_example.get("value", {})
-                return first_example
+                return _first_example_value(examples)
             schema = media.get("schema", {})
             return _schema_to_example(schema) if isinstance(schema, Mapping) else {}
 
@@ -739,26 +1014,60 @@ def _build_example_body(request_body: Any) -> Any:
     return _schema_to_example(schema)
 
 
-def _schema_to_example(schema: Any) -> Any:
-    """Convert a JSON schema to an example value."""
-    if not isinstance(schema, Mapping):
-        return None
+_EXAMPLE_MAX_DEPTH = 6
 
-    schema_type = schema.get("type", schema.get("schema_type", "object"))
+
+def _schema_to_example(schema: Any, _depth: int = 0) -> Any:
+    """Convert a JSON schema to an example value.
+
+    Depth-bounded (``_EXAMPLE_MAX_DEPTH``) so a circular schema — e.g. a node
+    that references itself, which the extractor leaves as a bare ``$ref`` leaf —
+    can never blow the stack or loop forever.
+    """
+    if not isinstance(schema, Mapping) or _depth > _EXAMPLE_MAX_DEPTH:
+        return None
 
     if "example" in schema:
         return schema["example"]
 
+    # An enum constrains the value regardless of the declared type, so the first
+    # allowed value is the most representative example.
+    enum = schema.get("enum")
+    if enum:
+        return enum[0]
+
+    # Composition: a oneOf/anyOf example is the first branch's example; allOf is
+    # the merge of all branch object examples (plus any direct properties).
+    for kind in ("oneOf", "anyOf"):
+        branches = schema.get(kind)
+        if _is_sequence(branches) and branches:
+            return _schema_to_example(branches[0], _depth + 1)
+    all_of = schema.get("allOf")
+    if _is_sequence(all_of) and all_of:
+        merged: dict[str, Any] = {}
+        for branch in all_of:
+            branch_example = _schema_to_example(branch, _depth + 1)
+            if isinstance(branch_example, Mapping):
+                merged.update(branch_example)
+        direct_props = schema.get("properties")
+        if isinstance(direct_props, Mapping):
+            for name, prop in direct_props.items():
+                merged[name] = _schema_to_example(prop, _depth + 1)
+        return merged
+
+    schema_type = schema.get("type", schema.get("schema_type", "object"))
+
     if schema_type == "object":
-        properties = schema.get("properties", {})
+        properties = schema.get("properties")
         result = {}
-        for name, prop in properties.items():
-            result[name] = _schema_to_example(prop)
+        if isinstance(properties, Mapping):
+            for name, prop in properties.items():
+                result[name] = _schema_to_example(prop, _depth + 1)
         return result
 
     if schema_type == "array":
         items = schema.get("items", {})
-        return [_schema_to_example(items)]
+        return [_schema_to_example(items, _depth + 1)]
 
     if schema_type == "string":
         if schema.get("enum"):

--- a/bengal/themes/default/assets/css/components/autodoc.css
+++ b/bengal/themes/default/assets/css/components/autodoc.css
@@ -369,6 +369,23 @@ article[data-autodoc]>p:first-of-type,
   color: var(--color-error-text);
 }
 
+/* Schema property flags (#285): nullable / read-only / write-only.
+   `deprecated` is already styled above and reused as-is. */
+.autodoc-badge[data-badge="nullable"] {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-muted);
+}
+
+.autodoc-badge[data-badge="readonly"] {
+  background: var(--color-info-bg);
+  color: var(--color-info-text);
+}
+
+.autodoc-badge[data-badge="writeonly"] {
+  background: var(--color-example-bg);
+  color: var(--color-example-text);
+}
+
 /* ============================================
    TABLES: Parameters, attributes
    ============================================ */
@@ -1736,9 +1753,175 @@ body[data-type="autodoc-rest"] #main-content {
   margin-bottom: var(--space-2);
 }
 
+.api-schema-viewer__example-summary {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--gray-400);
+  margin-bottom: var(--space-2);
+}
+
 .api-schema-viewer__example-code {
   font-size: var(--text-xs);
   color: var(--gray-200);
+}
+
+/* ============================================
+   ADVANCED SCHEMA CONSTRUCTS (#285)
+   Composition, constraints, additional props,
+   and circular-reference indicators. All rules
+   reuse existing design tokens — no new colors.
+   ============================================ */
+
+/* Validation constraint chips (format, pattern, min/max, lengths, ...) */
+.api-schema-viewer__constraints {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3) var(--space-2);
+}
+
+.api-schema-viewer__constraint {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-tertiary);
+  padding: var(--space-0-5) var(--space-1);
+  border-radius: var(--radius-sm);
+}
+
+/* Open / typed-map (additionalProperties) section */
+.api-schema-viewer__additional {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--color-border-light);
+}
+
+.api-schema-viewer__note {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+/* Depth-cutoff / circular-reference indicator */
+.api-schema-viewer__truncated {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.api-schema-viewer--ref {
+  padding: var(--space-2) var(--space-3);
+}
+
+/* Composition: oneOf / anyOf / allOf */
+.api-schema-composition {
+  margin: var(--space-2) var(--space-3) var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-inline-start: 3px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+}
+
+.api-schema-composition[data-composition="oneOf"] {
+  border-inline-start-color: var(--color-info);
+}
+
+.api-schema-composition[data-composition="anyOf"] {
+  border-inline-start-color: var(--color-success);
+}
+
+.api-schema-composition[data-composition="allOf"] {
+  border-inline-start-color: var(--color-warning);
+}
+
+.api-schema-composition__title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+}
+
+.api-schema-composition__discriminator {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.api-schema-composition__discriminator-label {
+  color: var(--color-text-muted);
+}
+
+.api-schema-composition__mapping {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.api-schema-composition__mapping li {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+}
+
+.api-schema-composition__mapping-arrow {
+  color: var(--color-text-muted);
+}
+
+.api-schema-composition__branches {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.api-schema-composition__branch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.api-schema-composition__branch-type {
+  color: var(--color-text-muted);
+}
+
+/* Catalog tile summary chips (composition / deprecated / polymorphic) */
+.api-schema-catalog__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+.api-schema-catalog__chip {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  padding: var(--space-0-5) var(--space-1);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  text-transform: lowercase;
+}
+
+.api-schema-catalog__chip[data-kind="deprecated"] {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+}
+
+.api-schema-catalog__chip[data-kind="discriminator"] {
+  background: var(--color-info-bg);
+  color: var(--color-info-text);
 }
 
 /* ============================================

--- a/bengal/themes/default/templates/autodoc/openapi/_schema.html
+++ b/bengal/themes/default/templates/autodoc/openapi/_schema.html
@@ -12,11 +12,18 @@ Usage:
 
 Parameters:
 - schema: OpenAPISchemaMetadata or dict (schema_type/type, properties, required,
-  enum, example, items, description)
+  enum, example, items, description, and — for advanced specs — oneOf/anyOf/allOf,
+  discriminator, additionalProperties, and per-property constraints/flags).
 - name: Schema name for display (optional, default none)
 - depth: Nesting depth for indentation + recursion guard (default 0)
 
-Kida Features (confirmed against installed kida-templates 0.6.0):
+Advanced rendering (#285) is driven by template-function filters so the same
+recursion handles top-level schemas and nested raw property schemas:
+  schema_composition / schema_constraints / schema_flags /
+  schema_additional_properties. Each returns an empty/None result when its
+  construct is absent, so simple schemas render exactly as before.
+
+Kida Features (confirmed against installed kida-templates):
 - {% def name(param=default) %} with recursive self-invocation
 - {% cache %} for expensive recursive rendering
 - {% with %} for nil-safe optional sections
@@ -28,11 +35,15 @@ Kida Features (confirmed against installed kida-templates 0.6.0):
 {% let properties = schema?.properties ?? {} %}
 {% let required_props = schema?.required ?? () %}
 {% let enum_vals = schema?.enum ?? none %}
-{% let example_val = schema?.example ?? none %}
 {% let items_schema = schema?.items ?? none %}
 {% let description = schema?.description ?? '' %}
 {% let current_depth = depth ?? 0 %}
 {% let max_depth = 4 %}
+{% let composition = schema | schema_composition %}
+{% let constraints = schema | schema_constraints %}
+{% let flags = schema | schema_flags %}
+{% let additional = schema | schema_additional_properties %}
+{% let ref_name = schema | schema_ref %}
 
 {# Distinct cache namespace ('oa-schema-def-') so this {% def %} never collides
    with the legacy partials/schema-viewer.html {% include %} (key prefix
@@ -40,12 +51,20 @@ Kida Features (confirmed against installed kida-templates 0.6.0):
    partial keys only on (name, depth); sharing that namespace caused anonymous
    nested schemas to return each other's cached fragments. #}
 {% cache 'oa-schema-def-' ~ (schema_name or 'anon') ~ '-' ~ current_depth %}
+{% if ref_name is not none %}
+{# Cyclic $ref left by the extractor: show a readable indicator, not an empty box. #}
+<div class="api-schema-viewer api-schema-viewer--ref" data-schema-type="$ref">
+    <span class="api-schema-viewer__truncated">&#8635; {{ ref_name }} (circular reference)</span>
+</div>
+{% else %}
 <div class="api-schema-viewer api-schema-viewer--depth-{{ current_depth }}" data-schema-type="{{ schema_type }}">
     {# Schema Header #}
     {% if schema_name %}
     <div class="api-schema-viewer__header">
         <code class="api-schema-viewer__name">{{ schema_name }}</code>
         <span class="api-schema-viewer__type">{{ schema_type }}</span>
+        {% if flags?.nullable %}<span class="autodoc-badge" data-badge="nullable">nullable</span>{% end %}
+        {% if flags?.deprecated %}<span class="autodoc-badge" data-badge="deprecated">deprecated</span>{% end %}
     </div>
     {% end %}
 
@@ -53,6 +72,48 @@ Kida Features (confirmed against installed kida-templates 0.6.0):
     {% if description %}
     <div class="api-schema-viewer__description prose-sm">
         {{ description | markdownify | safe }}
+    </div>
+    {% end %}
+
+    {# Validation constraints on a primitive / leaf schema #}
+    {% if constraints | length > 0 %}
+    <div class="api-schema-viewer__constraints">
+        {% for clabel, cvalue in constraints |> items %}
+        <code class="api-schema-viewer__constraint" data-constraint="{{ clabel }}">{{ clabel }}{% if cvalue %}: {{ cvalue }}{% end %}</code>
+        {% end %}
+    </div>
+    {% end %}
+
+    {# Composition: oneOf / anyOf / allOf (+ discriminator) #}
+    {% if composition is not none %}
+    <div class="api-schema-composition" data-composition="{{ composition.kind }}">
+        <div class="api-schema-composition__title">
+            {% if composition.kind == 'oneOf' %}One of{% elif composition.kind == 'anyOf' %}Any of{% else %}All of{% end %}
+        </div>
+        {% if composition.discriminator %}
+        <div class="api-schema-composition__discriminator">
+            <span class="api-schema-composition__discriminator-label">Discriminated by</span>
+            <code class="api-schema-composition__discriminator-prop">{{ composition.discriminator.property_name }}</code>
+            {% if composition.discriminator.mapping | length > 0 %}
+            <ul class="api-schema-composition__mapping">
+                {% for row in composition.discriminator.mapping %}
+                <li><code class="api-schema-composition__mapping-value">{{ row.value }}</code> <span class="api-schema-composition__mapping-arrow" aria-hidden="true">&rarr;</span> <span class="api-schema-composition__mapping-target">{{ row.target }}</span></li>
+                {% end %}
+            </ul>
+            {% end %}
+        </div>
+        {% end %}
+        <div class="api-schema-composition__branches">
+            {% for branch in composition.branches %}
+            {% if composition.kind == 'allOf' %}
+            <span class="api-schema-composition__branch"><code>{{ branch.label }}</code> <span class="api-schema-composition__branch-type">{{ branch.schema_type }}</span></span>
+            {% elif current_depth < max_depth %}
+            <div class="api-schema-composition__variant">{{ schema_viewer(branch.schema, name=branch.label, depth=current_depth + 1) }}</div>
+            {% else %}
+            <span class="api-schema-viewer__truncated">{{ branch.label }} ({{ branch.schema_type }})&hellip;</span>
+            {% end %}
+            {% end %}
+        </div>
     </div>
     {% end %}
 
@@ -65,83 +126,121 @@ Kida Features (confirmed against installed kida-templates 0.6.0):
         {% let prop_desc = prop_schema?.description ?? '' %}
         {% let prop_enum = prop_schema?.enum %}
         {% let prop_default = prop_schema?.default %}
+        {% let prop_flags = prop_schema | schema_flags %}
+        {% let prop_constraints = prop_schema | schema_constraints %}
+        {% let prop_composition = prop_schema | schema_composition %}
+        {% let prop_additional = prop_schema | schema_additional_properties %}
+        {% let prop_structural = prop_schema?.properties or prop_composition is not none or prop_additional is not none %}
 
         <div class="api-schema-viewer__property{% if is_required %} api-schema-viewer__property--required{% end %}">
             <div class="api-schema-viewer__property-header">
                 <code class="api-schema-viewer__property-name">{{ prop_name }}</code>
                 <span class="api-schema-viewer__property-type">{{ prop_type }}</span>
-                {% if is_required %}
-                <span class="badge badge--danger-subtle badge--xs">required</span>
-                {% end %}
+                {% if is_required %}<span class="badge badge--danger-subtle badge--xs">required</span>{% end %}
+                {% if prop_flags?.nullable %}<span class="autodoc-badge" data-badge="nullable">nullable</span>{% end %}
+                {% if prop_flags?.readOnly %}<span class="autodoc-badge" data-badge="readonly">read-only</span>{% end %}
+                {% if prop_flags?.writeOnly %}<span class="autodoc-badge" data-badge="writeonly">write-only</span>{% end %}
+                {% if prop_flags?.deprecated %}<span class="autodoc-badge" data-badge="deprecated">deprecated</span>{% end %}
             </div>
 
             {% if prop_desc %}
             <div class="api-schema-viewer__property-desc">{{ prop_desc }}</div>
             {% end %}
 
-            {# Nested object (recursive, with depth limit) #}
-            {% if prop_type == 'object' and current_depth < max_depth %}{{ schema_viewer(prop_schema, name=prop_name, depth=current_depth + 1) }}{% end %}{#
-                Array items #}{% if prop_type == 'array' and prop_schema?.items and current_depth < max_depth %}<div
-                class="api-schema-viewer__array-items">
-                <span class="api-schema-viewer__label">Items:</span>
-                {{ schema_viewer(prop_schema.items, name=prop_name ~ ' items', depth=current_depth + 1) }}
-        </div>
-        {% end %}
-
-        {# Property enum #}
-        {% with prop_enum as enums %}
-        {% if enums | length > 0 %}
-        <div class="api-schema-viewer__enum">
-            <span class="api-schema-viewer__enum-label">Allowed:</span>
-            {% for val in enums %}
-            <code class="api-schema-viewer__enum-value">{{ val }}</code>
+            {# Per-property validation constraints (format, pattern, min/max, ...) #}
+            {% if prop_constraints | length > 0 %}
+            <div class="api-schema-viewer__constraints">
+                {% for clabel, cvalue in prop_constraints |> items %}
+                <code class="api-schema-viewer__constraint" data-constraint="{{ clabel }}">{{ clabel }}{% if cvalue %}: {{ cvalue }}{% end %}</code>
+                {% end %}
+            </div>
             {% end %}
-        </div>
-        {% end %}
-        {% end %}
 
-        {# Property default #}
-        {% with prop_default as default %}
-        <div class="api-schema-viewer__default">
-            <span class="api-schema-viewer__label">Default:</span>
-            <code>{{ default }}</code>
+            {# Structural property: nested object, composition (oneOf/anyOf/allOf),
+               or a typed/open map (additionalProperties). Recurse into the full
+               viewer so inline compositions and maps render, not just top-level
+               component schemas. Depth-bounded with a truncation marker. #}
+            {% if prop_structural %}
+            {% if current_depth < max_depth %}{{ schema_viewer(prop_schema, name=prop_name, depth=current_depth + 1) }}{% else %}<span class="api-schema-viewer__truncated">{{ prop_name }} (nested {{ prop_type }})&hellip;</span>{% end %}
+            {% end %}
+
+            {# Array items #}
+            {% if prop_type == 'array' and prop_schema?.items %}
+            <div class="api-schema-viewer__array-items">
+                <span class="api-schema-viewer__label">Items:</span>
+                {% if current_depth < max_depth %}{{ schema_viewer(prop_schema.items, name=prop_name ~ ' items', depth=current_depth + 1) }}{% else %}<span class="api-schema-viewer__truncated">{{ prop_schema.items?.type ?? prop_schema.items?.schema_type ?? 'item' }}&hellip;</span>{% end %}
+            </div>
+            {% end %}
+
+            {# Property enum #}
+            {% with prop_enum as enums %}
+            {% if enums | length > 0 %}
+            <div class="api-schema-viewer__enum">
+                <span class="api-schema-viewer__enum-label">Allowed:</span>
+                {% for val in enums %}
+                <code class="api-schema-viewer__enum-value">{{ val }}</code>
+                {% end %}
+            </div>
+            {% end %}
+            {% end %}
+
+            {# Property default #}
+            {% with prop_default as default %}
+            <div class="api-schema-viewer__default">
+                <span class="api-schema-viewer__label">Default:</span>
+                <code>{{ default }}</code>
+            </div>
+            {% end %}
         </div>
         {% end %}
     </div>
     {% end %}
-</div>
-{% end %}
 
-{# Array Items Schema #}
-{% if schema_type == 'array' and items_schema %}
-<div class="api-schema-viewer__array">
-    <span class="api-schema-viewer__label">Array of:</span>
-    {% if current_depth < max_depth %}{{ schema_viewer(items_schema, name=schema_name ~ ' items', depth=current_depth + 1) }}{% else %}<code>{{ items_schema?.type ??
-        items_schema?.schema_type ?? 'any' }}</code>
+    {# Additional properties (typed maps / open objects) #}
+    {% if additional is not none %}
+    <div class="api-schema-viewer__additional">
+        {% if additional?.value_schema %}
+        <span class="api-schema-viewer__label">Additional properties</span>
+        {% if current_depth < max_depth %}{{ schema_viewer(additional.value_schema, name='(values)', depth=current_depth + 1) }}{% else %}<code class="api-schema-viewer__property-type">{{ additional.schema_type }}</code>{% end %}
+        {% elif additional?.allowed %}
+        <span class="api-schema-viewer__note">Allows additional properties</span>
+        {% else %}
+        <span class="api-schema-viewer__note">No additional properties</span>
         {% end %}
-</div>
-{% end %}
+    </div>
+    {% end %}
 
-{# Enum Values (top-level) #}
-{% with enum_vals as enums %}
-{% if enums | length > 0 %}
-<div class="api-schema-viewer__enum">
-    <span class="api-schema-viewer__enum-label">Allowed values:</span>
-    {% for val in enums %}
-    <code class="api-schema-viewer__enum-value">{{ val }}</code>
+    {# Array Items Schema (top-level array) #}
+    {% if schema_type == 'array' and items_schema %}
+    <div class="api-schema-viewer__array">
+        <span class="api-schema-viewer__label">Array of:</span>
+        {% if current_depth < max_depth %}{{ schema_viewer(items_schema, name=schema_name ~ ' items', depth=current_depth + 1) }}{% else %}<span class="api-schema-viewer__truncated">{{ items_schema?.type ?? items_schema?.schema_type ?? 'item' }}&hellip;</span>{% end %}
+    </div>
+    {% end %}
+
+    {# Enum Values (top-level) #}
+    {% with enum_vals as enums %}
+    {% if enums | length > 0 %}
+    <div class="api-schema-viewer__enum">
+        <span class="api-schema-viewer__enum-label">Allowed values:</span>
+        {% for val in enums %}
+        <code class="api-schema-viewer__enum-value">{{ val }}</code>
+        {% end %}
+    </div>
+    {% end %}
+    {% end %}
+
+    {# Examples: a singular `example`, a 3.1 `examples` list, or a named
+       `examples` map are all normalized to a uniform tuple and rendered here. #}
+    {% for ex in (schema | schema_examples) %}
+    <div class="api-schema-viewer__example">
+        <span class="api-schema-viewer__example-label">{% if ex.name %}{{ ex.name }}{% else %}Example{% end %}</span>
+        {% if ex.summary %}<span class="api-schema-viewer__example-summary">{{ ex.summary }}</span>{% end %}
+        <pre
+            class="api-schema-viewer__example-code"><code class="language-json">{{ ex.value | tojson(indent=2) }}</code></pre>
+    </div>
     {% end %}
 </div>
 {% end %}
-{% end %}
-
-{# Example Value #}
-{% with example_val as example %}
-<div class="api-schema-viewer__example">
-    <span class="api-schema-viewer__example-label">Example</span>
-    <pre
-        class="api-schema-viewer__example-code"><code class="language-json">{{ example | tojson(indent=2) }}</code></pre>
-</div>
-{% end %}
-</div>
 {% end %}
 {% end %}

--- a/bengal/themes/default/templates/autodoc/openapi/schema.html
+++ b/bengal/themes/default/templates/autodoc/openapi/schema.html
@@ -30,14 +30,22 @@ Kida Features:
 {% let example_val = schema?.example %}
 {% let description = schema?.description ?? element?.description ?? '' %}
 {% let schema_format = schema?.raw_schema?.format ?? '' %}
+{% let composition = schema?.display_schema | schema_composition %}
+{% let additional = schema?.display_schema | schema_additional_properties %}
+{% let flags = schema?.display_schema | schema_flags %}
+{# A schema has a renderable "body" when it has properties, is composed
+   (oneOf/anyOf/allOf), or is an open/typed map (additionalProperties). #}
+{% let has_body = properties | length > 0 or composition is not none or additional is not none %}
 
 {% block api_left %}
 <nav class="openapi-nav" aria-label="Schema sections">
   <a href="{{ section?.href ?? page?.href ?? '#' }}" class="openapi-nav__back">{{ icon('arrow-left', size=14) }} {{ section?.title ?? 'Schemas' }}</a>
-  {% if properties | length > 0 %}<a href="#properties">Properties</a>{% end %}
+  {% if has_body %}<a href="#properties">{% if properties | length > 0 %}Properties{% elif composition is not none %}Variants{% else %}Structure{% end %}</a>{% end %}
   {% if enum_vals | length > 0 %}<a href="#enum">Allowed values</a>{% end %}
-  {% if properties | length == 0 and enum_vals | length == 0 %}<a href="#shape">Shape</a>{% end %}
-  {% if example_val is not none %}<a href="#example">Example</a>{% end %}
+  {% if not has_body and enum_vals | length == 0 %}<a href="#shape">Shape</a>{% end %}
+  {# Body schemas render their example inside the viewer; only link a standalone
+     #example section for primitive/enum schemas that have no viewer body. #}
+  {% if example_val is not none and not has_body %}<a href="#example">Example</a>{% end %}
 </nav>
 {% end %}
 
@@ -46,6 +54,7 @@ Kida Features:
 <h1 class="api-schema__title">
   <code>{{ schema_name }}</code>
   <span class="badge badge--outline">{{ schema_type }}</span>
+  {% if flags?.deprecated %}<span class="autodoc-badge" data-badge="deprecated">deprecated</span>{% end %}
 </h1>
 
 {% if description %}
@@ -58,10 +67,13 @@ Kida Features:
 {% block api_main %}
 <div class="api-schema" id="schema-{{ schema_name | slugify }}" data-autodoc="openapi" data-element="schema">
 
-  {# Schema Properties #}
-  {% if properties | length > 0 %}
+  {# Schema body: properties, composition (oneOf/anyOf/allOf), and/or open maps.
+     Rendered once through the recursive viewer so composed and polymorphic
+     schemas (which often have no direct properties) still get a full detail
+     body, not an empty page. #}
+  {% if has_body %}
   <section class="api-schema__section autodoc-section" id="properties" data-section="properties">
-    <h2 class="api-schema__section-title">Properties</h2>
+    <h2 class="api-schema__section-title">{% if properties | length > 0 %}Properties{% elif composition is not none %}Variants{% else %}Structure{% end %}</h2>
 
     {% cache 'openapi-schema-' ~ schema_name %}
     {{ schema_viewer(schema?.display_schema ?? {}, name=schema_name, depth=0) }}
@@ -69,7 +81,7 @@ Kida Features:
   </section>
   {% end %}
 
-  {% if properties | length == 0 and enum_vals | length == 0 %}
+  {% if not has_body and enum_vals | length == 0 %}
   <section class="api-schema__section autodoc-section" id="shape" data-section="shape">
     <h2 class="api-schema__section-title">Shape</h2>
     <div class="api-schema-shape">
@@ -84,6 +96,23 @@ Kida Features:
       </div>
       {% end %}
     </div>
+    {# Primitive schemas don't go through the viewer, so render their flags and
+       validation constraints here so pattern/min/max/format still surface. #}
+    {% let shape_flags = schema?.display_schema | schema_flags %}
+    {% if shape_flags?.nullable or shape_flags?.deprecated %}
+    <div class="api-schema-viewer__property-header">
+      {% if shape_flags?.nullable %}<span class="autodoc-badge" data-badge="nullable">nullable</span>{% end %}
+      {% if shape_flags?.deprecated %}<span class="autodoc-badge" data-badge="deprecated">deprecated</span>{% end %}
+    </div>
+    {% end %}
+    {% let shape_constraints = schema?.display_schema | schema_constraints %}
+    {% if shape_constraints | length > 0 %}
+    <div class="api-schema-viewer__constraints">
+      {% for clabel, cvalue in shape_constraints |> items %}
+      <code class="api-schema-viewer__constraint" data-constraint="{{ clabel }}">{{ clabel }}{% if cvalue %}: {{ cvalue }}{% end %}</code>
+      {% end %}
+    </div>
+    {% end %}
   </section>
   {% end %}
 
@@ -101,8 +130,9 @@ Kida Features:
   {% end %}
   {% end %}
 
-  {# Example #}
-  {% if example_val is not none %}
+  {# Example — only for primitive/enum schemas without a viewer body; body
+     schemas render their examples inside the viewer above (no duplication). #}
+  {% if example_val is not none and not has_body %}
   {% let example = example_val %}
   <section class="api-schema__section autodoc-section" id="example" data-section="example">
     <h2 class="api-schema__section-title">Example</h2>
@@ -138,6 +168,8 @@ Kida Features:
     <div><dt>Properties</dt><dd>{{ properties | length }}</dd></div>
     <div><dt>Required</dt><dd>{{ required_props | length }}</dd></div>
     {% if enum_vals | length > 0 %}<div><dt>Values</dt><dd>{{ enum_vals | length }}</dd></div>{% end %}
+    {% if composition is not none %}<div><dt>{{ composition.kind }}</dt><dd>{{ composition.branches | length }} variants</dd></div>{% end %}
+    {% if composition?.discriminator %}<div><dt>Discriminator</dt><dd><code>{{ composition.discriminator.property_name }}</code></dd></div>{% end %}
   </dl>
 </div>
 {% end %}

--- a/bengal/themes/default/templates/autodoc/openapi/section-index.html
+++ b/bengal/themes/default/templates/autodoc/openapi/section-index.html
@@ -74,11 +74,20 @@ Context:
     <div class="api-schema-catalog">
       {% for schema in schema_items %}
       {% let property_preview = schema.properties |> items |> take(4) %}
+      {% let tile_composition = schema.display_schema | schema_composition %}
+      {% let tile_flags = schema.display_schema | schema_flags %}
       <a href="{{ schema.href }}" class="api-schema-catalog__tile">
         <span class="api-schema-catalog__tile-top">
           <code>{{ schema.name }}</code>
           <span>{{ schema.schema_type }}</span>
         </span>
+        {% if tile_composition is not none or tile_flags?.deprecated %}
+        <span class="api-schema-catalog__chips">
+          {% if tile_composition is not none %}<span class="api-schema-catalog__chip" data-kind="{{ tile_composition.kind }}">{{ tile_composition.kind }}</span>{% end %}
+          {% if tile_composition?.discriminator %}<span class="api-schema-catalog__chip" data-kind="discriminator">polymorphic</span>{% end %}
+          {% if tile_flags?.deprecated %}<span class="api-schema-catalog__chip" data-kind="deprecated">deprecated</span>{% end %}
+        </span>
+        {% end %}
         {% if schema.description %}
         <span class="api-schema-catalog__description">{{ schema.description | truncate(120) }}</span>
         {% end %}

--- a/changelog.d/openapi-advanced-schema-rendering.added.md
+++ b/changelog.d/openapi-advanced-schema-rendering.added.md
@@ -1,0 +1,22 @@
+REST autodoc schema pages now render advanced OpenAPI constructs as structured
+model documentation instead of dropping or flattening them (#285). `oneOf`,
+`anyOf`, and `allOf` render as labeled composition blocks; polymorphic schemas
+show their `discriminator` property and `value → schema` mapping; per-property
+validation constraints (`format`, `pattern`, numeric `min`/`max`/`multipleOf`,
+string `minLength`/`maxLength`, and array `minItems`/`maxItems`/`uniqueItems`)
+render as chips; and `nullable`, `readOnly`, `writeOnly`, and `deprecated`
+render as badges. Open and typed maps (`additionalProperties`) get their own
+section, primitive schemas surface their constraints and example, and a
+self-referential schema renders a bounded, readable "circular reference"
+indicator rather than an empty box or runaway recursion. Schema catalog tiles
+gained composition/discriminator/deprecated summary chips. Examples normalize a
+singular `example`, a 3.1 `examples` list, and a named `examples` map into a
+uniform rendering. The work is driven by additive normalization filters in
+`bengal/rendering/template_functions/openapi.py`
+(`schema_composition`/`schema_constraints`/`schema_flags`/
+`schema_additional_properties`/`schema_examples`/`schema_ref`), so simple schemas
+render byte-identically. The demo commerce spec marks server-assigned fields
+`readOnly` and credentials `writeOnly` to exercise the new rendering. Covered by
+unit tests for the normalization helpers (including circular-ref bounding and
+malformed-input robustness), template/CSS contract tests, and an end-to-end
+build of a fixture exercising every construct.

--- a/site/api/openapi.yaml
+++ b/site/api/openapi.yaml
@@ -330,12 +330,15 @@ components:
       properties:
         id:
           type: string
+          readOnly: true
         created_at:
           type: string
           format: date-time
+          readOnly: true
         updated_at:
           type: string
           format: date-time
+          readOnly: true
 
     UserBase:
       type: object
@@ -434,8 +437,11 @@ components:
       properties:
         password:
           type: string
+          writeOnly: true
+          minLength: 8
         mfa_code:
           type: string
+          writeOnly: true
 
     SessionToken:
       type: object

--- a/tests/integration/test_openapi_advanced_schema.py
+++ b/tests/integration/test_openapi_advanced_schema.py
@@ -1,0 +1,160 @@
+"""
+End-to-end rendering tests for advanced OpenAPI schema constructs (#285).
+
+Builds the ``test-openapi-advanced`` root — a spec exercising oneOf/anyOf/allOf
+composition, discriminators, nullable/readOnly/writeOnly/deprecated flags,
+numeric/string/array constraints, additionalProperties (boolean + typed map),
+self-referential schemas, and field-level examples — and asserts the generated
+schema detail pages render them as structured documentation rather than raw
+JSON dumps.
+
+These render through the real Kida engine, so they also guard against template
+syntax regressions in ``autodoc/openapi/_schema.html`` and ``schema.html``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.autodoc
+
+
+def _schema_html(site, name: str) -> str:
+    """Read a generated schema detail page, failing clearly if it is missing."""
+    page = site.output_dir / "api" / "schemas" / name / "index.html"
+    assert page.exists(), f"Expected schema page missing: {page}"
+    html = page.read_text(encoding="utf-8")
+    # Pages must be non-blank, styled shells — not error stubs.
+    assert "api-schema" in html, f"{name} page is not a styled schema shell"
+    return html
+
+
+@pytest.mark.bengal(testroot="test-openapi-advanced")
+def test_oneof_discriminator_renders_variants_and_mapping(site, build_site) -> None:
+    """A polymorphic oneOf schema renders its variants and discriminator mapping."""
+    build_site()
+    html = _schema_html(site, "PaymentMethod")
+
+    assert 'data-composition="oneOf"' in html
+    assert "One of" in html
+    # Discriminator + mapping rows (value -> target schema name).
+    assert "Discriminated by" in html
+    assert "api-schema-composition__discriminator-prop" in html
+    assert ">card<" in html
+    assert "CardPayment" in html
+    assert ">bank<" in html
+    assert "BankPayment" in html
+    # The composed schema has no direct properties yet still gets a real body.
+    assert "api-schema-composition__variant" in html
+
+
+@pytest.mark.bengal(testroot="test-openapi-advanced")
+def test_constraints_and_flags_render_on_account(site, build_site) -> None:
+    """Numeric/string/array constraints and field flags render as structured chips."""
+    build_site()
+    html = _schema_html(site, "Account")
+
+    # Flags.
+    assert 'data-badge="readonly"' in html  # id
+    assert 'data-badge="nullable"' in html  # nickname
+    assert 'data-badge="deprecated"' in html  # legacy_token
+    # Constraints.
+    for constraint in (
+        'data-constraint="format"',
+        'data-constraint="min"',
+        'data-constraint="max"',
+        'data-constraint="multiple of"',
+        'data-constraint="min length"',
+        'data-constraint="max length"',
+        'data-constraint="unique items"',
+    ):
+        assert constraint in html, f"missing constraint chip: {constraint}"
+
+    # Constraint VALUES are interpolated, not just the labels — exercises the
+    # template's `{% if cvalue %}: {{ cvalue }}` branch (balance property).
+    assert "min: 0" in html
+    assert "max: 1000000" in html
+    assert "multiple of: 0.01" in html
+
+    # Property-level composition (primary_method: oneOf) and a typed map
+    # (labels: additionalProperties) render inline, not just at the top level.
+    assert 'data-composition="oneOf"' in html
+    assert "api-schema-viewer__additional" in html
+
+
+@pytest.mark.bengal(testroot="test-openapi-advanced")
+def test_writeonly_and_pattern_render_on_card_payment(site, build_site) -> None:
+    """writeOnly fields and regex patterns surface on the variant schema page."""
+    build_site()
+    html = _schema_html(site, "CardPayment")
+
+    assert 'data-badge="writeonly"' in html  # cvv
+    assert 'data-constraint="pattern"' in html  # number
+
+
+@pytest.mark.bengal(testroot="test-openapi-advanced")
+def test_additional_properties_render(site, build_site) -> None:
+    """Open maps and typed maps both render an additionalProperties section."""
+    build_site()
+
+    settings = _schema_html(site, "Settings")
+    assert "api-schema-viewer__additional" in settings
+    assert "Allows additional properties" in settings
+    assert "&quot;theme&quot;" in settings or '"theme"' in settings  # schema-level example
+
+    metadata = _schema_html(site, "Metadata")
+    assert "api-schema-viewer__additional" in metadata
+    assert "Additional properties" in metadata
+
+
+@pytest.mark.bengal(testroot="test-openapi-advanced")
+def test_allof_and_anyof_render_as_composition(site, build_site) -> None:
+    """allOf inheritance and anyOf unions render as labeled composition blocks."""
+    build_site()
+
+    dog = _schema_html(site, "Dog")
+    assert 'data-composition="allOf"' in dog
+    assert "All of" in dog
+
+    search = _schema_html(site, "SearchValue")
+    assert 'data-composition="anyOf"' in search
+    assert "Any of" in search
+
+
+@pytest.mark.bengal(testroot="test-openapi-advanced")
+def test_primitive_schema_shows_constraints_and_example(site, build_site) -> None:
+    """A primitive schema (no object body) still surfaces its constraints + example."""
+    build_site()
+    html = _schema_html(site, "CurrencyCode")
+
+    assert "api-schema-shape" in html  # primitive shape section
+    assert 'data-constraint="pattern"' in html
+    assert 'data-constraint="min length"' in html
+    # Primitives render a standalone example section (not via the viewer body).
+    assert 'id="example"' in html
+    assert "USD" in html
+
+
+@pytest.mark.bengal(testroot="test-openapi-advanced")
+def test_circular_schema_is_bounded_and_readable(site, build_site) -> None:
+    """A self-referential schema renders a bounded, readable circular indicator."""
+    build_site()
+    html = _schema_html(site, "TreeNode")
+
+    assert "circular reference" in html
+    assert "api-schema-viewer--ref" in html
+    # Bounded: recursion does not explode the page with unbounded nested viewers.
+    assert html.count("api-schema-viewer--depth-") < 12
+
+
+@pytest.mark.bengal(testroot="test-openapi-advanced")
+def test_schema_index_tiles_summarize_composition(site, build_site) -> None:
+    """The schema catalog index surfaces composition/deprecated tile chips."""
+    build_site()
+    index = site.output_dir / "api" / "schemas" / "index.html"
+    assert index.exists(), f"Schema index missing: {index}"
+    html = index.read_text(encoding="utf-8")
+
+    assert "api-schema-catalog__chip" in html
+    assert 'data-kind="oneOf"' in html
+    assert 'data-kind="discriminator"' in html

--- a/tests/roots/test-openapi-advanced/api/openapi.yaml
+++ b/tests/roots/test-openapi-advanced/api/openapi.yaml
@@ -1,0 +1,170 @@
+openapi: 3.0.3
+info:
+  title: Advanced Schema Demo
+  version: 1.0.0
+  description: |
+    Fixture exercising advanced OpenAPI schema constructs for #285:
+    oneOf + discriminator, anyOf, allOf inheritance, nullable/readOnly/
+    writeOnly/deprecated flags, numeric/string/array constraints,
+    additionalProperties (boolean + typed map), self-referential schemas,
+    and field-level examples.
+
+paths:
+  /payments:
+    post:
+      summary: Create a payment
+      operationId: createPayment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentMethod'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+
+components:
+  schemas:
+    # --- Polymorphism: oneOf + discriminator ---
+    PaymentMethod:
+      type: object
+      discriminator:
+        propertyName: kind
+        mapping:
+          card: '#/components/schemas/CardPayment'
+          bank: '#/components/schemas/BankPayment'
+      oneOf:
+        - $ref: '#/components/schemas/CardPayment'
+        - $ref: '#/components/schemas/BankPayment'
+
+    CardPayment:
+      type: object
+      required: [kind, number]
+      properties:
+        kind:
+          type: string
+          enum: [card]
+        number:
+          type: string
+          pattern: '^[0-9]{16}$'
+          minLength: 16
+          maxLength: 16
+        cvv:
+          type: string
+          writeOnly: true
+          description: Card verification value.
+
+    BankPayment:
+      type: object
+      required: [kind, iban]
+      properties:
+        kind:
+          type: string
+          enum: [bank]
+        iban:
+          type: string
+          format: iban
+
+    # --- anyOf without a discriminator ---
+    SearchValue:
+      anyOf:
+        - type: string
+        - type: integer
+        - type: boolean
+
+    # --- allOf inheritance ---
+    Animal:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+    Dog:
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+        - type: object
+          properties:
+            breed:
+              type: string
+
+    # --- constraints + flags ---
+    Account:
+      type: object
+      required: [id, balance]
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        nickname:
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 64
+        balance:
+          type: number
+          minimum: 0
+          maximum: 1000000
+          multipleOf: 0.01
+        legacy_token:
+          type: string
+          deprecated: true
+          description: Use access tokens instead.
+        tags:
+          type: array
+          uniqueItems: true
+          minItems: 0
+          maxItems: 20
+          items:
+            type: string
+        status:
+          type: string
+          enum: [active, frozen, closed]
+          example: active
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        primary_method:
+          oneOf:
+            - $ref: '#/components/schemas/CardPayment'
+            - $ref: '#/components/schemas/BankPayment'
+
+    # --- additionalProperties as a typed map ---
+    Metadata:
+      type: object
+      additionalProperties:
+        type: string
+
+    # --- additionalProperties: true (open map) + schema-level example ---
+    Settings:
+      type: object
+      additionalProperties: true
+      example:
+        theme: dark
+        notifications: true
+
+    # --- primitive schema with constraints (no object body) ---
+    CurrencyCode:
+      type: string
+      description: ISO 4217 currency code.
+      pattern: '^[A-Z]{3}$'
+      minLength: 3
+      maxLength: 3
+      example: USD
+
+    # --- self-referential / circular schema ---
+    TreeNode:
+      type: object
+      properties:
+        label:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/TreeNode'

--- a/tests/roots/test-openapi-advanced/bengal.toml
+++ b/tests/roots/test-openapi-advanced/bengal.toml
@@ -1,0 +1,11 @@
+[site]
+title = "OpenAPI Advanced Schemas"
+baseurl = "/"
+
+[build]
+theme = "default"
+
+[autodoc.openapi]
+enabled = true
+spec_file = "api/openapi.yaml"
+output_prefix = "api"

--- a/tests/roots/test-openapi-advanced/content/index.md
+++ b/tests/roots/test-openapi-advanced/content/index.md
@@ -1,0 +1,7 @@
+---
+title: Home
+---
+
+# Advanced OpenAPI Schemas
+
+This site exists to render the advanced schema fixture under `/api/`.

--- a/tests/unit/rendering/template_functions/test_openapi_filters.py
+++ b/tests/unit/rendering/template_functions/test_openapi_filters.py
@@ -13,10 +13,18 @@ from typing import Any
 from bengal.rendering.template_functions.openapi import (
     EndpointView,
     SchemaView,
+    _build_example_body,
     _generate_anchor_id,
+    _schema_to_example,
     endpoints_filter,
     generate_code_sample,
     get_response_example,
+    schema_additional_properties,
+    schema_composition,
+    schema_constraints,
+    schema_examples,
+    schema_flags,
+    schema_ref,
     schema_view_filter,
     schemas_filter,
 )
@@ -798,3 +806,328 @@ class TestOpenAPICodeSamples:
         )
 
         assert example == {"id": "user_123"}
+
+
+# =============================================================================
+# Tests for advanced schema normalization (#285)
+# =============================================================================
+
+
+class TestSchemaComposition:
+    """Tests for schema_composition() (oneOf/anyOf/allOf + discriminator)."""
+
+    def test_one_of_with_discriminator(self) -> None:
+        """oneOf polymorphism exposes branches and a normalized discriminator."""
+        raw = {
+            "type": "object",
+            "discriminator": {
+                "propertyName": "type",
+                "mapping": {
+                    "credit_card": "#/components/schemas/CreditCard",
+                    "bank_account": "#/components/schemas/BankAccount",
+                    "paypal": "#/components/schemas/PayPal",
+                },
+            },
+            "oneOf": [
+                {"type": "object", "properties": {"type": {"enum": ["credit_card"]}}},
+                {"type": "object", "properties": {"type": {"enum": ["bank_account"]}}},
+                {"type": "object", "title": "PayPal"},
+            ],
+        }
+
+        composition = schema_composition(raw)
+
+        assert composition is not None
+        assert composition["kind"] == "oneOf"
+        assert len(composition["branches"]) == 3
+        # Branch labels derive from a single-value type enum, else title.
+        assert [b["label"] for b in composition["branches"]] == [
+            "credit_card",
+            "bank_account",
+            "PayPal",
+        ]
+        disc = composition["discriminator"]
+        assert disc is not None
+        assert disc["property_name"] == "type"
+        assert {row["value"] for row in disc["mapping"]} == {
+            "credit_card",
+            "bank_account",
+            "paypal",
+        }
+        # The ref string is shortened to its schema name for display.
+        assert {row["target"] for row in disc["mapping"]} == {
+            "CreditCard",
+            "BankAccount",
+            "PayPal",
+        }
+
+    def test_any_of_without_discriminator(self) -> None:
+        """anyOf is recognized and reports no discriminator when absent."""
+        composition = schema_composition({"anyOf": [{"type": "string"}, {"type": "integer"}]})
+        assert composition is not None
+        assert composition["kind"] == "anyOf"
+        assert composition["discriminator"] is None
+        assert composition["branches"][0]["schema_type"] == "string"
+
+    def test_all_of_is_recognized_as_composition(self) -> None:
+        """allOf is exposed as composition even though properties stay flattened."""
+        composition = schema_composition({"allOf": [{"type": "object"}, {"type": "object"}]})
+        assert composition is not None
+        assert composition["kind"] == "allOf"
+
+    def test_plain_schema_has_no_composition(self) -> None:
+        """A non-composed schema returns None (discriminating, not vacuous)."""
+        assert schema_composition({"type": "object", "properties": {}}) is None
+        assert schema_composition(None) is None
+
+
+class TestSchemaConstraints:
+    """Tests for schema_constraints() validation-constraint extraction."""
+
+    def test_extracts_present_constraints_only(self) -> None:
+        """Only set constraint keys are returned, with their values."""
+        constraints = schema_constraints(
+            {
+                "type": "string",
+                "pattern": "^[a-z]+$",
+                "minLength": 3,
+                "maxLength": 64,
+                "format": "email",
+            }
+        )
+        assert constraints == {
+            "format": "email",
+            "pattern": "^[a-z]+$",
+            "min length": "3",
+            "max length": "64",
+        }
+
+    def test_unique_items_renders_as_label_only(self) -> None:
+        """Boolean uniqueItems maps to an empty value (label-only chip)."""
+        assert schema_constraints({"type": "array", "uniqueItems": True}) == {"unique items": ""}
+        # False boolean constraints are omitted entirely.
+        assert schema_constraints({"type": "array", "uniqueItems": False}) == {}
+
+    def test_exclusive_bounds(self) -> None:
+        """exclusiveMinimum/exclusiveMaximum (3.1 numeric form) are surfaced."""
+        assert schema_constraints(
+            {"type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 100}
+        ) == {"exclusive min": "0", "exclusive max": "100"}
+
+    def test_no_constraints_yields_empty_dict(self) -> None:
+        """A property with no constraints yields an empty dict, not noise."""
+        assert schema_constraints({"type": "string"}) == {}
+        assert schema_constraints(None) == {}
+
+
+class TestSchemaFlags:
+    """Tests for schema_flags() (nullable/readOnly/writeOnly/deprecated)."""
+
+    def test_surfaces_true_flags_only(self) -> None:
+        """Only flags set to true are returned."""
+        assert schema_flags({"type": "string", "writeOnly": True}) == {"writeOnly": True}
+        assert schema_flags({"type": "string", "readOnly": True, "deprecated": True}) == {
+            "readOnly": True,
+            "deprecated": True,
+        }
+
+    def test_normal_field_has_no_flags(self) -> None:
+        """A plain field reports no flags (the discriminating negative case)."""
+        assert schema_flags({"type": "string"}) == {}
+
+    def test_nullable_via_openapi_30_and_31_forms(self) -> None:
+        """nullable is recognized from 3.0 `nullable` and 3.1 type-array null."""
+        assert schema_flags({"type": "string", "nullable": True}) == {"nullable": True}
+        assert schema_flags({"type": ["string", "null"]}) == {"nullable": True}
+
+
+class TestSchemaAdditionalProperties:
+    """Tests for schema_additional_properties() normalization."""
+
+    def test_boolean_form(self) -> None:
+        assert schema_additional_properties({"type": "object", "additionalProperties": True}) == {
+            "allowed": True
+        }
+
+    def test_schema_form_is_typed_map(self) -> None:
+        result = schema_additional_properties(
+            {"type": "object", "additionalProperties": {"type": "string"}}
+        )
+        assert result is not None
+        assert result["schema_type"] == "string"
+        assert result["value_schema"] == {"type": "string"}
+
+    def test_absent_returns_none(self) -> None:
+        assert schema_additional_properties({"type": "object"}) is None
+
+
+class TestSchemaExamples:
+    """Tests for schema_examples() example normalization."""
+
+    def test_singular_example(self) -> None:
+        examples = schema_examples({"type": "string", "example": "hello"})
+        assert examples == ({"name": "", "summary": "", "value": "hello"},)
+
+    def test_examples_map_with_summary_and_value(self) -> None:
+        examples = schema_examples(
+            {
+                "examples": {
+                    "ok": {"summary": "A success", "value": {"id": 1}},
+                    "bare": "plain",
+                }
+            }
+        )
+        assert examples[0] == {"name": "ok", "summary": "A success", "value": {"id": 1}}
+        assert examples[1] == {"name": "bare", "summary": "", "value": "plain"}
+
+    def test_no_examples_yields_empty_tuple(self) -> None:
+        assert schema_examples({"type": "string"}) == ()
+
+
+class TestSchemaRef:
+    """Tests for schema_ref() (cyclic $ref leaf detection)."""
+
+    def test_bare_ref_returns_schema_name(self) -> None:
+        assert schema_ref({"$ref": "#/components/schemas/TreeNode"}) == "TreeNode"
+
+    def test_resolved_schema_returns_none(self) -> None:
+        assert schema_ref({"type": "object", "properties": {}}) is None
+        assert schema_ref(None) is None
+
+
+class TestSchemaViewExposesAdvancedConstructs:
+    """display_schema must carry advanced keys for advanced schemas only."""
+
+    def test_advanced_keys_surface_for_composed_schema(self) -> None:
+        """A composed schema's display_schema exposes the raw construct keys."""
+        element = MockDocElement(
+            name="PaymentMethod",
+            typed_metadata=MockOpenAPISchemaMetadata(schema_type="object"),
+            metadata={
+                "raw_schema": {
+                    "type": "object",
+                    "discriminator": {"propertyName": "type"},
+                    "oneOf": [{"type": "object"}, {"type": "object"}],
+                }
+            },
+        )
+
+        view = SchemaView.from_doc_element(element)
+
+        assert schema_composition(view.display_schema) is not None
+        assert "oneOf" in view.display_schema
+        assert "discriminator" in view.display_schema
+
+    def test_simple_schema_display_schema_stays_minimal(self) -> None:
+        """A simple schema gains no advanced keys (byte-stable output guard)."""
+        element = MockDocElement(
+            name="Tag",
+            typed_metadata=MockOpenAPISchemaMetadata(schema_type="string"),
+            metadata={"raw_schema": {"type": "string"}},
+        )
+
+        view = SchemaView.from_doc_element(element)
+
+        advanced = {
+            "oneOf",
+            "anyOf",
+            "allOf",
+            "discriminator",
+            "additionalProperties",
+            "examples",
+            "nullable",
+            "readOnly",
+            "writeOnly",
+            "deprecated",
+            "pattern",
+            "format",
+        }
+        assert advanced.isdisjoint(view.display_schema.keys())
+
+
+class TestSchemaExampleBounding:
+    """_schema_to_example / _build_example_body must bound recursion + handle oneOf."""
+
+    def test_self_referential_schema_is_bounded(self) -> None:
+        """A directly circular schema returns within the depth bound, no hang.
+
+        This assertion would stack-overflow / hang forever if the depth guard
+        regressed — that is the point of the test.
+        """
+        node: dict[str, Any] = {"type": "object", "properties": {}}
+        node["properties"]["self"] = node  # direct cycle
+
+        result = _schema_to_example(node)
+
+        # Bounded: the recursion terminates and yields a finite nested dict.
+        assert isinstance(result, dict)
+
+    def test_indirect_cycle_is_bounded(self) -> None:
+        """An A -> B -> A cycle also terminates."""
+        a: dict[str, Any] = {"type": "object", "properties": {}}
+        b: dict[str, Any] = {"type": "object", "properties": {}}
+        a["properties"]["b"] = b
+        b["properties"]["a"] = a
+
+        result = _schema_to_example(a)
+        assert isinstance(result, dict)
+
+    def test_one_of_request_body_uses_first_branch(self) -> None:
+        """A polymorphic (oneOf) request body yields the first branch example."""
+        body = _build_example_body(
+            {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {"kind": {"enum": ["card"]}},
+                                },
+                                {"type": "object", "properties": {"kind": {"enum": ["cash"]}}},
+                            ]
+                        }
+                    }
+                }
+            }
+        )
+        assert body == {"kind": "card"}
+
+    def test_media_type_examples_take_precedence(self) -> None:
+        """An explicit media-type examples map is preferred over schema synthesis."""
+        body = _build_example_body(
+            {
+                "content": {
+                    "application/json": {
+                        "examples": {"sample": {"value": {"id": "abc"}}},
+                        "schema": {"type": "object", "properties": {"id": {"type": "string"}}},
+                    }
+                }
+            }
+        )
+        assert body == {"id": "abc"}
+
+    def test_list_form_examples_do_not_crash(self) -> None:
+        """A JSON-Schema list-form `examples` must not raise (it is not a map).
+
+        Regression for an AttributeError when `examples.values()` was called on
+        a list — at both the top-level and the media-type example sites.
+        """
+        assert _build_example_body({"examples": [{"value": "first"}, {"value": "second"}]}) == (
+            "first"
+        )
+        assert _build_example_body({"examples": ["plain", "other"]}) == "plain"
+        media_body = _build_example_body(
+            {"content": {"application/json": {"examples": [{"value": {"id": 1}}]}}}
+        )
+        assert media_body == {"id": 1}
+
+    def test_malformed_properties_do_not_crash(self) -> None:
+        """A non-Mapping `properties` (malformed spec) degrades, never crashes."""
+        # allOf merge path.
+        assert isinstance(
+            _schema_to_example({"allOf": [{"type": "object"}], "properties": ["a", "b"]}),
+            dict,
+        )
+        # object branch path.
+        assert _schema_to_example({"type": "object", "properties": ["a", "b"]}) == {}

--- a/tests/unit/rendering/test_autodoc_layout_contract.py
+++ b/tests/unit/rendering/test_autodoc_layout_contract.py
@@ -150,7 +150,10 @@ def test_openapi_schema_pages_render_primitive_and_enum_shapes() -> None:
 
     assert "api-schema-shape" in schema_template
     assert "schema?.raw_schema?.format" in schema_template
-    assert "{% if example_val is not none %}" in schema_template
+    # Primitive/enum schemas (no viewer body) render a standalone example section;
+    # body schemas render examples inside the viewer instead (no duplication).
+    assert "{% if example_val is not none and not has_body %}" in schema_template
+    assert 'id="example"' in schema_template
     assert "<div><dt>Required</dt><dd>{{ required_props | length }}</dd></div>" in schema_template
 
 
@@ -221,3 +224,91 @@ def test_autodoc_css_has_no_legacy_rest_layout_selectors() -> None:
         ".api-sidebar-nav",
     ):
         assert live in css, f"live REST shell selector missing from autodoc.css: {live}"
+
+
+def test_openapi_schema_viewer_renders_advanced_constructs() -> None:
+    """The schema viewer macro must render composition, constraints, flags, and
+    a bounded circular-reference indicator (#285).
+
+    File-content contract — the viewer is recursive and depends on the full
+    rendering graph, so we assert the rendering hooks are wired rather than
+    rendering ``base.html`` in a unit test.
+    """
+    viewer = Path("bengal/themes/default/templates/autodoc/openapi/_schema.html").read_text(
+        encoding="utf-8"
+    )
+
+    # Composition (oneOf/anyOf/allOf) + discriminator.
+    assert "schema | schema_composition" in viewer
+    assert 'class="api-schema-composition"' in viewer
+    assert 'data-composition="{{ composition.kind }}"' in viewer
+    assert "Discriminated by" in viewer
+    assert "api-schema-composition__mapping" in viewer
+
+    # Per-property validation constraints + flag badges.
+    assert "prop_schema | schema_constraints" in viewer
+    assert 'class="api-schema-viewer__constraints"' in viewer
+    assert 'data-constraint="{{ clabel }}"' in viewer
+    assert 'data-badge="readonly"' in viewer
+    assert 'data-badge="writeonly"' in viewer
+    assert 'data-badge="nullable"' in viewer
+
+    # Open / typed maps (additionalProperties).
+    assert "schema | schema_additional_properties" in viewer
+    assert 'class="api-schema-viewer__additional"' in viewer
+
+    # Bounded circular references render a readable indicator, not an empty box.
+    assert "schema | schema_ref" in viewer
+    assert "api-schema-viewer__truncated" in viewer
+    assert "circular reference" in viewer
+
+
+def test_openapi_schema_detail_page_surfaces_composition() -> None:
+    """Composed/polymorphic schemas (no direct properties) still get a body and
+    surface composition metadata in the side panel.
+    """
+    schema_template = Path("bengal/themes/default/templates/autodoc/openapi/schema.html").read_text(
+        encoding="utf-8"
+    )
+
+    # A composed schema with no properties must still render a body section.
+    assert "schema?.display_schema | schema_composition" in schema_template
+    assert "has_body" in schema_template
+    # Side panel exposes composition kind + discriminator for polymorphic models.
+    assert "{{ composition.kind }}" in schema_template
+    assert "composition.discriminator.property_name" in schema_template
+    # Deprecated schemas get a header badge.
+    assert 'data-badge="deprecated"' in schema_template
+
+
+def test_openapi_schema_index_tiles_show_composition_chips() -> None:
+    """Schema catalog tiles expose composition/deprecated summary metadata (#285)."""
+    section_template = Path(
+        "bengal/themes/default/templates/autodoc/openapi/section-index.html"
+    ).read_text(encoding="utf-8")
+
+    assert "schema.display_schema | schema_composition" in section_template
+    assert 'class="api-schema-catalog__chip"' in section_template
+    assert 'data-kind="discriminator"' in section_template
+    # Must not regress the existing tile contract.
+    assert "schema.properties |> items |> take(4)" in section_template
+    assert "api-schema-catalog__preview" in section_template
+
+
+def test_autodoc_css_styles_advanced_schema_constructs() -> None:
+    """The new advanced-schema markup must be styled in autodoc.css (#285)."""
+    css = Path("bengal/themes/default/assets/css/components/autodoc.css").read_text(
+        encoding="utf-8"
+    )
+
+    for selector in (
+        ".api-schema-composition",
+        '.api-schema-composition[data-composition="oneOf"]',
+        ".api-schema-viewer__constraint",
+        ".api-schema-viewer__additional",
+        ".api-schema-viewer__truncated",
+        ".api-schema-catalog__chip",
+        '.autodoc-badge[data-badge="readonly"]',
+        '.autodoc-badge[data-badge="writeonly"]',
+    ):
+        assert selector in css, f"advanced-schema selector missing from autodoc.css: {selector}"


### PR DESCRIPTION
## Summary

- Completes #285 (part of the S-tier REST autodoc epic #289): REST autodoc schema pages now render advanced OpenAPI constructs as structured model documentation instead of dropping or flattening them.
- `oneOf`/`anyOf`/`allOf` render as labeled composition blocks; polymorphic schemas show their `discriminator` property + `value → schema` mapping; per-property constraints (`format`, `pattern`, numeric `min`/`max`/`multipleOf`, string `minLength`/`maxLength`, array `minItems`/`maxItems`/`uniqueItems`) render as chips; `nullable`/`readOnly`/`writeOnly`/`deprecated` render as badges.
- `additionalProperties` (boolean + typed map) gets its own section; primitive schemas surface their constraints + example; a self-referential schema renders a bounded, readable "circular reference" indicator (no empty box, no runaway recursion). Catalog tiles gained composition/discriminator/deprecated summary chips.
- All driven by additive normalization filters in `bengal/rendering/template_functions/openapi.py` (`schema_composition`, `schema_constraints`, `schema_flags`, `schema_additional_properties`, `schema_examples`, `schema_ref`); the data model and extractor are unchanged. Simple schemas render byte-identically (advanced `display_schema` keys are added only when present).
- Hardened the example builders against list-form `examples` and malformed `properties` so a non-conformant spec degrades instead of crashing the build.
- The demo commerce spec marks server-assigned fields `readOnly` and credentials `writeOnly` to dogfood the new rendering.

## Proof

- [x] Focused tests: `tests/unit/rendering/template_functions/test_openapi_filters.py` (normalization helpers incl. circular-ref bounding + malformed-input robustness), `tests/unit/rendering/test_autodoc_layout_contract.py` (template/CSS contract), `tests/integration/test_openapi_advanced_schema.py` (end-to-end build of a fixture exercising every construct).
- [x] `poe proof-pr` or scoped equivalent: 744 passed / 14 skipped across `tests/unit/rendering/**`, `tests/unit/autodoc/**`, the autodoc integration tests, and `tests/performance/test_autodoc_render_regression.py`; `ruff check`, `ruff format --check`, and `ty check` clean (enforced by pre-commit).
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/openapi-advanced-schema-rendering.added.md`; demo spec enriched.

## Performance Evidence

Required when this PR makes a performance claim, changes a hot path, or changes free-threaded/concurrent behavior.

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: No performance claim. The normalization filters run per schema page during render but make no perf claim; a clean dogfood build (1503 pages) showed broken-link count and health quality unchanged from baseline (10 links / 80%, all pre-existing content/Python-autodoc pages — none in OpenAPI schemas).

## Steward Notes

- Composition rendering is additive: `allOf` properties stay flattened into the property table (preserving the existing `test_flattens_all_of_schema_properties` contract) while the composition block adds the inheritance/variant structure.
- Circular references are bounded in two places: the extractor already terminates `$ref` cycles with a bare `{"$ref": …}` leaf, and the viewer renders that leaf as a "circular reference" indicator; the recursive example builder is independently depth-bounded.
- Findings from an adversarial self-review (list-form `examples` crash at two sites; non-Mapping `properties` crash) are fixed and regression-tested.
