### PR TITLE
feat(render): WorkerSite menus + NavTree precompute (#350 S13.3c/d)

### DIFF
--- a/bengal/orchestration/render/isolated/worker_site.py
+++ b/bengal/orchestration/render/isolated/worker_site.py
@@ -103,8 +103,49 @@ def build_worker_site(
     # uniformly), so the element type is open — same rationale as merge_shard_pages.
     top_level: list[Any] = [s for s in plan.navigation.top_level_sections if s.path != content_dir]
     site.sections = top_level
+
+    # Register every section in the ContentRegistry. ``__post_init__`` builds an EMPTY
+    # registry (no discovery runs in a worker), but a live page's ``_section`` resolves
+    # lazily via ``site.get_section_by_path`` → ``registry.get_section`` — so without this,
+    # ``get_page_section(page)`` returns None and the renderer misroutes every section-index
+    # page through its *root-home* branch (top-level tiles instead of the section's own
+    # children). We register the **tree** (top_level → subsections, recursively) because
+    # only those SectionSnapshots carry ``.parent`` links — the flat ``plan.sections`` tuple
+    # is parent-less (the snapshot stores hierarchy via subsections, not the flat list), and
+    # a parent-less ancestor breaks ``page.ancestors`` → breadcrumbs drop intermediate crumbs.
+    # The flat pass first guarantees completeness (any section not reachable from a top-level
+    # root still resolves); the recursive pass then overwrites tree-reachable entries with
+    # their parent-linked versions (registry is keyed by path, last write wins).
+    # SectionSnapshots stand in for live Sections here (same rationale as ``top_level``).
+    all_sections: list[Any] = list(plan.sections)
+    for section in all_sections:
+        site.registry.register_section(section)
+    for section in top_level:
+        site.registry.register_sections_recursive(section)
+
     site.taxonomies = dict(plan.taxonomy.taxonomies)
     site.xref_index = dict(plan.xref_index)
+
+    # Menus (S13.3d). The plan's menus were snapshotted AFTER the in-process menu phase,
+    # so they are the FINAL assembled hierarchy (auto-nav + dev-bundle + dropdowns, or the
+    # config [[menus.main]] menu), already page-view-ified. The render engine builds the
+    # template menu via ``[item.to_dict() for item in site.menu[name]]`` — MenuItemSnapshot
+    # answers ``to_dict()`` byte-identically to the live MenuItem. We assign the snapshots
+    # directly: re-running MenuOrchestrator here would re-derive auto-nav against
+    # SectionSnapshots (which lack ``_site``/``_path``) and diverge. ``_dev_menu_metadata``
+    # is left at its ``__post_init__`` default (None) — these menus already bake in any
+    # dev-bundle decision the parent made, and base.html reads it null-safe.
+    # MenuItemSnapshot stands in for the live MenuItem (both answer ``to_dict()``); the
+    # Any-typed locals keep ty's invariant ``dict[str, list[MenuItem]]`` attribute happy.
+    worker_menu: dict[str, list[Any]] = {
+        name: list(items) for name, items in plan.navigation.menus.items()
+    }
+    site.menu = worker_menu
+    worker_menu_localized: dict[str, dict[str, list[Any]]] = {
+        name: {lang: list(items) for lang, items in langs.items()}
+        for name, langs in plan.menu_localized.items()
+    }
+    site.menu_localized = worker_menu_localized
 
     return site
 

--- a/bengal/snapshots/render_plan.py
+++ b/bengal/snapshots/render_plan.py
@@ -40,10 +40,12 @@ Design decisions (deliberate, documented):
   is order-independent (deterministic global sort), so a plan assembled from N
   shards is byte-equal to one assembled from a single whole-site shard — which is
   exactly what the S11 parity test proves.
-- **nav_trees are excluded.** ``NavTree`` nodes reference the live mutable
-  Page/Section graph and are not picklable; each worker rebuilds them from the
-  plan's sections+pages at startup (saga S13). The plan carries the *inputs*
-  (sections, pages, versioning) that ``NavTree.build`` needs.
+- **nav_trees are view-ified, not rebuilt (S13.3c).** ``NavTree.build`` calls
+  live-Section-only APIs, so a worker cannot reconstruct trees from snapshots. Instead
+  the parent ships its already-built trees with every ``NavNode.page`` swapped to a
+  ``PageView`` and ``.section`` to a ``SectionSnapshot`` (``_view_ify_nav_trees``) —
+  picklable and live-ref-free — and the worker installs them via
+  ``NavTreeCache.set_precomputed`` so the lock-free fast path never reaches ``build``.
 
 S13 (the worker actor protocol) will extend :class:`ShardPageMeta` with the
 section/menu metadata that today is sourced from the parent's already-built
@@ -67,8 +69,9 @@ raw config today, so the worker does no more than the main process:
   variant).
 - **site.indexes (QueryIndexRegistry)** ← rebuilt from PageView ``metadata``
   (author/date/series/status are plain scalars, carried).
-- **nav_trees** ← rebuilt from ``sections``+``pages`` via ``NavTree.build`` (they
-  hold live refs and are intentionally not shipped).
+- **nav_trees** ← shipped view-ified in ``navigation.nav_trees`` and installed via
+  ``NavTreeCache.set_precomputed`` (the parent builds them; ``NavTree.build`` needs
+  live Sections, so the worker never rebuilds — S13.3c).
 - **Generated-page render objects** (``_paginator``, resolved ``_posts``/``_tags``
   page lists) ← S14 reconstructs from ``taxonomy``/``pages_by_path``. Denormalized
   page references in metadata (``_tags``/``_posts``) are preserved as *source_paths*
@@ -84,7 +87,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from bengal.snapshots.types import (
     NO_SECTION,
@@ -96,7 +99,8 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from bengal.config.snapshot import ConfigSnapshot
-    from bengal.protocols import PageLike, SiteLike
+    from bengal.core.nav_tree import NavNode, NavTree
+    from bengal.protocols import PageLike, SectionLike, SiteLike
     from bengal.snapshots.types import PageSnapshot, SiteSnapshot
 
 
@@ -550,15 +554,21 @@ def _related_source_paths(page: PageLike) -> tuple[Path, ...]:
 
 @dataclass(frozen=True, slots=True)
 class RenderPlanNavigation:
-    """Page-view-ified analog of :class:`NavigationPlan` (no nav_trees).
+    """Page-view-ified analog of :class:`NavigationPlan`.
 
-    ``nav_trees`` are intentionally excluded — they hold live Page/Section refs and
-    are rebuilt worker-side from ``sections``+``pages`` (saga S13).
+    ``nav_trees`` carries the parent-built navigation trees, *view-ified* (every
+    ``NavNode.page`` swapped to a :class:`PageView` and ``NavNode.section`` to a
+    :class:`SectionSnapshot`) so they are picklable and free of live refs. A shard
+    worker installs them via ``NavTreeCache.set_precomputed`` so the lock-free fast
+    path serves nav without ever calling ``NavTree.build`` (which needs live Sections).
+    Keyed by version string (``"__default__"`` for the unversioned tree), matching
+    ``builder._build_nav_trees``.
     """
 
     menus: dict[str, tuple[MenuItemSnapshot, ...]]
     top_level_pages: tuple[PageView, ...]
     top_level_sections: tuple[SectionSnapshot, ...]
+    nav_trees: dict[str, NavTree] = dataclasses.field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -676,20 +686,24 @@ def assemble_render_plan(
             f"{len(pv_by_path)} unique source_paths (duplicates: {dupes[:5]})"
         )
 
-    # Deterministic global order: (weight, source_path). Independent of how pages
-    # were sharded, so the plan is identical across worker counts.
-    #
-    # KNOWN QUIRK (#354, deferred): str(source_path) embeds os.sep, so this order is
-    # cross-OS-sensitive — AND it already diverges from the live thread build's page
-    # order (site.pages is the discovery walk order; it is never globally re-sorted by
-    # this key). Do NOT swap to Path.parts in isolation: it neither fixes nor regresses
-    # thread-vs-shard byte parity (a blind swap just produces a different order that
-    # still does not match the walk). The real reconcile — align plan.pages with the
-    # live walk order, gated by a cross-OS sitemap byte-diff test — is scheduled for
-    # S16 (see plan/epic-shard-parallel-build.md, the str(source_path)/S13–S16 note).
-    ordered_pages = tuple(
-        sorted(pv_by_path.values(), key=lambda pv: (pv.weight, str(pv.source_path)))
-    )
+    # Global page order. ``site.pages`` is the discovery *walk* order, and the render
+    # path reads it directly (``page.next``/``page.prev`` index into ``site.pages``), so
+    # for byte-parity ``plan.pages`` MUST reproduce it. When the parent holds the full
+    # live page list (the ``from_site`` / S11 whole-site case, and S13.3's single-process
+    # driver) we order by that walk directly. Only when the parent lacks some page (the
+    # future S13.4 multi-shard reduce, where parsed pages live in workers) do we fall back
+    # to the deterministic ``(weight, source_path)`` key — reconciling THAT with the walk
+    # order (it diverges, and str(source_path) embeds os.sep cross-OS) is S16's job, gated
+    # by a cross-OS sitemap byte-diff test (see plan/epic-shard-parallel-build.md).
+    live_order = {p.source_path: i for i, p in enumerate(getattr(site, "pages", []) or [])}
+    if live_order and all(sp in live_order for sp in pv_by_path):
+        ordered_pages = tuple(
+            sorted(pv_by_path.values(), key=lambda pv: live_order[pv.source_path])
+        )
+    else:
+        ordered_pages = tuple(
+            sorted(pv_by_path.values(), key=lambda pv: (pv.weight, str(pv.source_path)))
+        )
 
     regular_pages = tuple(
         pv
@@ -975,10 +989,75 @@ def _relink_navigation(
         or _relink_one_section(s, pv_by_path)
         for s in snapshot.navigation.top_level_sections
     )
+    nav_trees = _view_ify_nav_trees(snapshot.navigation.nav_trees, pv_by_path, sec_by_path)
     return RenderPlanNavigation(
         menus=menus,
         top_level_pages=top_pages,
         top_level_sections=top_sections,
+        nav_trees=nav_trees,
+    )
+
+
+def _view_ify_nav_trees(
+    nav_trees: Mapping[str, NavTree],
+    pv_by_path: dict[Path, PageView],
+    sec_by_path: dict[Path, SectionSnapshot],
+) -> dict[str, NavTree]:
+    """Page-view-ify the parent's live ``NavTree``s for spawn transport.
+
+    The parent builds the real trees against live Sections/Pages
+    (``builder._build_nav_trees``); a worker cannot rebuild them because
+    ``NavTree.build`` calls live-Section-only APIs. So we ship the *structure*:
+    each :class:`NavNode` is rebuilt fresh (never mutated in place — the live tree is
+    shared with the parent's own ``NavTreeCache``) with ``page`` swapped to its
+    :class:`PageView` and ``section`` to its :class:`SectionSnapshot`, preserving
+    ``id/title/_path/icon/weight/is_index`` and the page-vs-section discriminator
+    (``section is not None``). Re-wrapping in a fresh ``NavTree`` rebuilds ``_flat_nodes``.
+    """
+    from bengal.core.nav_tree import NavTree
+
+    out: dict[str, NavTree] = {}
+    for key, tree in (nav_trees or {}).items():
+        new_root = _view_ify_nav_node(tree.root, pv_by_path, sec_by_path)
+        out[key] = NavTree(
+            root=new_root,
+            version_id=tree.version_id,
+            versions=list(tree.versions),
+            current_version=tree.current_version,
+        )
+    return out
+
+
+def _view_ify_nav_node(
+    node: NavNode,
+    pv_by_path: dict[Path, PageView],
+    sec_by_path: dict[Path, SectionSnapshot],
+) -> NavNode:
+    """Rebuild a single ``NavNode`` (and its subtree) with body-free, picklable refs."""
+    from bengal.core.nav_tree import NavNode
+
+    # PageView / SectionSnapshot stand in for the live PageLike / SectionLike NavNode
+    # fields (body-free, picklable) — the cast records that structural substitution ty
+    # can't infer (no body/live ref is ever read off these nodes during render).
+    section_view: SectionSnapshot | None = None
+    if node.section is not None:
+        sec_path = getattr(node.section, "path", None)
+        section_view = sec_by_path.get(sec_path) if sec_path is not None else None
+    page_view = _pv_one(node.page, pv_by_path) if node.page is not None else None
+    return NavNode(
+        id=node.id,
+        title=node.title,
+        _path=node._path,
+        icon=node.icon,
+        weight=node.weight,
+        children=[_view_ify_nav_node(c, pv_by_path, sec_by_path) for c in node.children],
+        page=cast("PageLike | None", page_view),
+        section=cast("SectionLike | None", section_view),
+        is_index=node.is_index,
+        is_current=node.is_current,
+        is_in_trail=node.is_in_trail,
+        is_expanded=node.is_expanded,
+        _depth=node._depth,
     )
 
 
@@ -1069,10 +1148,22 @@ def assert_picklable(plan: RenderPlan) -> None:
             raise AssertionError("RenderPlan contains a MappingProxyType (won't pickle on spawn)")  # noqa: TRY004
         if isinstance(obj, _PageSnapshot):
             raise AssertionError("RenderPlan leaks a PageSnapshot (body not page-view-ified)")  # noqa: TRY004
-        if type(obj).__name__ == "NavTree":
-            raise AssertionError(
-                "RenderPlan contains a NavTree (holds live refs; rebuild worker-side)"
-            )
+        # NavTrees are now CARRIED (view-ified) rather than rejected wholesale — but a
+        # NavNode must hold only body-free refs. Inspect its page/section instead of the
+        # tree's class name so a live-ref tree (the spawn-safety hazard) is still caught.
+        if type(obj).__name__ == "NavNode":
+            node_page = getattr(obj, "page", None)
+            if node_page is not None and not isinstance(node_page, PageView):
+                raise AssertionError(
+                    f"RenderPlan NavNode leaks a live page ref ({type(node_page).__name__}); "
+                    "NavNode.page must be a PageView"
+                )
+            node_section = getattr(obj, "section", None)
+            if node_section is not None and not isinstance(node_section, SectionSnapshot):
+                raise AssertionError(
+                    f"RenderPlan NavNode leaks a live section ref ({type(node_section).__name__}); "
+                    "NavNode.section must be a SectionSnapshot"
+                )
 
         if isinstance(obj, dict):
             stack.extend(obj.keys())

--- a/bengal/snapshots/scheduling.py
+++ b/bengal/snapshots/scheduling.py
@@ -186,6 +186,7 @@ def _snapshot_menu_item(
         page=page_snapshot,
         section=section_snapshot,
         is_active=item_is_active,
+        icon=getattr(item, "icon", None),
     )
 
 

--- a/bengal/snapshots/types.py
+++ b/bengal/snapshots/types.py
@@ -141,6 +141,20 @@ class SectionSnapshot:
         """Alias for metadata (template compatibility)."""
         return self.metadata
 
+    @property
+    def _path(self) -> str:
+        """Site-relative section URL (no baseurl), mirroring ``Section._path``.
+
+        Breadcrumb and nav ancestor-trail rendering reads ``section._path`` off section
+        ancestors. In-process those ancestors are live ``Section``s; in a shard worker
+        (#350) they are ``SectionSnapshot``s standing in for them. ``href`` is already
+        built from the live ``section._path`` (baseurl-free; see ``snapshots/content.py``
+        ``_snapshot_section_recursive``), so this returns that same value — without it,
+        ``get_breadcrumbs`` falls back to a ``/{slug}/`` guess and mis-detects section
+        indexes, emitting a duplicate ancestor crumb.
+        """
+        return self.href
+
     def __bool__(self) -> bool:
         """Always truthy (replaces SectionContext None-safety)."""
         return True
@@ -305,6 +319,23 @@ class MenuItemSnapshot:
     page: PageSnapshot | None = None
     section: SectionSnapshot | None = None
     is_active: bool = False
+    icon: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Mirror :meth:`bengal.core.menu.MenuItem.to_dict` byte-for-byte.
+
+        The render engine builds the template menu via ``[item.to_dict() for item in
+        site.menu[name]]`` (``rendering/engines/kida.py``), so a shard worker that
+        assigns these snapshots onto ``site.menu`` must answer ``to_dict()`` with the
+        identical ``{name, href, icon, children}`` shape the live ``MenuItem`` produces
+        (active state is excluded — templates compute it via URL comparison).
+        """
+        return {
+            "name": self.name,
+            "href": self.href,
+            "icon": self.icon,
+            "children": [child.to_dict() for child in self.children],
+        }
 
 
 # Forward-compatible alias: SitePlan is the public name going forward.

--- a/changelog.d/worker-site-render-world-reconstruction.added.md
+++ b/changelog.d/worker-site-render-world-reconstruction.added.md
@@ -1,0 +1,16 @@
+Extended `build_worker_site` (issue #350, Phase 2, sagas S13.3c+d) so a separate-heap shard
+worker reconstructs the *full* render world from a `RenderPlan` and renders byte-identically to
+the in-process build, not just the single-page surface S13.3b proved. It now assigns
+`site.menu`/`menu_localized` from the plan (with `MenuItemSnapshot` gaining an `icon` field and
+a `to_dict()` that byte-mirrors `MenuItem.to_dict`), ships the parent-built navigation trees
+*view-ified* in a new `RenderPlanNavigation.nav_trees` and installs them via
+`NavTreeCache.set_precomputed` (so the lock-free path never calls `NavTree.build`, which needs
+live Sections), registers sections in the worker `ContentRegistry` (so `get_page_section`
+resolves and section-index pages stop misrouting to the root-home tile branch), adds
+`SectionSnapshot._path` (fixing breadcrumb ancestor detection), and orders `plan.pages` to the
+live discovery walk (so `page.next`/`prev` are byte-stable). `render_isolation` stays `off` and
+the path has no production caller yet, so the default build is unchanged. Proven by
+`test_shard_build_is_byte_identical_to_in_process`, which renders every page of `test-product`
+and `test-navigation` across N∈{2,3} disjoint shards (clean subprocess, pickle-round-tripped
+plan) byte-identical to the in-process build; the unseeded `random_posts` widget page is
+byte-excluded but overlay-checked.

--- a/plan/epic-shard-parallel-build.md
+++ b/plan/epic-shard-parallel-build.md
@@ -292,6 +292,57 @@ are *not* blockers under this design.
       all hit the same `item._path` / empty-`site.menu` path (`_auto_nav` fires with dicts
       lacking `_path` because the worker has no menu yet). Unblocking them is rung d (menu
       reconstruction) + rung c (NavTree precompute / transported section data for tiles).
+    - [x] **S13.3c/d — menus + NavTree precompute + section/index reconstruction at N≥2
+      (DONE, shipped as one PR).** c and d were entangled (both gating fixtures crash on the
+      same empty-`site.menu` path and `test-navigation` needs both the menu *and* the docs
+      sidebar to render), so they shipped together. Proven by
+      `test_shard_build_is_byte_identical_to_in_process` — every page of **test-product** and
+      **test-navigation** rendered across **N∈{2,3} disjoint shards** is byte-identical to the
+      in-process build, in a clean subprocess with a pickle-round-tripped plan. Six findings,
+      each a real reconstruction gap the render-level gate caught that the S13.2 PageView-lens
+      parity could not:
+      - **Menus carried, not re-derived.** `plan.navigation.menus` is snapshotted *after* the
+        in-process menu phase, so it is the final assembled hierarchy, page-view-ified.
+        `build_worker_site` assigns it straight onto `site.menu`; the engine builds the
+        template menu via `[item.to_dict() …]`, so `MenuItemSnapshot` gained an `icon` field +
+        a `to_dict()` byte-mirroring `MenuItem.to_dict` (carried through `_snapshot_menu_item`).
+        Re-running `MenuOrchestrator` would re-derive auto-nav against `_site`/`_path`-less
+        SectionSnapshots and diverge.
+      - **NavTrees shipped view-ified, installed via `set_precomputed`.** `NavTree.build` calls
+        live-Section-only APIs, so the parent's already-built trees are carried in a new
+        `RenderPlanNavigation.nav_trees` field with every `NavNode.page`→`PageView`,
+        `.section`→`SectionSnapshot` (`_view_ify_nav_trees`, fresh graph — never mutates the
+        parent's live tree). `assert_picklable` relaxed: allow view-ified NavTrees, still reject
+        live page/section refs by inspecting `NavNode.page`/`.section` types. The worker (test
+        caller / future S13.4 driver) calls `NavTreeCache.invalidate()` +
+        `set_precomputed(plan.navigation.nav_trees)` per shard — the lock-free fast path never
+        reaches `build`.
+      - **Section registry rebuilt.** `__post_init__` builds an empty `ContentRegistry`; a live
+        page's `_section` resolves lazily via `registry.get_section`, so without registration
+        `get_page_section()` returns None and the renderer misroutes every section-index page
+        into its *root-home* tile branch. `build_worker_site` registers `plan.sections` (flat,
+        completeness) then `register_sections_recursive(top_level)` (the tree carries the
+        `.parent` links the flat tuple lacks — needed for `page.ancestors`/breadcrumb depth).
+      - **`SectionSnapshot._path` added** (= `href`, which `snapshots/content.py` already builds
+        baseurl-free). Breadcrumbs read `ancestor._path`; without it `get_breadcrumbs` fell back
+        to a `/{slug}/` guess and emitted a duplicate ancestor crumb (`//`).
+      - **`plan.pages` ordered to the live discovery walk.** `page.next`/`prev` index into
+        `site.pages`; the old `(weight, str(source_path))` sort diverged from the walk, breaking
+        leaf-page prev/next. `assemble_render_plan` now orders by the live `site.pages` when the
+        parent holds the full list (from_site / single-process driver), falling back to the
+        deterministic key only for the future multi-shard reduce — pulling part of S16's
+        ordering reconcile forward; the cross-OS `str(source_path)` reconcile remains S16.
+      - **Indexes deferred, justified.** `site.indexes` lazy-builds correctly over the merged
+        heterogeneous page list at N≥2; the SectionIndex/PageView-`section` gap and the
+        per-worker index `cache_dir` (parallel-worker file race) did **not** surface in the
+        gating fixtures, so they move to S13.4 (where parallel workers actually race).
+      The **random-posts widget** (`site.regular_pages | sample(3)`, unseeded) is provably
+      non-reproducible once the pool exceeds the sample size (test-navigation/api.md); those
+      pages are byte-excluded but overlay-checked (same reason `test_isolated_render_parity.py`
+      uses only deterministic test-product). Gate is non-vacuous (#130): asserts ≥2 shards
+      fired, exact cover, ≥2 real pages byte-compared, no overlay on skipped pages — and a
+      mutation (breaking `SectionSnapshot._path`) was confirmed to fail it. `ty` floor
+      unchanged (539); `render_isolation` stays **off**.
   - [ ] **S13.4 — actor protocol + small-parent driver + barrier-owns-globals**
     (taxonomy/related/menus reduced from shard metas) + generated-page synthesis.
   - [ ] **S13.5 — render-phase A/B + byte-parity** on a deterministic fixture.

--- a/tests/unit/orchestration/render/test_shard_worker.py
+++ b/tests/unit/orchestration/render/test_shard_worker.py
@@ -294,3 +294,219 @@ def test_worker_site_renders_page_byte_identical(tmp_path):
         "WorkerSite render diverged from the in-process build "
         f"(expected {result['expected_len']}B, got {result['actual_len']}B)"
     )
+
+
+# ---------------------------------------------------------------------------
+# S13.3c/d: multi-shard byte-parity — menus + NavTree precompute + section/
+# breadcrumb/index reconstruction across N>=2 disjoint shards.
+# ---------------------------------------------------------------------------
+#
+# Rung b (above) proved the empty-Site recipe on one page of test-basic. Rungs c/d add
+# the full render world: site.menu reconstructed from the plan (so base.html stops
+# crashing on `_auto_nav` dicts lacking `_path`), the parent-built NavTrees shipped
+# view-ified and installed via NavTreeCache.set_precomputed (so the docs sidebar renders
+# without NavTree.build, which needs live Sections), the section registry rebuilt (so
+# `get_page_section` resolves and section-index pages don't misroute to the root-home
+# tile branch), and plan.pages ordered to match the live discovery walk (so page.next/prev
+# are byte-stable). This gate renders EVERY page across N>=2 disjoint shards — where
+# PageViews stand in for the pages other shards own — and diffs each against the
+# in-process oracle.
+#
+# Non-determinism: the `random-posts-widget` (`site.regular_pages | sample(3)`, UNSEEDED)
+# is provably non-reproducible across processes once the candidate pool exceeds the
+# sample size (test-navigation/api.md). Those pages are byte-EXCLUDED (the same reason the
+# fork-path parity test, tests/integration/test_isolated_render_parity.py, uses only the
+# deterministic test-product) but still asserted to render without an error overlay, so a
+# reconstruction crash there cannot hide. Anti-vacuity (#130): we assert the shard backend
+# actually split into >=2 shards, the cover is exact, and a non-trivial number of pages
+# (incl. multi-level ones) were byte-compared — a silent single-shard fallback or an
+# all-widget-skip fails the test.
+
+_MULTISHARD_PARITY_CHILD = """
+import json, pickle, sys
+from pathlib import Path
+
+from bengal.assets.manifest import AssetManifest
+from bengal.cache import directive_cache
+from bengal.core.nav_tree import NavTreeCache
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+from bengal.orchestration.build_context import BuildContext
+from bengal.orchestration.render.isolated.partition import (
+    discover_content_files,
+    partition_content_files,
+)
+from bengal.orchestration.render.isolated.shard_worker import parse_shard, render_shard
+from bengal.orchestration.render.isolated.worker_site import build_worker_site, merge_shard_pages
+from bengal.rendering.assets import AssetManifestContext
+from bengal.snapshots import create_site_snapshot
+from bengal.snapshots.render_plan import RenderPlan, assert_picklable
+from bengal.utils.cache_registry import clear_all_caches
+
+WIDGET_MARK = b"random-posts-widget"
+
+root, out, wout, nshards = Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), int(sys.argv[4])
+
+# --- Oracle: a normal in-process cold build writes the canonical HTML ---
+site = Site.from_config(root)
+site.output_dir = out
+site.build(BuildOptions(quiet=True, force_sequential=True))
+oracle = {
+    p.source_path: (p.output_path.read_bytes(), str(p.output_path.relative_to(out)))
+    for p in site.pages
+    if getattr(p, "output_path", None)
+}
+
+# --- Plan, exercised through a real pickle round-trip (heap transport) ---
+snapshot = create_site_snapshot(site)
+plan = RenderPlan.from_site(site, snapshot)
+assert_picklable(plan)
+plan = pickle.loads(pickle.dumps(plan))
+
+content_dir = plan.root_path / "content"
+all_files = discover_content_files(content_dir, site=build_worker_site(plan))
+shards = partition_content_files(all_files, nshards, "balanced")
+
+manifest_path = out / "asset-manifest.json"
+manifest = AssetManifest.load(manifest_path)
+entries = {k: v.output_path for k, v in manifest.entries.items()} if manifest else {}
+
+# --- Each shard reconstructs its own WorkerSite and renders its own parsed pages,
+#     all writing into the shared worker output dir (as parallel workers would). ---
+rendered = {}
+shard_errors = []
+for i, idxs in enumerate(shards):
+    ws = build_worker_site(plan, shard_index=i)
+    ws.output_dir = wout
+    files_i = [all_files[j] for j in idxs]
+    worker_pages = parse_shard(files_i, ws, content_dir=content_dir)
+    ws.pages = merge_shard_pages(plan.pages, worker_pages)
+
+    # Per-worker process-global reset + the precomputed nav-tree install (the caller's
+    # job; a real worker IS a fresh process, here we mirror it per shard in one process).
+    clear_all_caches()
+    directive_cache.clear_cache()
+    directive_cache.configure_for_site(ws)
+    NavTreeCache.invalidate()
+    NavTreeCache.set_precomputed(dict(plan.navigation.nav_trees))
+
+    asset_ctx = AssetManifestContext(
+        entries=entries, mtime=manifest_path.stat().st_mtime if manifest_path.exists() else None
+    )
+    ctx = BuildContext(site=ws, pages=list(worker_pages))
+    ctx.snapshot = snapshot
+    result = render_shard(list(worker_pages), ws, ctx, asset_ctx=asset_ctx)
+    shard_errors.extend([list(e) for e in result.errors])
+    for p in worker_pages:
+        rendered[str(p.source_path)] = p.output_path.read_bytes()
+
+# --- Compare every rendered page to the oracle; widget pages are overlay-checked only. ---
+pages = []
+for sp, (exp, rel) in oracle.items():
+    act = rendered.get(str(sp))
+    has_widget = WIDGET_MARK in exp
+    pages.append({
+        "rel": rel,
+        "rendered": act is not None,
+        "match": (act == exp) if act is not None else None,
+        "overlay": (b"data-bengal-overlay" in act) if act is not None else None,
+        "widget": has_widget,
+        "exp_len": len(exp),
+    })
+
+print("MSREPORT " + json.dumps({
+    "num_shards": len(shards),
+    "cover_ok": set(rendered.keys()) == {str(sp) for sp in oracle},
+    "n_rendered": len(rendered),
+    "n_oracle": len(oracle),
+    "errors": shard_errors,
+    "pages": pages,
+}))
+"""
+
+
+@pytest.mark.serial
+@pytest.mark.parametrize("fixture", ["test-product", "test-navigation"])
+@pytest.mark.parametrize("num_shards", [2, 3])
+def test_shard_build_is_byte_identical_to_in_process(fixture, num_shards, tmp_path):
+    """A cold build split across N>=2 WorkerSite shards is byte-identical to the
+    in-process build, page by page — proving the S13.3c/d reconstruction (menus,
+    precomputed NavTrees, section registry, walk-order page list) is faithful when
+    PageViews stand in for the pages other shards own.
+
+    test-product and test-navigation together cover a 2-level section + tiles and a
+    3-level docs sidebar with a multi-item config menu (children + active trail).
+    The non-deterministic random-posts widget page is overlay-checked, not byte-diffed.
+    """
+    import json
+    import os
+    import shutil
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    src = Path(__file__).parents[3] / "roots" / fixture
+    if not src.exists():  # pragma: no cover - fixture must exist
+        pytest.skip(f"missing test root {src}")
+
+    site_root = tmp_path / "site"
+    shutil.copytree(src, site_root)
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = "0"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _MULTISHARD_PARITY_CHILD,
+            str(site_root),
+            str(tmp_path / "out"),
+            str(tmp_path / "worker_out"),
+            str(num_shards),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    report = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("MSREPORT "):
+            report = json.loads(line[len("MSREPORT ") :])
+    assert report is not None, (
+        f"multi-shard parity child produced no report; rc={proc.returncode}\n"
+        f"stderr tail:\n{proc.stderr[-4000:]}"
+    )
+
+    # The shard backend must actually have split — a silent single-shard fallback would
+    # make "N-shard parity" vacuous (the #130 lesson). With >=4 source files per fixture
+    # and num_shards in {2,3}, the partitioner always yields >=2 non-empty shards.
+    assert report["num_shards"] >= 2, (
+        f"expected >=2 shards, got {report['num_shards']} (single-shard fallback?)"
+    )
+    assert report["cover_ok"], (
+        f"shard cover incomplete: rendered {report['n_rendered']} of {report['n_oracle']} pages"
+    )
+    assert not report["errors"], f"shard render errors: {report['errors']}"
+
+    compared = [p for p in report["pages"] if not p["widget"]]
+    skipped = [p for p in report["pages"] if p["widget"]]
+
+    # Anti-vacuity: a non-trivial number of real pages must be byte-compared (not all
+    # skipped as widgets), and every oracle page must be non-empty.
+    assert len(compared) >= 2, (
+        f"too few byte-compared pages ({len(compared)}) — gate would be vacuous"
+    )
+    assert all(p["exp_len"] > 0 for p in report["pages"]), "oracle produced an empty page"
+
+    mismatches = [p["rel"] for p in compared if p["match"] is not True]
+    assert not mismatches, (
+        f"{fixture} (N={num_shards}): shard build diverged from in-process on: {mismatches}"
+    )
+
+    # Widget pages are not byte-comparable (unseeded random sample), but a reconstruction
+    # crash there must not hide behind the exclusion.
+    for p in skipped:
+        assert p["rendered"], f"widget page not rendered: {p['rel']}"
+        assert not p["overlay"], f"widget page rendered a build-error overlay: {p['rel']}"


### PR DESCRIPTION
## Summary

- Reconstruct the full render world inside the #350 shard `WorkerSite` so a worker renders byte-identically to the in-process build: assign `site.menu`/`menu_localized` from the plan (with `MenuItemSnapshot` gaining `icon` + a `to_dict()` that byte-mirrors `MenuItem`), ship parent-built NavTrees view-ified in a new `RenderPlanNavigation.nav_trees` and install them via `NavTreeCache.set_precomputed`, register sections in the worker `ContentRegistry`, add `SectionSnapshot._path`, and order `plan.pages` to the live discovery walk.
- This completes epic #350 rungs S13.3c+d (shipped together — both gating fixtures crash on the same empty-`site.menu` path); it is correctness/setup only, `render_isolation` stays off by default with no perf change.

## Proof

- [x] Focused tests: `tests/unit/orchestration/render/test_shard_worker.py::test_shard_build_is_byte_identical_to_in_process` (N in {2,3} x test-product/test-navigation) — every non-widget page byte-identical; a mutation reverting one fix was confirmed to fail it.
- [x] `poe proof-pr` or scoped equivalent: 161 snapshot/shard tests + fork-path parity + 3089 rendering/core unit tests green; ruff + ruff format clean; ty floor unchanged at 539; dependency-layers no violations; all pre-commit hooks passed.
- [x] Docs/examples/changelog updated or no-impact noted: `plan/epic-shard-parallel-build.md` updated (S13.3c/d marked done with findings); no user-facing change (flag off by default) so changelog no-impact.

## Performance Evidence

Required when this PR makes a performance claim, changes a hot path, or changes
free-threaded/concurrent behavior.

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable - the shard render path is gated behind render_isolation (off by default) and is not wired into any runnable build; this PR proves byte-parity only and makes no performance claim. The realized render-phase A/B is gated at S13.5, after the S13.4 actor driver.

## Steward Notes

- Deferred to S13.4 (verified not load-bearing for these fixtures at N>=2): per-worker index `cache_dir` (parallel-worker file race) and `PageView.section`. Still S16: the cross-OS `str(source_path)` ordering reconcile (this PR pulled forward only the live-walk ordering needed for `page.next`/`prev` parity).
- The default-theme `random_posts` widget uses unseeded `random.sample`, so any `page.html` page whose `regular_pages` pool exceeds 3 is non-reproducible across processes; those pages are byte-excluded from the gate but overlay-checked. This is a project-wide byte-parity constraint, not a fixture quirk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
