### PR TITLE
perf(theme): cache theme-library provider resolution (#365)

### DIFF
--- a/benchmarks/theme_provider_cache_benchmark.py
+++ b/benchmarks/theme_provider_cache_benchmark.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Benchmark: theme-library provider resolution cache (#365).
+
+resolve_theme_providers() is called on two independent build paths with no
+shared state — asset discovery (orchestration/content.py) and Kida engine
+loader/filter setup (rendering/engines/kida.py) — and, under the #350
+shard-parallel render backend, once per worker-thread pipeline. Each
+uncached call does importlib.import_module + convention-hook probing
+(get_library_contract / get_loader / static_path / register_filters) for
+every declared library, so the contract is rebuilt strictly more than twice
+per build.
+
+This benchmark builds a library-backed theme.toml in a temp dir and measures:
+
+  1. cold     — first resolution per process (cache miss, real import work)
+  2. warm     — repeated resolution of the SAME (site_root, chain) key
+                (cache hit; this is what every extra caller/shard now pays)
+  3. uncached — bypassing the cache via the private _resolve_*_uncached
+                (what every extra caller paid BEFORE this change)
+
+The headline number is warm-vs-uncached: how much each *extra* resolution
+costs after the first. Wall times are tiny and noisy; we report medians over
+many rounds and the ratio, and acknowledge measurement noise.
+
+Usage:
+    uv run python -m benchmarks.theme_provider_cache_benchmark
+"""
+
+from __future__ import annotations
+
+import statistics
+import sys
+import tempfile
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+from bengal.core.theme import providers as P
+
+# A library module with the full convention-hook surface so resolution does
+# the maximum probing work (get_library_contract → get_loader → static_path →
+# register_filters), mirroring a real Kida UI library.
+_FAKE_ASSET_ROOT = Path(tempfile.mkdtemp(prefix="theme_lib_assets_"))
+(_FAKE_ASSET_ROOT / "ui.css").write_text(".ui{}", encoding="utf-8")
+(_FAKE_ASSET_ROOT / "ui.js").write_text("window.ui=true", encoding="utf-8")
+
+
+def _make_lib(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.get_loader = lambda: f"loader::{name}"  # type: ignore[attr-defined]
+    mod.static_path = lambda: _FAKE_ASSET_ROOT  # type: ignore[attr-defined]
+    mod.register_filters = lambda app: None  # type: ignore[attr-defined]
+    mod.get_library_contract = lambda: {  # type: ignore[attr-defined]
+        "asset_root": _FAKE_ASSET_ROOT,
+        "assets": [
+            {"path": "ui.css", "mode": "link", "type": "css"},
+            {"path": "ui.js", "mode": "link", "type": "javascript"},
+        ],
+        "runtime": ["alpine"],
+    }
+    return mod
+
+
+def _build_site_root(num_libs: int) -> tuple[Path, list[str]]:
+    """Create a temp site with a library-backed theme; return (root, chain)."""
+    root = Path(tempfile.mkdtemp(prefix="theme_provider_bench_"))
+    libs = [f"bench_lib_{i}" for i in range(num_libs)]
+    theme_dir = root / "themes" / "benchtheme"
+    theme_dir.mkdir(parents=True, exist_ok=True)
+    libs_toml = ", ".join(f'"{lib}"' for lib in libs)
+    (theme_dir / "theme.toml").write_text(
+        f'name = "benchtheme"\nlibraries = [{libs_toml}]\n', encoding="utf-8"
+    )
+    return root, ["benchtheme"]
+
+
+def _time_median(fn, *, rounds: int) -> float:
+    """Return the median wall time (seconds) of fn over `rounds` calls."""
+    samples: list[float] = []
+    for _ in range(rounds):
+        start = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - start)
+    return statistics.median(samples)
+
+
+def run(num_libs: int = 3, warm_rounds: int = 2000) -> dict[str, float]:
+    root, chain = _build_site_root(num_libs)
+    libs = {f"bench_lib_{i}": _make_lib(f"bench_lib_{i}") for i in range(num_libs)}
+
+    def fake_import(name: str):
+        # Real importlib.import_module would do disk + sys.modules work here;
+        # we keep it cheap so the benchmark isolates Bengal's resolution cost,
+        # not import-system caching. The relative cold/warm gap is the signal.
+        return libs[name]
+
+    with patch(
+        "bengal.core.theme.providers.importlib.import_module",
+        side_effect=fake_import,
+    ):
+        # Cold: clear, then time the single first resolution (cache miss).
+        P.clear_theme_provider_cache()
+        cold = _time_median(
+            lambda: (P.clear_theme_provider_cache(), P.resolve_theme_providers(root, chain))[1],
+            rounds=max(50, warm_rounds // 20),
+        )
+
+        # Warm: cache populated; every subsequent caller/shard pays this.
+        P.clear_theme_provider_cache()
+        P.resolve_theme_providers(root, chain)  # populate
+        warm = _time_median(
+            lambda: P.resolve_theme_providers(root, chain),
+            rounds=warm_rounds,
+        )
+
+        # Uncached: what each extra resolution cost BEFORE this change.
+        uncached = _time_median(
+            lambda: P._resolve_theme_providers_uncached(root, chain),
+            rounds=max(50, warm_rounds // 20),
+        )
+
+    return {
+        "num_libs": num_libs,
+        "cold_us": cold * 1e6,
+        "warm_us": warm * 1e6,
+        "uncached_us": uncached * 1e6,
+        "speedup_warm_vs_uncached": (uncached / warm) if warm > 0 else float("inf"),
+    }
+
+
+def main() -> int:
+    print("=" * 72)
+    print("Theme-library provider resolution cache benchmark (#365)")
+    print("=" * 72)
+    print()
+    print("NOTE: wall times are sub-millisecond and noisy. The signal is the")
+    print("warm (cache-hit) vs uncached ratio: how much each EXTRA resolution")
+    print("(second build path + each #350 shard worker) costs before/after.")
+    print()
+
+    for num_libs in (1, 3, 6):
+        r = run(num_libs=num_libs)
+        print(f"libraries declared: {r['num_libs']}")
+        print(f"  cold (first/miss)      : {r['cold_us']:8.2f} us")
+        print(f"  uncached (per old call): {r['uncached_us']:8.2f} us")
+        print(f"  warm (cache hit)       : {r['warm_us']:8.2f} us")
+        print(f"  warm speedup vs uncached: {r['speedup_warm_vs_uncached']:6.1f}x")
+        print()
+
+    print("Interpretation: every caller/shard after the first now pays the warm")
+    print("(hit) cost instead of the uncached cost. With a real importlib.import_module")
+    print("and disk-backed theme.toml + library packages, the uncached cost is")
+    print("substantially higher than shown here, so the real-build win is larger.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bengal/core/theme/__init__.py
+++ b/bengal/core/theme/__init__.py
@@ -57,6 +57,7 @@ from bengal.core.theme.config import Theme
 from bengal.core.theme.providers import (
     LibraryAsset,
     ThemeLibraryProvider,
+    clear_theme_provider_cache,
     get_provider_asset_dirs,
     get_provider_assets,
     resolve_theme_providers,
@@ -83,6 +84,7 @@ __all__ = [
     "_read_theme_extends",
     "check_theme_compatibility",
     "clear_theme_cache",
+    "clear_theme_provider_cache",
     "format_compatibility_warning",
     "get_engine_capabilities",
     "get_installed_themes",

--- a/bengal/core/theme/providers.py
+++ b/bengal/core/theme/providers.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bengal.utils.observability.logger import get_logger
+from bengal.utils.primitives.lru_cache import LRUCache
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -39,6 +40,34 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _ASSET_MODES = frozenset({"bundle", "link", "none"})
+
+# Thread-safe cache for resolved theme-library providers.
+#
+# resolve_theme_providers() is invoked on two independent build paths with no
+# shared state: asset discovery (orchestration/content.py) and Kida engine
+# loader/filter setup (rendering/engines/kida.py). Under the #350 shard-parallel
+# render path the Kida engine is constructed per-thread-local pipeline, so the
+# providers would otherwise be re-imported (importlib.import_module + hook
+# probing) once per worker thread on top of the asset-discovery pass -- i.e.
+# strictly more than twice per build. Caching by (site_root, theme_chain)
+# collapses all of that into a single resolution that every caller and shard
+# thread shares.
+#
+# RLock-backed and free-threading-safe (CPython 3.14t): LRUCache.get_or_set
+# computes the factory OUTSIDE the lock and resolves the simultaneous-miss race
+# by re-checking under the lock before storing. maxsize=32 is generous; the key
+# space is (site_root, chain), of which a single process sees very few distinct
+# values (one per site in a multi-site build).
+#
+# Cache-key parity assumption: the two callers reach resolve_theme_providers()
+# via two different resolve_theme_chain implementations
+# (bengal.core.theme.resolution vs bengal.rendering.template_engine.environment).
+# They produce the same chain for a given site today, so a single
+# (site_root, theme_chain) key hits across both. If one diverges later the cache
+# would simply miss and recompute -- a perf regression, never a correctness bug.
+_provider_cache: LRUCache[tuple[str, tuple[str, ...]], tuple[ThemeLibraryProvider, ...]] = LRUCache(
+    maxsize=32, name="theme_providers"
+)
 
 
 def _theme_library_debug_payload(
@@ -204,6 +233,14 @@ def resolve_theme_providers(
     resolves each to a ThemeLibraryProvider, and deduplicates by package
     name (earlier theme in chain — i.e. child — wins).
 
+    The resolved tuple is cached by ``(site_root, theme_chain)`` so the two
+    independent build paths (asset discovery and Kida engine setup) — plus
+    every shard worker thread under the #350 render backend — share one
+    resolution instead of re-importing each library package per call. The
+    result is a frozen+slots dataclass tuple, safe to share read-only across
+    threads. The cache is RLock-backed (free-threading-safe under CPython
+    3.14t) and registered for invalidation on full rebuild / config change.
+
     Args:
         site_root: Site root directory.
         theme_chain: Theme names from child to parent.
@@ -212,6 +249,20 @@ def resolve_theme_providers(
         Tuple of deduplicated ThemeLibraryProvider records.
 
     """
+    # str() normalizes the key so Path-vs-str drift between callers cannot
+    # split the cache; tuple() makes the (unhashable) chain list hashable.
+    key = (str(site_root), tuple(theme_chain))
+    return _provider_cache.get_or_set(
+        key,
+        lambda: _resolve_theme_providers_uncached(site_root, theme_chain),
+    )
+
+
+def _resolve_theme_providers_uncached(
+    site_root: Path,
+    theme_chain: list[str],
+) -> tuple[ThemeLibraryProvider, ...]:
+    """Resolve providers from the theme chain without consulting the cache."""
     from bengal.core.theme.resolution import _read_theme_manifest
 
     seen: set[str] = set()
@@ -226,6 +277,32 @@ def resolve_theme_providers(
                 providers.append(provider)
 
     return tuple(providers)
+
+
+def clear_theme_provider_cache() -> None:
+    """Clear the resolved theme-library provider cache."""
+    _provider_cache.clear()
+
+
+# Register cache for centralized invalidation (test cleanup + rebuilds).
+# Mirrors registry.py's theme_cache: default invalidate_on={FULL_REBUILD} is
+# augmented with CONFIG_CHANGED + BUILD_START so a theme.toml `libraries` edit
+# in a long-lived dev-server/incremental process re-resolves providers.
+try:
+    from bengal.utils.cache_registry import InvalidationReason, register_cache
+
+    register_cache(
+        "theme_provider_cache",
+        clear_theme_provider_cache,
+        invalidate_on={
+            InvalidationReason.FULL_REBUILD,
+            InvalidationReason.CONFIG_CHANGED,
+            InvalidationReason.BUILD_START,
+        },
+    )
+except ImportError:
+    # Cache registry not available (shouldn't happen in normal usage).
+    pass
 
 
 def get_provider_asset_dirs(

--- a/changelog.d/cache-theme-provider-resolution.changed.md
+++ b/changelog.d/cache-theme-provider-resolution.changed.md
@@ -1,0 +1,16 @@
+Theme-library provider resolution is now cached per `(site_root, theme_chain)`.
+`resolve_theme_providers()` was previously called on two independent build paths
+with no shared state — asset discovery and Kida engine loader/filter setup — and,
+under the #350 shard-parallel render backend, once per worker-thread pipeline.
+Each call did `importlib.import_module` plus convention-hook probing
+(`get_library_contract` / `get_loader` / `static_path` / `register_filters`) for
+every declared library, rebuilding the contract strictly more than twice per
+build. A module-level `LRUCache` (RLock-backed, free-threading-safe under CPython
+3.14t) now collapses all of these to a single resolution that every caller and
+shard thread shares; the resolved tuple of frozen+slots providers is read-only
+and safe to share. The cache is registered with the central cache registry
+(invalidated on full rebuild / config change / build start) so theme.toml
+`libraries` edits in long-lived dev-server/incremental processes re-resolve.
+The default-theme happy path is unchanged: a theme that declares no libraries
+caches the empty tuple `()` and short-circuits identically, keeping output
+byte-identical (verified against baseline on the default-theme path). See #365.

--- a/tests/unit/core/theme/test_providers.py
+++ b/tests/unit/core/theme/test_providers.py
@@ -18,6 +18,7 @@ import pytest
 
 from bengal.core.theme.providers import (
     ThemeLibraryProvider,
+    clear_theme_provider_cache,
     get_provider_asset_dirs,
     resolve_provider,
     resolve_theme_providers,
@@ -575,3 +576,147 @@ class TestProviderEnvShim:
 
         assert filter_owners["foo"] == "lib_a"
         assert global_owners["foo"] == "lib_a"
+
+
+class TestResolveThemeProvidersCache:
+    """Resolution is cached per (site_root, theme_chain).
+
+    The asset-discovery path and the Kida engine path both call
+    resolve_theme_providers with the same (site_root, theme_chain); under the
+    #350 shard render backend the engine is built per worker thread. The cache
+    must collapse all of these to a single import_module + hook-probe pass.
+    """
+
+    def _write_theme_toml(self, tmp_path: Path, name: str, content: str) -> None:
+        theme_dir = tmp_path / "themes" / name
+        theme_dir.mkdir(parents=True, exist_ok=True)
+        (theme_dir / "theme.toml").write_text(content)
+
+    def test_second_call_is_cache_hit_no_reimport(self, tmp_path):
+        """A repeat call with the same key does NOT re-import the library."""
+        self._write_theme_toml(tmp_path, "themed", 'name = "themed"\nlibraries = ["cached_ui"]')
+
+        calls: list[str] = []
+
+        def mock_import(name):
+            calls.append(name)
+            return _make_library_module(has_loader=True, loader_value=f"loader_{name}")
+
+        with patch(
+            "bengal.core.theme.providers.importlib.import_module",
+            side_effect=mock_import,
+        ):
+            first = resolve_theme_providers(tmp_path, ["themed"])
+            second = resolve_theme_providers(tmp_path, ["themed"])
+
+        # The library was imported exactly once across both calls (cache hit).
+        assert calls == ["cached_ui"]
+        # Both callers receive the SAME resolved tuple object (shared, read-only).
+        assert first is second
+        assert [p.package for p in first] == ["cached_ui"]
+
+    def test_simulated_dual_caller_paths_share_one_resolution(self, tmp_path):
+        """Asset-discovery + per-shard engine calls collapse to one import.
+
+        Simulates the asset-discovery call plus several worker-thread engine
+        constructions: all hit the same key, so import_module fires once total.
+        """
+        self._write_theme_toml(
+            tmp_path, "themed", 'name = "themed"\nlibraries = ["lib_x", "lib_y"]'
+        )
+
+        import_counts: dict[str, int] = {}
+
+        def mock_import(name):
+            import_counts[name] = import_counts.get(name, 0) + 1
+            return _make_library_module(has_loader=True, loader_value=name)
+
+        with patch(
+            "bengal.core.theme.providers.importlib.import_module",
+            side_effect=mock_import,
+        ):
+            # 1x asset discovery + 4x per-shard engine setup = 5 logical calls.
+            results = [resolve_theme_providers(tmp_path, ["themed"]) for _ in range(5)]
+
+        # Each declared library was imported exactly once, not 5x.
+        assert import_counts == {"lib_x": 1, "lib_y": 1}
+        # Every caller got the identical tuple instance.
+        assert all(r is results[0] for r in results)
+
+    def test_distinct_keys_do_not_share(self, tmp_path):
+        """Different theme chains resolve independently (no false cache hit)."""
+        self._write_theme_toml(tmp_path, "alpha", 'name = "alpha"\nlibraries = ["lib_a"]')
+        self._write_theme_toml(tmp_path, "beta", 'name = "beta"\nlibraries = ["lib_b"]')
+
+        calls: list[str] = []
+
+        def mock_import(name):
+            calls.append(name)
+            return _make_library_module(has_loader=True, loader_value=name)
+
+        with patch(
+            "bengal.core.theme.providers.importlib.import_module",
+            side_effect=mock_import,
+        ):
+            alpha = resolve_theme_providers(tmp_path, ["alpha"])
+            beta = resolve_theme_providers(tmp_path, ["beta"])
+
+        assert [p.package for p in alpha] == ["lib_a"]
+        assert [p.package for p in beta] == ["lib_b"]
+        # Distinct keys → both libraries imported (one each), no cross-pollination.
+        assert sorted(calls) == ["lib_a", "lib_b"]
+
+    def test_clear_cache_forces_reresolve(self, tmp_path):
+        """clear_theme_provider_cache() drops entries so the next call re-imports."""
+        self._write_theme_toml(tmp_path, "themed", 'name = "themed"\nlibraries = ["reload_ui"]')
+
+        calls: list[str] = []
+
+        def mock_import(name):
+            calls.append(name)
+            return _make_library_module(has_loader=True, loader_value=name)
+
+        with patch(
+            "bengal.core.theme.providers.importlib.import_module",
+            side_effect=mock_import,
+        ):
+            resolve_theme_providers(tmp_path, ["themed"])
+            clear_theme_provider_cache()
+            resolve_theme_providers(tmp_path, ["themed"])
+
+        # Cleared between calls → imported twice (once per cache miss).
+        assert calls == ["reload_ui", "reload_ui"]
+
+    def test_clear_all_caches_clears_provider_cache(self, tmp_path):
+        """The cache is wired into the centralized registry (test-cleanup safety)."""
+        from bengal.utils.cache_registry import clear_all_caches
+
+        self._write_theme_toml(tmp_path, "themed", 'name = "themed"\nlibraries = ["reg_ui"]')
+
+        calls: list[str] = []
+
+        def mock_import(name):
+            calls.append(name)
+            return _make_library_module(has_loader=True, loader_value=name)
+
+        with patch(
+            "bengal.core.theme.providers.importlib.import_module",
+            side_effect=mock_import,
+        ):
+            resolve_theme_providers(tmp_path, ["themed"])
+            clear_all_caches()
+            resolve_theme_providers(tmp_path, ["themed"])
+
+        # clear_all_caches() reached the registered provider cache → re-import.
+        assert calls == ["reg_ui", "reg_ui"]
+
+    def test_empty_chain_default_theme_caches_empty_tuple(self, tmp_path):
+        """Default-theme happy path: () is cached and short-circuits identically."""
+        self._write_theme_toml(tmp_path, "default", 'name = "default"')
+
+        first = resolve_theme_providers(tmp_path, ["default"])
+        second = resolve_theme_providers(tmp_path, ["default"])
+
+        assert first == ()
+        # The cached empty tuple is returned on the second call (same object).
+        assert first is second


### PR DESCRIPTION
## Summary

Closes #365. `resolve_theme_providers()` was called on two independent build paths (asset discovery + Kida loader/filter setup) with no shared cache — each call did `importlib.import_module` + hook-probing, so the provider contract was rebuilt at least twice per build (and once per worker pipeline under the #350 shard path).

- Caches resolution in a module-level `LRUCache` keyed by `(str(site_root), tuple(theme_chain))`, delegating through `get_or_set` to a new `_resolve_theme_providers_uncached()`.
- Adds `clear_theme_provider_cache()` and registers the cache with the central registry on `FULL_REBUILD` / `CONFIG_CHANGED` / `BUILD_START` (so dev-server / incremental `theme.toml` `libraries` edits re-resolve).
- Both call sites are untouched; the value is a pure function of `(site_root, theme_chain)`, so the two distinct `resolve_theme_chain` implementations can only cause a cache *miss*, never wrong output.

Free-threading-safe: `LRUCache.get_or_set` computes the factory outside the lock and re-checks under it; `ThemeLibraryProvider` is frozen + slots and safe to share read-only across shard workers.

## Verification

86 tests pass under CPython 3.14t; ruff clean. **Non-vacuity proven**: bypassing the cache makes the two core feature tests fail (import counts 2 and 5 instead of 1). **Byte-identity proven**: building `test-basic` with branch vs `main` providers yields identical HTML aggregate hash, so the default-theme happy path is unchanged. The cache is cleared at the start of every build (registered `BUILD_START`), matching the existing `content_cache`/rendering-context pattern.

## Performance Evidence

- Benchmark matrix row: library-backed theme build, provider resolution call count
- Command: uv run pytest tests/unit/core/theme/test_providers.py (cache-hit assertions); benchmarks/theme_provider_cache_benchmark.py
- Python build: CPython 3.14.2+freethreaded
- Machine/OS: developer workstation (macOS, Darwin)
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: benchmarks/theme_provider_cache_benchmark.py
- Interpretation: Eliminates redundant import + hook-probe work (>=2 resolutions per build, more under #350 shards) collapsing to one per (site_root, theme_chain). Verified no output change (identical HTML hash) on the default theme; no committed clean-box A/B wall-clock baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
