### PR TITLE
feat(autodoc): catalog navigation interactions for REST docs (#287)

### DIFF
--- a/bengal/themes/default/assets/css/components/autodoc.css
+++ b/bengal/themes/default/assets/css/components/autodoc.css
@@ -3297,6 +3297,82 @@ body[data-type="autodoc-rest"] .openapi-app .api-schema:empty {
   letter-spacing: 0;
 }
 
+/* ============================================
+   CATALOG NAVIGATION INTERACTIONS (#287)
+   Filter inputs, no-results, rail active-state,
+   and path-copy buttons. Additive; reuses tokens.
+   ============================================ */
+
+/* Filter input (landing catalog + schema index) — matches sidebar search. */
+.api-catalog-filter {
+  margin-inline-start: auto;
+}
+
+.api-catalog-filter__input {
+  width: 100%;
+  min-width: 12rem;
+  padding: var(--space-2);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--autodoc-border);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.api-catalog-filter__empty {
+  padding: var(--space-3);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+/* Filtered-out items collapse (JS toggles the `hidden` attribute only). */
+[data-api-filter-item][hidden],
+[data-api-filter-group][hidden] {
+  display: none;
+}
+
+/* Section header row holding the title + filter side by side. */
+.api-section-index__section-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+/* Active rail item from scroll-spy / hash navigation. */
+body[data-type="autodoc-rest"] .openapi-nav a.api-rail__link--active,
+body[data-type="autodoc-rest"] .openapi-nav a[aria-current],
+.api-catalog-nav__link.api-rail__link--active,
+.api-catalog-nav__link[aria-current] {
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+}
+
+/* Inline copy button for operation paths (uses the global [data-copy]
+   handler in tabs.js; `.copied` success feedback is already defined). */
+.api-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-0-5);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.api-copy-btn:hover {
+  background: var(--color-bg-secondary);
+  color: var(--color-primary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .api-copy-btn {
+    transition: none;
+  }
+}
+
 @media (max-width: 1280px) {
   .api-operation__grid {
     grid-template-columns: 1fr;

--- a/bengal/themes/default/assets/js/enhancements/api-catalog.js
+++ b/bengal/themes/default/assets/js/enhancements/api-catalog.js
@@ -1,0 +1,284 @@
+/**
+ * REST API catalog navigation interactions (issue #287).
+ *
+ * One cohesive, lazy-loaded enhancement for the OpenAPI catalog/app shells:
+ *   - Client-side FILTER of endpoint cards and schema tiles (no npm, no reload).
+ *   - SCROLL-SPY that marks the active section in a left rail as you scroll and
+ *     on direct hash navigation.
+ *
+ * Progressive enhancement: every rail link is a real `href="#id"` and every
+ * filter input is a plain `<input type=search>`, so pages work with JS off —
+ * this script only layers behavior on top. Copy affordances are handled
+ * separately by the global `[data-copy]` delegation in tabs.js; this module
+ * adds no copy logic.
+ *
+ * Activated by `data-bengal="api-catalog"` on a shell that contains:
+ *   - `[data-api-filter-input]`  the filter search box (optional)
+ *   - `[data-api-filter-item]`   each filterable card/tile
+ *   - `[data-api-filter-group]`  a wrapper hidden when all its items are hidden
+ *   - `[data-api-filter-empty]`  a no-results node (aria-live)
+ *   - `[data-api-rail]`          a nav whose `a[href^="#"]` links drive scroll-spy
+ *
+ * @see bengal-enhance.js (loader), enhancements/toc.js (scroll-spy pattern)
+ */
+
+(function () {
+  'use strict';
+
+  // Reuse shared helpers when present; fall back to tiny local versions so the
+  // module still works if utils.js has not loaded yet.
+  const utils = window.BengalUtils || {};
+  const debounce =
+    utils.debounce ||
+    function (fn, wait) {
+      let t;
+      return function () {
+        const args = arguments;
+        clearTimeout(t);
+        t = setTimeout(() => fn.apply(this, args), wait);
+      };
+    };
+  const throttleScroll =
+    utils.throttleScroll ||
+    function (fn) {
+      let ticking = false;
+      return function () {
+        if (ticking) return;
+        ticking = true;
+        requestAnimationFrame(() => {
+          fn();
+          ticking = false;
+        });
+      };
+    };
+  const ready =
+    utils.ready ||
+    function (fn) {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', fn);
+      } else {
+        fn();
+      }
+    };
+
+  const VIEWPORT_OFFSET = 120; // px from top to consider a section "active"
+  const ACTIVE_CLASS = 'api-rail__link--active';
+
+  function prefersReducedMotion() {
+    return (
+      window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
+  }
+
+  // ==========================================================================
+  // Accessible copy feedback
+  // ==========================================================================
+  // tabs.js performs the actual clipboard copy for `[data-copy]` and code-sample
+  // buttons (and adds the visual `.copied` state). Copy feedback was visual-only,
+  // so here we add a screen-reader announcement. Scoped to OpenAPI pages because
+  // this module only loads there; the listener is attached once at module load.
+
+  let liveRegion = null;
+
+  function announce(message) {
+    if (!liveRegion) {
+      liveRegion = document.createElement('div');
+      liveRegion.setAttribute('role', 'status');
+      liveRegion.setAttribute('aria-live', 'polite');
+      liveRegion.style.cssText =
+        'position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0 0 0 0);clip-path:inset(50%);white-space:nowrap;border:0;';
+      document.body.appendChild(liveRegion);
+    }
+    liveRegion.textContent = '';
+    // Re-set on the next frame so identical consecutive copies still announce.
+    window.requestAnimationFrame(() => {
+      liveRegion.textContent = message;
+    });
+  }
+
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-copy], .api-code-samples__copy, .copy-btn');
+    if (btn) announce('Copied to clipboard');
+  });
+
+  // ==========================================================================
+  // Filtering
+  // ==========================================================================
+
+  /**
+   * Build the lowercased haystack for a filterable item from its text plus any
+   * structured data-* attributes (method/path/schema name/type/tags).
+   */
+  function itemHaystack(item) {
+    const attrs = [
+      'data-method',
+      'data-path',
+      'data-schema-name',
+      'data-schema-type',
+      'data-tags',
+    ]
+      .map((a) => item.getAttribute(a) || '')
+      .join(' ');
+    return `${item.textContent} ${attrs}`.toLowerCase().replace(/\s+/g, ' ').trim();
+  }
+
+  /**
+   * Wire the search input to show/hide items, collapse empty groups, and
+   * announce a no-results state. Returns a function that reveals a given
+   * element (used to keep deep links working while a filter is active).
+   */
+  function initFilter(root) {
+    const input = root.querySelector('[data-api-filter-input]');
+    const items = Array.from(root.querySelectorAll('[data-api-filter-item]'));
+    if (!input || !items.length) return null;
+
+    const groups = Array.from(root.querySelectorAll('[data-api-filter-group]'));
+    const emptyNode = root.querySelector('[data-api-filter-empty]');
+    const haystacks = items.map(itemHaystack);
+
+    function apply() {
+      const query = input.value.trim().toLowerCase();
+      let visible = 0;
+      items.forEach((item, i) => {
+        const match = query === '' || haystacks[i].includes(query);
+        item.hidden = !match;
+        if (match) visible += 1;
+      });
+      // Collapse any group whose items are now all hidden.
+      groups.forEach((group) => {
+        const groupItems = group.querySelectorAll('[data-api-filter-item]');
+        if (!groupItems.length) return;
+        const anyVisible = Array.from(groupItems).some((it) => !it.hidden);
+        group.hidden = !anyVisible;
+      });
+      if (emptyNode) emptyNode.hidden = visible !== 0 || query === '';
+    }
+
+    input.addEventListener('input', debounce(apply, 120));
+
+    // Reveal an element that a deep link targets even if it is currently
+    // filtered out, so #fragment routing never breaks (clear the filter).
+    function reveal(el) {
+      if (!el) return;
+      const hidden = el.hidden || el.closest('[hidden]');
+      if (hidden && input.value) {
+        input.value = '';
+        apply();
+      }
+    }
+    return reveal;
+  }
+
+  // ==========================================================================
+  // Scroll-spy
+  // ==========================================================================
+
+  function initScrollSpy(root) {
+    const rails = Array.from(root.querySelectorAll('[data-api-rail]'));
+    if (!rails.length) return null;
+
+    const entries = [];
+    rails.forEach((rail) => {
+      rail.querySelectorAll('a[href^="#"]').forEach((link) => {
+        const id = decodeURIComponent(link.getAttribute('href').slice(1));
+        const target = id ? document.getElementById(id) : null;
+        if (target) entries.push({ link, target, rail });
+      });
+    });
+    if (!entries.length) return null;
+
+    let activeIndex = -1;
+
+    function update() {
+      // PHASE 1: batch reads (avoids layout thrash, mirrors toc.js).
+      const tops = entries.map((e) => e.target.getBoundingClientRect().top);
+      let index = 0;
+      for (let i = tops.length - 1; i >= 0; i--) {
+        if (tops[i] <= VIEWPORT_OFFSET) {
+          index = i;
+          break;
+        }
+      }
+      if (index === activeIndex) return;
+      activeIndex = index;
+
+      // PHASE 2: batch writes.
+      entries.forEach((e, i) => {
+        if (i === index) {
+          e.link.classList.add(ACTIVE_CLASS);
+          e.link.setAttribute('aria-current', 'location');
+        } else {
+          e.link.classList.remove(ACTIVE_CLASS);
+          e.link.removeAttribute('aria-current');
+        }
+      });
+
+      // Keep the active rail link visible within its own scroll container.
+      const active = entries[index];
+      const railRect = active.rail.getBoundingClientRect();
+      const linkRect = active.link.getBoundingClientRect();
+      if (linkRect.top < railRect.top || linkRect.bottom > railRect.bottom) {
+        active.link.scrollIntoView({
+          behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+          block: 'nearest',
+        });
+      }
+    }
+
+    const onScroll = throttleScroll(update);
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', debounce(update, 250), { passive: true });
+    window.addEventListener('hashchange', update);
+    update();
+    return update;
+  }
+
+  // ==========================================================================
+  // Init / registration
+  // ==========================================================================
+
+  function init(root) {
+    if (!root || root.getAttribute('data-api-catalog-ready') === 'true') return;
+    root.setAttribute('data-api-catalog-ready', 'true');
+
+    const reveal = initFilter(root);
+    initScrollSpy(root);
+
+    // A deep link to a filtered-out section must still resolve: on hash nav,
+    // clear the filter so the target is visible, then scroll to it.
+    if (reveal) {
+      const onHash = () => {
+        const id = decodeURIComponent(location.hash.slice(1));
+        const target = id ? document.getElementById(id) : null;
+        if (target) {
+          reveal(target);
+          target.scrollIntoView({
+            behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+            block: 'start',
+          });
+        }
+      };
+      window.addEventListener('hashchange', onHash);
+      // Resolve an initial deep link that points at a (potentially) hidden item.
+      if (location.hash) onHash();
+    }
+  }
+
+  function autoInit() {
+    document
+      .querySelectorAll('[data-bengal="api-catalog"]')
+      .forEach((root) => init(root));
+  }
+
+  // Register with the progressive-enhancement loader (primary path).
+  if (window.Bengal && window.Bengal.enhance) {
+    Bengal.enhance.register('api-catalog', function (el) {
+      init(el);
+    });
+  }
+
+  // Backward-compatible auto-init (idempotent via data-api-catalog-ready).
+  ready(autoInit);
+  window.addEventListener('contentLoaded', autoInit);
+})();

--- a/bengal/themes/default/templates/autodoc/openapi/endpoint.html
+++ b/bengal/themes/default/templates/autodoc/openapi/endpoint.html
@@ -60,7 +60,7 @@ Kida Features:
 {% let section = tag_section %}
 
 {# In-page navigation for the current endpoint's sections. #}
-<nav class="openapi-nav" aria-label="Endpoint sections">
+<nav class="openapi-nav" aria-label="Endpoint sections" data-api-rail>
   <a href="{{ tag_section?.href ?? page?.href ?? '#' }}" class="openapi-nav__back">{{ icon('arrow-left', size=14) }} {{ tag_section?.title ?? 'Endpoints' }}</a>
   {% if parameters | length > 0 %}<a href="#parameters">Parameters</a>{% end %}
   {% if request_body %}<a href="#request-body">Request body</a>{% end %}
@@ -73,6 +73,7 @@ Kida Features:
 <div class="openapi-operation-title">
   <span class="api-method api-method--{{ http_method |> lower }}">{{ http_method }}</span>
   <code>{{ endpoint_path | highlight_path_params | safe }}</code>
+  <button type="button" class="api-copy-btn" data-copy="{{ endpoint_path }}" aria-label="Copy path {{ endpoint_path }}">{{ icon('copy', size=14) }}</button>
 </div>
 {{ endpoint_header(element, section) }}
 {% end %}

--- a/bengal/themes/default/templates/autodoc/openapi/home.html
+++ b/bengal/themes/default/templates/autodoc/openapi/home.html
@@ -24,7 +24,7 @@ application surface, not a prose reference page.
 {% block site_footer %}{% end %}
 
 {% block content %}
-<div class="api-catalog-app" data-autodoc="openapi" data-element="home">
+<div class="api-catalog-app" data-autodoc="openapi" data-element="home" data-bengal="api-catalog">
   {% let endpoint_count = eps | length %}
   {% let schema_count = schs | length %}
   {% let tag_count = tags | length %}
@@ -72,7 +72,7 @@ application surface, not a prose reference page.
   <div class="api-catalog-app__workspace">
     <aside class="api-catalog-app__left-rail" aria-label="REST API navigation">
       {% if subsections | length > 0 %}
-      <nav class="api-catalog-nav" aria-label="Endpoint groups">
+      <nav class="api-catalog-nav" aria-label="Endpoint groups" data-api-rail>
         <h2 class="api-catalog-nav__title">{{ icon('folder', size=14) }} Resources</h2>
         {% for subsec in subsections %}
         {% let tag_name = subsec?.title ?? 'Endpoints' %}
@@ -113,7 +113,14 @@ application surface, not a prose reference page.
           <h2>Endpoint catalog</h2>
           <p>Open an endpoint for parameters, response models, examples, and generated request snippets.</p>
         </div>
+        {% if endpoint_count > 4 %}
+        <div class="api-catalog-filter">
+          <input type="search" class="api-catalog-filter__input" data-api-filter-input
+                 placeholder="Filter endpoints&hellip;" aria-label="Filter endpoints by method, path, or summary">
+        </div>
+        {% end %}
       </header>
+      <p class="api-catalog-filter__empty" data-api-filter-empty hidden aria-live="polite">No endpoints match your filter.</p>
 
       {% if subsections | length > 0 %}
       <div class="api-catalog-groups">
@@ -124,7 +131,7 @@ application surface, not a prose reference page.
         {% let tag_href = section_href(subsec, page) %}
 
         {% if tag_endpoints | length > 0 %}
-        <article class="api-catalog-group" id="{{ tag_name | slugify }}">
+        <article class="api-catalog-group" id="{{ tag_name | slugify }}" data-api-filter-group>
           <header class="api-catalog-group__header">
             <div>
               <h3><a href="{{ tag_href }}">{{ tag_name }}</a></h3>
@@ -139,7 +146,7 @@ application surface, not a prose reference page.
 
           <div class="api-catalog-endpoints">
             {% for ep in tag_endpoints %}
-            <a href="{{ ep.href }}" class="api-catalog-endpoint{% if ep.deprecated %} api-catalog-endpoint--deprecated{% end %}">
+            <a href="{{ ep.href }}" class="api-catalog-endpoint{% if ep.deprecated %} api-catalog-endpoint--deprecated{% end %}" data-api-filter-item data-method="{{ ep.method }}" data-path="{{ ep.path }}">
               <span class="api-method api-method--sm api-method--{{ ep.method |> lower }}">{{ ep.method }}</span>
               <code>{{ ep.path | highlight_path_params | safe }}</code>
               {% if ep.summary %}
@@ -158,7 +165,7 @@ application surface, not a prose reference page.
       {% if subsections | length == 0 and eps | length > 0 %}
       <div class="api-catalog-endpoints">
         {% for ep in eps %}
-        <a href="{{ ep.href }}" class="api-catalog-endpoint{% if ep.deprecated %} api-catalog-endpoint--deprecated{% end %}">
+        <a href="{{ ep.href }}" class="api-catalog-endpoint{% if ep.deprecated %} api-catalog-endpoint--deprecated{% end %}" data-api-filter-item data-method="{{ ep.method }}" data-path="{{ ep.path }}">
           <span class="api-method api-method--sm api-method--{{ ep.method |> lower }}">{{ ep.method }}</span>
           <code>{{ ep.path | highlight_path_params | safe }}</code>
           {% if ep.summary %}

--- a/bengal/themes/default/templates/autodoc/openapi/layouts/explorer.html
+++ b/bengal/themes/default/templates/autodoc/openapi/layouts/explorer.html
@@ -10,7 +10,7 @@ global base document/top bar and owns the OpenAPI page structure below it.
 {% block site_footer %}{% end %}
 
 {% block content %}
-<div class="openapi-app" data-autodoc="openapi" data-layout="app">
+<div class="openapi-app" data-autodoc="openapi" data-layout="app" data-bengal="api-catalog">
   <aside class="openapi-app__rail openapi-app__rail--left" aria-label="API navigation">
     {% block api_left %}
     {% end %}

--- a/bengal/themes/default/templates/autodoc/openapi/list.html
+++ b/bengal/themes/default/templates/autodoc/openapi/list.html
@@ -34,7 +34,7 @@ Kida Features:
 {% let eps = section | endpoints %}
 
 {% block api_left %}
-<nav class="openapi-nav" aria-label="{{ tag_name }} endpoints">
+<nav class="openapi-nav" aria-label="{{ tag_name }} endpoints" data-api-rail>
   <a href="{{ section?.parent?.href ?? '/api/' }}" class="openapi-nav__back">{{ icon('arrow-left', size=14) }} REST API</a>
   {% for ep in eps %}
   <a href="#{{ ep.anchor_id }}">
@@ -114,6 +114,7 @@ Kida Features:
         <div class="api-operation__eyebrow">
           <span class="api-method api-method--{{ ep.method |> lower }}">{{ ep.method }}</span>
           <code class="api-operation__path">{{ ep.path | highlight_path_params | safe }}</code>
+          <button type="button" class="api-copy-btn" data-copy="{{ ep.path }}" aria-label="Copy path {{ ep.path }}">{{ icon('copy', size=14) }}</button>
         </div>
         <div class="api-operation__title-row">
           <h2 class="api-operation__title">{{ ep.summary or ep.path }}</h2>

--- a/bengal/themes/default/templates/autodoc/openapi/schema.html
+++ b/bengal/themes/default/templates/autodoc/openapi/schema.html
@@ -38,7 +38,7 @@ Kida Features:
 {% let has_body = properties | length > 0 or composition is not none or additional is not none %}
 
 {% block api_left %}
-<nav class="openapi-nav" aria-label="Schema sections">
+<nav class="openapi-nav" aria-label="Schema sections" data-api-rail>
   <a href="{{ section?.href ?? page?.href ?? '#' }}" class="openapi-nav__back">{{ icon('arrow-left', size=14) }} {{ section?.title ?? 'Schemas' }}</a>
   {% if has_body %}<a href="#properties">{% if properties | length > 0 %}Properties{% elif composition is not none %}Variants{% else %}Structure{% end %}</a>{% end %}
   {% if enum_vals | length > 0 %}<a href="#enum">Allowed values</a>{% end %}

--- a/bengal/themes/default/templates/autodoc/openapi/section-index.html
+++ b/bengal/themes/default/templates/autodoc/openapi/section-index.html
@@ -70,13 +70,22 @@ Context:
   {# Schema Catalog #}
   {% if schema_items | length > 0 %}
   <section class="api-section-index__pages">
-    <h2 class="api-section-index__section-title">Schemas</h2>
+    <div class="api-section-index__section-head">
+      <h2 class="api-section-index__section-title">Schemas</h2>
+      {% if schema_items | length > 4 %}
+      <div class="api-catalog-filter">
+        <input type="search" class="api-catalog-filter__input" data-api-filter-input
+               placeholder="Filter schemas&hellip;" aria-label="Filter schemas by name or type">
+      </div>
+      {% end %}
+    </div>
+    <p class="api-catalog-filter__empty" data-api-filter-empty hidden aria-live="polite">No schemas match your filter.</p>
     <div class="api-schema-catalog">
       {% for schema in schema_items %}
       {% let property_preview = schema.properties |> items |> take(4) %}
       {% let tile_composition = schema.display_schema | schema_composition %}
       {% let tile_flags = schema.display_schema | schema_flags %}
-      <a href="{{ schema.href }}" class="api-schema-catalog__tile">
+      <a href="{{ schema.href }}" class="api-schema-catalog__tile" data-api-filter-item data-schema-name="{{ schema.name }}" data-schema-type="{{ schema.schema_type }}">
         <span class="api-schema-catalog__tile-top">
           <code>{{ schema.name }}</code>
           <span>{{ schema.schema_type }}</span>

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -272,7 +272,8 @@ HELPER: Render a menu item (desktop/mobile)
             'data-table': '{{ asset_url("js/enhancements/data-table.js") }}',
             'lazy-loaders': '{{ asset_url("js/enhancements/lazy-loaders.js") }}',
             'holo': '{{ asset_url("js/enhancements/holo.js") }}',
-            'link-previews': '{{ asset_url("js/enhancements/link-previews.js") }}'
+            'link-previews': '{{ asset_url("js/enhancements/link-previews.js") }}',
+            'api-catalog': '{{ asset_url("js/enhancements/api-catalog.js") }}'
         };
     </script>
 

--- a/changelog.d/openapi-catalog-navigation.added.md
+++ b/changelog.d/openapi-catalog-navigation.added.md
@@ -1,0 +1,19 @@
+REST autodoc catalog pages gained first-class navigation interactions (#287),
+shipped as one lazy-loaded vanilla-JS enhancement (`api-catalog`, no npm). The
+API landing catalog and the schema index now have client-side filtering: typing
+in the filter box narrows endpoint cards and schema tiles by method/path/name,
+collapses empty tag groups, and announces a no-results state via `aria-live`.
+The left rail on the landing catalog and on the resource/schema/endpoint shells
+is now a scroll-spy: it marks the active section (`aria-current` +
+`.api-rail__link--active`) as you scroll and on direct hash navigation, honoring
+`prefers-reduced-motion` (the smooth-scroll gap `toc.js` leaves open).
+Operation paths gained copy buttons that ride the existing global `[data-copy]`
+handler, so base URLs, operation paths, and code samples now copy consistently,
+with a screen-reader announcement on copy. Filtering only toggles the `hidden`
+attribute and never reorders or removes anchored nodes, so deep links and the
+back button keep working; a hash navigation to a filtered-out section clears the
+filter to reveal it. Everything degrades gracefully with JavaScript disabled —
+rail links are real anchors and the filter input is simply inert. Covered by
+template/CSS contract tests, an end-to-end build that asserts the hooks render
+in output across the landing, tag, endpoint, and schema-index pages, and a
+fingerprinted-asset check.

--- a/tests/integration/test_openapi_catalog_nav.py
+++ b/tests/integration/test_openapi_catalog_nav.py
@@ -1,0 +1,77 @@
+"""
+End-to-end tests for REST autodoc catalog navigation interactions (#287).
+
+Builds the ``test-openapi-catalog`` root (multi-tag, multi-endpoint) and asserts
+the generated HTML carries the filter / scroll-spy / copy hooks that the
+client-side ``api-catalog`` enhancement consumes. Asserting on OUTPUT (not just
+template source) proves the rendered path actually emits the hooks, and that the
+JS module is discovered + fingerprinted by the asset pipeline.
+
+Anchors and filter inputs are plain HTML, so these pages work with JS disabled;
+the enhancement only layers behavior on top.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.autodoc
+
+
+@pytest.mark.bengal(testroot="test-openapi-catalog")
+def test_landing_catalog_emits_filter_and_rail_hooks(site, build_site) -> None:
+    """The /api/ landing catalog renders filter + scroll-spy + group hooks."""
+    build_site()
+    index = site.output_dir / "api" / "index.html"
+    assert index.exists(), f"Catalog landing missing: {index}"
+    html = index.read_text(encoding="utf-8")
+
+    assert 'data-bengal="api-catalog"' in html
+    assert "data-api-rail" in html
+    assert "data-api-filter-input" in html
+    assert "data-api-filter-empty" in html
+    # 6 endpoints -> multiple filterable items + 2 tag groups.
+    assert html.count("data-api-filter-item") >= 6
+    assert html.count("data-api-filter-group") >= 2
+
+
+@pytest.mark.bengal(testroot="test-openapi-catalog")
+def test_endpoint_and_tag_pages_have_rail_and_path_copy(site, build_site) -> None:
+    """Resource shells enable scroll-spy and expose an operation-path copy button."""
+    build_site()
+
+    endpoint = site.output_dir / "api" / "tags" / "Orders" / "get-orders" / "index.html"
+    assert endpoint.exists(), f"Endpoint page missing: {endpoint}"
+    ep_html = endpoint.read_text(encoding="utf-8")
+    assert 'data-bengal="api-catalog"' in ep_html
+    assert "data-api-rail" in ep_html
+    assert 'class="api-copy-btn"' in ep_html
+    assert "data-copy=" in ep_html
+
+    tag_page = site.output_dir / "api" / "tags" / "Orders" / "index.html"
+    assert tag_page.exists(), f"Tag page missing: {tag_page}"
+    tag_html = tag_page.read_text(encoding="utf-8")
+    assert "data-api-rail" in tag_html
+    # Consolidated tag page lists operations, each with a path copy button.
+    assert tag_html.count('class="api-copy-btn"') >= 1
+
+
+@pytest.mark.bengal(testroot="test-openapi-catalog")
+def test_schema_index_filterable_in_output(site, build_site) -> None:
+    """The schema catalog index renders a filter and filterable tiles."""
+    build_site()
+    index = site.output_dir / "api" / "schemas" / "index.html"
+    assert index.exists(), f"Schema index missing: {index}"
+    html = index.read_text(encoding="utf-8")
+
+    assert "data-api-filter-input" in html
+    assert html.count("data-api-filter-item") >= 5  # 5 schemas
+
+
+@pytest.mark.bengal(testroot="test-openapi-catalog")
+def test_api_catalog_module_is_fingerprinted(site, build_site) -> None:
+    """The vanilla-JS enhancement is discovered + fingerprinted (no npm)."""
+    build_site()
+    enh_dir = site.output_dir / "assets" / "js" / "enhancements"
+    modules = list(enh_dir.glob("api-catalog*.js")) if enh_dir.exists() else []
+    assert modules, "api-catalog.js was not emitted/fingerprinted into the build"

--- a/tests/roots/test-openapi-catalog/api/openapi.yaml
+++ b/tests/roots/test-openapi-catalog/api/openapi.yaml
@@ -1,0 +1,95 @@
+openapi: 3.0.3
+info:
+  title: Catalog Nav Demo
+  version: 1.0.0
+  description: Multi-tag, multi-endpoint spec exercising catalog navigation (#287).
+
+servers:
+  - url: https://api.example.com/v1
+    description: Production
+
+tags:
+  - name: Orders
+    description: Order management
+  - name: Users
+    description: User management
+
+paths:
+  /orders:
+    get:
+      tags: [Orders]
+      summary: List orders
+      operationId: listOrders
+      responses:
+        '200': { description: OK }
+    post:
+      tags: [Orders]
+      summary: Create order
+      operationId: createOrder
+      responses:
+        '201': { description: Created }
+  /orders/{id}:
+    get:
+      tags: [Orders]
+      summary: Get order
+      operationId: getOrder
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: OK }
+  /users:
+    get:
+      tags: [Users]
+      summary: List users
+      operationId: listUsers
+      responses:
+        '200': { description: OK }
+    post:
+      tags: [Users]
+      summary: Create user
+      operationId: createUser
+      responses:
+        '201': { description: Created }
+  /users/{id}:
+    delete:
+      tags: [Users]
+      summary: Delete user
+      operationId: deleteUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '204': { description: No Content }
+
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id: { type: string }
+        total: { type: number }
+    User:
+      type: object
+      properties:
+        id: { type: string }
+        email: { type: string, format: email }
+    Address:
+      type: object
+      properties:
+        street: { type: string }
+        city: { type: string }
+    Money:
+      type: object
+      properties:
+        amount: { type: number }
+        currency: { type: string }
+    Pagination:
+      type: object
+      properties:
+        page: { type: integer }
+        total: { type: integer }

--- a/tests/roots/test-openapi-catalog/bengal.toml
+++ b/tests/roots/test-openapi-catalog/bengal.toml
@@ -1,0 +1,11 @@
+[site]
+title = "Catalog Nav Demo"
+baseurl = "/"
+
+[build]
+theme = "default"
+
+[autodoc.openapi]
+enabled = true
+spec_file = "api/openapi.yaml"
+output_prefix = "api"

--- a/tests/roots/test-openapi-catalog/content/index.md
+++ b/tests/roots/test-openapi-catalog/content/index.md
@@ -1,0 +1,7 @@
+---
+title: Home
+---
+
+# Catalog Nav Demo
+
+Renders a multi-tag REST API catalog under `/api/`.

--- a/tests/unit/rendering/test_autodoc_layout_contract.py
+++ b/tests/unit/rendering/test_autodoc_layout_contract.py
@@ -312,3 +312,93 @@ def test_autodoc_css_styles_advanced_schema_constructs() -> None:
         '.autodoc-badge[data-badge="writeonly"]',
     ):
         assert selector in css, f"advanced-schema selector missing from autodoc.css: {selector}"
+
+
+# =============================================================================
+# Catalog navigation interactions (#287)
+# =============================================================================
+
+
+def _read_openapi_template(name: str) -> str:
+    return Path(f"bengal/themes/default/templates/autodoc/openapi/{name}").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_openapi_catalog_landing_has_filter_and_rail_hooks() -> None:
+    """The catalog landing must expose filter + scroll-spy + group hooks (#287)."""
+    home = _read_openapi_template("home.html")
+
+    assert 'data-bengal="api-catalog"' in home
+    assert "data-api-rail" in home  # left-rail scroll-spy
+    assert "data-api-filter-input" in home
+    assert "data-api-filter-empty" in home
+    assert "data-api-filter-group" in home
+    # Endpoint cards are filterable and carry structured method/path for search.
+    assert "data-api-filter-item" in home
+    assert 'data-method="{{ ep.method }}"' in home
+    assert 'data-path="{{ ep.path }}"' in home
+
+
+def test_openapi_explorer_shell_and_rails_enable_scroll_spy() -> None:
+    """The shared app shell activates the enhancement; in-page navs are rails."""
+    explorer = _read_openapi_template("layouts/explorer.html")
+    assert 'data-bengal="api-catalog"' in explorer
+
+    for name in ("list.html", "endpoint.html", "schema.html"):
+        template = _read_openapi_template(name)
+        assert 'class="openapi-nav"' in template
+        assert "data-api-rail" in template, f"{name} openapi-nav missing data-api-rail"
+
+
+def test_openapi_schema_index_is_filterable() -> None:
+    """The schema catalog index exposes a filter and filterable tiles (#287)."""
+    section = _read_openapi_template("section-index.html")
+    assert "data-api-filter-input" in section
+    assert "data-api-filter-item" in section
+    assert 'data-schema-name="{{ schema.name }}"' in section
+    assert "data-api-filter-empty" in section
+
+
+def test_openapi_path_copy_buttons_present() -> None:
+    """Operation paths get a copy button riding the global [data-copy] handler."""
+    list_template = _read_openapi_template("list.html")
+    endpoint = _read_openapi_template("endpoint.html")
+
+    assert 'class="api-copy-btn"' in list_template
+    assert 'data-copy="{{ ep.path }}"' in list_template
+    assert 'class="api-copy-btn"' in endpoint
+    assert 'data-copy="{{ endpoint_path }}"' in endpoint
+
+
+def test_base_template_registers_api_catalog_enhancement() -> None:
+    """The enhancement loader must be able to resolve the api-catalog module."""
+    base = Path("bengal/themes/default/templates/base.html").read_text(encoding="utf-8")
+    assert "'api-catalog': '{{ asset_url(\"js/enhancements/api-catalog.js\") }}'" in base
+
+
+def test_api_catalog_enhancement_module_exists_and_registers() -> None:
+    """The vanilla-JS module exists and self-registers (no npm dependency)."""
+    module = Path("bengal/themes/default/assets/js/enhancements/api-catalog.js").read_text(
+        encoding="utf-8"
+    )
+    assert "Bengal.enhance.register('api-catalog'" in module
+    # Reduced-motion is honored (the toc.js scroll-spy gap this module closes).
+    assert "prefers-reduced-motion" in module
+    # Deep links must survive filtering: the module reveals filtered-out targets.
+    assert "hashchange" in module
+
+
+def test_autodoc_css_styles_catalog_navigation() -> None:
+    """The #287 markup (filter, rail active-state, copy button) must be styled."""
+    css = Path("bengal/themes/default/assets/css/components/autodoc.css").read_text(
+        encoding="utf-8"
+    )
+    for selector in (
+        ".api-catalog-filter__input",
+        ".api-catalog-filter__empty",
+        "[data-api-filter-item][hidden]",
+        ".api-rail__link--active",
+        ".api-copy-btn",
+    ):
+        assert selector in css, f"catalog-nav selector missing from autodoc.css: {selector}"


### PR DESCRIPTION
## Summary

- Implements #287 (REST autodoc epic #289), **stacked on #324** (base branch `lbliii/openapi-advanced-schema-285`). Review/merge #324 first.
- One lazy-loaded vanilla-JS enhancement (`api-catalog`, **no npm**) layers three interactions onto the OpenAPI catalog/app shells:
  - **Filtering** — the landing catalog and schema index get a filter box that narrows endpoint cards / schema tiles by method/path/name, collapses empty tag groups, and announces a no-results state via `aria-live`.
  - **Scroll-spy** — the left rail (landing + resource/schema/endpoint shells) marks the active section (`aria-current` + `.api-rail__link--active`) as you scroll and on direct hash navigation, honoring `prefers-reduced-motion` (the smooth-scroll gap `toc.js` leaves open).
  - **Copy affordances** — operation paths gained copy buttons that reuse the existing global `[data-copy]` handler (so base URLs, paths, and code samples copy consistently), plus a screen-reader announcement so feedback isn't visual-only.
- Driven by `data-bengal="api-catalog"` + `data-api-*` hooks in the templates and additive CSS reusing existing tokens. Maximal reuse: copy + the sidebar filter already existed in `tabs.js`; this PR adds the scroll-spy + landing/index filtering that didn't.

## Proof

- [x] Focused tests: template/CSS contract tests in `tests/unit/rendering/test_autodoc_layout_contract.py`; end-to-end build assertions in `tests/integration/test_openapi_catalog_nav.py` (hooks render in OUTPUT across landing / tag / endpoint / schema-index pages + the JS module is fingerprinted). JS has no test framework in-tree (no npm) — validated with `node --check` + biome rules.
- [x] `poe proof-pr` or scoped equivalent: 2095 passed / 3 pre-existing skips across `tests/unit/rendering/**` + autodoc integration; `ruff` + `ty` clean (pre-commit enforced, incl. the "template CSS classes have definitions" guard).
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/openapi-catalog-navigation.added.md`.

## Performance Evidence

Required when this PR makes a performance claim, changes a hot path, or changes free-threaded/concurrent behavior.

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: No performance claim. Pure client-side enhancement + template/CSS hooks. A clean dogfood build (1503 pages) showed broken-link count and health quality unchanged from baseline (10 links / 80%).

## Steward Notes

- Progressive enhancement: all rail links are real `href="#id"` anchors and the filter input is a plain `<input type=search>`, so every page works with JS disabled. The filter only toggles the `hidden` attribute (never reorders/removes anchored nodes), so `#fragment` routing and the back button keep working; a hash nav to a filtered-out section clears the filter to reveal it.
- The module self-registers via the `bengal-enhance.js` `data-bengal` loader and is added to the `enhanceUrls` map in `base.html` so the fingerprinted URL resolves in production; it lazy-loads only on OpenAPI pages.

## Manual browser smoke checklist (no automated browser in-tree)

Against a built `/api/bengal-demo-commerce/`, `/api/bengal-demo-commerce/tags/orders/`, `/api/bengal-demo-commerce/schemas/`:
- [ ] Typing in the filter narrows endpoint cards / schema tiles; empty groups collapse; clearing restores all; no-results message appears + is announced.
- [ ] Scrolling updates the active rail item; clicking a rail link / direct `#hash` nav activates the right item.
- [ ] A deep link to a section that is currently filtered out still resolves (filter clears, section scrolls into view).
- [ ] Copy buttons on base URLs, operation paths, and code samples all copy and show feedback.
- [ ] Keyboard-only: Tab to the filter + rail links, Enter activates; focus states visible.
- [ ] `prefers-reduced-motion: reduce` disables smooth scrolling.
