### PR TITLE
fix(snapshots): populate SiteSnapshot.taxonomy + keep tag render byte-identical (#354)

### DIFF
--- a/bengal/rendering/renderer.py
+++ b/bengal/rendering/renderer.py
@@ -106,6 +106,13 @@ class Renderer:
         self._tag_pages_cache: dict[str, list[PageLike]] | None = None
         # Thread-safety: Lock for initializing caches under free-threading (PEP 703)
         self._cache_lock = threading.Lock()
+        # i18n: when taxonomies are per-language (i18n enabled + share_taxonomies=False),
+        # each generated tag page carries its own language-narrowed membership in its
+        # _posts metadata. The snapshot/instance tag-page cache is language-blind, so the
+        # tag-page renderer must defer to that per-page path (#354). Computed lazily on the
+        # first tag-page render (None = not yet computed); the value is a deterministic
+        # bool, so a concurrent recompute under free-threading is benign.
+        self._per_language_taxonomies: bool | None = None
 
     @staticmethod
     def _default_pagination(base_url: str) -> dict[str, Any]:
@@ -239,6 +246,21 @@ class Renderer:
                 result.append(snap)
         return result
 
+    def _compute_per_language_taxonomies(self) -> bool:
+        """Whether taxonomies are per-language (i18n enabled, taxonomies not shared).
+
+        In that mode tag membership is language-narrowed per generated tag page (stored
+        in its ``_posts`` metadata), so the language-blind tag-page cache must not be used.
+        """
+        # Read the two config keys directly (mirrors get_i18n_config's strategy /
+        # share_taxonomies semantics) rather than importing it: rendering (layer 6) must
+        # not depend on orchestration (layer 7). Defensive .get chains also keep this from
+        # raising on the minimal/mock site.config used by some renderer unit tests.
+        i18n = self.site.config.get("i18n", {}) or {}
+        strategy = i18n.get("strategy") or "none"
+        share_taxonomies = bool(i18n.get("share_taxonomies", False))
+        return strategy != "none" and not share_taxonomies
+
     def _get_resolved_tag_pages(self, tag_slug: str) -> list[PageLike]:
         """
         Get resolved and filtered pages for a tag (cached).
@@ -257,10 +279,33 @@ class Renderer:
         Returns:
             List of filtered, resolved Page objects for the tag
         """
-        # Fast path: use pre-computed snapshot data (lock-free)
+        # Per-language taxonomies (i18n enabled + share_taxonomies=False): the snapshot
+        # and instance caches below are language-blind (built from the full cross-language
+        # site.taxonomies), so returning them here would leak other languages' posts into a
+        # per-language tag page. Defer to the per-page _posts path in
+        # _add_tag_generated_page_context, which carries the language-narrowed membership
+        # (#354 — before the snapshot fix, the now-live fast path masked this by returning []).
+        if self._per_language_taxonomies is None:
+            self._per_language_taxonomies = self._compute_per_language_taxonomies()
+        if self._per_language_taxonomies:
+            return []
+
+        # Fast path: use pre-computed snapshot data (lock-free). The snapshot
+        # supplies the filtered, ordered tag membership without taking a lock;
+        # we resolve each PageSnapshot back to its live Page via the path map so
+        # the rendered output (which reads Page.content == parsed HTML, not the
+        # snapshot's raw-markdown .content) is byte-identical to the slow path.
         snapshot = getattr(self.build_context, "snapshot", None) if self.build_context else None
         if snapshot is not None and snapshot.taxonomy.tag_pages:
-            return list(snapshot.taxonomy.tag_pages.get(tag_slug, ()))
+            tag_snapshots = snapshot.taxonomy.tag_pages.get(tag_slug, ())
+            if not tag_snapshots:
+                return []
+            str_page_map = self.site.get_page_path_map()
+            resolved: list[PageLike] = []
+            for tax_page in tag_snapshots:
+                live_page = str_page_map.get(str(tax_page.source_path))
+                resolved.append(live_page if live_page is not None else tax_page)
+            return resolved
 
         # Check instance cache
         if self._tag_pages_cache is not None:

--- a/bengal/snapshots/render_plan.py
+++ b/bengal/snapshots/render_plan.py
@@ -567,11 +567,12 @@ class RenderPlanTaxonomy:
 
     ``taxonomies`` is ``{kind: {slug: {"name", "slug", "pages": tuple[PageView]}}}`` —
     the exact structure template functions read off ``site.taxonomies`` (``tag_data
-    ['pages']``/``['name']``/``['slug']``). NB: this is built from the *live*
-    ``site.taxonomies`` (slug-keyed), **not** from ``SiteSnapshot.taxonomy``, whose
-    page lists are silently empty because ``_snapshot_taxonomies`` mis-iterates the
-    ``{name,slug,pages}`` term dict (a pre-existing latent bug; the live render path
-    reads ``site.taxonomies`` directly, so it is unaffected — and so is this).
+    ['pages']``/``['name']``/``['slug']``). This is built from the *live*
+    ``site.taxonomies`` (slug-keyed) for its body-free PageView shape, **not** from
+    ``SiteSnapshot.taxonomy`` (which carries ``PageSnapshot``s). Both now hold the real
+    per-term page sets: ``_snapshot_taxonomies`` formerly mis-iterated the
+    ``{name,slug,pages}`` term dict and left ``SiteSnapshot.taxonomy`` silently empty,
+    fixed in #354.
     ``tag_pages`` is the filtered tag→pages cache (matches builder._compute_tag_pages).
     """
 
@@ -677,6 +678,15 @@ def assemble_render_plan(
 
     # Deterministic global order: (weight, source_path). Independent of how pages
     # were sharded, so the plan is identical across worker counts.
+    #
+    # KNOWN QUIRK (#354, deferred): str(source_path) embeds os.sep, so this order is
+    # cross-OS-sensitive — AND it already diverges from the live thread build's page
+    # order (site.pages is the discovery walk order; it is never globally re-sorted by
+    # this key). Do NOT swap to Path.parts in isolation: it neither fixes nor regresses
+    # thread-vs-shard byte parity (a blind swap just produces a different order that
+    # still does not match the walk). The real reconcile — align plan.pages with the
+    # live walk order, gated by a cross-OS sitemap byte-diff test — is scheduled for
+    # S16 (see plan/epic-shard-parallel-build.md, the str(source_path)/S13–S16 note).
     ordered_pages = tuple(
         sorted(pv_by_path.values(), key=lambda pv: (pv.weight, str(pv.source_path)))
     )

--- a/bengal/snapshots/scheduling.py
+++ b/bengal/snapshots/scheduling.py
@@ -198,7 +198,11 @@ def _snapshot_taxonomies(
 
     for taxonomy_name, taxonomy_dict in site.taxonomies.items():
         taxonomy_snapshot: dict[str, tuple[PageSnapshot, ...]] = {}
-        for term, pages_list in taxonomy_dict.items():
+        for term, term_data in taxonomy_dict.items():
+            # Each term value is the {name, slug, pages} dict (the real shape);
+            # tolerate a bare page list too, mirroring
+            # render_plan._page_view_ify_taxonomies.
+            pages_list = term_data.get("pages", ()) if isinstance(term_data, dict) else term_data
             taxonomy_snapshot[term] = tuple(
                 page_cache[id(p)] for p in pages_list if id(p) in page_cache
             )

--- a/changelog.d/taxonomy-snapshot-populated.fixed.md
+++ b/changelog.d/taxonomy-snapshot-populated.fixed.md
@@ -1,0 +1,6 @@
+Fixed a latent bug where the internal taxonomy snapshot (`SiteSnapshot.taxonomy`)
+was always empty because `_snapshot_taxonomies` mis-iterated the `{name, slug,
+pages}` term dict, leaving the renderer's lock-free tag-page fast path dead. Tag
+pages now resolve through the corrected snapshot with byte-identical output, and
+per-language tag pages under i18n `share_taxonomies = false` correctly list only
+their own language's posts.

--- a/tests/roots/test-i18n-taxonomy/bengal.toml
+++ b/tests/roots/test-i18n-taxonomy/bengal.toml
@@ -1,0 +1,24 @@
+[site]
+title = "i18n taxonomy test"
+baseurl = "/"
+
+[build]
+content_dir = "content"
+output_dir = "public"
+theme = "default"
+
+[markdown]
+parser = "patitas"
+
+# share_taxonomies defaults to False: each language gets its own tag pages whose
+# membership is narrowed to that language. Regression fixture for #354 — the snapshot
+# tag-page cache is language-blind, so the renderer must defer to per-page _posts here.
+[i18n]
+default_language = "en"
+strategy = "prefix"
+content_structure = "dir"
+share_taxonomies = false
+languages = [
+  { code = "en", name = "English", weight = 1 },
+  { code = "fr", name = "Francais", weight = 2 },
+]

--- a/tests/roots/test-i18n-taxonomy/content/en/blog/post-en.md
+++ b/tests/roots/test-i18n-taxonomy/content/en/blog/post-en.md
@@ -1,0 +1,7 @@
+---
+title: "English Post"
+date: 2024-01-01
+lang: en
+tags: [shared]
+---
+English body.

--- a/tests/roots/test-i18n-taxonomy/content/fr/blog/post-fr.md
+++ b/tests/roots/test-i18n-taxonomy/content/fr/blog/post-fr.md
@@ -1,0 +1,7 @@
+---
+title: "Article Francais"
+date: 2024-01-02
+lang: fr
+tags: [shared]
+---
+Corps francais.

--- a/tests/unit/snapshots/test_snapshot_taxonomy.py
+++ b/tests/unit/snapshots/test_snapshot_taxonomy.py
@@ -1,0 +1,178 @@
+"""SiteSnapshot.taxonomy parity tests — issue #354.
+
+``_snapshot_taxonomies`` (bengal/snapshots/scheduling.py) used to iterate the
+``{name, slug, pages}`` term dict directly instead of its ``pages`` list, so every
+term snapshotted to an empty tuple. The bug was masked at the render-output layer by
+the ``_posts`` metadata fallback in ``Renderer._add_tag_generated_page_context``, so a
+build-output byte-parity test alone does NOT discriminate it. These tests assert at the
+DATA level that the snapshot's per-term page sets match the live ``site.taxonomies``,
+and that the renderer fast path (which reads ``snapshot.taxonomy.tag_pages``) resolves
+the same pages as the live slow path.
+
+Run on the deterministic ``test-taxonomy`` fixture: post1=python+testing, post2=python,
+post3=testing => tags/python=2, tags/testing=2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bengal.orchestration.build.options import BuildOptions
+from bengal.snapshots import create_site_snapshot
+
+if TYPE_CHECKING:
+    from bengal.core.site import Site
+    from bengal.snapshots.types import SiteSnapshot
+
+
+def _built(site_factory, root: str) -> tuple[Site, SiteSnapshot]:
+    """Build a fixture site once (sequential, quiet) and snapshot it."""
+    site = site_factory(root)
+    site.build(BuildOptions(quiet=True, force_sequential=True))
+    return site, create_site_snapshot(site)
+
+
+def test_snapshot_taxonomy_term_counts_match_live(site_factory):
+    """Every live taxonomy term's page set must survive into the snapshot.
+
+    DISCRIMINATING: with the pre-fix mis-iteration every snapshot term is an empty
+    tuple, so ``len(snapshot...) == len(term_data['pages'])`` evaluates ``0 == 2`` and
+    FAILS. The non-vacuity guard below proves the fixture actually carries tagged pages,
+    so the assertion cannot pass on an empty taxonomy.
+    """
+    site, snapshot = _built(site_factory, "test-taxonomy")
+    live = site.taxonomies
+
+    # Non-vacuity: the fixture must actually have tagged pages, else the per-term
+    # assertions below would be trivially satisfiable.
+    assert any(td["pages"] for terms in live.values() for td in terms.values()), (
+        "test-taxonomy produced no tagged pages; assertions would be vacuous"
+    )
+
+    assert set(snapshot.taxonomy.taxonomies) == set(live)
+    for kind, terms in live.items():
+        snap_terms = snapshot.taxonomy.taxonomies[kind]
+        assert set(snap_terms) == set(terms), f"taxonomy {kind} term keys differ"
+        for slug, term_data in terms.items():
+            live_paths = {p.source_path for p in term_data["pages"]}
+            snap_paths = {ps.source_path for ps in snap_terms[slug]}
+            assert snap_paths == live_paths, f"taxonomy {kind}/{slug} page set differs"
+            assert len(snap_terms[slug]) == len(term_data["pages"]), (
+                f"taxonomy {kind}/{slug} page count differs"
+            )
+
+
+def test_snapshot_tag_pages_counts_match_live(site_factory):
+    """``snapshot.taxonomy.tag_pages`` (the field the renderer fast path consumes) must
+    carry the real per-tag page sets.
+
+    DISCRIMINATING: pre-fix ``tag_pages`` is a truthy dict whose values are all empty
+    tuples, so these explicit counts (2 for each tag on test-taxonomy) evaluate ``0 == 2``
+    and FAIL. The fast-path guard ``if snapshot.taxonomy.tag_pages:`` is truthy in both
+    states, so this is a real correctness gap the empty tuples hide.
+    """
+    _site, snapshot = _built(site_factory, "test-taxonomy")
+    tag_pages = snapshot.taxonomy.tag_pages
+
+    assert len(tag_pages.get("python", ())) == 2
+    assert len(tag_pages.get("testing", ())) == 2
+    assert {ps.source_path.name for ps in tag_pages["python"]} == {"post1.md", "post2.md"}
+    assert {ps.source_path.name for ps in tag_pages["testing"]} == {"post1.md", "post3.md"}
+
+
+def test_renderer_fast_path_matches_slow_path(site_factory):
+    """The snapshot-backed fast path must resolve the same pages as the live slow path.
+
+    Builds the site (so ``build_context.snapshot`` is populated), then a single Renderer
+    instance is used to compare ``_get_resolved_tag_pages`` (fast path, fed by the
+    snapshot) against ``_build_all_tag_pages_cache`` (slow path, fed by live
+    ``site.taxonomies``).
+
+    DISCRIMINATING: pre-fix the fast path returns ``[]`` (empty snapshot tuples) while
+    the slow path returns the 2 live posts per tag, so the source_path sets DIVERGE.
+    Post-fix the fast path resolves the snapshot's tag membership back to live pages,
+    matching the slow path exactly.
+    """
+    from bengal.orchestration.build_context import BuildContext
+    from bengal.rendering.renderer import Renderer
+    from bengal.rendering.template_engine import TemplateEngine
+
+    site = site_factory("test-taxonomy")
+    site.build(BuildOptions(quiet=True, force_sequential=True))
+    snapshot = create_site_snapshot(site)
+
+    # A build_context whose .snapshot is set forces the fast path at renderer.py:262.
+    build_context = BuildContext(site=site)
+    build_context.snapshot = snapshot
+
+    engine = TemplateEngine(site)
+    renderer = Renderer(engine, build_context=build_context)
+    slow_cache = renderer._build_all_tag_pages_cache()
+
+    assert set(slow_cache), "slow-path cache empty; fixture has no tags"
+    for tag_slug, slow_pages in slow_cache.items():
+        fast_pages = renderer._get_resolved_tag_pages(tag_slug)
+        assert [p.source_path for p in fast_pages] == [p.source_path for p in slow_pages], (
+            f"fast vs slow tag-page set/order diverged for {tag_slug!r}"
+        )
+        # The fast path must surface live pages (parsed-HTML .content), not raw-markdown
+        # snapshots, or the rendered excerpt would diverge byte-for-byte.
+        for fast, slow in zip(fast_pages, slow_pages, strict=True):
+            assert fast.content == slow.content
+
+
+def test_i18n_per_language_tag_pages_stay_language_scoped(site_factory):
+    """With i18n share_taxonomies=False, a per-language tag page must list only that
+    language's posts — the now-populated snapshot tag-page cache is language-blind.
+
+    The default-language (``en``) tag page at ``tags/shared/index.html`` is the
+    discriminator: ``site.taxonomies['tags']['shared']`` holds BOTH posts (collection is
+    language-blind), while the generated EN tag page's ``_posts`` is narrowed to the EN
+    post via ``filter_pages_by_language``.
+
+    DISCRIMINATING: the #354 snapshot fix activates the renderer fast path; without the
+    per-language guard (``renderer._per_language_taxonomies``) the fast path returns the
+    full cross-language set, so ``"Article Francais" not in en_html`` FAILS (the FR post
+    leaks in). Before the #354 fix the empty snapshot masked this via the ``_posts``
+    fallback. (The non-default ``fr`` tag page is not emitted to disk under the current
+    i18n rendering path — a pre-existing behavior, independent of #354 — so this asserts
+    on the EN page only.)
+    """
+    site = site_factory("test-i18n-taxonomy")
+    site.build(BuildOptions(quiet=True, force_sequential=True))
+
+    en_tag_page = site.output_dir / "tags" / "shared" / "index.html"
+    assert en_tag_page.exists(), "EN tag page was not generated; fixture/build regressed"
+    en_html = en_tag_page.read_text()
+
+    assert "English Post" in en_html, "EN post missing from its own tag page"
+    assert "Article Francais" not in en_html, "FR post leaked into the EN tag page (#354)"
+
+
+def test_snapshot_taxonomies_handles_dict_and_bare_list_terms():
+    """``_snapshot_taxonomies`` must read ``term_data['pages']`` for the real
+    ``{name,slug,pages}`` term shape AND tolerate a bare page-list term.
+
+    DISCRIMINATING (dict branch): the pre-#354 code iterated the term dict's string keys,
+    so the dict term would snapshot to ``()`` and the ``== ("s1", "s2")`` assertion FAILS.
+    DISCRIMINATING (bare-list branch): dropping the ``else term_data`` fallback (writing
+    just ``term_data.get("pages", ())``) makes the bare list — which has no ``.get`` —
+    raise ``AttributeError``, so this test pins the otherwise-dead defensive branch.
+    """
+    from types import SimpleNamespace
+
+    from bengal.snapshots.scheduling import _snapshot_taxonomies
+
+    p1, p2, p3 = object(), object(), object()
+    page_cache = {id(p1): "s1", id(p2): "s2", id(p3): "s3"}
+    site = SimpleNamespace(
+        taxonomies={
+            "tags": {"python": {"name": "python", "slug": "python", "pages": [p1, p2]}},
+            "categories": {"guides": [p3]},  # bare-list term: the defensive fallback
+        }
+    )
+
+    result = _snapshot_taxonomies(site, page_cache)
+
+    assert result["tags"]["python"] == ("s1", "s2")
+    assert result["categories"]["guides"] == ("s3",)


### PR DESCRIPTION
## Summary

Fixes #354 — `SiteSnapshot.taxonomy` was silently empty. `_snapshot_taxonomies`
iterated each `{name, slug, pages}` term dict directly, so `for p in pages_list`
walked the dict's string keys (`'name'`/`'slug'`/`'pages'`) — never the pages —
and every term snapshotted to an empty tuple. The renderer's lock-free tag-page
fast path reads this on every normal build; the empty-but-truthy dict made it
return `[]`, and the `_posts` metadata fallback silently produced correct output.
A latent trap sitting directly under the #350 Phase-2 reduce work.

## What changed

- **`snapshots/scheduling.py`** — read `term_data['pages']` (tolerant of a bare
  list), mirroring the oracle `render_plan._page_view_ify_taxonomies`.
- **`rendering/renderer.py`** — two byte-parity consequences of the now-live fast
  path, both handled:
  - Resolve each `PageSnapshot` back to its live `Page` via
    `site.get_page_path_map()` (the snapshot's `.content` is raw markdown; live
    `Page.content` is parsed HTML, which the themed excerpt reads) — exactly what
    the slow path `_build_all_tag_pages_cache` already does.
  - **i18n guard.** The bug was load-bearing for per-language tag pages
    (`share_taxonomies = false`): the language-blind cache returning `[]` is what
    forced the per-language `_posts` path. The fast path now defers to `_posts`
    when taxonomies are per-language. Empirically confirmed: without the guard the
    EN tag page leaks the FR post. (Config keys read inline — rendering must not
    import orchestration, per the layer contract.)
- **`snapshots/render_plan.py`** — documents the deferred cross-OS
  `str(source_path)` reduce tie-break (reconcile in S16; it already diverges from
  the live walk order, so a blind `.parts` swap neither fixes nor regresses
  parity) and corrects the now-stale `RenderPlanTaxonomy` docstring.

## Verification

- **Byte-identical**: a full `test-taxonomy` build is byte-identical to the buggy
  build on all HTML/MD output (zero diffs vs the run-to-run nondeterminism
  baseline; only volatile JSON-sidecar key-ordering differs, same as buggy-vs-buggy).
- **5 discriminating tests** in `tests/unit/snapshots/test_snapshot_taxonomy.py`,
  each verified to FAIL on the buggy code and PASS on the fix (data-level parity,
  fast-vs-slow content equality, the i18n regression, and the bare-list branch).
- **New `tests/roots/test-i18n-taxonomy` fixture** locks in the per-language guard.
- No new test failures across snapshots/rendering/orchestration + the isolated
  render-parity integration suite (pre-existing unrelated failures only).

This was scoped, found, and adversarially verified via two multi-agent workflows;
the i18n regression and the raw-markdown-content divergence were both caught by
review and confirmed empirically before fixing.

## Test plan

- [x] `pytest tests/unit/snapshots/test_snapshot_taxonomy.py` (5 pass; fail when patched code reverted)
- [x] `test-taxonomy` byte-parity (zero HTML/MD diffs)
- [x] i18n repro: EN tag page lists EN post only (FR leaks without the guard)
- [x] snapshots + rendering + orchestration + isolated-render-parity sweeps

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: 3.14.2t (free-threaded)
- Machine/OS: macOS (darwin), local
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Correctness fix, not a perf change. Proven byte-identical on the test-taxonomy build (zero HTML/MD diffs); the renderer fast path was already firing before this change (returning empty), so no new per-page work is introduced — the resolve-to-live-page step mirrors the existing slow path and `_posts` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
