### PR TITLE
chore(concurrency): consolidate duplicated GIL-detection helpers

### DIFF
--- a/bengal/orchestration/render/parallel.py
+++ b/bengal/orchestration/render/parallel.py
@@ -12,9 +12,10 @@ Key Features:
 
 from __future__ import annotations
 
-import sys
 import threading
 from typing import TYPE_CHECKING, Any
+
+from bengal.utils.concurrency import is_gil_disabled
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -32,25 +33,15 @@ def is_free_threaded() -> bool:
     Free-threaded Python (python3.13t+) has the GIL disabled, allowing
     true parallel execution with ThreadPoolExecutor.
 
+    Thin alias over the canonical
+    :func:`bengal.utils.concurrency.is_gil_disabled`. Kept so the
+    ``is_free_threaded`` symbol (re-exported from
+    ``bengal.orchestration.render``) keeps resolving for existing callers.
+
     Returns:
         True if running on free-threaded Python, False otherwise
     """
-    # Check if sys._is_gil_enabled() exists and returns False
-    if hasattr(sys, "_is_gil_enabled"):
-        try:
-            return not sys._is_gil_enabled()
-        except AttributeError, TypeError:
-            pass
-
-    # Fallback: check sysconfig for Py_GIL_DISABLED
-    try:
-        import sysconfig
-
-        return sysconfig.get_config_var("Py_GIL_DISABLED") == 1
-    except ImportError, AttributeError:
-        pass
-
-    return False
+    return is_gil_disabled()
 
 
 def get_or_create_pipeline(

--- a/bengal/postprocess/social_cards.py
+++ b/bengal/postprocess/social_cards.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import sys
 from dataclasses import dataclass, replace
 from threading import Lock
 from typing import TYPE_CHECKING, Any
@@ -67,13 +66,6 @@ logger = get_logger(__name__)
 CARD_WIDTH = 1200
 CARD_HEIGHT = 630
 SOCIAL_CARD_FINGERPRINT_PREFIX = "social_card:"
-
-
-# Check if running in free-threading (no-GIL) mode
-# Pillow's C extensions are NOT thread-safe without the GIL
-def _is_free_threading() -> bool:
-    """Check if running in Python's free-threading (no-GIL) mode."""
-    return hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled()
 
 
 @dataclass

--- a/bengal/server/build_executor.py
+++ b/bengal/server/build_executor.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 
 import multiprocessing
 import os
-import sys
 import time
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from dataclasses import dataclass, field
@@ -53,6 +52,7 @@ from typing import TYPE_CHECKING
 # Runtime re-export for existing ``bengal.server.build_executor.BuildRequest`` callers.
 from bengal.orchestration.build.requests import BuildRequest  # noqa: TC001
 from bengal.server.reload_types import SerializedOutputRecord
+from bengal.utils.concurrency import is_gil_disabled
 from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
@@ -185,13 +185,16 @@ def is_free_threaded() -> bool:
     truly parallel. In this mode, ThreadPoolExecutor is as good as
     ProcessPoolExecutor without the serialization overhead.
 
+    Thin alias over the canonical
+    :func:`bengal.utils.concurrency.is_gil_disabled`. Kept so the
+    ``is_free_threaded`` symbol (patched by server/build tests and used by
+    :func:`get_executor_type`) keeps resolving for existing callers.
+
     Returns:
         True if running on free-threaded Python, False otherwise
 
     """
-    if hasattr(sys, "_is_gil_enabled"):
-        return not sys._is_gil_enabled()
-    return False
+    return is_gil_disabled()
 
 
 def get_executor_type() -> str:

--- a/changelog.d/381.changed.md
+++ b/changelog.d/381.changed.md
@@ -1,0 +1,6 @@
+Consolidated the four drifting free-threading/GIL-detection helpers into the
+single canonical `bengal.utils.concurrency.is_gil_disabled()` (#381). The local
+copies in the render orchestrator, dev-server build executor, and social-card
+generator (two of which lacked the `sysconfig` fallback) now delegate to the
+canonical check, so executor selection and build behavior stay consistent across
+the build, dev-server, and render paths.

--- a/tests/unit/utils/test_workers.py
+++ b/tests/unit/utils/test_workers.py
@@ -12,6 +12,7 @@ Tests the unified worker auto-tune utility including:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -558,3 +559,42 @@ class TestIntegration:
                 config_override=12,
             )
             assert workers == 12  # Ignores CI cap
+
+
+class TestGilDetectionConsolidation:
+    """Guard: GIL detection lives only in bengal.utils.concurrency (issue #381)."""
+
+    def test_no_duplicate_gil_detection_outside_concurrency(self) -> None:
+        """
+        Assert no module outside ``bengal/utils/concurrency`` defines its own
+        free-threading / GIL detection.
+
+        Finding 7 of #381 consolidated four drifting copies of GIL detection
+        into the canonical :func:`bengal.utils.concurrency.is_gil_disabled`.
+        Re-introducing a local ``sys._is_gil_enabled()`` probe or a
+        ``Py_GIL_DISABLED`` ``sysconfig`` lookup anywhere else resurrects the
+        drift this consolidation removed, so this test fails if either idiom
+        reappears outside the concurrency package.
+        """
+        import bengal
+
+        package_root = Path(bengal.__file__).resolve().parent
+        canonical_dir = package_root / "utils" / "concurrency"
+
+        # Idioms that constitute a *local* GIL-detection implementation.
+        gil_idioms = ("_is_gil_enabled", "Py_GIL_DISABLED")
+
+        offenders: list[str] = []
+        for path in package_root.rglob("*.py"):
+            if canonical_dir in path.parents or path == canonical_dir:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if any(idiom in text for idiom in gil_idioms):
+                rel = path.relative_to(package_root)
+                offenders.append(str(rel))
+
+        assert not offenders, (
+            "GIL-detection idioms found outside bengal/utils/concurrency; "
+            "import is_gil_disabled() from bengal.utils.concurrency instead. "
+            f"Offending modules: {sorted(offenders)}"
+        )


### PR DESCRIPTION
Implements Finding 7 of #381: consolidate the four drifting copies of free-threading / GIL detection into the single canonical `bengal.utils.concurrency.is_gil_disabled()`.

Two of the local copies (`build_executor.py`, `social_cards.py`) lacked the `sysconfig.get_config_var("Py_GIL_DISABLED")` fallback that the canonical helper has — exactly the drift that produces inconsistent behavior across the build, dev-server, and render paths. Routing every site through the canonical check removes that drift. Executor-type selection and build behavior are unchanged (`get_executor_type()` returns the same value; existing server/build/social-card tests pass).

## What changed
- `bengal/orchestration/render/parallel.py`: `is_free_threaded()` body replaced with a thin alias calling `is_gil_disabled()`. The symbol is preserved because it is re-exported from `bengal.orchestration.render` and read by the render orchestrator (`self._free_threaded`); removed the now-unused `import sys`.
- `bengal/server/build_executor.py`: `is_free_threaded()` body replaced with a thin alias calling `is_gil_disabled()` (this copy previously had no `sysconfig` fallback). The symbol is preserved because `get_executor_type()` calls it and server/build tests patch `bengal.server.build_executor.is_free_threaded`; removed the now-unused `import sys`.
- `bengal/postprocess/social_cards.py`: deleted the dead, never-called `_is_free_threading()` helper (it had no callers; social-card generation is unconditionally sequential). The Pillow thread-safety rationale is preserved by the existing module docstring and the call-site comment in `generate_all()`; removed the now-unused `import sys`.
- `tests/unit/utils/test_workers.py`: added `TestGilDetectionConsolidation`, a guard test asserting no module outside `bengal/utils/concurrency` contains a `_is_gil_enabled` / `Py_GIL_DISABLED` detection idiom (verified non-vacuous: it fails when an idiom is reintroduced).
- `changelog.d/381.changed.md`: towncrier fragment.

Note: the `except AttributeError, TypeError:` clauses in the canonical `gil.py` are valid PEP 758 syntax and were left untouched.

Refs #381

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Pure consolidation of duplicated GIL-detection helpers; identical detection logic, no perf delta. Finding 5 (worker-ceiling tuning) deferred pending a measured sweep.
