### PR TITLE
fix(autodoc): anchor hrefs for non-page member elements (no more dangling /api links)

### DIFF
--- a/bengal/autodoc/orchestration/page_builders.py
+++ b/bengal/autodoc/orchestration/page_builders.py
@@ -138,11 +138,37 @@ def normalize_element_for_templates(element: DocElement) -> None:
     _normalize(element)
 
 
+#: Element types that are rendered on their OWN page (vs. inline on an
+#: ancestor's page), per doc_type. Only these own a standalone URL; inline
+#: descendants resolve to ``{owner_path}#{anchor}`` so links never 404.
+#: Mirrors SymbolResolver.DEFAULT_PAGE_OWNER_TYPES (page-building reality):
+#: Python modules own pages; classes/functions/methods render inline as cards.
+#: CLI commands and groups each own a page; their options render inline.
+#: OpenAPI schemas and endpoints each own a page (the overview does not -- the
+#: root section index page represents it).
+_PAGE_OWNER_TYPES_BY_DOC: dict[str, frozenset[str]] = {
+    "python": frozenset({"module"}),
+    "cli": frozenset({"command", "command-group"}),
+    "openapi": frozenset({"openapi_schema", "openapi_endpoint"}),
+}
+
+
+def _element_owns_page(element: DocElement, doc_type: str) -> bool:
+    """Return whether ``element`` is materialized as its own page."""
+    owners = _PAGE_OWNER_TYPES_BY_DOC.get(doc_type)
+    if owners is None:
+        # Unknown doc_type: treat top-level fallback elements as page owners.
+        return True
+    return element.element_type in owners
+
+
 def compute_element_urls(
     element: DocElement,
     site: Site,
     doc_type: str,
     resolve_output_prefix: Callable[..., Any],
+    parent_page_path: str | None = None,
+    inline_anchor: str | None = None,
 ) -> None:
     """
     Compute _path and href for an element and all its children.
@@ -150,40 +176,79 @@ def compute_element_urls(
     This sets URL properties on DocElement so templates can use {{ child.href }}
     directly without manual URL building or filters.
 
+    Members that do NOT get their own page (Python classes/functions/methods,
+    CLI options) are never built as standalone pages -- they render as
+    ``id``-anchored cards on their first page-owning ancestor. For those, the
+    href points at that ancestor page plus a ``#anchor`` fragment so
+    ``{{ child.href }}`` resolves to the on-page card instead of a dangling
+    ``/api/<module>/<member>/`` URL (issue #401). The anchor is the HIGHEST
+    inline ancestor's simple name (a stable, page-unique card id), so a method
+    in a class anchors onto its CLASS card -- mirroring the resolution encoded
+    by SymbolResolver and test_symbol_resolver.py.
+
     Args:
         element: DocElement to process
         site: Site instance (for baseurl)
         doc_type: Type of documentation ("python", "cli", "openapi")
         resolve_output_prefix: Function to resolve output prefix
+        parent_page_path: Site-relative ``_path`` of the nearest page-owning
+            ancestor (None at the top of the tree). Threaded through recursion.
+        inline_anchor: The anchor fragment (top-level inline card name) inherited
+            from an ancestor, or None when no inline card has been opened yet.
 
     """
     prefix = resolve_output_prefix(doc_type)
 
-    # Compute URL based on element type
-    if doc_type == "cli":
-        cli_path = resolve_cli_url_path(element.qualified_name)
-        url_path = f"{prefix}/{cli_path}" if cli_path else prefix
-    elif doc_type == "python":
-        url_path = f"{prefix}/{element.qualified_name.replace('.', '/')}"
-    elif doc_type == "openapi":
-        if element.element_type == "openapi_endpoint":
-            url_path = _openapi_endpoint_url_path(element, prefix)
-        elif element.element_type == "openapi_schema":
-            url_path = f"{prefix}/schemas/{element.name}"
+    if _element_owns_page(element, doc_type):
+        # This element gets its own page: compute its standalone URL path.
+        if doc_type == "cli":
+            cli_path = resolve_cli_url_path(element.qualified_name)
+            url_path = f"{prefix}/{cli_path}" if cli_path else prefix
+        elif doc_type == "python":
+            url_path = f"{prefix}/{element.qualified_name.replace('.', '/')}"
+        elif doc_type == "openapi":
+            if element.element_type == "openapi_endpoint":
+                url_path = _openapi_endpoint_url_path(element, prefix)
+            elif element.element_type == "openapi_schema":
+                url_path = f"{prefix}/schemas/{element.name}"
+            else:
+                url_path = f"{prefix}/{element.name}"
         else:
             url_path = f"{prefix}/{element.name}"
-    else:
-        url_path = f"{prefix}/{element.name}"
 
-    # Set _path (site-relative, no baseurl)
-    element._path = f"/{url_path}/"
+        element._path = f"/{url_path}/"
+        # Descendants anchor onto THIS page; reset the inline-card anchor so the
+        # first inline child becomes the top-level card.
+        child_page_path: str | None = element._path
+        child_anchor: str | None = None
+    elif parent_page_path is not None:
+        # Inline member rendered on a page-owning ancestor. Anchor onto the
+        # highest inline card (its simple name is a unique id on that page),
+        # so a method anchors onto its CLASS card, not the module page.
+        anchor = inline_anchor if inline_anchor is not None else element.name
+        element._path = f"{parent_page_path}#{anchor}"
+        child_page_path = parent_page_path
+        child_anchor = anchor
+    else:
+        # No page-owning ancestor in scope (e.g. an orphan top-level non-owner).
+        # Fall back to the legacy standalone path so href stays non-None.
+        element._path = f"/{prefix}/{element.name}/"
+        child_page_path = None
+        child_anchor = None
 
     # Set href (public URL with baseurl)
     element.href = apply_baseurl(element._path, site)
 
-    # Recursively process children
+    # Recursively process children, threading the page/anchor context.
     for child in element.children:
-        compute_element_urls(child, site, doc_type, resolve_output_prefix)
+        compute_element_urls(
+            child,
+            site,
+            doc_type,
+            resolve_output_prefix,
+            parent_page_path=child_page_path,
+            inline_anchor=child_anchor,
+        )
 
 
 def create_pages(

--- a/changelog.d/401.fixed.md
+++ b/changelog.d/401.fixed.md
@@ -1,0 +1,4 @@
+Autodoc members that do not get their own page (Python classes, functions, and
+methods; CLI options) now receive an on-page anchor `href`
+(`<parent-page>#<card>`) instead of a dangling `/api/<module>/<member>/` page
+URL, so templates using `{{ child.href }}` no longer emit broken internal links.

--- a/tests/unit/autodoc/test_member_anchor_hrefs.py
+++ b/tests/unit/autodoc/test_member_anchor_hrefs.py
@@ -1,0 +1,112 @@
+"""
+Tests for compute_element_urls anchor hrefs on non-page members (#401).
+
+Members that never get their own page (Python classes/functions/methods, CLI
+options) must receive an on-page anchor href (``{parent_page}#{card}``) rather
+than a dangling ``/api/<module>/<member>/`` page URL, so templates following the
+documented ``{{ child.href }}`` contract never emit broken internal links.
+
+Assertions discriminate: each fails if a member's href regresses to a
+standalone page path, or if a method anchors onto the module page instead of
+its top-level CLASS card.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bengal.autodoc.base import DocElement
+from bengal.autodoc.orchestration.page_builders import compute_element_urls
+
+
+def _el(name: str, qualified: str, element_type: str) -> DocElement:
+    return DocElement(
+        name=name,
+        qualified_name=qualified,
+        description="",
+        element_type=element_type,
+    )
+
+
+# Prefix resolution mirrors the orchestrator: python -> "api/pkg", cli -> "cli",
+# openapi -> "api". The site has no baseurl so href == _path.
+_PREFIX = {"python": "api/pkg", "cli": "cli", "openapi": "api"}
+
+
+def _resolve_prefix(doc_type: str) -> str:
+    return _PREFIX[doc_type]
+
+
+_SITE = SimpleNamespace(baseurl="")
+
+
+def test_python_module_owns_its_page() -> None:
+    mod = _el("site", "pkg.core.site", "module")
+    compute_element_urls(mod, _SITE, "python", _resolve_prefix)
+    assert mod._path == "/api/pkg/pkg/core/site/"
+    assert mod.href == "/api/pkg/pkg/core/site/"
+
+
+def test_python_class_anchors_onto_module_page() -> None:
+    mod = _el("site", "pkg.core.site", "module")
+    cls = _el("Site", "pkg.core.site.Site", "class")
+    mod.children = [cls]
+    compute_element_urls(mod, _SITE, "python", _resolve_prefix)
+    # The class renders inline as a card on the module page -> anchor, not a
+    # dangling /api/pkg/pkg/core/site/Site/ page.
+    assert cls._path == "/api/pkg/pkg/core/site/#Site"
+    assert cls.href == "/api/pkg/pkg/core/site/#Site"
+
+
+def test_python_method_anchors_onto_class_card_not_module() -> None:
+    mod = _el("site", "pkg.core.site", "module")
+    cls = _el("Site", "pkg.core.site.Site", "class")
+    method = _el("build", "pkg.core.site.Site.build", "method")
+    cls.children = [method]
+    mod.children = [cls]
+    compute_element_urls(mod, _SITE, "python", _resolve_prefix)
+    # Mirrors test_symbol_resolver.test_method_resolves_to_top_level_card_anchor:
+    # the method anchors onto its CLASS card (highest inline ancestor), not a
+    # #build fragment and not the bare module page.
+    assert method._path == "/api/pkg/pkg/core/site/#Site"
+    assert method.href == "/api/pkg/pkg/core/site/#Site"
+
+
+def test_python_module_level_function_anchors_with_own_name() -> None:
+    mod = _el("site", "pkg.core.site", "module")
+    func = _el("build_site", "pkg.core.site.build_site", "function")
+    mod.children = [func]
+    compute_element_urls(mod, _SITE, "python", _resolve_prefix)
+    # A top-level function card uses its own simple name as the anchor.
+    assert func._path == "/api/pkg/pkg/core/site/#build_site"
+
+
+def test_cli_command_owns_page_options_anchor() -> None:
+    group = _el("assets", "bengal.assets", "command-group")
+    command = _el("build", "bengal.assets.build", "command")
+    option = _el("--force", "bengal.assets.build.force", "option")
+    command.children = [option]
+    group.children = [command]
+    compute_element_urls(group, _SITE, "cli", _resolve_prefix)
+    # Commands and groups each own a page; the option anchors onto the command.
+    assert command._path == "/cli/assets/build/"
+    assert command.href == "/cli/assets/build/"
+    assert option._path == "/cli/assets/build/#--force"
+
+
+def test_openapi_endpoint_and_schema_own_pages() -> None:
+    schema = _el("User", "User", "openapi_schema")
+    compute_element_urls(schema, _SITE, "openapi", _resolve_prefix)
+    assert schema._path == "/api/schemas/User/"
+    assert "#" not in (schema._path or "")
+
+
+def test_baseurl_is_applied_to_anchor_hrefs() -> None:
+    site = SimpleNamespace(baseurl="/docs")
+    mod = _el("site", "pkg.core.site", "module")
+    cls = _el("Site", "pkg.core.site.Site", "class")
+    mod.children = [cls]
+    compute_element_urls(mod, site, "python", _resolve_prefix)
+    # baseurl prefixes the path while preserving the fragment.
+    assert cls.href == "/docs/api/pkg/pkg/core/site/#Site"
+    assert cls._path == "/api/pkg/pkg/core/site/#Site"


### PR DESCRIPTION
Autodoc previously assigned a standalone page `href` to every `DocElement`, including class/function/method members (Python) and options (CLI) that never get their own page. Those members render as `id`-anchored cards on their first page-owning ancestor, so `{{ child.href }}` produced links to non-existent `/api/<module>/<member>/` URLs and tripped the H101 broken-link check.

`compute_element_urls()` now threads the nearest page-owning ancestor's path and the top-level inline-card anchor through the recursion. Page owners get their own URL; inline members get `{parent_page}#{card}`, where the anchor is the HIGHEST inline ancestor's simple name — so a method in a class anchors onto its CLASS card (not the module page), mirroring the resolution already encoded by `SymbolResolver` and `test_symbol_resolver.py::test_method_resolves_to_top_level_card_anchor`.

## What changed
- `bengal/autodoc/orchestration/page_builders.py`: added a per-doc-type page-owner table (`_PAGE_OWNER_TYPES_BY_DOC`) and `_element_owns_page()`; rewrote `compute_element_urls()` to set `_path`/`href` to an on-page anchor for non-page members across the python, cli, and openapi branches, with the page/anchor context threaded through recursion. Top-level page owners are unchanged; the OpenAPI overview and orphan non-owners keep their legacy standalone path (no behavior change).
- Added `tests/unit/autodoc/test_member_anchor_hrefs.py` — 7 discriminating tests covering module page ownership, class→module-page anchor, method→class-card anchor, module-level-function anchor, CLI command page + option anchor, OpenAPI schema page, and baseurl application to anchor hrefs. Verified each assertion fails against the old behavior.
- Added `changelog.d/401.fixed.md`.

Backward-compatible: templates already read `element.href`.

Closes #401