### PR TITLE
fix(server): serve dev assets from hidden buffer dirs (theme drops to unstyled while editing)

### DIFF
--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -130,7 +130,15 @@ def create_bengal_dev_app(
         # within this request use the same buffer (double-buffer consistency).
         serving_dir = _resolve_dir()
 
-        if method in {"GET", "HEAD"} and _should_delegate_to_pounce_static(path):
+        # Pounce's static handler 404s any path with a hidden (dot-prefixed) component.
+        # The double-buffer serves from <root>/.bengal/staging half the time, so route
+        # asset requests around Pounce to _serve_static whenever the active buffer (or any
+        # ancestor) is hidden — otherwise every asset 404s and pages render unstyled.
+        if (
+            method in {"GET", "HEAD"}
+            and _should_delegate_to_pounce_static(path)
+            and not _has_hidden_path_component(serving_dir)
+        ):
             served = await _serve_pounce_static_asset(
                 scope,
                 receive,
@@ -226,6 +234,26 @@ def _should_delegate_to_pounce_static(path: str) -> bool:
     if is_deferred_generated_artifact_path(raw_path) or _is_html_path(raw_path):
         return False
     return any(raw_path.endswith(ext) for ext in _POUNCE_STATIC_ASSET_EXTENSIONS)
+
+
+def _has_hidden_path_component(directory: Path) -> bool:
+    """True when the serving directory's resolved path contains a dot-prefixed component.
+
+    Pounce's static handler rejects any path whose *resolved absolute* path contains a
+    hidden component (a part starting with ``.``, except ``.well-known``) — see
+    ``pounce/_static.py`` ``_resolve_file``. The dev server's double-buffer stages builds
+    in ``<root>/.bengal/staging``; whenever that buffer is the active one after a swap,
+    Pounce would 404 *every* asset under it (CSS/JS/fonts/icons), leaving pages unstyled
+    while HTML — served by ``_serve_static`` — still loads. Detecting a hidden serving dir
+    lets us route around Pounce to ``_serve_static`` (which has no such restriction and
+    serves assets with correct content types), so assets keep serving regardless of which
+    buffer is active. Also covers the rarer case of a project rooted under a dot-directory.
+    """
+    try:
+        resolved = directory.resolve()
+    except OSError:
+        resolved = directory
+    return any(part.startswith(".") and part != ".well-known" for part in resolved.parts)
 
 
 def _scope_without_sendfile(scope: dict[str, Any]) -> dict[str, Any]:

--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -21,9 +21,12 @@ from bengal.server.live_reload.sse import (
 )
 from bengal.server.responses import get_rebuilding_badge_script
 from bengal.server.utils import find_html_injection_point, get_content_type
+from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+logger = get_logger(__name__)
 
 # ASGI app type: async (scope, receive, send) -> None
 type ASGIApp = Callable[..., Any]
@@ -308,7 +311,36 @@ async def _serve_pounce_static_asset(
         )
         static_asset_handlers[key] = handler
 
-    await handler(_scope_without_sendfile(scope), receive, send)
+    # Capture the response status (transparently forwarding all messages) so we can
+    # emit a diagnostic when an asset 404s. The defining symptom of serve-path bugs
+    # (e.g. the .bengal/staging hidden-path 404) is a 404 for a file that is present
+    # on disk — distinct from a genuinely-missing file. Surface that loudly, and log
+    # which buffer served the request at debug level so swap-related issues are visible.
+    captured_status: dict[str, int | None] = {"status": None}
+
+    async def status_capturing_send(message: dict[str, Any]) -> None:
+        if message.get("type") == "http.response.start":
+            captured_status["status"] = message.get("status")
+        await send(message)
+
+    await handler(_scope_without_sendfile(scope), receive, status_capturing_send)
+
+    status = captured_status["status"]
+    raw_path = scope.get("path", "").split("?", 1)[0]
+    logger.debug("static_asset_served", path=raw_path, status=status, buffer=str(key))
+    if status == 404:
+        file_path = key / raw_path.lstrip("/")
+        if file_path.is_file():
+            logger.warning(
+                "static_asset_404_but_file_present",
+                path=raw_path,
+                buffer=str(key),
+                hint=(
+                    "Asset exists on disk but the static handler returned 404 — a "
+                    "serving-path bug, not a missing file (e.g. a hidden/dot path "
+                    "component the handler rejects). The served buffer is logged above."
+                ),
+            )
     return True
 
 

--- a/changelog.d/dev-server-hidden-buffer-asset-404.fixed.md
+++ b/changelog.d/dev-server-hidden-buffer-asset-404.fixed.md
@@ -1,0 +1,13 @@
+Fixed a dev-server (`bengal serve`) bug where the theme would repeatedly "drop" to unstyled
+HTML for long stretches while editing — every CSS/JS/font/icon request returning `404` even
+though the files were present on disk. The double-buffer stages builds in `<root>/.bengal/staging`
+and serves from whichever buffer is active after a swap; Pounce's static handler rejects any path
+whose resolved absolute path contains a hidden (dot-prefixed) component, so whenever the
+`.bengal/staging` buffer was the active one (≈half the time under rapid edits) it 404'd *every*
+asset — while HTML kept loading (it is served by Bengal's own `_serve_static`, which has no such
+restriction), producing the characteristic fully-rendered-but-unstyled page. Bengal now detects a
+hidden serving directory and routes asset requests around Pounce to `_serve_static` (correct
+content types, no HTML injection for non-HTML), so assets serve regardless of which buffer is
+active. A live reproduction went from 53% of CSS requests 404ing to 0%. Also covers the rarer
+case of a project rooted under a dot-directory. Tracked upstream as
+[lbliii/pounce#74](https://github.com/lbliii/pounce/issues/74).

--- a/tests/unit/server/test_asgi_app.py
+++ b/tests/unit/server/test_asgi_app.py
@@ -192,6 +192,48 @@ def test_has_hidden_path_component(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_asset_404_with_present_file_emits_diagnostic(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A 404 for an asset that exists on disk emits a loud diagnostic (serve-path-bug canary).
+
+    A genuinely-missing file 404 and an existing-file-404 (a serving bug) look identical to a
+    client. This diagnostic distinguishes them — it is what would have made the hidden-buffer
+    bug a one-line signal instead of a multi-theory investigation. Driven directly through the
+    Pounce path with a hidden serving dir (which Pounce rejects) so the file is present yet 404s.
+    """
+    from bengal.server import asgi_app
+
+    hidden = tmp_path / ".bengal" / "staging" / "assets" / "css"
+    hidden.mkdir(parents=True)
+    (hidden / "style.css").write_text("body {}")
+
+    warnings: list[tuple[str, dict]] = []
+
+    class _Recorder:
+        def debug(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def warning(self, message: str, **context: object) -> None:
+            warnings.append((message, dict(context)))
+
+    monkeypatch.setattr(asgi_app, "logger", _Recorder())
+
+    sent, send = _make_send_capture()
+    served = await asgi_app._serve_pounce_static_asset(
+        {"type": "http", "method": "GET", "path": "/assets/css/style.css", "headers": []},
+        _noop_receive,
+        send,
+        output_dir=tmp_path / ".bengal" / "staging",
+        static_asset_handlers={},
+    )
+
+    assert served is True
+    assert sent[0]["status"] == 404  # Pounce rejects the hidden path even though the file exists
+    assert any("404_but_file_present" in msg for msg, _ in warnings), (
+        "an asset that exists on disk but 404s must emit a diagnostic warning"
+    )
+
+
+@pytest.mark.asyncio
 async def test_static_asset_uses_pounce_etag_and_304(tmp_path: Path) -> None:
     """Static assets use Pounce conditional request handling."""
     assets = tmp_path / "assets"

--- a/tests/unit/server/test_asgi_app.py
+++ b/tests/unit/server/test_asgi_app.py
@@ -149,6 +149,49 @@ async def test_get_static_asset_serves_file(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_static_asset_served_from_hidden_buffer_dir(tmp_path: Path) -> None:
+    """Assets under a hidden (dot-prefixed) serving dir must serve, not 404 (regression).
+
+    The dev double-buffer stages builds in ``<root>/.bengal/staging`` and serves from
+    whichever buffer is active. Pounce's static handler rejects any path whose resolved
+    absolute path contains a hidden component (``.bengal``), so when that buffer was
+    active *every* asset 404'd while HTML still loaded — the "theme drops to unstyled
+    for long periods while editing" bug. The app must route around Pounce to
+    ``_serve_static`` for hidden serving dirs so assets keep serving regardless of which
+    buffer is active. Before the fix this returned 404.
+    """
+    staging = tmp_path / ".bengal" / "staging"
+    (staging / "assets" / "css").mkdir(parents=True)
+    (staging / "assets" / "css" / "style.css").write_text("body { color: red; }")
+    app = create_bengal_dev_app(
+        # Active buffer is the hidden staging dir (callable mirrors the BufferManager wiring).
+        output_dir=lambda: staging,
+        build_in_progress=lambda: False,
+    )
+    sent, send = _make_send_capture()
+
+    await app(
+        scope={"type": "http", "method": "GET", "path": "/assets/css/style.css", "headers": []},
+        receive=_noop_receive,
+        send=send,
+    )
+
+    assert sent[0]["status"] == 200, "asset under .bengal/staging must serve, not 404"
+    assert any(h[0] == b"content-type" and b"text/css" in h[1] for h in sent[0]["headers"])
+    assert _body(sent) == b"body { color: red; }"
+
+
+def test_has_hidden_path_component(tmp_path: Path) -> None:
+    """Detects dot-prefixed components anywhere in the resolved path (except .well-known)."""
+    from bengal.server.asgi_app import _has_hidden_path_component
+
+    assert _has_hidden_path_component(tmp_path / ".bengal" / "staging") is True
+    assert _has_hidden_path_component(tmp_path / "public") is False
+    assert _has_hidden_path_component(tmp_path / "public-bengal-staging") is False
+    assert _has_hidden_path_component(tmp_path / ".well-known") is False
+
+
+@pytest.mark.asyncio
 async def test_static_asset_uses_pounce_etag_and_304(tmp_path: Path) -> None:
     """Static assets use Pounce conditional request handling."""
     assets = tmp_path / "assets"


### PR DESCRIPTION
## Summary

Fixes the dev-server (`bengal serve`) bug where the theme repeatedly "drops" to unstyled HTML for long stretches while editing — every CSS/JS/font/icon `404`s even though the files exist on disk.

Root cause: the hot-reload double-buffer stages builds in `<root>/.bengal/staging` and serves from whichever buffer is active after a swap. Pounce's static handler (`pounce/_static.py` `_resolve_file`) rejects any path whose **resolved absolute** path contains a hidden (dot-prefixed) component, scanning the mount root's own ancestors — so whenever the `.bengal/staging` buffer was active (≈half the time under rapid edits) it `404`'d every asset, while HTML kept loading (served by `_serve_static`, which has no such check). That produces the fully-rendered-but-unstyled page.

Fix: detect a hidden serving directory and route asset requests around Pounce to bengal's own `_serve_static` (correct content types, no HTML injection for non-HTML), so assets serve regardless of which buffer is active. Also covers the rarer case of a project rooted under a dot-directory. The true root cause is upstream — filed as lbliii/pounce#74 (sibling of #72).

Also adds two serve-path diagnostics (the cheap fixes that would have made this a one-line signal): a WARNING when an asset 404s but the file exists on disk, and a debug log of the served buffer per asset request. Heavier follow-ups filed as #398 (startup serve-ability smoke check), #399 (live `bengal serve` HTTP test fixture), #400 (boundary guard / staging location).

## Proof

- [x] Focused tests: `tests/unit/server/test_asgi_app.py::test_static_asset_served_from_hidden_buffer_dir` (verified it 404s without the fix), `test_asset_404_with_present_file_emits_diagnostic`, `test_has_hidden_path_component`
- [x] `poe proof-pr` or scoped equivalent: `pytest tests/unit/server/` — 446 passed; ruff/format/ty/check-cycles/check-deps all pass (pre-push hooks)
- [x] Live reproduction: rapid theme/content edits + concurrent CSS GETs went from 53% of CSS requests 404ing (9473/18000) to 0% (9687/9687)
- [x] Docs/examples/changelog updated: `changelog.d/dev-server-hidden-buffer-asset-404.fixed.md`

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Dev-server-only request routing (`bengal/server/asgi_app.py`); no performance claim. When the active buffer is hidden, assets are served by `_serve_static` (read + send) instead of Pounce's sendfile/precompressed fast path — negligible for single-user local dev, and strictly better than the previous behavior (a 404). The production-like preview server is unaffected.

## Steward Notes

Server/dev-serve path. The deeper fix belongs in Pounce (lbliii/pounce#74): its hidden-component guard should only inspect path components below the mount root, not the mount root's own ancestors. This PR is the Bengal-side mitigation so users on Pounce 0.7.1 get a working dev server today.
