### PR TITLE
fix(tests): reset active plugin registry contextvar between tests

### DIFF
--- a/changelog.d/test-isolation-active-plugin-registry.fixed.md
+++ b/changelog.d/test-isolation-active-plugin-registry.fixed.md
@@ -3,8 +3,6 @@ A build sets the `_active_registry` contextvar (`set_active_registry()`) but
 never resets it, so any test that ran a build leaked its `FrozenPluginRegistry`
 into the contextvar for every later test sharing the same `pytest-xdist` worker.
 Under random test ordering this caused intermittent failures in
-`test_active_plugin_registry_is_context_scoped` (which expects `None`) and, via
-patitas' `get_active_registry()` read during parsing, in
-`test_parse_shard_matches_in_process_parse` (in-process parses diverging from
-fresh-subprocess shard parses). The autouse `reset_bengal_state` fixture now
-clears the contextvar before and after each test.
+`test_active_plugin_registry_is_context_scoped`, which expects the ambient
+registry to be `None`. The autouse `reset_bengal_state` fixture now clears the
+contextvar before and after each test.

--- a/changelog.d/test-isolation-active-plugin-registry.fixed.md
+++ b/changelog.d/test-isolation-active-plugin-registry.fixed.md
@@ -1,0 +1,10 @@
+The shared test suite no longer leaks the active plugin registry between tests.
+A build sets the `_active_registry` contextvar (`set_active_registry()`) but
+never resets it, so any test that ran a build leaked its `FrozenPluginRegistry`
+into the contextvar for every later test sharing the same `pytest-xdist` worker.
+Under random test ordering this caused intermittent failures in
+`test_active_plugin_registry_is_context_scoped` (which expects `None`) and, via
+patitas' `get_active_registry()` read during parsing, in
+`test_parse_shard_matches_in_process_parse` (in-process parses diverging from
+fresh-subprocess shard parses). The autouse `reset_bengal_state` fixture now
+clears the contextvar before and after each test.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -526,11 +526,8 @@ def reset_bengal_state(request):
     # set_active_registry() (bengal/orchestration/build/__init__.py) but never
     # resets it, so a test that runs a build leaks its FrozenPluginRegistry into
     # the contextvar for every later test sharing the same xdist worker. That
-    # breaks active-registry-scope tests and, because patitas reads
-    # get_active_registry() during parsing, makes in-process parses diverge from
-    # fresh-subprocess shard parses — the source of the intermittent
-    # test_active_plugin_registry_is_context_scoped and
-    # test_parse_shard_matches_in_process_parse failures under random ordering.
+    # intermittently fails test_active_plugin_registry_is_context_scoped (which
+    # expects the ambient registry to be None) under random test ordering.
     try:
         from bengal.plugins import set_active_registry
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -451,6 +451,15 @@ def reset_bengal_state(request):
 
     # Mistune directives factory removed — Patitas registry is immutable after creation
 
+    # Reset the active plugin registry contextvar before the test, so a leak from
+    # an earlier test (see the teardown note) can't bleed into this one.
+    try:
+        from bengal.plugins import set_active_registry
+
+        set_active_registry(None)
+    except ImportError:
+        logger.debug("Active plugin registry reset skipped: set_active_registry not available")
+
     yield
 
     # Teardown: Reset all stateful components after each test
@@ -512,6 +521,22 @@ def reset_bengal_state(request):
             clear_global_context_cache()
         except ImportError:
             logger.debug("Manual cache cleanup skipped: modules not available")
+
+    # Reset the active plugin registry contextvar. The build sets it via
+    # set_active_registry() (bengal/orchestration/build/__init__.py) but never
+    # resets it, so a test that runs a build leaks its FrozenPluginRegistry into
+    # the contextvar for every later test sharing the same xdist worker. That
+    # breaks active-registry-scope tests and, because patitas reads
+    # get_active_registry() during parsing, makes in-process parses diverge from
+    # fresh-subprocess shard parses — the source of the intermittent
+    # test_active_plugin_registry_is_context_scoped and
+    # test_parse_shard_matches_in_process_parse failures under random ordering.
+    try:
+        from bengal.plugins import set_active_registry
+
+        set_active_registry(None)
+    except ImportError:
+        logger.debug("Active plugin registry reset skipped: set_active_registry not available")
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
## Summary

Fixes a pre-existing test-isolation bug in `main`: the active plugin registry leaks between tests, intermittently failing CI depending on `pytest-randomly` ordering and `pytest-xdist --dist worksteal` distribution.

**Root cause:** `BuildOrchestrator.build()` calls `set_active_registry(plugin_registry)` (`bengal/orchestration/build/__init__.py:433`) but there is **no `reset_active_registry` anywhere in production**. So any test that runs a build leaks its `FrozenPluginRegistry` into the `_active_registry` contextvar for every later test sharing the same xdist worker.

That surfaces as intermittent failures of `tests/unit/plugins/test_plugin_parser_wiring.py::test_active_plugin_registry_is_context_scoped`, which expects `get_active_registry()` to be `None`.

**Fix:** the existing autouse `reset_bengal_state` fixture (`tests/conftest.py`) now resets the contextvar (`set_active_registry(None)`) before and after every test, alongside the other singletons/caches it already clears. This is the standard pytest remedy for contextvar leaks and covers *all* leak sources, not just this one path.

**Why test-side, not production:** the production `set_active_registry` is effectively self-correcting — each build overwrites it at the start, and parsers only read it *during* a build, so the post-build "leak" has no live production consequence. Wrapping the 900-line, multi-exit `build()` in `try/finally` would be high-churn and high-risk for no runtime benefit.

## Scope note (corrected)

An earlier revision of this PR also claimed to fix the intermittent `test_parse_shard_matches_in_process_parse` divergence. That was **wrong** — verified: resetting the active plugin registry does **not** fix it. `parse_shard` runs in-process (same globals as the build), so that divergence has a different, still-open root cause. It is tracked separately and is **not** addressed here.

## Verification

Reproduced the bug deterministically on `main` (`-n 0 -p no:randomly`, the leaking build test then the victim → `1 failed`), then confirmed the fix:
- repro now `2 passed`.
- Full `tests/unit/plugins/` + `test_build_orchestrator.py`: `12 passed`. Ruff/ty/cycle hooks clean.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Test-infrastructure-only change (tests/conftest.py); no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
