### PR TITLE
feat(snapshots): barrier taxonomy + related meta-reduce — S13.4a (#350)

### DIFF
--- a/bengal/snapshots/render_plan.py
+++ b/bengal/snapshots/render_plan.py
@@ -656,6 +656,7 @@ def assemble_render_plan(
     *,
     snapshot: SiteSnapshot,
     site: SiteLike,
+    reduce_taxonomy_from_metas: bool = False,
 ) -> RenderPlan:
     """
     Reduce per-shard metadata into one immutable :class:`RenderPlan` (the barrier).
@@ -664,6 +665,17 @@ def assemble_render_plan(
     from the union of ``shard_metas`` with a single deterministic global ordering, so
     the result is independent of how pages were sharded. The section/menu/config
     structure is page-view-ified from the parent's ``snapshot`` (see module docstring).
+
+    ``reduce_taxonomy_from_metas`` (S13.4a) switches the taxonomy structure + related
+    index from the parent's already-built ``site.taxonomies`` / ``page.related_posts``
+    (which require a fully-built site) to a pure reduce over the global PageView union:
+    taxonomies are re-collected from PageView tags/categories (reproducing
+    ``TaxonomyOrchestrator.collect_taxonomies`` byte-for-byte), and the related index is
+    recomputed at the barrier (reproducing ``RelatedPostsOrchestrator.build_index``,
+    since the real map step emits ``related_pairs=()`` — related is a global computation
+    no single shard can do). This is the first step of "barrier-owns-globals": the small
+    parent never builds ``site.taxonomies``. Off by default so ``from_site`` (the parity
+    oracle) and every existing caller keep the snapshot-sourced path unchanged.
     """
     # --- 1. Global page-view map + deterministic ordering ----------------
     pv_by_path: dict[Path, PageView] = {}
@@ -711,21 +723,31 @@ def assemble_render_plan(
         if not pv.is_generated and pv.source_path.stem not in ("index", "_index")
     )
 
-    # --- 2. Taxonomy (page-view-ified from the live site.taxonomies) -----
-    # The barrier reuses the parent's collected taxonomy (slug-keyed
-    # {name,slug,pages}); we only swap the live Page lists for body-free
-    # PageViews. The per-shard taxonomy_terms edges are the S13 input for when the
-    # parent rebuilds taxonomies from scratch; for S11 the parent already has them.
-    taxonomies = _page_view_ify_taxonomies(getattr(site, "taxonomies", {}) or {}, pv_by_path)
+    # --- 2. Taxonomy -----------------------------------------------------
+    # Default (S11): page-view-ify the parent's already-collected site.taxonomies
+    # (slug-keyed {name,slug,pages}), swapping live Page lists for body-free PageViews.
+    # S13.4a: re-collect from the PageView union instead, so the small parent need not
+    # build site.taxonomies at all. Both produce the identical {kind:{slug:{name,slug,
+    # pages}}} structure — proven field-equal in tests/unit/snapshots/test_render_plan.py.
+    if reduce_taxonomy_from_metas:
+        taxonomies = _reduce_taxonomies(ordered_pages, config=getattr(site, "config", {}) or {})
+    else:
+        taxonomies = _page_view_ify_taxonomies(getattr(site, "taxonomies", {}) or {}, pv_by_path)
     tag_pages = _tag_pages(taxonomies)
 
     # --- 3. Frozen xref index --------------------------------------------
     xref_index = _assemble_xref_index(shard_metas, pv_by_path)
 
     # --- 4. Related index -------------------------------------------------
-    related_index: dict[Path, tuple[Path, ...]] = {
-        sp: related for meta in shard_metas for sp, related in meta.related_pairs
-    }
+    # Default (S11): reduce from per-shard related_pairs (the parent pre-computed
+    # page.related_posts). S13.4a: the real map step emits related_pairs=() because
+    # related is a whole-site computation, so recompute it at the barrier from the
+    # reduced taxonomy + PageView tags — byte-identical to RelatedPostsOrchestrator.
+    related_index: dict[Path, tuple[Path, ...]]
+    if reduce_taxonomy_from_metas:
+        related_index = _reduce_related_index(ordered_pages, taxonomies)
+    else:
+        related_index = {sp: related for meta in shard_metas for sp, related in meta.related_pairs}
 
     # --- 5. Sections (page-view-ified) -----------------------------------
     sections, root_section = _relink_all_sections(snapshot, pv_by_path)
@@ -830,6 +852,162 @@ def _tag_pages(
         )
         out[tag_slug] = filtered
     return out
+
+
+def _reduce_taxonomies(
+    ordered_pages: Sequence[PageView],
+    *,
+    config: Mapping[str, Any],
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Re-collect ``site.taxonomies`` from the global PageView union (S13.4a barrier reduce).
+
+    Reproduces :meth:`TaxonomyOrchestrator.collect_taxonomies` byte-for-byte without a
+    built site: iterate pages in the global walk order (``ordered_pages`` mirrors
+    ``site.pages``), skip ineligible pages (generated + ``content/api``/``content/cli``),
+    bucket by ``normalize_taxonomy_slug`` with **first-writer-wins** display name, then
+    stable-sort each term's pages **date-DESC** (``date or datetime.min``). The container
+    shape (``{kind:{slug:{name,slug,pages: tuple[PageView]}}}``) matches
+    :func:`_page_view_ify_taxonomies` exactly, so :func:`_tag_pages` consumes it unchanged.
+
+    The PageView objects appended ARE the global-union instances (same identity as
+    ``pv_by_path``), so equality with the snapshot-sourced taxonomy holds field-for-field.
+
+    i18n taxonomy filtering (per-language tag pages) is NOT reproduced yet — it is a later
+    rung. Raise rather than silently emit a non-i18n taxonomy on an i18n site.
+    """
+    from bengal.orchestration.utils.i18n import get_i18n_config
+
+    i18n = get_i18n_config(config)
+    if i18n.is_enabled and not i18n.share_taxonomies:
+        raise NotImplementedError(
+            "barrier taxonomy reduce does not yet reproduce per-language i18n filtering "
+            "(share_taxonomies=False); use the snapshot-sourced path until the i18n rung"
+        )
+
+    from bengal.utils.primitives.text import normalize_taxonomy_slug
+
+    taxonomies: dict[str, dict[str, dict[str, Any]]] = {"tags": {}, "categories": {}}
+
+    def _add(kind: str, raw_term: str, pv: PageView) -> None:
+        term_str = str(raw_term)
+        slug = normalize_taxonomy_slug(term_str)
+        bucket = taxonomies[kind]
+        entry: dict[str, Any] | None = bucket.get(slug)
+        if entry is None:
+            # First-writer-wins display name (taxonomy.py:339-343 / 352-357).
+            entry = {"name": term_str, "slug": slug, "pages": []}
+            bucket[slug] = entry
+        entry["pages"].append(pv)
+
+    for pv in ordered_pages:
+        # _is_eligible_for_taxonomy (taxonomy.py:116-140): drop generated + autodoc.
+        if pv.is_generated:
+            continue
+        source_str = str(pv.source_path)
+        if "content/api" in source_str or "content/cli" in source_str:
+            continue
+
+        for tag in pv.tags:
+            _add("tags", tag, pv)
+        # Categories come from the SINGULAR ``category`` frontmatter key — exactly what
+        # collect_taxonomies reads (taxonomy.py:347-358), NOT PageView.categories.
+        category = pv.metadata.get("category")
+        if category is not None:
+            _add("categories", category, pv)
+
+    # Stable date-DESC sort within each term (taxonomy.py:361-365). Stable → walk-order
+    # tie-break preserved for equal dates, matching the live append-then-sort.
+    for kind_bucket in taxonomies.values():
+        for entry in kind_bucket.values():
+            entry["pages"].sort(key=lambda p: p.date if p.date else datetime.min, reverse=True)
+            entry["pages"] = tuple(entry["pages"])
+
+    return taxonomies
+
+
+def _is_valid_related_candidate_view(pv: PageView) -> bool:
+    """PageView mirror of ``RelatedPostsOrchestrator._is_valid_related_candidate`` (related_posts.py:333-349).
+
+    Candidate-intrinsic filters: skip generated pages, the home page, and section index
+    pages. The ``kind != "index"`` check is reproduced via ``getattr`` for fidelity to the
+    live predicate; ``Page.kind`` only ever yields home/section/page (never "index") for
+    real pages, so it is a no-op here — PageView deliberately carries no ``kind`` field
+    (deferred until a rung actually needs it).
+    """
+    if pv.is_generated:
+        return False
+    path = pv.site_path or pv.href or ""
+    path_str = str(path).rstrip("/") if path else ""
+    if path_str in ("", "/") or str(path) in ("/", "/index.html", ""):
+        return False  # Home page
+    return getattr(pv, "kind", None) != "index"  # Section indices (no-op for PageViews)
+
+
+def _reduce_related_index(
+    ordered_pages: Sequence[PageView],
+    taxonomies: dict[str, dict[str, dict[str, Any]]],
+    *,
+    limit: int = 5,
+) -> dict[Path, tuple[Path, ...]]:
+    """Recompute the related-posts index at the barrier (S13.4a).
+
+    Reproduces :meth:`RelatedPostsOrchestrator.build_index` (limit=5, the live call at
+    build/content.py:328) over PageViews: a page→tag-slug map over ALL non-generated pages,
+    a per-tag pre-filtered candidate list in taxonomy (date-DESC) order with a stable
+    ``str(source_path)`` tie-break key, then per page a shared-tag score sorted by
+    ``(-score, sort_key)`` truncated to ``limit``. Returns ``{source_path: ordered related
+    source_paths}`` for pages WITH related posts only — matching the oracle, whose
+    ``related_index`` is reduced from ``related_pairs`` that are appended only when
+    non-empty (render_plan.py related_pairs / shard_meta_from_pages).
+
+    ``pages_to_process`` is the non-generated set (== live ``site.regular_pages`` =
+    ``page_cache.regular_pages``, which excludes ONLY generated pages — section ``_index``
+    pages stay in and legitimately get related posts), NOT the RenderPlan ``regular_pages``
+    field (which also drops index pages).
+    """
+    if not taxonomies.get("tags"):
+        return {}
+
+    from bengal.utils.primitives.text import normalize_taxonomy_slug
+
+    # page → set of tag slugs, over EVERY page (mirrors _build_page_tags_map over site.pages).
+    page_tag_slugs: dict[Path, set[str]] = {}
+    for pv in ordered_pages:
+        page_tag_slugs[pv.source_path] = (
+            {normalize_taxonomy_slug(t) for t in pv.tags if t is not None} if pv.tags else set()
+        )
+
+    # Pre-filtered candidate lists per tag (preserving taxonomy date-DESC order) + the
+    # stable tie-break key, computed once (_build_candidate_index, related_posts.py:351-389).
+    candidates_by_tag: dict[str, list[PageView]] = {}
+    sort_keys: dict[Path, str] = {}
+    for tag_slug, term_data in taxonomies["tags"].items():
+        valid: list[PageView] = []
+        for cand in term_data.get("pages", ()):  # type: ignore[union-attr]
+            if _is_valid_related_candidate_view(cand):
+                valid.append(cand)
+                sort_keys.setdefault(cand.source_path, str(cand.source_path))
+        candidates_by_tag[tag_slug] = valid
+
+    related_index: dict[Path, tuple[Path, ...]] = {}
+    for pv in ordered_pages:
+        if pv.is_generated:
+            continue  # generated pages get [] related (cleared in the live finalize pass)
+        tag_slugs = page_tag_slugs.get(pv.source_path) or set()
+        if not tag_slugs:
+            continue
+        scored: dict[Path, int] = {}
+        for tag_slug in tag_slugs:
+            for cand in candidates_by_tag.get(tag_slug, ()):
+                if cand.source_path == pv.source_path:
+                    continue  # skip self
+                scored[cand.source_path] = scored.get(cand.source_path, 0) + 1
+        if not scored:
+            continue
+        ordered = sorted(scored.items(), key=lambda kv: (-kv[1], sort_keys[kv[0]]))
+        related_index[pv.source_path] = tuple(sp for sp, _ in ordered[:limit])
+
+    return related_index
 
 
 def _assemble_xref_index(

--- a/changelog.d/render-plan-barrier-taxonomy-reduce.added.md
+++ b/changelog.d/render-plan-barrier-taxonomy-reduce.added.md
@@ -1,0 +1,17 @@
+Added an opt-in `reduce_taxonomy_from_metas` path to `assemble_render_plan` (epic #350
+S13.4a, "barrier-owns-globals"): the barrier can now recompute the taxonomy structure and
+the related-posts index *purely from the global PageView union* instead of from a
+fully-built `site.taxonomies` / `page.related_posts`. `_reduce_taxonomies` reproduces
+`TaxonomyOrchestrator.collect_taxonomies` byte-for-byte (first-writer display name,
+`normalize_taxonomy_slug`, singular `category` frontmatter key, stable date-DESC ordering)
+and `_reduce_related_index` reproduces `RelatedPostsOrchestrator.build_index` (limit=5),
+closing the long-standing gap where the real worker map step (`shard_meta_from_live_pages`)
+emits `related_pairs=()` and the assembled plan's `related_index` was therefore empty.
+
+This is the first step toward a *small* shard-parallel build parent that never builds the
+whole-site snapshot. It is off by default — `from_site` and every existing caller keep the
+snapshot-sourced path, byte-unchanged. Proven in `tests/unit/snapshots/test_render_plan.py`
+against the `from_site` oracle across N∈{1,2,3,5,7} shards and against the live site
+(`site.taxonomies` / `page.related_posts`) as independent ground truth, plus discriminating
+synthetic unit tests for the date-DESC sort, first-writer name, slug normalization, and the
+generated/autodoc eligibility filter.

--- a/tests/unit/snapshots/test_render_plan.py
+++ b/tests/unit/snapshots/test_render_plan.py
@@ -24,6 +24,7 @@ widget). Each fixture is built once and all assertions reuse the build.
 from __future__ import annotations
 
 import pickle
+from datetime import datetime
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -427,3 +428,186 @@ def test_sections_carry_page_views_not_snapshots(site_factory):
         if section.index_page is not None:
             assert isinstance(section.index_page, PageView)
     assert seen_section, "test-product fixture produced no section pages"
+
+
+# ---------------------------------------------------------------------------
+# S13.4a: barrier-owns-globals — taxonomy + related recomputed from the PageView
+# union (no built site.taxonomies / page.related_posts). Gated against both the
+# snapshot-sourced from_site oracle AND the live site as independent ground truth.
+# ---------------------------------------------------------------------------
+
+
+def _assemble_meta_reduced(site: Site, snapshot: SiteSnapshot, n: int) -> RenderPlan:
+    """Round-robin into ``n`` shards and assemble with taxonomy/related meta-reduced."""
+    pages = list(site.pages)
+    groups = [pages[i::n] for i in range(n)]
+    metas = [
+        shard_meta_from_pages(g, snapshot, shard_index=i, site=site) for i, g in enumerate(groups)
+    ]
+    return assemble_render_plan(
+        metas, snapshot=snapshot, site=site, reduce_taxonomy_from_metas=True
+    )
+
+
+@pytest.mark.parametrize("root", ROOTS)
+def test_meta_reduced_taxonomy_and_related_match_from_site(site_factory, root):
+    """The barrier reduce (``reduce_taxonomy_from_metas=True``) produces the SAME
+    taxonomies / tag_pages / related_index as the snapshot-sourced ``from_site`` oracle,
+    independent of shard count — so the small parent can stop building site.taxonomies
+    and page.related_posts. (Sections/menus/config still snapshot-sourced; later rungs.)"""
+    site, snapshot = _built(site_factory, root)
+    oracle = RenderPlan.from_site(site, snapshot)
+
+    n_pages = len(site.pages)
+    for n in (1, 2, 3, 5, 7):
+        if n > n_pages:
+            break
+        plan = _assemble_meta_reduced(site, snapshot, n)
+        assert plan.taxonomy.taxonomies == oracle.taxonomy.taxonomies, f"{root} N={n} taxonomy"
+        assert plan.taxonomy.tag_pages == oracle.taxonomy.tag_pages, f"{root} N={n} tag_pages"
+        assert plan.related_index == oracle.related_index, f"{root} N={n} related"
+
+
+@pytest.mark.parametrize("root", ROOTS)
+def test_meta_reduced_from_live_map_step_recovers_related(site_factory, root):
+    """The REAL map step (``shard_meta_from_live_pages``) emits ``related_pairs=()``
+    because related is a whole-site computation. With ``reduce_taxonomy_from_metas`` the
+    barrier recomputes it from scratch — closing the gap that
+    ``test_render_plan_from_live_pages_matches_from_site`` documents (related_index=={}).
+    This is the load-bearing S13.4a proof: a worker's body-free map output reduces to the
+    same taxonomy + related world the in-process build produced."""
+    site, snapshot = _built(site_factory, root)
+    oracle = RenderPlan.from_site(site, snapshot)
+
+    live_meta = shard_meta_from_live_pages(list(site.pages), site, shard_index=0)
+    plan = assemble_render_plan(
+        [live_meta], snapshot=snapshot, site=site, reduce_taxonomy_from_metas=True
+    )
+
+    assert plan.taxonomy.taxonomies == oracle.taxonomy.taxonomies, f"{root} taxonomy"
+    assert plan.related_index == oracle.related_index, f"{root} related"
+
+
+def test_meta_reduced_related_matches_live_and_is_nonvacuous(site_factory):
+    """Related index reduced from the real (related-free) live map step matches the live
+    ``page.related_posts`` as INDEPENDENT ground truth — and the fixture actually has
+    related posts, so the gate is not vacuously comparing two empty dicts."""
+    site, snapshot = _built(site_factory, "test-taxonomy")
+    live_meta = shard_meta_from_live_pages(list(site.pages), site, shard_index=0)
+    plan = assemble_render_plan(
+        [live_meta], snapshot=snapshot, site=site, reduce_taxonomy_from_metas=True
+    )
+
+    found_related = False
+    for page in site.pages:
+        related = getattr(page, "related_posts", None) or []
+        expected = tuple(r.source_path for r in related)
+        if expected:
+            found_related = True
+            assert plan.related_index.get(page.source_path) == expected, (
+                f"meta-reduced related diverged for {page.source_path}"
+            )
+        else:
+            assert page.source_path not in plan.related_index
+    assert found_related, "test-taxonomy produced no related posts — related gate is vacuous"
+    assert plan.related_index, "barrier did not populate related_index from the live map step"
+
+
+def test_meta_reduced_taxonomy_matches_live_site_taxonomies(site_factory):
+    """Taxonomy reduced from the live map step matches live ``site.taxonomies`` as
+    INDEPENDENT ground truth: same kinds, same term keys, same first-writer display name,
+    same membership AND page order (the comparison is order-sensitive, so a membership or
+    ordering regression goes red against the live build)."""
+    site, snapshot = _built(site_factory, "test-taxonomy")
+    live_meta = shard_meta_from_live_pages(list(site.pages), site, shard_index=0)
+    plan = assemble_render_plan(
+        [live_meta], snapshot=snapshot, site=site, reduce_taxonomy_from_metas=True
+    )
+
+    live = site.taxonomies
+    assert set(plan.taxonomy.taxonomies) == set(live)
+
+    checked_terms = 0
+    for kind, terms in live.items():
+        plan_terms = plan.taxonomy.taxonomies[kind]
+        assert set(plan_terms) == set(terms), f"taxonomy {kind} term keys differ"
+        for slug, term_data in terms.items():
+            live_pages = [p.source_path for p in term_data["pages"]]
+            plan_pages = [pv.source_path for pv in plan_terms[slug]["pages"]]
+            assert plan_pages == live_pages, f"taxonomy {kind}/{slug} membership/order differs"
+            assert plan_terms[slug]["name"] == term_data["name"]
+            assert plan_terms[slug]["slug"] == term_data["slug"]
+            checked_terms += 1
+    assert checked_terms, "test-taxonomy produced no taxonomy terms — gate is vacuous"
+
+
+def _mk_pv(
+    source_path: str,
+    *,
+    tags: tuple[str, ...] = (),
+    date: datetime | None = None,
+    is_generated: bool = False,
+    metadata: dict | None = None,
+) -> PageView:
+    """Minimal PageView for direct ``_reduce_taxonomies`` unit tests (no fixture build)."""
+    return PageView(
+        title=source_path,
+        href=f"/{source_path}",
+        site_path=f"/{source_path}",
+        source_path=Path(source_path),
+        output_path=Path(source_path),
+        slug=source_path,
+        ref_id=None,
+        template_name="page.html",
+        date=date,
+        weight=0.0,
+        tags=tags,
+        categories=(),
+        excerpt="",
+        meta_description="",
+        reading_time=0,
+        word_count=0,
+        toc_items=(),
+        content_hash="",
+        metadata=metadata or {},
+        section_path=None,
+        version=None,
+        is_generated=is_generated,
+    )
+
+
+def test_reduce_taxonomies_sorts_date_desc_with_first_writer_name():
+    """Discriminating unit test for the taxonomy reduce, independent of fixture data:
+    pages sharing a slug are ordered date-DESC (NOT walk order), the display name is the
+    first raw term seen in walk order, and case-variant raw terms collapse to one slug."""
+    from bengal.snapshots.render_plan import _reduce_taxonomies
+
+    # Fed in walk order old/new/mid; 'X' first (first-writer name), 'x' collapses to it.
+    p_old = _mk_pv("a.md", tags=("X",), date=datetime(2020, 1, 1))
+    p_new = _mk_pv("b.md", tags=("x",), date=datetime(2023, 1, 1))
+    p_mid = _mk_pv("c.md", tags=("X",), date=datetime(2021, 1, 1))
+
+    taxes = _reduce_taxonomies([p_old, p_new, p_mid], config={})
+
+    term = taxes["tags"]["x"]
+    assert term["name"] == "X", "first-writer-wins display name not preserved"
+    # Date-DESC, NOT the walk order [a, b, c] — this is the discriminating assertion.
+    assert [pv.source_path for pv in term["pages"]] == [Path("b.md"), Path("c.md"), Path("a.md")]
+
+
+def test_reduce_taxonomies_eligibility_and_singular_category():
+    """The reduce drops generated + content/api|cli pages and reads categories from the
+    SINGULAR ``category`` frontmatter key (exactly as collect_taxonomies), not PageView.categories."""
+    from bengal.snapshots.render_plan import _reduce_taxonomies
+
+    gen = _mk_pv("g.md", tags=("x",), is_generated=True)
+    api = _mk_pv("content/api/m.md", tags=("x",))
+    ok = _mk_pv("ok.md", tags=("x",), metadata={"category": "Guides"})
+
+    taxes = _reduce_taxonomies([gen, api, ok], config={})
+
+    # Only the eligible page survives under tag 'x'.
+    assert [pv.source_path for pv in taxes["tags"]["x"]["pages"]] == [Path("ok.md")]
+    # Category from the singular key, slug-normalized, first-writer name preserved.
+    assert taxes["categories"]["guides"]["name"] == "Guides"
+    assert [pv.source_path for pv in taxes["categories"]["guides"]["pages"]] == [Path("ok.md")]


### PR DESCRIPTION
## Summary

- Epic #350 S13.4a ("barrier-owns-globals"): `assemble_render_plan` gains an opt-in `reduce_taxonomy_from_metas` path that recomputes the taxonomy structure **and** the related-posts index purely from the global PageView union, instead of from a fully-built `site.taxonomies` / `page.related_posts`.
- `_reduce_taxonomies` reproduces `TaxonomyOrchestrator.collect_taxonomies` byte-for-byte (first-writer display name, `normalize_taxonomy_slug`, singular `category` frontmatter key, stable date-DESC ordering) and `_reduce_related_index` reproduces `RelatedPostsOrchestrator.build_index` (limit=5) — closing the gap where the real worker map step (`shard_meta_from_live_pages`) emits `related_pairs=()` and the assembled plan's `related_index` was empty.
- Off by default: `from_site` and every existing caller keep the snapshot-sourced path byte-unchanged; this is the first step toward a small shard-parallel parent that never builds the whole-site snapshot.
- Two design false-positives caught during implementation: `PageView.kind` is *not* required (the related candidate filter's `!= "index"` is dead code for real pages, which never have kind `"index"`), and related `pages_to_process` must be all non-generated pages (`== site.regular_pages`), not the RenderPlan `regular_pages` field (which also drops `_index` pages).

## Proof

- [x] Focused tests: `pytest tests/unit/snapshots/test_render_plan.py` — 51 passed (meta-reduce vs `from_site` oracle across N∈{1,2,3,5,7}; live map-step related recovery; live `site.taxonomies`/`page.related_posts` as independent ground truth; discriminating synthetic unit tests for sort/name/slug/eligibility)
- [x] `poe proof-pr` or scoped equivalent: ruff + ruff format + ty clean (pre-commit); no ty floor regression
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/render-plan-barrier-taxonomy-reduce.added.md`

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

Correctness-only change behind an off-by-default flag; no hot path changed and no performance claim made (the shard-parallel speedup is gated by later S13.4 rungs + S17, not this one).

## Steward Notes

- Architecture contract unaffected: changes are confined to `bengal/snapshots/render_plan.py` (reduce helpers + an additive keyword arg) and its tests — no core `Site`/`Page`/`Section` surface touched.
- `render_isolation` stays **off**; nothing merges as the default path until the epic's S17 end-to-end A/B gate. This is a self-contained, byte-parity-gated increment toward that.
