### PR TITLE
fix(cache): invalidate stale parsed/rendered output on parser, config, and dep changes

### DIFF
--- a/bengal/cache/build_cache/rendered_output_cache.py
+++ b/bengal/cache/build_cache/rendered_output_cache.py
@@ -21,12 +21,14 @@ from __future__ import annotations
 import contextlib
 import json
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bengal.utils.observability.logger import get_logger
 from bengal.utils.primitives.hashing import hash_str
 from bengal.utils.primitives.sentinel import MISSING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = get_logger(__name__)
 
@@ -39,6 +41,8 @@ class RenderedOutputCacheMixin:
         - rendered_output: dict[str, dict[str, Any]]
         - is_changed: Callable[[Path], bool]  (from FileTrackingMixin)
         - _cache_key: Callable[[Path], str]  # Canonical path key
+        - site_root: Path | None  # For resolving dep keys to paths
+        - _resolve_dep_path: Callable[[str], Path | None]  (from ParsedContentCacheMixin)
 
     """
 
@@ -182,10 +186,17 @@ class RenderedOutputCacheMixin:
         if cached.get("template") != template:
             return MISSING
 
-        # Validate dependencies haven't changed (templates, partials)
+        # Validate dependencies haven't changed (templates, partials).
+        # Dependency keys are relative CacheKeys (e.g. templates/base.html), so
+        # they must be resolved against site_root, not the process CWD. Mirror
+        # ParsedContentCacheMixin.get_parsed_content: a dep that is unresolvable/
+        # deleted is a miss, and a changed dep is a miss (issue #379).
         for dep_path in cached.get("dependencies", []):
-            dep = Path(dep_path)
-            if dep.exists() and self.is_changed(dep):
+            full_dep = self._resolve_dep_path(dep_path)
+            if full_dep is None:
+                # Unresolvable or deleted dependency - invalidate cache
+                return MISSING
+            if self.is_changed(full_dep):
                 # A dependency changed - invalidate cache
                 return MISSING
 

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -649,10 +649,26 @@ class BuildOrchestrator:
             configure_for_site(self.site)
 
             # Save snapshot for incremental builds (RFC: rfc-bengal-snapshot-engine)
-            # This enables near-instant parsing on subsequent builds
+            # This enables near-instant parsing on subsequent builds.
+            # Persist parser version + config hash so the next build's
+            # load_page_cache() can reject byte-stale parsed HTML after a parser
+            # upgrade or markdown/directive config change (issue #377). Save/load
+            # meta handling must stay symmetric or the cache silently never hits.
+            from bengal.config.hash import compute_config_hash
+            from bengal.rendering.pipeline import RenderingPipeline
+
             cache_dir = self.site.root_path / ".bengal" / "cache" / "snapshots"
             snapshot_cache = SnapshotCache(cache_dir)
-            snapshot_cache.save(site_snapshot)
+            snapshot_cache.save(
+                site_snapshot,
+                parser_version=RenderingPipeline(
+                    self.site,
+                    quiet=True,
+                    build_stats=None,
+                    build_context=None,
+                )._get_parser_version(),
+                config_hash=compute_config_hash(self.site.config),
+            )
 
             # === SERVICE INSTANTIATION (RFC: bengal-v2-architecture Phase 1) ===
             # Services operate on the frozen snapshot for thread-safe rendering.

--- a/bengal/orchestration/build/parsing.py
+++ b/bengal/orchestration/build/parsing.py
@@ -70,7 +70,23 @@ def phase_parse_content(
     if use_snapshot_cache:
         cache_dir = orchestrator.site.root_path / ".bengal" / "cache" / "snapshots"
         snapshot_cache = SnapshotCache(cache_dir)
-        cached_pages = snapshot_cache.load_page_cache()
+        # Gate the parse cache on parser version + config hash so a parser
+        # upgrade or markdown/directive config change forces a full re-parse
+        # instead of replaying byte-stale parsed HTML (issue #377). The snapshot
+        # cache is not registered with register_cache(), so the gate lives here.
+        from bengal.config.hash import compute_config_hash
+
+        parser_version = RenderingPipeline(
+            orchestrator.site,
+            quiet=True,
+            build_stats=None,
+            build_context=None,
+        )._get_parser_version()
+        config_hash = compute_config_hash(orchestrator.site.config)
+        cached_pages = snapshot_cache.load_page_cache(
+            parser_version=parser_version,
+            config_hash=config_hash,
+        )
 
         if cached_pages:
             pages_to_parse, _pages_from_cache, cache_hits = apply_cached_parsing(

--- a/bengal/snapshots/persistence.py
+++ b/bengal/snapshots/persistence.py
@@ -81,9 +81,21 @@ class SnapshotCache:
         self._meta_path = cache_dir / "snapshot_meta.json"
         self._pages_path = cache_dir / "snapshot_pages.json"
 
-    def load_page_cache(self) -> dict[str, CachedPageData] | None:
+    def load_page_cache(
+        self,
+        parser_version: str | None = None,
+        config_hash: str | None = None,
+    ) -> dict[str, CachedPageData] | None:
         """
         Load cached page data from previous build.
+
+        Args:
+            parser_version: Current build's parser version string. When provided,
+                the whole cache is missed if it differs from the persisted value
+                (a parser upgrade would otherwise replay byte-stale parsed HTML).
+            config_hash: Current build's config hash. When provided, the whole
+                cache is missed if it differs from the persisted value (a markdown/
+                directive config change would otherwise replay stale parsed HTML).
 
         Returns:
             Dict mapping source_path -> CachedPageData, or None if no cache
@@ -103,6 +115,28 @@ class SnapshotCache:
                     reason="version_mismatch",
                     cached=meta.get("version"),
                     current=SNAPSHOT_VERSION,
+                )
+                return None
+
+            # Parser-upgrade gate: parser version differs -> full re-parse.
+            # The snapshot cache is not registered with register_cache(), so
+            # this gate must live here rather than relying on CONFIG_CHANGED.
+            if parser_version is not None and meta.get("parser_version") != parser_version:
+                logger.debug(
+                    "snapshot_cache_miss",
+                    reason="parser_version_mismatch",
+                    cached=meta.get("parser_version"),
+                    current=parser_version,
+                )
+                return None
+
+            # Config-change gate: config hash differs -> full re-parse.
+            if config_hash is not None and meta.get("config_hash") != config_hash:
+                logger.debug(
+                    "snapshot_cache_miss",
+                    reason="config_hash_mismatch",
+                    cached=meta.get("config_hash"),
+                    current=config_hash,
                 )
                 return None
 
@@ -139,7 +173,12 @@ class SnapshotCache:
             )
             return None
 
-    def save(self, snapshot: SiteSnapshot) -> None:
+    def save(
+        self,
+        snapshot: SiteSnapshot,
+        parser_version: str | None = None,
+        config_hash: str | None = None,
+    ) -> None:
         """
         Save snapshot to disk for future incremental builds.
 
@@ -147,6 +186,11 @@ class SnapshotCache:
 
         Args:
             snapshot: SiteSnapshot to persist
+            parser_version: Parser version string to persist so a later
+                ``load_page_cache()`` can miss the whole cache after a parser
+                upgrade (see issue #377). Must stay symmetric with the load site.
+            config_hash: Config hash to persist so a later ``load_page_cache()``
+                can miss the whole cache after a config change.
         """
         self._cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -157,6 +201,8 @@ class SnapshotCache:
                 "timestamp": time.time(),
                 "page_count": snapshot.page_count,
                 "section_count": snapshot.section_count,
+                "parser_version": parser_version,
+                "config_hash": config_hash,
             }
 
             # Build page cache data (only what we need for incremental)

--- a/changelog.d/377.fixed.md
+++ b/changelog.d/377.fixed.md
@@ -1,0 +1,1 @@
+The snapshot parse cache now keys on the parser version and resolved config hash, so a parser upgrade or a markdown/directive config change forces a full re-parse instead of silently replaying byte-stale parsed HTML on the next build.

--- a/changelog.d/379.fixed.md
+++ b/changelog.d/379.fixed.md
@@ -1,0 +1,1 @@
+The rendered-output cache now resolves template/partial dependency keys against the site root (mirroring the parsed-content cache) instead of the process working directory, so a changed or deleted template dependency correctly invalidates the cached HTML.

--- a/tests/unit/cache/test_build_cache.py
+++ b/tests/unit/cache/test_build_cache.py
@@ -641,21 +641,27 @@ class TestRenderedOutputCache:
 
     def test_store_and_get_rendered_output(self, tmp_path):
         """Test storing and retrieving rendered HTML output."""
-        cache = BuildCache()
+        cache = BuildCache(site_root=tmp_path)
 
         # Create a test file
         test_file = tmp_path / "page.md"
         test_file.write_text("# Test Content")
         cache.update_file(test_file)
 
-        # Store rendered output
+        # Create the template dependency so it resolves against site_root
+        template_file = tmp_path / "templates" / "default.html"
+        template_file.parent.mkdir(parents=True, exist_ok=True)
+        template_file.write_text("<html></html>")
+        cache.update_file(template_file)
+
+        # Store rendered output with a relative dependency key
         metadata = {"title": "Test Page", "date": "2025-01-01"}
         cache.store_rendered_output(
             test_file,
             "<html><body>Rendered content</body></html>",
             "default.html",
             metadata,
-            dependencies=[str(tmp_path / "templates" / "default.html")],
+            dependencies=["templates/default.html"],
         )
 
         # Get it back
@@ -736,8 +742,13 @@ class TestRenderedOutputCache:
         assert result is MISSING
 
     def test_rendered_output_invalid_on_dependency_change(self, tmp_path):
-        """Rendered output cache is invalidated when a dependency file changes."""
-        cache = BuildCache()
+        """Rendered output cache is invalidated when a dependency file changes.
+
+        Dependency keys are relative CacheKeys resolved against ``site_root``
+        (issue #379), so the cache must set ``site_root`` and use a relative key
+        to exercise the dependency-validation loop.
+        """
+        cache = BuildCache(site_root=tmp_path)
 
         # Create files
         test_file = tmp_path / "page.md"
@@ -749,14 +760,15 @@ class TestRenderedOutputCache:
         template_file.write_text("<html>{% block content %}{% endblock %}</html>")
         cache.update_file(template_file)
 
-        # Store rendered output with dependency
+        # Store rendered output with a *relative* dependency key (resolved against
+        # site_root), mirroring how store_rendered_output is fed in production.
         metadata = {"title": "Test Page"}
         cache.store_rendered_output(
             test_file,
             "<html>Rendered</html>",
             "default.html",
             metadata,
-            dependencies=[str(template_file)],
+            dependencies=["templates/base.html"],
         )
 
         # Verify cache hit before change
@@ -767,6 +779,40 @@ class TestRenderedOutputCache:
         template_file.write_text("<html>Modified template</html>")
 
         # Cache should be invalid
+        result = cache.get_rendered_output(test_file, "default.html", metadata)
+        assert result is MISSING
+
+    def test_rendered_output_invalid_on_dependency_deletion(self, tmp_path):
+        """Deleting a relative template dependency invalidates the rendered cache.
+
+        Mirrors ParsedContentCacheMixin.get_parsed_content: an unresolvable/deleted
+        dependency is treated as a cache miss, not a silent skip (issue #379).
+        """
+        cache = BuildCache(site_root=tmp_path)
+
+        test_file = tmp_path / "page.md"
+        test_file.write_text("# Test Content")
+        cache.update_file(test_file)
+
+        template_file = tmp_path / "templates" / "base.html"
+        template_file.parent.mkdir(parents=True, exist_ok=True)
+        template_file.write_text("<html>{% block content %}{% endblock %}</html>")
+        cache.update_file(template_file)
+
+        metadata = {"title": "Test Page"}
+        cache.store_rendered_output(
+            test_file,
+            "<html>Rendered</html>",
+            "default.html",
+            metadata,
+            dependencies=["templates/base.html"],
+        )
+
+        # Cache hit before deletion
+        assert cache.get_rendered_output(test_file, "default.html", metadata) is not None
+
+        # Delete the dependency -> unresolvable -> cache miss
+        template_file.unlink()
         result = cache.get_rendered_output(test_file, "default.html", metadata)
         assert result is MISSING
 

--- a/tests/unit/snapshots/test_snapshot_persistence.py
+++ b/tests/unit/snapshots/test_snapshot_persistence.py
@@ -279,3 +279,136 @@ class TestPostCardRenderWithPageFromCache:
         )
         assert "reading: 3 min" in html
         assert "excerpt" in html
+
+
+# =============================================================================
+# Parser-version / config-hash gating (issue #377)
+# =============================================================================
+
+
+def _make_snapshot_stub() -> SimpleNamespace:
+    """Minimal SiteSnapshot stand-in for SnapshotCache.save()."""
+    page = SimpleNamespace(
+        source_path=Path("content/post.md"),
+        content_hash="abc",
+        parsed_html="<p>Hello</p>",
+        toc="",
+        toc_items=(),
+        reading_time=5,
+        word_count=250,
+        excerpt="Short",
+        meta_description="",
+    )
+    return SimpleNamespace(page_count=1, section_count=0, pages=[page])
+
+
+class TestSnapshotCacheParserConfigGating:
+    """Verify load_page_cache() rejects the cache on parser/config drift (#377)."""
+
+    def test_save_persists_parser_version_and_config_hash(self, tmp_path: Path) -> None:
+        """save() writes parser_version and config_hash into snapshot_meta.json."""
+        cache_dir = tmp_path / "cache"
+        cache = SnapshotCache(cache_dir)
+        cache.save(
+            _make_snapshot_stub(),
+            parser_version="markdown-3.6-toc2",
+            config_hash="deadbeefcafe0000",
+        )
+
+        meta = json.loads((cache_dir / "snapshot_meta.json").read_text())
+        assert meta["parser_version"] == "markdown-3.6-toc2"
+        assert meta["config_hash"] == "deadbeefcafe0000"
+
+    def test_load_hit_when_parser_and_config_match(self, tmp_path: Path) -> None:
+        """Matching parser_version + config_hash yields a cache hit."""
+        cache_dir = tmp_path / "cache"
+        cache = SnapshotCache(cache_dir)
+        cache.save(
+            _make_snapshot_stub(),
+            parser_version="markdown-3.6-toc2",
+            config_hash="deadbeefcafe0000",
+        )
+
+        result = cache.load_page_cache(
+            parser_version="markdown-3.6-toc2",
+            config_hash="deadbeefcafe0000",
+        )
+        assert result is not None
+        assert "content/post.md" in result
+
+    def test_load_miss_on_parser_version_change(self, tmp_path: Path) -> None:
+        """A changed parser_version is a whole-cache miss (no stale parsed_html)."""
+        cache_dir = tmp_path / "cache"
+        cache = SnapshotCache(cache_dir)
+        cache.save(
+            _make_snapshot_stub(),
+            parser_version="markdown-3.6-toc2",
+            config_hash="deadbeefcafe0000",
+        )
+
+        result = cache.load_page_cache(
+            parser_version="markdown-3.6-toc3",  # bumped TOC_EXTRACTION_VERSION
+            config_hash="deadbeefcafe0000",
+        )
+        assert result is None
+
+    def test_load_miss_on_config_hash_change(self, tmp_path: Path) -> None:
+        """A changed config_hash is a whole-cache miss (no stale parsed_html)."""
+        cache_dir = tmp_path / "cache"
+        cache = SnapshotCache(cache_dir)
+        cache.save(
+            _make_snapshot_stub(),
+            parser_version="markdown-3.6-toc2",
+            config_hash="deadbeefcafe0000",
+        )
+
+        result = cache.load_page_cache(
+            parser_version="markdown-3.6-toc2",
+            config_hash="1111222233334444",  # markdown/directive config changed
+        )
+        assert result is None
+
+    def test_load_miss_when_legacy_meta_lacks_fields(self, tmp_path: Path) -> None:
+        """Old snapshot_meta.json (no parser_version/config_hash) misses under new build."""
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+
+        # Legacy meta: only the pre-#377 fields.
+        (cache_dir / "snapshot_meta.json").write_text(
+            json.dumps(
+                {"version": SNAPSHOT_VERSION, "timestamp": 0, "page_count": 1, "section_count": 0}
+            )
+        )
+        (cache_dir / "snapshot_pages.json").write_text(
+            json.dumps(
+                {
+                    "content/post.md": {
+                        "content_hash": "abc",
+                        "parsed_html": "<p>Hello</p>",
+                    }
+                }
+            )
+        )
+
+        cache = SnapshotCache(cache_dir)
+        # A current build supplying values must treat the legacy (None) fields as a miss.
+        result = cache.load_page_cache(
+            parser_version="markdown-3.6-toc2",
+            config_hash="deadbeefcafe0000",
+        )
+        assert result is None
+
+    def test_load_skips_gates_when_args_omitted(self, tmp_path: Path) -> None:
+        """Backward compat: omitting parser_version/config_hash skips the new gates."""
+        cache_dir = tmp_path / "cache"
+        cache = SnapshotCache(cache_dir)
+        cache.save(
+            _make_snapshot_stub(),
+            parser_version="markdown-3.6-toc2",
+            config_hash="deadbeefcafe0000",
+        )
+
+        # No gating args -> falls back to SNAPSHOT_VERSION-only behavior (hit).
+        result = cache.load_page_cache()
+        assert result is not None
+        assert "content/post.md" in result


### PR DESCRIPTION
Fixes two cache-correctness bugs surfaced by the 2026-06-10 tech-debt audit. Both ship stale output without warning under specific conditions.

**#377 (high):** The snapshot parse cache (`SnapshotCache`) keyed only on `SNAPSHOT_VERSION` and a raw-source content hash, so after a parser upgrade or a markdown/directive config change a warm build replayed byte-stale parsed HTML.

**#379 (low, dormant):** `RenderedOutputCacheMixin.get_rendered_output` validated template/partial dependencies with a bare `Path(dep_path)` loop, resolving relative `CacheKey`s against the process CWD — so changed/deleted template deps never invalidated. Dormant today (`cache.dependencies` is generally empty and `_detect_changed_templates` is the live backstop) but latently wrong.

## What changed
- `SnapshotCache.save()` now persists `parser_version` and `config_hash` into `snapshot_meta.json`; `load_page_cache()` accepts both and returns `None` (full re-parse) when either differs from the current build. Backward compatible: omitting the args skips the new gates, and a legacy meta (fields absent → `None`) is treated as a miss under a current build.
- Threaded the parser version (from `RenderingPipeline._get_parser_version()`, reused exactly) and `compute_config_hash(site.config)` into the save site (`orchestration/build/__init__.py`) and load site (`orchestration/build/parsing.py`), keeping save/load meta symmetric. The gate lives in the load/save logic because the snapshot cache is not registered with `register_cache()`.
- Replaced the CWD-relative dependency loop in `get_rendered_output` with `_resolve_dep_path`-based resolution (mirroring `ParsedContentCacheMixin`): returns `MISSING` when a dep is unresolvable/deleted or `is_changed`. No `Path(dep_path)`/CWD resolution remains. Documented `site_root` and `_resolve_dep_path` as host-provided attributes on the mixin.
- Added regression tests: snapshot cache hits when parser/config match and misses on either change (plus legacy-meta and no-args cases); rendered cache misses when a relative template dep is modified or deleted (existing dep test updated to set `site_root` and use a relative key).
- Added changelog fragments `changelog.d/377.fixed.md` and `changelog.d/379.fixed.md`.

Closes #377
Closes #379

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Correctness fix. Steady-state warm path adds only one pipeline construction + one config hash per build (not per page); a changed parser/config now forces a full re-parse instead of replaying stale HTML.
