### PR TITLE
feat(render): WorkerSite renders a shard from a RenderPlan — S13.3b (#350)

### DIFF
--- a/bengal/orchestration/render/isolated/worker_site.py
+++ b/bengal/orchestration/render/isolated/worker_site.py
@@ -1,0 +1,128 @@
+"""
+WorkerSite — reconstruct a real :class:`~bengal.core.site.Site` from a RenderPlan
+(issue #350, saga S13.3b).
+
+A Phase-2 shard worker parses its OWN ~1/N of the corpus into its own heap, then has
+to *render* those pages — which means it needs a site object the render pipeline will
+accept. :func:`build_worker_site` produces that object from the picklable
+:class:`~bengal.snapshots.render_plan.RenderPlan` the parent shipped at the barrier.
+
+**It is a real ``Site``, not a facade or subclass — deliberately.** The render path
+reads the world through ``SiteContext``, whose ``__getattr__`` silently returns ``""``
+for any missing attribute. A facade that forgot a field would therefore produce *blank
+HTML that passes the build but fails the byte-diff with no stack trace* — the hardest
+class of shard bug to find. A real ``Site`` has every attribute or raises. And it is
+nearly free: ``Site.__post_init__`` rebuilds theme / config_service / page_cache /
+version_config / registries from ``config`` + ``root_path`` **alone, with zero content
+discovery** — so the worker constructs an empty ``Site`` and then assigns the plan's
+already-reduced state (pages, sections, taxonomy, xref index, ...) onto it.
+
+This is the rung-b core (empty Site + the site-stable read surface base templates need).
+Later rungs assign onto the same object: heterogeneous pages + NavTree precompute
+(S13.3c), reconstructed menus + per-worker indexes (S13.3d), taxonomy/related/generated
+(S13.3e). The per-worker process-global reset (caches, directive cache) is the caller's
+job — it is process state, not site state (see ``plan/epic-shard-parallel-build.md``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from bengal.core.site import Site
+    from bengal.protocols.core import PageLike
+    from bengal.snapshots.render_plan import PageView, RenderPlan
+
+__all__ = ["build_worker_site", "merge_shard_pages"]
+
+
+def build_worker_site(
+    plan: RenderPlan,
+    shard_pages: Sequence[PageLike] = (),
+    *,
+    shard_index: int = 0,
+) -> Site:
+    """
+    Build a real :class:`~bengal.core.site.Site` that renders a worker's shard.
+
+    Constructs an empty ``Site`` from the plan's ``config`` + ``root_path`` (which
+    ``__post_init__`` turns into theme/config_service/page_cache/version_config with no
+    discovery), then assigns the plan's reduced global state. ``site.pages`` is the
+    *heterogeneous* render world: this worker's freshly-parsed live pages for its own
+    shard, and body-free :class:`~bengal.snapshots.render_plan.PageView` stand-ins for
+    every page another worker owns — in the plan's canonical order, so listings and
+    lookups are identical to the in-process build.
+
+    The real worker flow is two-phase, because parsing needs a site and the site needs
+    the parsed pages: call ``build_worker_site(plan)`` (no shard_pages → ``site.pages``
+    is the plan's PageViews), ``parse_shard(files, worker_site)`` against the returned
+    site (so each parsed page's ``_site`` — which ``get_path`` reads to relativise
+    ``output_path`` — is the worker site, keeping URLs consistent), then assign
+    ``site.pages = merge_shard_pages(plan.pages, shard_pages)``. The one-shot
+    ``build_worker_site(plan, shard_pages)`` form is for callers that already parsed
+    against a site sharing this plan's ``root_path``/``output_dir``.
+
+    Args:
+        plan: the barrier-assembled global render plan (shipped by the parent).
+        shard_pages: this worker's own fully-parsed live pages (from ``parse_shard``);
+            their bodies live in this heap and are what actually gets rendered. Defaults
+            to empty for the parse-then-merge flow above.
+        shard_index: this worker's index (carried for diagnostics / per-worker paths).
+
+    Returns:
+        A populated ``Site`` ready to pass to ``render_shard`` as the render world.
+    """
+    from bengal.core.site import Site
+
+    # root_path MUST be the real project root: __post_init__ resolves the theme
+    # (themes/<name>/theme.yaml) and the data/ directory from it, so a redirected root
+    # would diverge from the parent's render output. build_time + current_language are
+    # the two render-visible fields __post_init__ does NOT derive from config.
+    site = Site(
+        root_path=plan.root_path,
+        config=plan.config,
+        build_time=plan.build_time,
+        current_language=plan.current_language,
+    )
+    site.output_dir = plan.output_dir
+
+    # The render world. The page_cache lambda (`lambda: self.pages`) reads this live;
+    # its token auto-builds on first access, so no explicit invalidate() is needed.
+    site.pages = merge_shard_pages(plan.pages, shard_pages)
+    # Live ``site.sections`` is the TOP-LEVEL *real* sections (subsections nested via
+    # ``.subsections``). The plan's navigation.top_level_sections is that set EXCEPT it
+    # also carries the synthetic content-root container (the snapshot keeps a ``root``
+    # section whose ``path`` is the content dir, which the live ``site.sections`` never
+    # holds). Drop it by path — otherwise ``get_auto_nav`` emits a bogus ``/root/`` nav
+    # item and ``base.html`` crashes on its absent ``_path``. Verified to reproduce the
+    # live ``site.sections`` exactly across test-basic/product/navigation/taxonomy.
+    content_dir = plan.root_path / "content"
+    # SectionSnapshots stand in for live Sections here (the render path consumes them
+    # uniformly), so the element type is open — same rationale as merge_shard_pages.
+    top_level: list[Any] = [s for s in plan.navigation.top_level_sections if s.path != content_dir]
+    site.sections = top_level
+    site.taxonomies = dict(plan.taxonomy.taxonomies)
+    site.xref_index = dict(plan.xref_index)
+
+    return site
+
+
+def merge_shard_pages(
+    plan_pages: Sequence[PageView],
+    shard_pages: Sequence[PageLike],
+) -> list[Any]:
+    """
+    Merge a worker's live shard pages into the plan's full, ordered page list.
+
+    Returns ``plan_pages`` with each :class:`PageView` whose ``source_path`` this worker
+    parsed replaced *in place* by the corresponding live page. The result is deliberately
+    *heterogeneous* — live ``PageLike`` pages for this shard, body-free ``PageView`` stand-ins
+    for the rest — which is why the element type is open: ``PageCacheManager`` and the render
+    readers treat both uniformly (they touch only ``source_path``/``metadata``). The plan's
+    order is the in-process build's canonical ``(weight, str(source_path))`` order, so the
+    merged list is byte-parity-faithful for every reader that iterates ``site.pages``.
+    """
+    live_by_path = {page.source_path: page for page in shard_pages}
+    return [live_by_path.get(pv.source_path, pv) for pv in plan_pages]

--- a/bengal/snapshots/render_plan.py
+++ b/bengal/snapshots/render_plan.py
@@ -621,6 +621,12 @@ class RenderPlan:
     schedule_template_groups: dict[str, tuple[Path, ...]]
     generated_page_assignments: dict[Path, int]
     snapshot_time: float = 0.0
+    # The build's wall-clock timestamp (``Site.build_time``). Shipped because the
+    # default theme footer renders ``site.build_time | dateformat('%Y')`` *directly*
+    # off the live attribute (base.html copyright year) — it is NOT derivable from
+    # config and is not in ``bengal_metadata``'s meta-tag timestamp, so a worker that
+    # left it ``None`` would emit a blank year and diverge byte-for-byte (S13.3b).
+    build_time: datetime | None = None
 
     @classmethod
     def from_site(cls, site: SiteLike, snapshot: SiteSnapshot) -> RenderPlan:
@@ -746,6 +752,7 @@ def assemble_render_plan(
         schedule_template_groups=schedule_template_groups,
         generated_page_assignments={},  # populated by the S12 sharder
         snapshot_time=snapshot.snapshot_time,
+        build_time=getattr(site, "build_time", None),
     )
 
 

--- a/changelog.d/worker-site-from-render-plan.added.md
+++ b/changelog.d/worker-site-from-render-plan.added.md
@@ -1,0 +1,12 @@
+Added `bengal/orchestration/render/isolated/worker_site.py` — `build_worker_site`, which
+reconstructs a real `bengal.core.site.Site` from a serializable `RenderPlan` (issue #350,
+Phase 2, saga S13.3b) so a separate-heap shard worker can render its own freshly-parsed pages
+without the live mutable `Site` graph. It builds an empty `Site` from the plan's config/root
+(theme/config_service/page_cache rebuilt by `__post_init__` with no content discovery), then
+assigns the plan's reduced state; `merge_shard_pages` forms the heterogeneous `site.pages`
+(this worker's live pages ∪ body-free `PageView` stand-ins for the rest, in canonical order).
+`RenderPlan` now also carries `build_time` (the default-theme footer reads `site.build_time`
+directly, and it is not config-derivable). It has no caller yet and `render_isolation` stays
+`off`, so the default build is byte-identical. Proven by a subprocess byte-parity test
+(`test_worker_site_renders_page_byte_identical`) that renders the `test-basic` fixture through a
+pickle-round-tripped plan and matches the in-process build exactly.

--- a/plan/epic-shard-parallel-build.md
+++ b/plan/epic-shard-parallel-build.md
@@ -260,6 +260,38 @@ are *not* blockers under this design.
     pages at N≥2 shards + NavTree precompute (test-product/test-navigation); **d**
     indexes + menus; **e** taxonomy/related/xref/generated (test-taxonomy); **f**
     global-reset hardening + worker-count-invariance sweep.
+    - [x] **S13.3b — empty WorkerSite + 1-page render (test-basic) (DONE).**
+      `isolated/worker_site.py::build_worker_site(plan, shard_pages=())` builds a real
+      `Site(root_path, config)` (theme/config_service/page_cache/version_config free via
+      `__post_init__`, no discovery) then assigns plan state; `merge_shard_pages` produces
+      the heterogeneous `site.pages` (live shard ∪ PageViews, in plan order). Proven
+      byte-identical to the in-process build on test-basic in a **clean subprocess**
+      (`test_worker_site_renders_page_byte_identical`) that also pickle-round-trips the
+      plan (real heap transport). Findings that diverged from the b-rung spec, each fixed:
+      - **`RenderPlan.build_time` added** — `base.html` renders `site.build_time |
+        dateformat('%Y')` directly (footer copyright); it is NOT config-derivable nor in
+        `bengal_metadata`, so a worker that left it `None` emitted a blank year. Sourced
+        in `assemble_render_plan` / `from_site`.
+      - **`site.sections` = top-level *real* sections, not `plan.sections`.** The snapshot
+        carries a synthetic `root` container (path == content dir) that live `site.sections`
+        never holds; assigning it makes `get_auto_nav` emit a bogus `/root/` item and
+        `base.html:477` crash on its absent `_path`. Reconstructed as
+        `[s for s in plan.navigation.top_level_sections if s.path != content_dir]` —
+        verified to reproduce live `site.sections` across all 4 fixtures.
+      - **URL parity needs `page._site` consistent with `output_path`.** `get_path`
+        relativises `output_path` against `page._site.output_dir`; the worker must parse
+        its shard AGAINST the worker site (two-phase: build → parse → `merge_shard_pages`),
+        not a foreign site, or the home page resolves to `/index/` not `/`.
+      - **Asset fingerprinting** needs the parent's `asset-manifest.json` passed as
+        `render_shard(asset_ctx=...)` (loaded from the shared `output_dir`).
+      - **In-process byte-parity is contaminated** by `id(site)`-keyed global caches +
+        the directive-cache singleton across fixtures → the test runs per-build in a clean
+        subprocess (mirrors `test_isolated_render_parity.py`); a real worker IS a separate
+        process, so this is also the faithful proof.
+      Triaged c–e scope: test-product/navigation/taxonomy still render an error overlay —
+      all hit the same `item._path` / empty-`site.menu` path (`_auto_nav` fires with dicts
+      lacking `_path` because the worker has no menu yet). Unblocking them is rung d (menu
+      reconstruction) + rung c (NavTree precompute / transported section data for tiles).
   - [ ] **S13.4 — actor protocol + small-parent driver + barrier-owns-globals**
     (taxonomy/related/menus reduced from shard metas) + generated-page synthesis.
   - [ ] **S13.5 — render-phase A/B + byte-parity** on a deterministic fixture.

--- a/tests/unit/orchestration/render/test_shard_worker.py
+++ b/tests/unit/orchestration/render/test_shard_worker.py
@@ -143,3 +143,154 @@ def test_render_shard_renders_all_pages(site_factory, root):
     assert result.pages_rendered == len(pages), f"{root}: not all pages rendered"
     assert not result.errors, f"{root} render errors: {result.errors[:3]}"
     assert result.render_time_ms >= 0
+
+
+# ---------------------------------------------------------------------------
+# S13.3b: the WorkerSite — a real Site reconstructed from a RenderPlan
+# ---------------------------------------------------------------------------
+#
+# This is the first rung that renders against a RECONSTRUCTED site rather than the
+# live built one: build_worker_site(plan) makes an empty real Site from the plan's
+# config (theme/config_service/page_cache rebuilt by __post_init__, no discovery), then
+# assigns the plan's reduced state. It renders a FRESHLY-PARSED page (not the live built
+# page) so there is no double-render perturbation — exactly what a real worker does.
+#
+# Runs in its OWN clean subprocess (mirrors tests/integration/test_isolated_render_parity.py):
+# a real worker IS a separate process, and a fresh interpreter is the only contamination-
+# free way to assert byte-parity. In-process, sharing the interpreter with other fixtures'
+# sites poisons render via id(site)-keyed global caches and the directive-cache singleton
+# (the same reason test_render_shard_renders_all_pages above does not assert byte-parity
+# in-process). The child also pickle-round-trips the RenderPlan, proving heap transport.
+#
+# test-basic is the right rung-b target: one content/index.md, no menus / taxonomy / nav
+# trees / query indexes, so it isolates the empty-Site recipe and the site-stable base.html
+# read surface (title / baseurl / build_time footer / fingerprinted assets).
+
+_WORKER_SITE_PARITY_CHILD = """
+import json, pickle, sys
+from pathlib import Path
+
+from bengal.assets.manifest import AssetManifest
+from bengal.cache import directive_cache
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+from bengal.orchestration.build_context import BuildContext
+from bengal.orchestration.render.isolated.partition import discover_content_files
+from bengal.orchestration.render.isolated.shard_worker import parse_shard, render_shard
+from bengal.orchestration.render.isolated.worker_site import build_worker_site, merge_shard_pages
+from bengal.rendering.assets import AssetManifestContext
+from bengal.snapshots import create_site_snapshot
+from bengal.snapshots.render_plan import RenderPlan, assert_picklable
+from bengal.utils.cache_registry import clear_all_caches
+
+root, out, worker_out = Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3])
+
+# --- Oracle: a normal in-process cold build writes the canonical HTML ---
+site = Site.from_config(root)
+site.output_dir = out
+site.build(BuildOptions(quiet=True, force_sequential=True))
+page = next(iter(site.pages))
+expected = page.output_path.read_bytes()
+
+# --- The plan the parent ships, exercised through a real pickle round-trip ---
+snapshot = create_site_snapshot(site)
+plan = RenderPlan.from_site(site, snapshot)
+assert_picklable(plan)
+plan = pickle.loads(pickle.dumps(plan))   # the worker receives a transported copy
+
+# --- The worker reconstructs a real Site and renders its own freshly-parsed shard ---
+worker_site = build_worker_site(plan)
+worker_site.output_dir = worker_out
+content_dir = plan.root_path / "content"
+worker_pages = parse_shard(
+    discover_content_files(content_dir, site=worker_site), worker_site, content_dir=content_dir
+)
+worker_site.pages = merge_shard_pages(plan.pages, worker_pages)
+worker_page = next(p for p in worker_pages if p.source_path == page.source_path)
+
+# Per-worker process-global reset (the caller's job; the live build fires it via BUILD_START).
+clear_all_caches()
+directive_cache.clear_cache()
+directive_cache.configure_for_site(worker_site)
+
+# Asset manifest: the parent's asset pipeline writes it once to the shared output_dir; the
+# worker loads it to resolve fingerprinted asset URLs (favicon.<hash>.ico, style.<hash>.css).
+manifest_path = out / "asset-manifest.json"
+manifest = AssetManifest.load(manifest_path)
+entries = {k: v.output_path for k, v in manifest.entries.items()} if manifest else {}
+asset_ctx = AssetManifestContext(
+    entries=entries, mtime=manifest_path.stat().st_mtime if manifest_path.exists() else None
+)
+
+ctx = BuildContext(site=worker_site, pages=[worker_page])
+ctx.snapshot = snapshot  # section tiles render from it (load-bearing, S13.3a)
+result = render_shard([worker_page], worker_site, ctx, asset_ctx=asset_ctx)
+actual = worker_page.output_path.read_bytes()
+
+print("RESULTJSON " + json.dumps({
+    "match": actual == expected,
+    "errors": [list(e) for e in result.errors],
+    "build_time_in_plan": plan.build_time is not None,
+    "expected_len": len(expected),
+    "actual_len": len(actual),
+    "is_error_page": b"data-bengal-overlay" in actual,
+}))
+"""
+
+
+@pytest.mark.serial
+def test_worker_site_renders_page_byte_identical(tmp_path):
+    """A page rendered through a WorkerSite reconstructed (and pickle-transported) from a
+    RenderPlan is byte-identical to the in-process build's HTML — proving the
+    empty-Site-then-assign recipe is faithful for the site-stable read surface, and that
+    the new RenderPlan.build_time field closes the footer-copyright-year diff (base.html
+    reads site.build_time directly; a worker that left it None would emit a blank year)."""
+    import json
+    import os
+    import shutil
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    src = Path(__file__).parents[3] / "roots" / "test-basic"
+    if not src.exists():  # pragma: no cover - fixture must exist
+        pytest.skip(f"missing test root {src}")
+
+    site_root = tmp_path / "site"
+    shutil.copytree(src, site_root)
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = "0"  # determinism across the oracle and worker render
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _WORKER_SITE_PARITY_CHILD,
+            str(site_root),
+            str(tmp_path / "out"),
+            str(tmp_path / "worker_out"),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    result = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("RESULTJSON "):
+            result = json.loads(line[len("RESULTJSON ") :])
+    assert result is not None, (
+        f"worker-site parity child produced no result; rc={proc.returncode}\n"
+        f"stderr tail:\n{proc.stderr[-3000:]}"
+    )
+
+    assert not result["errors"], f"worker render errors: {result['errors']}"
+    assert not result["is_error_page"], "worker rendered a build-error overlay (not real HTML)"
+    assert result["build_time_in_plan"], "RenderPlan dropped build_time"
+    # Anti-vacuity: a no-op builder cannot pass — the oracle HTML must be non-empty.
+    assert result["expected_len"] > 0, "oracle produced empty HTML — byte-parity is vacuous"
+    assert result["match"], (
+        "WorkerSite render diverged from the in-process build "
+        f"(expected {result['expected_len']}B, got {result['actual_len']}B)"
+    )


### PR DESCRIPTION
## Summary

- Reconstruct a real `bengal.core.site.Site` from a serializable `RenderPlan` (`isolated/worker_site.py::build_worker_site`) so a separate-heap shard worker can render its own freshly-parsed pages without the live mutable `Site` graph (issue #350, Phase 2, saga S13.3b) — a real `Site`, not a facade, because `SiteContext.__getattr__` silently returns `""` for missing attributes (blank HTML that passes the build but fails the diff with no stack trace), while `Site.__post_init__` rebuilds theme/config_service/page_cache/version_config from config alone with no content discovery.
- `merge_shard_pages` forms the heterogeneous `site.pages` (this worker's live pages ∪ body-free `PageView` stand-ins for the rest, in canonical order); `RenderPlan` gains a `build_time` field because the default-theme footer renders `site.build_time` directly and it is not config-derivable.
- Gated off — no caller yet and `render_isolation` stays `off`, so the default build is byte-identical; proven by a subprocess byte-parity test that renders `test-basic` through a pickle-round-tripped plan and matches the in-process build exactly.

## Proof

- [x] Focused tests: `pytest tests/unit/orchestration/render/test_shard_worker.py::test_worker_site_renders_page_byte_identical` (green; also green under the full parallel suite that previously surfaced cross-fixture global-state contamination)
- [x] `poe proof-pr` or scoped equivalent: `pytest tests/unit/snapshots/ tests/unit/orchestration/render/` → 206 passed; ruff + ruff format + ty clean (all pre-commit hooks passed)
- [x] Docs/examples/changelog updated or no-impact noted: added `changelog.d/worker-site-from-render-plan.added.md`; `plan/epic-shard-parallel-build.md` S13.3b marked done with findings

## Performance Evidence

This PR is dormant, gated-off infrastructure with no active-path behavior change, so it makes no performance claim.

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

## Steward Notes

- Next rungs (S13.3c–f): test-product/navigation/taxonomy currently render a build-error overlay — all hit the same `item._path` / empty-`site.menu` path (`_auto_nav` fires with dicts lacking `_path` because the worker has no menu yet). Unblocking them is rung d (reconstruct `site.menu`/`menu_localized` from `MenuItemSnapshot`) plus rung c (NavTree precompute + transported section data for "In This Section" tiles), each needing new `RenderPlan` fields.
- In-process byte-parity is poisoned by `id(site)`-keyed global caches and the directive-cache singleton across fixtures, so the test runs each build in its own clean subprocess (mirrors `tests/integration/test_isolated_render_parity.py`); a real worker is a separate process, so this is also the faithful proof.
- Commits are unsigned (GPG signing is unavailable in this dev environment).
