### PR TITLE
ci(architecture): enforce import-linter contracts in CI (#340)

### DIFF
--- a/.github/workflows/ty.yml
+++ b/.github/workflows/ty.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Run ruff (format check)
         run: uv run ruff format . --check
 
+      - name: Run import-linter (architecture contracts)
+        run: uv run lint-imports --config .importlinter
+
       - name: Run ty type checker
         run: |
           set -o pipefail

--- a/.importlinter
+++ b/.importlinter
@@ -46,16 +46,21 @@ allow_indirect_imports = True
 # Remaining baseline (each Sprint B task below removes entries):
 #   B1 followup: TYPE_CHECKING imports for BuildOptions/BuildInput/BuildStats/
 #                BuildState are typing-only and will move to forward refs in B3.
-#   S4 followup: bengal.core.site -> bengal.orchestration.feature_detector —
-#                FeatureDetector is pure analysis with only protocols deps; move
-#                to bengal.core.feature_detector in a follow-up to clear this edge.
 #   B1 transient: bengal.core.site -> bengal.orchestration.site_runner —
 #                NEW edge from delegating shims; removed in v0.5.0 when shims drop.
+#   Live deferred edge: bengal.core.site -> bengal.orchestration.content —
+#                ContentOrchestrator is imported function-locally in
+#                _content_orchestrator() (site/__init__.py) to avoid a circular
+#                import. Ignoring (not refactoring) is correct per the baseline
+#                strategy above; the import is deferred precisely because of the
+#                documented circular-import fragility. This edge replaced the old
+#                feature_detector edge (both touched in #245); the S4-followup note
+#                about feature_detector is now resolved (that import is gone).
 ignore_imports =
     bengal.core.site -> bengal.orchestration.build.inputs
     bengal.core.site -> bengal.orchestration.build.options
     bengal.core.site -> bengal.orchestration.build_state
-    bengal.core.site -> bengal.orchestration.feature_detector
+    bengal.core.site -> bengal.orchestration.content
     bengal.core.site -> bengal.orchestration.site_runner
     bengal.core.site -> bengal.orchestration.stats.models
 
@@ -80,8 +85,7 @@ allow_indirect_imports = True
 # Allow only the context submodule. Each importer is listed explicitly because
 # import-linter matches module-pair edges, not subpackage rollups.
 ignore_imports =
-    bengal.core.page -> bengal.core.site.context
     bengal.core.page.computed -> bengal.core.site.context
     bengal.core.page.navigation -> bengal.core.site.context
+    bengal.core.page.runtime -> bengal.core.site.context
     bengal.core.section -> bengal.core.site.context
-    bengal.core.section.navigation -> bengal.core.site.context

--- a/bengal/core/page/runtime.py
+++ b/bengal/core/page/runtime.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from bengal.core.page.page_core import PageCore
     from bengal.core.records import SourcePage
     from bengal.core.series import Series
+    from bengal.core.site.context import SiteContext
     from bengal.parsing.ast.types import ASTNode
     from bengal.protocols.core import PageLike, SectionLike
 
@@ -76,7 +77,7 @@ class RuntimePage:
     lang: str | None = None
     translation_key: str | None = None
     aliases: list[str] = field(default_factory=list)
-    _site: Any | None = field(default=None, repr=False)
+    _site: SiteContext | None = field(default=None, repr=False)
     _section_path: Path | None = field(default=None, repr=False)
     _section_url: str | None = field(default=None, repr=False)
     _section_obj_cache: SectionLike | object | None = field(default=None, repr=False, init=False)

--- a/changelog.d/lint-imports-ci-gate.added.md
+++ b/changelog.d/lint-imports-ci-gate.added.md
@@ -1,0 +1,11 @@
+Added a CI architecture-contract gate: the `Lint & Type Check` workflow now runs
+`lint-imports --config .importlinter` (new step in the `lint-and-type` job, feeding the
+`lint-ok` branch-protection gate), so any violation of the Site/Page/Section import
+contracts fails the build instead of only being catchable by running the linter locally.
+Also cleaned up the `.importlinter` baseline so the gate exits green: removed three stale
+`ignore_imports` entries that no longer matched any edge (the `bengal.core.site ->
+bengal.orchestration.feature_detector` import was removed in `#245`, and neither
+`bengal.core.page` nor `bengal.core.section.navigation` imports `bengal.core.site.context`),
+and added the live deferred `bengal.core.site -> bengal.orchestration.content` edge that the
+contract had been silently broken by. Tightened `RuntimePage._site` from `Any | None` to
+`SiteContext | None` to match `Section`, keeping the read-only Site coupling surface explicit.


### PR DESCRIPTION
## Summary

Closes #340. Wires `lint-imports` into CI so the Site/Page/Section architecture contracts in `.importlinter` are durably enforced (they were held but had **zero** CI signal).

- Adds a "Run import-linter (architecture contracts)" step to the `lint-and-type` job in `.github/workflows/ty.yml`, which feeds the existing `lint-ok` branch-protection gate (no new required check to register).
- Cleans the stale `ignore_imports` entries and adds the one real missing edge so the linter exits 0 with no "no matches for ignored import" warnings.
- Tightens `RuntimePage._site` typing from `Any | None` to `SiteContext | None` (matching `Section`); `TYPE_CHECKING`-only import, no cycle, ty floor unchanged.

## Scope correction (caught during scoping)

The issue's premise that `lint-imports` exits 0 today was **false** — it exited 1 on this branch's base. The cleanup turned out to be larger than the one stale entry the issue named: three entries were stale (`feature_detector` + two `page`/`section.navigation → site.context` edges that no longer exist), **and** a real un-ignored Contract-1 edge (`bengal.core.site → bengal.orchestration.content`, a deferred import at `site/__init__.py:374` introduced in #245) was breaking the contract. All reconciled.

## Verification

The gate is proven **discriminating**: removing the `bengal.core.site → bengal.orchestration.content` ignore makes the linter exit 1, confirming it fails on real violations (and that the content edge is genuinely load-bearing). Independently re-ran: `lint-imports` (exit 0, "2 kept, 0 broken"), ruff clean, ty 544 diagnostics (under floor), `test_no_core_mixins` 11 passed, full `tests/unit/core/` 1003 passed.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: CI/config/typing change only; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
