### PR TITLE
fix(rendering): route Kida render_template errors through ErrorClassifier

### DIFF
--- a/bengal/rendering/engines/kida.py
+++ b/bengal/rendering/engines/kida.py
@@ -38,6 +38,7 @@ from bengal.protocols import EngineCapability, TemplateEngineProtocol
 from bengal.protocols.capabilities import has_clear_template_cache
 from bengal.rendering.context.lazy import LazyPageContext
 from bengal.rendering.engines.errors import TemplateError, TemplateNotFoundError
+from bengal.rendering.errors.classifier import ErrorClassifier
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -806,12 +807,13 @@ class KidaTemplateEngine:
                 line_number=getattr(e, "lineno", None),
             ) from e
         except TypeError as e:
-            # Enhanced error messages for common template callable errors
-            error_str = str(e).lower()
-            if (
-                "'nonetype' object is not callable" in error_str
-                or "nonetype object is not callable" in error_str
-            ):
+            # Enhanced error messages for common template callable errors.
+            # Delegate code classification to the canonical ErrorClassifier so
+            # the live render path cannot drift from its tests: NoneType-not-
+            # callable -> R015, macro-resolved-to-Undefined -> R006, otherwise
+            # the generic render-output code.
+            code = ErrorClassifier().classify(e)
+            if code is ErrorCode.R015:
                 # Try to identify what was being called
                 import traceback
 
@@ -832,17 +834,17 @@ class KidaTemplateEngine:
                         f"Call stack:\n{context_str}\n"
                         f"Check that all filters and template functions are properly registered."
                     ),
-                    code=ErrorCode.R008,
+                    code=code,
                     original_error=e,
                 ) from e
-            if "_undefined" in error_str and "not callable" in error_str:
+            if code is ErrorCode.R006:
                 raise BengalRenderingError(
                     message=(
                         f"Template '{name}': A macro from {{% from X import y %}} resolved to "
                         "Undefined. Check that the imported template defines the macro. "
                         "If this occurs during parallel builds, try --no-parallel."
                     ),
-                    code=ErrorCode.R006,
+                    code=code,
                     original_error=e,
                     suggestion="Check that the imported template defines the macro. "
                     "If this occurs during parallel builds, try --no-parallel.",

--- a/bengal/rendering/errors/classifier.py
+++ b/bengal/rendering/errors/classifier.py
@@ -55,6 +55,8 @@ class ErrorClassifier:
         error_str = str(exc).lower()
 
         if isinstance(exc, TypeError):
+            if self._is_undefined_macro_call(error_str):
+                return ErrorCode.R006
             if self._is_callable_error(error_str):
                 return ErrorCode.R015
             if self._is_type_comparison(error_str):
@@ -87,6 +89,17 @@ class ErrorClassifier:
             "'nonetype' object is not callable" in error_str
             or "nonetype object is not callable" in error_str
         )
+
+    @staticmethod
+    def _is_undefined_macro_call(error_str: str) -> bool:
+        """True when a macro resolved to Undefined and was then called.
+
+        ``{% from X import y %}`` where ``y`` is missing yields a
+        ``TypeError`` mentioning an ``_undefined`` object that is
+        ``not callable``. This is a macro-resolution error (R006), not the
+        generic NoneType-callable error (R015), so it must be checked first.
+        """
+        return "_undefined" in error_str and "not callable" in error_str
 
     @staticmethod
     def _is_type_comparison(error_str: str) -> bool:
@@ -202,6 +215,7 @@ _LEGACY_CODE_TO_STRING: dict[ErrorCode, str] = {
     ErrorCode.R002: "syntax",
     ErrorCode.R003: "undefined",
     ErrorCode.R004: "filter",
+    ErrorCode.R006: "macro",
     ErrorCode.R010: "other",
     ErrorCode.R014: "runtime",
     ErrorCode.R015: "callable",

--- a/changelog.d/391.fixed.md
+++ b/changelog.d/391.fixed.md
@@ -1,0 +1,1 @@
+Kida template render errors are now classified through the canonical `ErrorClassifier`: a `None` filter/function (`'NoneType' object is not callable`) reports `R015` instead of the mislabeled `R008`, keeping the live render path and the error-classifier in sync.

--- a/tests/unit/rendering/test_error_classifier.py
+++ b/tests/unit/rendering/test_error_classifier.py
@@ -68,6 +68,20 @@ class TestClassifyByMessage:
     @pytest.mark.parametrize(
         "message",
         [
+            "'_Undefined' object is not callable",
+            "'_undefined' object is not callable",
+        ],
+    )
+    def test_undefined_macro_call_maps_to_r006(
+        self, classifier: ErrorClassifier, message: str
+    ) -> None:
+        # A macro resolved to Undefined and was then called: R006, and it must
+        # win over the generic NoneType-callable (R015) check.
+        assert classifier.classify(TypeError(message)) == ErrorCode.R006
+
+    @pytest.mark.parametrize(
+        "message",
+        [
             "'<' not supported between instances of 'int' and 'str'",
             "'>' not supported between instances of 'NoneType' and 'int'",
         ],
@@ -125,6 +139,7 @@ class TestLegacyShim:
             (UndefinedError("nope"), "undefined"),
             (TemplateRuntimeError("boom"), "runtime"),
             (TypeError("'NoneType' object is not callable"), "callable"),
+            (TypeError("'_Undefined' object is not callable"), "macro"),
             (TypeError("'NoneType' object is not iterable"), "none_access"),
             (
                 TypeError("'<' not supported between instances of 'int' and 'str'"),

--- a/tests/unit/rendering/test_kida_error_classification.py
+++ b/tests/unit/rendering/test_kida_error_classification.py
@@ -1,0 +1,111 @@
+"""Regression tests for KidaTemplateEngine error-code classification (#391).
+
+``KidaTemplateEngine.render_template`` used to inline-classify TypeErrors with
+its own string heuristics, emitting ``R008`` (``template_context_error``) for the
+NoneType-not-callable case while the canonical :class:`ErrorClassifier` returns
+``R015`` (``template_callable_error``). These tests pin the live render path to
+the classifier so the two cannot drift again.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import pytest
+
+from bengal.errors import BengalRenderingError
+from bengal.errors.codes import ErrorCode
+from bengal.rendering.engines.kida import KidaTemplateEngine
+from bengal.rendering.errors.classifier import ErrorClassifier
+
+
+class _FakeTemplate:
+    """A compiled-template stand-in whose render raises a chosen exception."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def render(self, _ctx: Any) -> str:
+        raise self._exc
+
+
+class _FakeEnv:
+    """Minimal environment exposing ``get_template`` and ``globals``."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+        self.globals: dict[str, Any] = {}
+
+    def get_template(self, _name: str) -> _FakeTemplate:
+        return _FakeTemplate(self._exc)
+
+
+class _FakeSite:
+    config: ClassVar[dict[str, Any]] = {}
+
+
+class _StubKidaEngine(KidaTemplateEngine):
+    """KidaTemplateEngine wired to raise a controlled exception at render time.
+
+    Bypasses ``__init__`` (no real Site/templates) and no-ops the dependency
+    bookkeeping that runs before the ``try`` block, so the real
+    ``except TypeError`` handler in ``render_template`` is exercised verbatim.
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        self._env = _FakeEnv(exc)
+        self.site = _FakeSite()
+        self._profiler = None
+
+    def get_template_path(self, name: str) -> None:  # type: ignore[override]
+        return None
+
+    def _track_referenced_templates(self, template_name: str) -> None:  # type: ignore[override]
+        return None
+
+
+def _render_error(exc: BaseException) -> BengalRenderingError:
+    engine = _StubKidaEngine(exc)
+    with pytest.raises(BengalRenderingError) as excinfo:
+        engine.render_template("page.html", {})
+    return excinfo.value
+
+
+class TestRenderTemplateErrorCodes:
+    def test_nonetype_not_callable_maps_to_r015_not_r008(self) -> None:
+        exc = TypeError("'NoneType' object is not callable")
+        err = _render_error(exc)
+        assert err.code == ErrorCode.R015
+        assert err.code != ErrorCode.R008
+
+    def test_undefined_macro_call_maps_to_r006(self) -> None:
+        exc = TypeError("'_Undefined' object is not callable")
+        err = _render_error(exc)
+        assert err.code == ErrorCode.R006
+
+    def test_generic_typeerror_maps_to_r010(self) -> None:
+        exc = TypeError("unsupported operand type(s)")
+        err = _render_error(exc)
+        assert err.code == ErrorCode.R010
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            TypeError("'NoneType' object is not callable"),
+            TypeError("'_Undefined' object is not callable"),
+            TypeError("something entirely different"),
+        ],
+    )
+    def test_no_drift_engine_matches_classifier(self, exc: TypeError) -> None:
+        # The TypeError branch derives every classifiable code from the
+        # classifier. The generic fallback is R010, which is also the
+        # classifier's fallback, so the codes match for all three cases.
+        err = _render_error(exc)
+        assert err.code == ErrorClassifier().classify(exc)
+
+    def test_nonetype_message_is_byte_stable(self) -> None:
+        # The user-facing message for the NoneType case must not change; only
+        # the code flips R008 -> R015.
+        exc = TypeError("'NoneType' object is not callable")
+        err = _render_error(exc)
+        assert "A function or filter is None (not callable)." in str(err)


### PR DESCRIPTION
`KidaTemplateEngine.render_template` inline string-matched `TypeError`s and emitted `R008` (`template_context_error`) for the `'NoneType' object is not callable` case, contradicting the canonical `ErrorClassifier.classify` (and its tests), which return `R015` (`template_callable_error`). The engine's label was also semantically wrong: a `None` filter/function is a callable error, not a context error.

## What changed
- Import `ErrorClassifier` into `bengal/rendering/engines/kida.py` and derive the `except TypeError` branch's `ErrorCode` from `ErrorClassifier().classify(e)` instead of inline string matching; the NoneType-not-callable case now emits `R015`.
- Add an `_is_undefined_macro_call` predicate to `bengal/rendering/errors/classifier.py` mapping the macro-resolved-to-Undefined case (`_undefined` + `not callable`) to `R006`, checked before the generic callable branch, with a matching `R006 -> "macro"` entry in `_LEGACY_CODE_TO_STRING`.
- `BengalRenderingError` messages for both the NoneType and macro cases stay byte-stable; only the NoneType code changes `R008` -> `R015`.
- `R008` remains in the `ErrorCode` enum and valid for genuine context errors (`navigation/tree.py`, `scaffold.py`); the `related_codes=["R008"]` `context_error` suggestion mapping in `bengal/errors/suggestions.py` is unchanged.
- Add regression tests: classifier-level R006/macro cases (incl. legacy round-trip) and an engine-render-path test asserting no drift between `render_template`'s emitted code and `ErrorClassifier().classify()` for the same exception.

Closes #391

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Correctness fix on the cold error path only; ErrorClassifier is instantiated solely inside the except handler, no hot-path render cost.
