### PR TITLE
fix(observability): add diagnostics to silent exception swallows

### DIFF
--- a/bengal/cache/paths.py
+++ b/bengal/cache/paths.py
@@ -308,7 +308,7 @@ def migrate_template_cache(paths: BengalPaths, output_dir: Path) -> bool:
             old_parent = output_dir / ".bengal-cache"
             if old_parent.exists() and not any(old_parent.iterdir()):
                 old_parent.rmdir()
-        except Exception:  # noqa: S110
+        except Exception:  # noqa: S110 -- stale-cache cleanup is best-effort; migration proceeds
             pass
         return False
 

--- a/bengal/cli/milo_commands/build.py
+++ b/bengal/cli/milo_commands/build.py
@@ -440,7 +440,7 @@ def build(
                                 / _prev.build_time_ms
                                 * 100
                             )
-                    except Exception:  # noqa: S110
+                    except Exception:  # noqa: S110 -- stats display is cosmetic; never break the build CLI
                         pass
                 display_simple_build_stats(stats, output_dir=str(site.output_dir))
             elif build_profile == BuildProfile.DEVELOPER:

--- a/bengal/config/env_overrides.py
+++ b/bengal/config/env_overrides.py
@@ -246,7 +246,7 @@ def apply_env_overrides(config: dict[str, Any]) -> dict[str, Any]:
         hints = collect_hints("config", baseurl=str(baseurl_val or ""), max_hints=1)
         for h in hints:
             logger.info("dx_hint", hint_id=h.id, hint_message=h.message)
-    except Exception:  # noqa: S110
+    except Exception:  # noqa: S110 -- DX hints are advisory; never block config load
         pass
 
     return config

--- a/bengal/content/versioning/artifacts.py
+++ b/bengal/content/versioning/artifacts.py
@@ -170,7 +170,7 @@ def _write_if_changed_atomic(path: Path, content: str, atomic_file_cls: type) ->
             existing = path.read_text(encoding="utf-8")
             if existing == content:
                 return
-    except Exception:  # noqa: S110
+    except Exception:  # noqa: S110 -- prior-artifact read is best-effort; we rewrite the file anyway
         pass
 
     with atomic_file_cls(path, "w", encoding="utf-8") as f:

--- a/bengal/core/asset/asset_core.py
+++ b/bengal/core/asset/asset_core.py
@@ -752,7 +752,7 @@ class Asset:
             ):
                 logical_str = str(self.logical_path) if self.logical_path else self.source_path.name
                 return self._site.template_engine._asset_url(logical_str)
-        except Exception:  # noqa: S110
+        except Exception:  # noqa: S110 -- template-engine asset_url is optional; fall back to baseurl
             pass
 
         # Fallback: simple baseurl application

--- a/bengal/errors/suggestions.py
+++ b/bengal/errors/suggestions.py
@@ -925,7 +925,7 @@ def identify_none_callable(error: BaseException, template_path: Path | None = No
             )
 
             suspects.extend(scan_template_for_callables(template_path))
-        except Exception:  # noqa: S110
+        except Exception:  # noqa: S110 -- suggestion scanning is advisory; never break error reporting
             pass
 
     unique_suspects = list(dict.fromkeys(suspects))

--- a/bengal/health/validators/asset_urls.py
+++ b/bengal/health/validators/asset_urls.py
@@ -73,6 +73,7 @@ class AssetURLValidator(BaseValidator):
 
         missing_assets: list[dict[str, Any]] = []
         checked = 0
+        skipped = 0
 
         # Get baseurl for path normalization
         baseurl = (site.baseurl or "").strip("/")
@@ -80,7 +81,11 @@ class AssetURLValidator(BaseValidator):
         for html_file in html_files:
             try:
                 content = html_file.read_text(encoding="utf-8", errors="ignore")
-            except Exception:  # noqa: S112
+            except Exception as e:  # unreadable sampled file is dropped, not fatal
+                # An unreadable file shrinks coverage; surface it instead of
+                # silently reporting a clean pass over a file we never scanned.
+                skipped += 1
+                logger.debug("asset_url_unreadable", html_file=str(html_file), error=str(e))
                 continue
 
             for match in self.ASSET_PATTERN.finditer(content):
@@ -189,11 +194,15 @@ class AssetURLValidator(BaseValidator):
 
         # Success if no issues
         if not unique_missing:
+            message = f"All {checked} asset references resolve to existing files"
+            if skipped:
+                message += f" ({skipped} unreadable file(s) skipped)"
             results.append(
                 CheckResult(
                     status=CheckStatus.SUCCESS,
-                    message=f"All {checked} asset references resolve to existing files",
+                    message=message,
                     code="asset_urls_valid",
+                    metadata={"checked": checked, "skipped": skipped},
                 )
             )
 

--- a/bengal/health/validators/autodoc.py
+++ b/bengal/health/validators/autodoc.py
@@ -11,9 +11,12 @@ from typing import TYPE_CHECKING, Any, ClassVar, override
 
 from bengal.health.base import BaseValidator
 from bengal.health.report import CheckResult, CheckStatus, ValidatorStats
+from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
     from bengal.protocols import SiteLike
+
+logger = get_logger(__name__)
 
 
 class AutodocValidator(BaseValidator):
@@ -201,6 +204,7 @@ class AutodocValidator(BaseValidator):
 
             # Check a sample of pages
             type_mismatches: list[str] = []
+            skipped = 0
             sample_pages = list(prefix_dir.rglob("index.html"))[:20]
 
             for page_path in sample_pages:
@@ -214,19 +218,46 @@ class AutodocValidator(BaseValidator):
                         type_mismatches.append(
                             f"{page_path.relative_to(site.output_dir)}: got {actual}"
                         )
-                except Exception:  # noqa: S110
-                    pass
+                except Exception as e:  # unreadable page is skipped, not fatal
+                    # Skipping a page silently shrinks type-check coverage; record
+                    # the skip so the result does not report a misleading all-clear.
+                    skipped += 1
+                    logger.debug("page_type_check_unreadable", page=str(page_path), error=str(e))
 
             if type_mismatches:
+                message = (
+                    f"Autodoc {prefix}: {len(type_mismatches)} pages have wrong type "
+                    f"(expected {expected_type})"
+                )
+                if skipped:
+                    message += f"; {skipped} page(s) skipped (unreadable)"
                 results.append(
                     CheckResult(
                         status=CheckStatus.WARNING,
-                        message=f"Autodoc {prefix}: {len(type_mismatches)} pages have wrong type (expected {expected_type})",
+                        message=message,
                         details=type_mismatches[:5],
                         metadata={
                             "prefix": prefix,
                             "expected_type": expected_type,
                             "mismatch_count": len(type_mismatches),
+                            "skipped": skipped,
+                        },
+                    )
+                )
+            elif skipped:
+                # No mismatches found, but coverage was reduced -- do not let a
+                # clean pass mask the fact that pages were skipped.
+                results.append(
+                    CheckResult(
+                        status=CheckStatus.WARNING,
+                        message=(
+                            f"Autodoc {prefix}: {skipped} page(s) skipped during "
+                            f"type check (unreadable)"
+                        ),
+                        metadata={
+                            "prefix": prefix,
+                            "expected_type": expected_type,
+                            "skipped": skipped,
                         },
                     )
                 )

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -665,8 +665,8 @@ class BuildOrchestrator:
                 from bengal.services.data import DataService
 
                 early_ctx.data_service = DataService.from_root(self.site.root_path)
-            except Exception:  # noqa: S110
-                pass  # data/ dir may not exist; service remains None
+            except Exception:  # noqa: S110 -- data/ dir may not exist; service remains None
+                pass
         run_plugin_phase("post_snapshot")
 
         # === DRY-RUN MODE: Skip output-producing phases ===

--- a/bengal/orchestration/content.py
+++ b/bengal/orchestration/content.py
@@ -1029,6 +1029,12 @@ class ContentOrchestrator:
             page.output_path = output_path
 
             if getattr(self.site, "url_registry", None):
+                # Pre-bind so the best-effort diagnostic handler can always
+                # reference these, even if url_from_output_path() raises before
+                # they are assigned. Preserves the original silent swallow; we
+                # only add a breadcrumb (no happy-path behavior change).
+                url = None
+                source = None
                 try:
                     url = URLStrategy.url_from_output_path(output_path, cast("SiteLike", self.site))
                     source = str(getattr(page, "source_path", page.title))
@@ -1042,8 +1048,18 @@ class ContentOrchestrator:
                         version=version,
                         lang=lang,
                     )
-                except Exception:  # noqa: S110
-                    pass
+                except Exception as e:  # claim is best-effort; URLCollisionValidator backstops
+                    # Detection is not lost: URLCollisionValidator recomputes
+                    # collisions from site.pages post-hoc. Leave a breadcrumb so
+                    # claim-time failures are diagnosable rather than invisible.
+                    logger.debug(
+                        "url_claim_failed",
+                        url=url,
+                        owner="content",
+                        source=source,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                    )
 
     def _validate_page_section_references(self) -> None:
         """

--- a/bengal/orchestration/render/block_cache.py
+++ b/bengal/orchestration/render/block_cache.py
@@ -58,7 +58,7 @@ def create_and_warm_block_cache(site: SiteLike) -> Any | None:
             try:
                 cached = block_cache.warm_site_blocks(engine, template_name, site_context)
                 total_cached += cached
-            except Exception:  # noqa: S110
+            except Exception:  # noqa: S110 -- block-cache warming is best-effort; render proceeds uncached
                 pass
 
         if total_cached > 0:

--- a/bengal/rendering/template_context_validation.py
+++ b/bengal/rendering/template_context_validation.py
@@ -70,7 +70,7 @@ def validate_template_contexts(
     for name in template_names:
         try:
             template = engine.env.get_template(name)
-        except Exception:  # noqa: S112
+        except Exception:  # noqa: S112 -- a template that fails to load is skipped, not validated
             continue
 
         if not hasattr(template, "validate_context"):

--- a/bengal/rendering/template_functions/blog.py
+++ b/bengal/rendering/template_functions/blog.py
@@ -19,11 +19,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from bengal.utils.observability.logger import get_logger
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from datetime import datetime
 
     from bengal.protocols import SiteLike, TemplateEnvironment
+
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -234,8 +238,10 @@ def posts_filter(pages: Iterable[Any]) -> list[PostView]:
     for page in pages:
         try:
             result.append(PostView.from_page(page))
-        except Exception:  # noqa: S112
-            # Skip pages that can't be converted
+        except Exception as e:  # one bad page must not break the listing
+            # Skip pages that can't be converted, but leave a breadcrumb so a
+            # post "mysteriously missing" from the listing is diagnosable.
+            logger.debug("post_view_skipped", error=str(e))
             continue
 
     return result

--- a/bengal/server/dev_server.py
+++ b/bengal/server/dev_server.py
@@ -655,8 +655,8 @@ class DevServer:
             if default_palette:
                 build_state.set_active_palette(default_palette)
                 logger.debug("rebuilding_page_palette_set", palette=default_palette)
-        except Exception:  # noqa: S110
-            pass
+        except Exception as e:  # palette set is best-effort; styling falls back
+            logger.debug("rebuilding_page_palette_failed", error=str(e))
 
     def _init_reload_controller(self) -> None:
         """Initialize reload controller with configuration."""

--- a/bengal/snapshots/scheduling.py
+++ b/bengal/snapshots/scheduling.py
@@ -232,7 +232,7 @@ def _compute_attention_score(page: PageLike) -> float:
             if isinstance(date, datetime):
                 days_ago = (datetime.now(UTC) - date).days
                 score += max(0, 10.0 - days_ago / 10.0)
-        except Exception:  # noqa: S110
+        except Exception:  # noqa: S110 -- recency boost is heuristic; bad date just skips the boost
             pass
 
     # Boost for featured pages

--- a/bengal/snapshots/templates.py
+++ b/bengal/snapshots/templates.py
@@ -82,7 +82,7 @@ def _get_template_partials(template_name: str, site: SiteLike) -> list[Path]:
                             if callable(extract_method):
                                 referenced = extract_method(ast)
                                 partials.update(referenced)
-                except Exception:  # noqa: S110
+                except Exception:  # noqa: S110 -- partial extraction is best-effort; engine compiles on demand
                     pass
 
         # Convert template names to Paths
@@ -249,7 +249,7 @@ def _analyze_template(template_name: str, site: SiteLike) -> TemplateSnapshot | 
                             for ref in extract_method(ast) or []:
                                 if isinstance(ref, str):
                                     all_deps.add(ref)
-            except Exception:  # noqa: S110
+            except Exception:  # noqa: S110 -- dependency extraction is best-effort; engine compiles on demand
                 pass
 
         # Get transitive dependencies
@@ -327,12 +327,12 @@ def _get_transitive_deps_for_template(
                                 if isinstance(r, str)
                             ]
                     next_queue.extend(ref for ref in deps if ref not in seen)
-                except Exception:  # noqa: S112
+                except Exception:  # noqa: S112 -- one unparseable template must not abort dep traversal
                     continue
 
             queue = next_queue
 
-    except Exception:  # noqa: S110
+    except Exception:  # noqa: S110 -- transitive-dep scan is best-effort; engine compiles on demand
         pass
 
     return all_deps

--- a/bengal/utils/dx/hints.py
+++ b/bengal/utils/dx/hints.py
@@ -190,7 +190,7 @@ def collect_hints(
                 continue
 
             hints.append(hint)
-        except Exception:  # noqa: S112
+        except Exception:  # noqa: S112 -- a single failing hint rule is skipped, not fatal
             continue
 
     hints.sort(key=lambda h: h.priority)

--- a/bengal/utils/observability/cli_progress.py
+++ b/bengal/utils/observability/cli_progress.py
@@ -417,7 +417,7 @@ class LiveProgressManager:
         if self._render_fn:
             try:
                 return self._render_fn("build_progress.kida", state=state).strip("\n")
-            except Exception:  # noqa: S110
+            except Exception:  # noqa: S110 -- rich progress render is cosmetic; fall back to plain output
                 pass
 
         import os

--- a/changelog.d/385.fixed.md
+++ b/changelog.d/385.fixed.md
@@ -1,0 +1,1 @@
+Silent exception swallows (`noqa: S110`/`S112`) across Bengal now carry a reason and, at meaningful subsystem boundaries, emit a `logger.debug` diagnostic; the asset-URL and autodoc health validators surface a nonzero skipped-file count instead of reporting a false all-clear, and a pre-commit guard now requires a justification on every such swallow.

--- a/prek.toml
+++ b/prek.toml
@@ -123,7 +123,7 @@ priority = 2
 
 [[repos.hooks]]
 id = "check-silent-suppress"
-name = "Require justification for contextlib.suppress in bengal/"
+name = "Require justification for silent exception swallows in bengal/ (contextlib.suppress + noqa: S110/S112)"
 entry = "uv run python scripts/check_silent_suppress.py"
 language = "system"
 files = "^bengal/.*\\.py$"

--- a/scripts/check_silent_suppress.py
+++ b/scripts/check_silent_suppress.py
@@ -1,11 +1,21 @@
 #!/usr/bin/env python3
-"""Pre-commit hook to require justification for contextlib.suppress in production code.
+"""Pre-commit hook to require justification for silent exception swallowing.
 
-Every contextlib.suppress() call in bengal/ must have a ``# silent: <reason>``
-comment on the same line or the preceding line.  This prevents silent exception
-swallowing from creeping back into the codebase.
+Two rules are enforced over production code in ``bengal/``:
 
-Tests are exempt — suppress is common and harmless in test teardown.
+1. Every ``contextlib.suppress()`` call must have a ``# silent: <reason>``
+   comment on the same line or a nearby line.
+2. Every S110 / S112 noqa directive (bare ``except ...: pass`` /
+   ``except ...: continue``) must carry an inline reason explaining what is
+   swallowed and why it is safe. The reason may be trailing text after the
+   noqa code on the same line, or a ``#`` comment on one of the next few
+   lines (matching the ``ruff format`` wrapping style used in the codebase,
+   e.g. ``finalization.py:626``).
+
+Together these prevent silent, undocumented exception swallowing from creeping
+back into the codebase.
+
+Tests are exempt -- suppress is common and harmless in test teardown.
 
 Usage:
     python scripts/check_silent_suppress.py [files...]
@@ -17,6 +27,35 @@ from pathlib import Path
 
 SUPPRESS_RE = re.compile(r"contextlib\.suppress\(")
 JUSTIFICATION_RE = re.compile(r"#\s*silent:")
+
+# Matches a noqa silencing S110 (try-except-pass) or S112 (try-except-continue).
+NOQA_RE = re.compile(r"#\s*noqa:\s*([A-Z0-9, ]*)")
+NOQA_CODE_RE = re.compile(r"S11[02]")
+# Bodies that mean "we reached the swallow without finding a reason comment".
+_SWALLOW_BODY = {"pass", "continue", "return", "return None"}
+
+
+def _noqa_has_reason(lines: list[str], i: int) -> bool:
+    """Return True if the noqa on ``lines[i]`` carries a reason comment."""
+    line = lines[i]
+    # 1. Trailing reason on the same line after the noqa code(s), e.g. a
+    #    "-- reason" or trailing "# reason" fragment following the codes.
+    #    Strip the whole noqa+codes prefix and see if any prose (letters)
+    #    remains afterwards.
+    m = NOQA_RE.search(line)
+    if m is not None:
+        rest = line[m.end() :].strip()
+        if rest and re.search(r"[A-Za-z]", rest):
+            return True
+    # 2. Reason comment on one of the next few body lines (before the
+    #    pass/continue), matching ruff-format wrapped style.
+    for w in lines[i + 1 : i + 4]:
+        stripped = w.strip()
+        if stripped.startswith("#") and re.search(r"#\s*\S", stripped):
+            return True
+        if stripped in _SWALLOW_BODY:
+            break
+    return False
 
 
 def check_file(path: Path) -> list[str]:
@@ -32,6 +71,17 @@ def check_file(path: Path) -> list[str]:
             has_reason = any(JUSTIFICATION_RE.search(w) for w in window)
             if not has_reason:
                 errors.append(f"{path}:{i + 1}: contextlib.suppress() without # silent: <reason>")
+
+        noqa_match = NOQA_RE.search(line)
+        if (
+            noqa_match
+            and NOQA_CODE_RE.search(noqa_match.group(1))
+            and not _noqa_has_reason(lines, i)
+        ):
+            errors.append(
+                f"{path}:{i + 1}: noqa: S110/S112 without an inline reason comment "
+                "(explain what is swallowed and why it is safe)"
+            )
     return errors
 
 
@@ -48,11 +98,12 @@ def main() -> int:
             all_errors.extend(check_file(f))
 
     if all_errors:
-        print("contextlib.suppress() requires a # silent: <reason> comment:")
+        print("Silent exception swallowing requires a justification comment:")
         for err in all_errors:
             print(f"  {err}")
         print(
-            f"\n{len(all_errors)} violation(s) found. Add '# silent: <reason>' to justify suppression."
+            f"\n{len(all_errors)} violation(s) found. Add '# silent: <reason>' to "
+            "contextlib.suppress(), or a reason comment to each noqa: S110/S112 swallow."
         )
         return 1
     return 0

--- a/tests/unit/health/validators/test_assets.py
+++ b/tests/unit/health/validators/test_assets.py
@@ -464,3 +464,61 @@ class TestEmptyAssetDetection:
             r for r in results if r.status == CheckStatus.WARNING and "empty" in r.message.lower()
         ]
         assert len(warning_results) > 0, "Many empty files should trigger a warning"
+
+
+# ---------------------------------------------------------------------------
+# AssetURLValidator: unreadable-file coverage diagnostics (issue #385, G10)
+# ---------------------------------------------------------------------------
+
+
+def _debug_events(logger_name: str):
+    """Return captured debug events for a BengalLogger by name."""
+    from bengal.utils.observability.logger import _loggers
+
+    if logger_name in _loggers:
+        return _loggers[logger_name].get_events()
+    return []
+
+
+def test_asset_url_validator_surfaces_skipped_unreadable_files(tmp_path):
+    """Unreadable HTML files must be counted as skipped, not silently dropped.
+
+    Regression for issue #385 (Finding 10): the validator used to ``continue``
+    on read failure with no counter, so it reported a clean pass over files it
+    never scanned. The skip count must surface in the CheckResult metadata and
+    a debug breadcrumb must be emitted.
+    """
+    from unittest.mock import Mock
+
+    from bengal.health.report import CheckStatus
+    from bengal.health.validators.asset_urls import AssetURLValidator
+    from bengal.utils.observability.logger import LogLevel, configure_logging, reset_loggers
+
+    reset_loggers()
+    configure_logging(level=LogLevel.DEBUG)
+
+    # A directory named like an HTML file is matched by rglob("*.html") but
+    # read_text() raises IsADirectoryError on it -> exercises the swallow.
+    (tmp_path / "broken.html").mkdir()
+    # A genuinely valid HTML file with no asset refs (clean otherwise).
+    (tmp_path / "ok.html").write_text("<html><body>no assets</body></html>")
+
+    site = Mock()
+    site.output_dir = tmp_path
+    site.baseurl = ""
+
+    validator = AssetURLValidator()
+    results = validator.validate(site)
+
+    # Success result must reflect the skipped count, not a misleading all-clear.
+    success = [r for r in results if r.code == "asset_urls_valid"]
+    assert success, "expected an asset_urls_valid result"
+    assert success[0].metadata.get("skipped") == 1
+    assert "skipped" in success[0].message
+    assert success[0].status == CheckStatus.SUCCESS
+
+    # A debug breadcrumb must have been emitted for the unreadable file.
+    messages = [e.message for e in _debug_events("bengal.health.validators.asset_urls")]
+    assert "asset_url_unreadable" in messages
+
+    reset_loggers()

--- a/tests/unit/health/validators/test_autodoc_validator.py
+++ b/tests/unit/health/validators/test_autodoc_validator.py
@@ -256,3 +256,60 @@ class TestAutodocValidatorDisabled:
         results = autodoc_validator.validate(site)
 
         assert results == []
+
+
+class TestAutodocPageTypeSkipDiagnostics:
+    """Unreadable autodoc pages must surface as skipped (issue #385, G10)."""
+
+    @staticmethod
+    def _debug_events(logger_name: str):
+        from bengal.utils.observability.logger import _loggers
+
+        if logger_name in _loggers:
+            return _loggers[logger_name].get_events()
+        return []
+
+    def test_unreadable_page_surfaces_skipped_count(
+        self, autodoc_validator: AutodocValidator, tmp_path: Path
+    ) -> None:
+        """A page that can't be read must increment a skip count and log a breadcrumb.
+
+        Regression for issue #385 (Finding 10): ``_check_page_types`` used to
+        ``pass`` on read failure, silently shrinking type-check coverage and
+        still reporting a clean result.
+        """
+        from unittest.mock import Mock
+
+        from bengal.health.report import CheckStatus
+        from bengal.utils.observability.logger import (
+            LogLevel,
+            configure_logging,
+            reset_loggers,
+        )
+
+        reset_loggers()
+        configure_logging(level=LogLevel.DEBUG)
+
+        # api/ prefix maps to expected_type "autodoc-python".
+        api_dir = tmp_path / "api" / "core"
+        api_dir.mkdir(parents=True)
+        # A directory named index.html is matched by rglob but read_text raises.
+        (api_dir / "index.html").mkdir()
+
+        site = Mock()
+        site.output_dir = tmp_path
+
+        results = autodoc_validator._check_page_types(site, ["api"])
+
+        # Coverage was reduced -> a warning surfaces the skip count rather than
+        # a clean/empty pass.
+        assert results, "expected a result surfacing the skipped page"
+        result = results[0]
+        assert result.status == CheckStatus.WARNING
+        assert result.metadata.get("skipped") == 1
+        assert "skipped" in result.message
+
+        messages = [e.message for e in self._debug_events("bengal.health.validators.autodoc")]
+        assert "page_type_check_unreadable" in messages
+
+        reset_loggers()

--- a/tests/unit/orchestration/test_content_url_claim_diagnostics.py
+++ b/tests/unit/orchestration/test_content_url_claim_diagnostics.py
@@ -1,0 +1,75 @@
+"""Diagnostics for URLRegistry claim failures in content output-path wiring.
+
+Regression for issue #385 (Finding 9): ``ContentOrchestrator._set_output_paths``
+used to swallow any ``url_registry.claim()`` failure with a bare ``pass`` and no
+trace. Detection is not lost (URLCollisionValidator backstops post-hoc), so this
+is purely an observability fix: the claim site must now emit a ``url_claim_failed``
+debug breadcrumb while the build still completes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from bengal.core.site import Site
+from bengal.orchestration.content import ContentOrchestrator
+
+
+@pytest.fixture
+def discovered_site():
+    """A minimal discovered site with at least one regular page."""
+    with TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        content_dir = root / "content"
+        content_dir.mkdir(parents=True)
+        (content_dir / "post.md").write_text("---\ntitle: Post\n---\n# Post")
+
+        site = Site(root_path=root, config={})
+        orchestrator = ContentOrchestrator(site)
+        orchestrator.discover()
+        yield site, orchestrator
+
+
+def _debug_events(logger_name: str = "bengal.orchestration.content"):
+    from bengal.utils.observability.logger import _loggers
+
+    if logger_name in _loggers:
+        return _loggers[logger_name].get_events()
+    return []
+
+
+def test_claim_failure_emits_debug_breadcrumb(discovered_site) -> None:
+    """A claim that raises must produce a url_claim_failed debug record."""
+    from bengal.utils.observability.logger import LogLevel, configure_logging, reset_loggers
+
+    site, orchestrator = discovered_site
+
+    reset_loggers()
+    configure_logging(level=LogLevel.DEBUG)
+
+    # Force claim() to raise for every page.
+    def boom(*args, **kwargs):
+        raise RuntimeError("synthetic claim failure")
+
+    site.url_registry.claim = boom  # type: ignore[method-assign]
+
+    # Re-run output-path assignment: clear any output_path set during discovery.
+    for page in site.pages:
+        page.output_path = None
+
+    # Must not raise -- the swallow keeps the build alive.
+    orchestrator._set_output_paths()
+
+    events = _debug_events()
+    failed = [e for e in events if e.message == "url_claim_failed"]
+    assert failed, "expected a url_claim_failed debug record"
+    assert failed[0].context.get("owner") == "content"
+    assert failed[0].context.get("error_type") == "RuntimeError"
+
+    # Output paths are still assigned despite the claim failure.
+    assert all(p.output_path is not None for p in site.pages)
+
+    reset_loggers()

--- a/tests/unit/rendering/template_functions/test_blog_views.py
+++ b/tests/unit/rendering/template_functions/test_blog_views.py
@@ -346,3 +346,55 @@ class TestFeaturedPostsFilter:
         result = featured_posts_filter(posts, limit=2)
 
         assert len(result) == 2
+
+
+class TestPostsFilterSkipDiagnostics:
+    """A page that fails PostView.from_page must log, not vanish silently (#385)."""
+
+    def test_failed_conversion_emits_debug_breadcrumb(self) -> None:
+        """posts_filter swallows conversion errors but now leaves a breadcrumb.
+
+        Regression for issue #385 (Finding 11): a post that fails to convert
+        used to be silently omitted from the listing ("mysteriously missing"),
+        with no diagnostic. The skip must now emit a post_view_skipped debug.
+        """
+        from bengal.utils.observability.logger import (
+            LogLevel,
+            configure_logging,
+            reset_loggers,
+        )
+
+        reset_loggers()
+        configure_logging(level=LogLevel.DEBUG)
+
+        class ExplodingPage:
+            @property
+            def metadata(self):
+                raise RuntimeError("synthetic metadata failure")
+
+        good = MagicMock()
+        good.title = "Good Post"
+        good.href = "/blog/good/"
+        good.date = None
+        good.metadata = {}
+        good.params = {}
+        good.excerpt = ""
+        good.reading_time = 3
+        good.word_count = 500
+        good.tags = []
+        good.draft = False
+        good.excerpt_words = None
+
+        result = posts_filter([ExplodingPage(), good])
+
+        # The bad page is dropped; the good one survives.
+        assert len(result) == 1
+        assert result[0].title == "Good Post"
+
+        from bengal.utils.observability.logger import _loggers
+
+        events = _loggers.get("bengal.rendering.template_functions.blog")
+        messages = [e.message for e in events.get_events()] if events else []
+        assert "post_view_skipped" in messages
+
+        reset_loggers()

--- a/tests/unit/server/test_dev_server_palette_diagnostics.py
+++ b/tests/unit/server/test_dev_server_palette_diagnostics.py
@@ -1,0 +1,47 @@
+"""Dev-server palette-rebuild swallow must emit a diagnostic (issue #385, G10).
+
+Regression for Finding 11: ``DevServer._set_active_palette`` used to ``pass`` on
+failure, so dev-preview styling could be wrong with no signal -- even though the
+sibling ``_clear_html_cache_after_build`` already logs the same failure class.
+The palette path must now emit ``rebuilding_page_palette_failed``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from bengal.server.dev_server import DevServer
+
+
+def _debug_events(logger_name: str = "bengal.server.dev_server"):
+    from bengal.utils.observability.logger import _loggers
+
+    if logger_name in _loggers:
+        return _loggers[logger_name].get_events()
+    return []
+
+
+def test_palette_set_failure_emits_debug_breadcrumb() -> None:
+    """A failure while setting the active palette must be logged, not swallowed."""
+    from bengal.utils.observability.logger import LogLevel, configure_logging, reset_loggers
+
+    reset_loggers()
+    configure_logging(level=LogLevel.DEBUG)
+
+    # Build a bare DevServer instance without running its heavy __init__.
+    server = DevServer.__new__(DevServer)
+    site = Mock()
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("synthetic config failure")
+
+    site.config.get = boom
+    server.site = site
+
+    # Must not raise -- the swallow keeps the dev server alive.
+    server._set_active_palette()
+
+    messages = [e.message for e in _debug_events()]
+    assert "rebuilding_page_palette_failed" in messages
+
+    reset_loggers()


### PR DESCRIPTION
Adds inline reasons and `logger.debug` breadcrumbs to the bare `noqa: S110`/`S112` exception swallows under `bengal/`, per the constitution anti-pattern (AGENTS.md, `pyproject.toml` S110/S112 config). The two health validators that previously shrank their own coverage and still reported a clean pass now surface a nonzero skip count. A pre-commit guard is extended to require a reason on every such swallow so the bare-swallow pattern cannot re-accrue. Happy-path output is byte-stable.

## What changed
- `health/validators/asset_urls.py`: count skipped unreadable HTML files, log `asset_url_unreadable`, and surface the skip count in the `asset_urls_valid` CheckResult message + metadata instead of a false all-clear.
- `health/validators/autodoc.py`: add a module logger; `_check_page_types` now counts skipped unreadable pages, logs `page_type_check_unreadable`, and emits a WARNING (with `skipped` metadata) rather than a clean/empty pass when coverage was reduced.
- `rendering/template_functions/blog.py`: add a module logger; `posts_filter` logs `post_view_skipped` when a page fails `PostView.from_page` (a "mysteriously missing" post is now diagnosable).
- `orchestration/content.py`: the `URLRegistry.claim()` swallow now logs `url_claim_failed` (URLCollisionValidator still backstops detection); diff kept to the swallow site only.
- `server/dev_server.py`: the palette-rebuild swallow emits `rebuilding_page_palette_failed`, paralleling the sibling `html_cache_clear_failed`.
- Remaining bare sites (`config/env_overrides.py`, `cache/paths.py`, `snapshots/scheduling.py`, `snapshots/templates.py`, `core/asset/asset_core.py`, `cli/milo_commands/build.py`, `content/versioning/artifacts.py`, `errors/suggestions.py`, `orchestration/build/__init__.py`, `orchestration/render/block_cache.py`, `rendering/template_context_validation.py`, `utils/dx/hints.py`, `utils/observability/cli_progress.py`): add one-line reason comments in the same-line `finalization.py` style.
- `scripts/check_silent_suppress.py`: extended to require a justification on every `noqa: S110`/`S112` in `bengal/` (alongside the existing `contextlib.suppress` rule); `prek.toml` hook name updated. Verified the guard discriminates (flags only bare sites).
- Unit tests for the four highest-impact sites assert the diagnostic / skip count and fail if the swallow is reintroduced.

Closes #385

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Observability-only additions (reason comments + logger.debug on cold error paths); happy-path output byte-stable, no perf delta.
