### PR TITLE
fix(nav): include shared content in every versioned NavTree

### DIFF
--- a/bengal/core/nav_tree.py
+++ b/bengal/core/nav_tree.py
@@ -272,6 +272,15 @@ class NavTree:
             ):
                 nav_root.children.append(section_node)
 
+        # Inject shared content (e.g. pages under _shared/) into version-specific
+        # trees. Shared pages have version=None and are not attached to any
+        # versioned section, so the section walk above never reaches them. They
+        # are version-agnostic and appear as-is in every version (no per-version
+        # duplication). For version_id=None they are already covered by the
+        # regular section walk and need no injection.
+        if version_id is not None:
+            cls._inject_shared_pages(site, nav_root)
+
         # Sort top-level by weight, then title
         nav_root.children.sort(key=lambda n: (n.weight, n.title))
 
@@ -284,6 +293,60 @@ class NavTree:
         return cls(
             root=nav_root, version_id=version_id, versions=versions, current_version=version_id
         )
+
+    @classmethod
+    def _inject_shared_pages(cls, site: SiteLike, nav_root: NavNode) -> None:
+        """
+        Add shared (version-agnostic) pages to a version-specific nav root.
+
+        Shared pages live under a configured shared directory (default
+        ``_shared/``) and carry ``version is None``. They are not attached to
+        any versioned section, so :meth:`build` would otherwise omit them from
+        every version-specific tree. They are added once, as-is, without
+        per-version duplication or URL rewriting.
+
+        Args:
+            site: Site whose pages may include shared content.
+            nav_root: Synthetic root node to append shared page nodes to.
+        """
+        version_config = getattr(site, "version_config", None)
+        shared_dirs = list(getattr(version_config, "shared", []) or [])
+        if not shared_dirs:
+            return
+
+        def _is_shared(page: PageLike) -> bool:
+            if getattr(page, "version", None) is not None:
+                return False
+            source = getattr(page, "source_path", None)
+            if source is None:
+                return False
+            source_str = str(source).replace("\\", "/")
+            return any(
+                shared and (f"/{shared}/" in source_str or source_str.startswith(f"{shared}/"))
+                for shared in shared_dirs
+            )
+
+        existing_urls = {node._path for node in nav_root.walk()}
+        for page in getattr(site, "pages", []):
+            if not _is_shared(page):
+                continue
+            if cls._should_exclude_from_nav(page):
+                continue
+            page_url = getattr(page, "_path", None) or getattr(page, "href", "/")
+            if page_url in existing_urls:
+                continue
+            existing_urls.add(page_url)
+            nav_root.children.append(
+                NavNode(
+                    id=f"shared-{page_url}",
+                    title=getattr(page, "nav_title", page.title),
+                    _path=page_url,
+                    icon=getattr(page, "icon", None),
+                    weight=page.metadata.get("weight", DEFAULT_WEIGHT),
+                    page=page,
+                    _depth=1,
+                )
+            )
 
     @classmethod
     def _should_exclude_from_nav(cls, page: PageLike) -> bool:

--- a/bengal/core/section/navigation.py
+++ b/bengal/core/section/navigation.py
@@ -62,13 +62,15 @@ def pages_for_version(section: Section, version_id: str | None) -> list[PageLike
     """
     Get pages matching the specified version.
 
-    Filters sorted_pages to return only pages whose version attribute
-    matches the given version_id. If version_id is None, returns all
-    sorted pages.
+    Filters sorted_pages to return pages whose version attribute matches the
+    given version_id. Pages with ``version is None`` are shared content
+    (e.g. anything under ``_shared/``) and are version-agnostic, so they are
+    included in every version-specific tree as-is (no per-version
+    duplication). If version_id is None, returns all sorted pages.
     """
     if version_id is None:
         return section.sorted_pages
-    return [p for p in section.sorted_pages if getattr(p, "version", None) == version_id]
+    return [p for p in section.sorted_pages if getattr(p, "version", None) in (version_id, None)]
 
 
 def subsections_for_version(section: Section, version_id: str | None) -> list[Section]:

--- a/bengal/core/version.py
+++ b/bengal/core/version.py
@@ -547,6 +547,16 @@ class VersionConfig:
         """
         path_str = str(content_path)
 
+        # Shared content (_shared/...) is version-agnostic: it belongs to no
+        # single version and is surfaced in every version-specific navigation
+        # tree as-is. Recognise it explicitly and keep its version None so the
+        # versioned-section substring check below cannot misclassify it.
+        for shared in self.shared:
+            if shared and (
+                path_str.startswith(f"{shared}/") or f"/{shared}/" in path_str or path_str == shared
+            ):
+                return None
+
         # Check _versions/<id>/
         if "_versions/" in path_str:
             parts = path_str.split("_versions/")

--- a/changelog.d/395.fixed.md
+++ b/changelog.d/395.fixed.md
@@ -1,0 +1,1 @@
+Shared documentation pages (under `_shared/`) now appear in every version-specific navigation tree (#395). Previously they were discovered and documented as shared but were silently absent from each version's NavTree, since they carry `version=None` and are not attached to any versioned section.

--- a/tests/integration/test_nav_tree_integration.py
+++ b/tests/integration/test_nav_tree_integration.py
@@ -44,9 +44,10 @@ class TestNavTreeVersionedSite:
     def test_shared_content_in_all_versions(self, shared_site):
         """Test that _shared/ pages appear in all version navigation trees.
 
-        NOTE: Currently shared content injection into nav trees is not implemented.
-        This test verifies that shared pages exist in the site and can be found.
-        TODO: Implement _shared/ content injection in NavTree.build() per Phase 1.2.
+        Shared pages (under ``_shared/``) are version-agnostic: they carry
+        ``version is None`` and are injected as-is into every version-specific
+        NavTree. This is the documented contract (see version.py and the theme
+        NavTree docs).
         """
 
         # Verify shared page exists in site
@@ -55,19 +56,20 @@ class TestNavTreeVersionedSite:
 
         changelog_page = next((p for p in shared_pages if "changelog" in str(p.source_path)), None)
         assert changelog_page is not None, "Changelog page should exist"
+        # Shared pages are version-agnostic.
+        assert changelog_page.version is None, "Shared content should have version None"
         # Use _path for comparison (excludes baseurl)
         assert changelog_page._path == "/_shared/changelog/", "Changelog should have correct URL"
 
-        # TODO: Once shared content injection is implemented in NavTree.build(),
-        # uncomment these assertions:
-        # NavTreeCache.invalidate()
-        # tree_v1 = NavTree.build(shared_site, version_id="v1")
-        # tree_v2 = NavTree.build(shared_site, version_id="v2")
-        # tree_v3 = NavTree.build(shared_site, version_id="v3")
-        # changelog_url = "/_shared/changelog/"
-        # assert tree_v1.find(changelog_url) is not None
-        # assert tree_v2.find(changelog_url) is not None
-        # assert tree_v3.find(changelog_url) is not None
+        # Shared content must appear in every version-specific navigation tree.
+        NavTreeCache.invalidate()
+        tree_v1 = NavTree.build(shared_site, version_id="v1")
+        tree_v2 = NavTree.build(shared_site, version_id="v2")
+        tree_v3 = NavTree.build(shared_site, version_id="v3")
+        changelog_url = "/_shared/changelog/"
+        assert tree_v1.find(changelog_url) is not None, "shared changelog missing from v1 tree"
+        assert tree_v2.find(changelog_url) is not None, "shared changelog missing from v2 tree"
+        assert tree_v3.find(changelog_url) is not None, "shared changelog missing from v3 tree"
 
     def test_version_specific_content_filtering(self, shared_site):
         """Test that version-specific content only appears in correct version tree.

--- a/tests/unit/core/test_section_versioning.py
+++ b/tests/unit/core/test_section_versioning.py
@@ -75,17 +75,23 @@ class TestPagesForVersion:
 
         assert result == []
 
-    def test_pages_without_version_not_matched(self, tmp_path):
-        """Pages without version attribute are not matched."""
+    def test_shared_pages_without_version_are_matched(self, tmp_path):
+        """Pages without a version (shared content) appear in every version.
+
+        Shared pages (e.g. under ``_shared/``) carry ``version is None`` and
+        are version-agnostic, so a version-specific filter includes them
+        as-is alongside the version's own pages (issue #395).
+        """
         section = Section(name="docs", path=tmp_path / "docs")
         page_v1 = make_page(tmp_path, "page1", version="v1")
-        page_no_version = make_page(tmp_path, "page2")  # No version
+        page_no_version = make_page(tmp_path, "page2")  # No version = shared
         section.pages = [page_v1, page_no_version]
 
         result = section.pages_for_version("v1")
 
-        assert len(result) == 1
-        assert result[0] == page_v1
+        assert len(result) == 2
+        assert page_v1 in result
+        assert page_no_version in result
 
     def test_preserves_weight_order(self, tmp_path):
         """Filtered pages maintain weight-based sort order."""


### PR DESCRIPTION
Shared documentation pages under `_shared/` were discovered, rebuilt, and documented as appearing in all versions, but were silently absent from every version-specific `NavTree`. They carry `version=None` and are not attached to any versioned section, so `NavTree.build()` never reached them — contradicting both the user docs and the `NavTree.build()` docstring that advertise shared-content injection.

This makes the documented behavior real: shared pages now appear, as-is (no per-version duplication), in each version's navigation tree.

## What changed
- `bengal/core/section/navigation.py` `pages_for_version()`: a version-specific filter now also includes pages with `version is None`, so shared pages that live inside a versioned section surface in every version.
- `bengal/core/version.py` `get_version_for_path()`: explicitly recognizes configured `_shared/` paths and keeps their version `None` (the correct version-agnostic state), so the versioned-section substring check below can't misclassify them.
- `bengal/core/nav_tree.py` `build()`: injects orphaned shared pages (those with `version is None` whose source lives under a configured shared dir, not attached to any iterated section) into the version-specific nav root via a new `_inject_shared_pages()` helper. Skipped for the `version_id=None` full tree, which the regular section walk already covers.
- `tests/integration/test_nav_tree_integration.py`: enabled the previously-disabled regression assertions — `NavTree.find("/_shared/changelog/")` is now non-None for v1/v2/v3 — and asserts the shared page's `version is None`.
- `tests/unit/core/test_section_versioning.py`: updated the `pages_for_version` unit test (was asserting the old buggy exclusion) to the new shared-content contract.
- Added `changelog.d/395.fixed.md`.

Closes #395