### PR TITLE
feat(server): serve-ability smoke check, live HTTP test fixture, hidden-buffer guard

### DIFF
--- a/bengal/assets/manifest.py
+++ b/bengal/assets/manifest.py
@@ -417,3 +417,41 @@ def inspect_asset_outputs(output_dir: Path, *, sample_limit: int = 5) -> AssetOu
         missing_count=missing_count,
         missing_outputs=tuple(missing_outputs),
     )
+
+
+def select_smoke_probe_asset(output_dir: Path) -> str | None:
+    """Pick a known, on-disk asset URL to probe the dev server's serve path.
+
+    Used by the dev-server serve-ability smoke check (#398): we want a request
+    path that *must* return 200 against the real serving setup. Prefers a CSS
+    entry from ``asset-manifest.json`` (the canonical #392 symptom was CSS
+    404ing), then any manifest entry whose output file is present on disk.
+
+    Returns a URL path (leading ``/``, e.g. ``/assets/css/style.css``) suitable
+    for an HTTP GET, or ``None`` when no manifest entry can be resolved to an
+    existing file. Callers fall back to probing ``index.html`` in that case.
+    """
+    manifest = AssetManifest.load(output_dir / "asset-manifest.json")
+    if manifest is None:
+        return None
+
+    css_candidate: str | None = None
+    first_candidate: str | None = None
+    for entry in manifest.entries.values():
+        output_path = entry.output_path
+        if not output_path:
+            continue
+        try:
+            on_disk = (output_dir / output_path).is_file()
+        except OSError:
+            on_disk = False
+        if not on_disk:
+            continue
+        url = "/" + output_path.lstrip("/")
+        if first_candidate is None:
+            first_candidate = url
+        if output_path.lower().endswith(".css"):
+            css_candidate = url
+            break
+
+    return css_candidate or first_candidate

--- a/bengal/server/backend.py
+++ b/bengal/server/backend.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 
     from pounce.server import Server
 
+    from bengal.server.serve_probe import ProbeResult
+
 
 class ServerBackend(Protocol):
     """Protocol for dev server HTTP backends (Pounce ASGI, legacy: TCPServer)."""
@@ -100,6 +102,33 @@ def create_pounce_backend(
     )
     server = Server(config, app)
     return PounceBackend(server, port)
+
+
+def probe_backend_serve_ability(
+    backend: ServerBackend,
+    *,
+    host: str,
+    serving_dir: Path,
+    attempts: int = 20,
+    retry_interval: float = 0.15,
+) -> ProbeResult:
+    """Run a serve-ability smoke probe against a listening backend (#398).
+
+    Verifies that a known asset is actually reachable over HTTP from the backend's
+    port, against the real serving setup (ASGI app + active buffer). The probe
+    retries connection failures so it can be fired right after the server thread
+    starts (coordinating with backend readiness), but treats any HTTP response
+    other than 200/304 as a hard serve-path failure.
+    """
+    from bengal.server.serve_probe import probe_serve_ability
+
+    return probe_serve_ability(
+        host=host,
+        port=backend.port,
+        serving_dir=serving_dir,
+        attempts=attempts,
+        retry_interval=retry_interval,
+    )
 
 
 def create_pounce_preview_backend(

--- a/bengal/server/buffer_manager.py
+++ b/bengal/server/buffer_manager.py
@@ -38,6 +38,24 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _hidden_path_component(directory: Path) -> str | None:
+    """Return the first hidden (dot-prefixed) component of a resolved path, or None.
+
+    ``.well-known`` is exempt: it is a hidden directory the static handler is
+    expected to serve. Mirrors the detection in ``asgi_app._has_hidden_path_component``
+    so the construction-time guard (#400) and the request-time serving fallback
+    (#392) agree on what "hidden" means.
+    """
+    try:
+        resolved = directory.resolve()
+    except OSError:
+        resolved = directory
+    for part in resolved.parts:
+        if part.startswith(".") and part not in {".", "..", ".well-known"}:
+            return part
+    return None
+
+
 class BufferManager:
     """Thread-safe double-buffer manager with in-process reference swap."""
 
@@ -60,6 +78,42 @@ class BufferManager:
         """Create buffer directories if they don't exist."""
         for d in self._dirs:
             d.mkdir(parents=True, exist_ok=True)
+        self._warn_on_hidden_buffer_paths()
+
+    def _warn_on_hidden_buffer_paths(self) -> None:
+        """Pin the hidden-path serving constraint at the integration boundary (#400).
+
+        Pounce's static handler rejects any path whose resolved absolute path
+        contains a hidden (dot-prefixed) component — see ``pounce/_static.py``
+        ``_resolve_file`` and upstream lbliii/pounce#74. The dev server's default
+        staging buffer lives under ``<root>/.bengal/staging``, a hidden directory,
+        so when that buffer is active Pounce 404s every asset under it. #392 works
+        around this by routing those requests through Bengal's own ``_serve_static``,
+        but the underlying constraint is invisible three layers from the cause.
+
+        This surfaces the constraint loudly at buffer construction so a future
+        change that introduces a *new* hidden serving path fails visibly here
+        rather than as mysterious runtime 404s. We log (not raise) because the
+        #392 mitigation keeps serving working; Part 2 (relocating the staging
+        buffer off ``.bengal/``) is upstream-gated on pounce#74.
+        """
+        for label, directory in (("active", self._dirs[0]), ("staging", self._dirs[1])):
+            hidden = _hidden_path_component(directory)
+            if hidden is not None:
+                logger.warning(
+                    "buffer_path_hidden_component",
+                    buffer=label,
+                    path=str(directory),
+                    hidden_component=hidden,
+                    ref="lbliii/pounce#74",
+                    hint=(
+                        "Buffer path contains a hidden (dot-prefixed) component that "
+                        "Pounce's static handler rejects; asset requests for this buffer "
+                        "fall back to bengal's _serve_static (#392 mitigation) instead of "
+                        "the fast Pounce static path. Relocating off .bengal/ (#400 Part 2) "
+                        "is gated on upstream pounce#74."
+                    ),
+                )
 
     @property
     def active_dir(self) -> Path:

--- a/bengal/server/dev_server.py
+++ b/bengal/server/dev_server.py
@@ -294,6 +294,17 @@ class DevServer:
                 server_thread = threading.Thread(target=_run_server, daemon=True)
                 server_thread.start()
 
+                # Serve-ability smoke check (#398): assert a known asset is actually
+                # reachable over HTTP now that the server is listening, before the
+                # user's first request. Catches the #392 hidden-buffer 404 class.
+                if server_error[0] is None and not self._run_serve_probe(actual_port):
+                    backend.shutdown()
+                    raise BengalServerError(
+                        "Dev server cannot serve assets over HTTP (see diagnostics above)",
+                        code=ErrorCode.S005,
+                        suggestion="See #392 / lbliii/pounce#74 for the hidden-buffer serve-path failure.",
+                    )
+
                 # Run validation build in foreground (shows progress)
                 self._run_validation_build(BuildProfile.WRITER, actual_port)
 
@@ -400,6 +411,19 @@ class DevServer:
                 elif watcher_runner is not None:
                     watcher_runner.start()
                     logger.info("file_watcher_started", watch_dirs=self._get_watched_directories())
+
+                # Serve-ability smoke check (#398). backend.start() blocks below, so
+                # run the probe from a daemon thread; it retries until the server is
+                # listening, then fails loudly + shuts down on a serve-path failure.
+                def _probe_when_ready() -> None:
+                    if not self._run_serve_probe(actual_port):
+                        backend.shutdown()
+
+                threading.Thread(
+                    target=_probe_when_ready,
+                    name="bengal-serve-probe",
+                    daemon=True,
+                ).start()
 
                 # Run until interrupted
                 try:
@@ -1283,6 +1307,71 @@ class DevServer:
             self._request_callback_holder[0] = _log_request
 
         cli.request_log_header()
+
+    def _run_serve_probe(self, port: int) -> bool:
+        """Verify a known asset is reachable over HTTP once the server is listening.
+
+        Serve-ability smoke check (#398): the build can produce perfect output on
+        disk that is nonetheless unreachable over HTTP (the #392 / pounce#74
+        hidden-buffer 404). This probes the *real* serving setup — the ASGI app
+        plus the active buffer — for a known asset (manifest entry, falling back
+        to ``index.html``) and returns whether it returned 200.
+
+        On failure it fails LOUDLY: the buffer path, serving dir, and reason are
+        surfaced via the CLI and the logger instead of leaking out as silent
+        404s. Returns True when the probe passed (or could not be evaluated), and
+        False when a definitive serve-path failure was detected.
+
+        The probe retries connection errors so it coordinates with backend
+        readiness — only a real HTTP response other than 200/304 is treated as a
+        failure.
+        """
+        from bengal.server.serve_probe import format_probe_failure, probe_serve_ability
+
+        serving_dir = self._buffer_manager.active_dir
+        staging_dir = self._buffer_manager.staging_dir
+        result = probe_serve_ability(self.host, port, serving_dir)
+
+        if result.ok:
+            logger.info(
+                "serve_probe_passed",
+                url=result.url,
+                status=result.status,
+                serving_dir=str(serving_dir),
+            )
+            return True
+
+        if result.status is None:
+            # No HTTP response after retries: the server isn't listening (e.g. it
+            # failed to bind, or this is a non-serving test harness). That is a
+            # *startup* failure surfaced by the server thread's own error path, not
+            # a serve-path bug — warn but don't abort on the probe's account.
+            logger.warning(
+                "serve_probe_no_response",
+                url=result.url,
+                reason=result.reason,
+                serving_dir=str(serving_dir),
+            )
+            return True
+
+        message = format_probe_failure(result, serving_dir=serving_dir, staging_dir=staging_dir)
+        logger.error(
+            "serve_probe_failed",
+            error_code=ErrorCode.S005.name,
+            url=result.url,
+            status=result.status,
+            reason=result.reason,
+            serving_dir=str(serving_dir),
+            staging_dir=str(staging_dir),
+            ref="#392",
+        )
+        cli = get_cli_output()
+        cli.blank()
+        first, *rest = message.splitlines()
+        cli.error(first)
+        for line in rest:
+            cli.raw(line, stream="stderr", level=None)
+        return False
 
     def _wait_for_server_ready(self, port: int, timeout_sec: float = 10.0) -> bool:
         """

--- a/bengal/server/serve_probe.py
+++ b/bengal/server/serve_probe.py
@@ -1,0 +1,150 @@
+"""Serve-ability smoke check for the dev server (#398).
+
+Bengal's build-time checks (``bengal.health``, ``inspect_asset_outputs``) verify
+that output *bytes exist on disk* — they never verify those outputs are actually
+*reachable over HTTP* from the running dev server. The hidden-buffer bug (#392,
+upstream lbliii/pounce#74) is the canonical failure: the CSS was on disk in both
+buffers, the build was perfect, yet ~half of asset requests 404'd because the
+active buffer (``.bengal/staging``) could not be served. Nothing caught it until
+a user saw an unstyled page.
+
+This module shifts that check left: once the server is listening, request a known
+asset (chosen from ``asset-manifest.json``, falling back to ``index.html``) against
+the *real* serving setup and assert it returns 200. On failure we fail startup
+loudly with the buffer path, the serving directory, and the reason — instead of
+letting users discover it as silent 404s.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from bengal.assets.manifest import select_smoke_probe_asset
+from bengal.utils.observability.logger import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = get_logger(__name__)
+
+# Fallback probe target when no manifest asset can be resolved. ``index.html`` is
+# always present once a build has produced servable output.
+_FALLBACK_PROBE_PATH = "/"
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeResult:
+    """Outcome of a serve-ability smoke probe."""
+
+    ok: bool
+    url: str
+    probe_path: str
+    status: int | None
+    reason: str | None = None
+
+
+def choose_probe_path(serving_dir: Path) -> str:
+    """Return the URL path to probe for serve-ability.
+
+    Prefers a known asset from the manifest (the #392 symptom was asset 404s);
+    falls back to ``"/"`` (``index.html``) when the manifest is empty or none of
+    its entries resolve to an on-disk file.
+    """
+    asset_path = select_smoke_probe_asset(serving_dir)
+    return asset_path if asset_path else _FALLBACK_PROBE_PATH
+
+
+def probe_serve_ability(
+    host: str,
+    port: int,
+    serving_dir: Path,
+    *,
+    timeout: float = 5.0,
+    attempts: int = 20,
+    retry_interval: float = 0.15,
+) -> ProbeResult:
+    """Issue an HTTP GET for a known asset and verify it returns 200.
+
+    Coordinates with backend readiness by retrying connection errors (the server
+    thread may still be binding) up to ``attempts`` times; a non-200 *response*
+    is treated as a hard failure immediately — that is a serve-path bug, not a
+    not-yet-listening race.
+
+    Args:
+        host: Server bind host.
+        port: Server port.
+        serving_dir: The active buffer the ASGI app serves from. Used to choose
+            the probe target and reported in diagnostics.
+        timeout: Per-request timeout in seconds.
+        attempts: Max connection attempts while the server comes up.
+        retry_interval: Seconds to sleep between connection retries.
+
+    Returns:
+        A :class:`ProbeResult`. ``ok`` is True only when the probe got a 200/304.
+    """
+    probe_path = choose_probe_path(serving_dir)
+    probe_host = "localhost" if host in {"", "0.0.0.0", "::", "::1"} else host  # noqa: S104
+    url = f"http://{probe_host}:{port}{probe_path}"
+
+    last_reason: str | None = None
+    for _attempt in range(max(1, attempts)):
+        try:
+            with urlopen(Request(url, method="GET"), timeout=timeout) as resp:
+                status = resp.status
+                if status in (200, 304):
+                    logger.debug("serve_probe_ok", url=url, status=status)
+                    return ProbeResult(ok=True, url=url, probe_path=probe_path, status=status)
+                return ProbeResult(
+                    ok=False,
+                    url=url,
+                    probe_path=probe_path,
+                    status=status,
+                    reason=f"server returned HTTP {status} for a known asset",
+                )
+        except HTTPError as exc:
+            # An HTTP error status (e.g. 404) is a definitive serve-path failure —
+            # the canonical #392 symptom is a 404 for a file present on disk.
+            return ProbeResult(
+                ok=False,
+                url=url,
+                probe_path=probe_path,
+                status=exc.code,
+                reason=f"server returned HTTP {exc.code} for a known asset",
+            )
+        except (URLError, OSError) as exc:
+            # Connection refused / reset: server may still be binding. Retry.
+            last_reason = str(getattr(exc, "reason", exc) or exc)
+            time.sleep(retry_interval)
+
+    return ProbeResult(
+        ok=False,
+        url=url,
+        probe_path=probe_path,
+        status=None,
+        reason=f"could not connect to server: {last_reason}",
+    )
+
+
+def format_probe_failure(result: ProbeResult, *, serving_dir: Path, staging_dir: Path) -> str:
+    """Build a loud, actionable failure message for a failed serve probe.
+
+    References #392 / pounce#74, the canonical serve-path failure where assets
+    are present on disk but 404 because the active buffer lives under a hidden
+    (dot-prefixed) directory that Pounce's static handler rejects.
+    """
+    return (
+        "Dev server serve-ability smoke check FAILED.\n"
+        f"  probe URL:    {result.url}\n"
+        f"  HTTP status:  {result.status if result.status is not None else 'no response'}\n"
+        f"  reason:       {result.reason}\n"
+        f"  serving dir:  {serving_dir}\n"
+        f"  staging dir:  {staging_dir}\n"
+        "The build wrote output to disk but it is not reachable over HTTP. This is the "
+        "serve-path failure class from #392 (upstream lbliii/pounce#74): assets can be "
+        "present on disk yet 404 when the active buffer lives under a hidden (dot-prefixed) "
+        "directory the static handler rejects."
+    )

--- a/changelog.d/398.added.md
+++ b/changelog.d/398.added.md
@@ -1,0 +1,1 @@
+The dev server now runs an HTTP serve-ability smoke check at startup (#398): once the server is listening it requests a known asset against the real serving setup and fails loudly with the buffer path, serving directory, and reason if it does not return 200, catching the #392-class serve-path failures before the first user request.

--- a/changelog.d/399.added.md
+++ b/changelog.d/399.added.md
@@ -1,0 +1,1 @@
+Added a live `bengal serve` HTTP integration test (#399) that boots a real dev-server subprocess on a temp site, drives concurrent content/CSS edits while continuously fetching referenced CSS/JS/favicon assets, asserts they stay reachable across rebuilds and buffer swaps, and verifies a broken save preserves the last-good output.

--- a/changelog.d/400.added.md
+++ b/changelog.d/400.added.md
@@ -1,0 +1,1 @@
+The dev server's double-buffer manager now warns loudly at construction when a served buffer path contains a hidden (dot-prefixed) component (#400), pinning the Pounce static-handler constraint (lbliii/pounce#74) at the integration boundary so a future hidden serving path fails visibly instead of as mysterious runtime 404s.

--- a/tests/integration/test_live_dev_server_http.py
+++ b/tests/integration/test_live_dev_server_http.py
@@ -1,0 +1,296 @@
+"""Live ``bengal serve`` HTTP integration test (#399).
+
+Self-contained: this module does NOT share fixtures with the mocked, in-process
+``test_dev_server_buffer_manifest.py`` — that test drove ``BufferManager`` +
+``Site.build`` directly and is exactly why it missed the hidden-buffer 404 bug
+(#392). Here we boot a *real* ``bengal serve`` subprocess on a temp site with
+static assets and exercise the actual ASGI serve path over HTTP.
+
+The test:
+- Boots ``bengal serve`` on a temp site with CSS/JS/favicon assets.
+- Uses a found free port (no fixed port → no CI conflicts) and probes
+  ``localhost`` (the server may bind IPv6 ``::1``).
+- Drives rapid concurrent content + CSS edits while continuously GETting the
+  referenced assets, asserting they return 200 throughout (pre-#392 fix: ~53%
+  of CSS requests 404'd; post-fix: 0%).
+- Asserts a broken save preserves the last-good served output (negative control).
+
+Config sets ``assets.fingerprint = false`` to match dev (``_prepare_dev_config``
+forces this anyway), so assets serve at stable URLs like ``/assets/css/style.css``.
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Generous readiness window: a cold first build on CI can be slow.
+_READY_TIMEOUT_SEC = 90.0
+_READY_POLL_INTERVAL = 0.25
+
+
+def _find_free_port() -> int:
+    """Bind an ephemeral port, then release it so the server can claim it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _bengal_executable() -> str:
+    """Resolve the ``bengal`` console script next to the running interpreter.
+
+    ``python -m bengal.cli.milo_app`` does not invoke the CLI (no ``__main__``
+    guard), so we run the installed console script from the same venv bin dir as
+    ``sys.executable``; fall back to bare ``bengal`` on PATH.
+    """
+    bin_dir = Path(sys.executable).parent
+    candidate = bin_dir / "bengal"
+    if candidate.exists():
+        return str(candidate)
+    return "bengal"
+
+
+def _http_get(url: str, *, timeout: float = 5.0) -> tuple[int, bytes]:
+    """GET a URL, returning (status, body). HTTP error statuses are returned, not raised."""
+    try:
+        with urlopen(Request(url, method="GET"), timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except HTTPError as exc:
+        return exc.code, b""
+
+
+def _make_site(root: Path) -> None:
+    """Write a minimal temp site with content + CSS/JS/favicon assets."""
+    (root / "content").mkdir(parents=True, exist_ok=True)
+    (root / "assets" / "css").mkdir(parents=True, exist_ok=True)
+    (root / "assets" / "js").mkdir(parents=True, exist_ok=True)
+
+    (root / "bengal.toml").write_text(
+        "\n".join(
+            [
+                "[site]",
+                'title = "Live Serve Test"',
+                "",
+                "[assets]",
+                "fingerprint = false",
+                "minify = false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (root / "content" / "index.md").write_text(
+        "---\ntitle: Home\n---\n\n# Heading\n\nLIVE_SERVE_MARKER body text.\n",
+        encoding="utf-8",
+    )
+    (root / "assets" / "css" / "style.css").write_text(
+        "body { color: rebeccapurple; }\n", encoding="utf-8"
+    )
+    (root / "assets" / "js" / "app.js").write_text('console.log("live");\n', encoding="utf-8")
+    (root / "assets" / "favicon.ico").write_text("FAVICON", encoding="utf-8")
+
+
+@contextmanager
+def _live_server(root: Path, port: int) -> Iterator[str]:
+    """Boot ``bengal serve`` as a subprocess; yield the base URL; tear down cleanly."""
+    proc = subprocess.Popen(
+        [
+            _bengal_executable(),
+            "serve",
+            "--source",
+            str(root),
+            "--host",
+            "localhost",
+            "--port",
+            str(port),
+            "--no-open-browser",
+            "--no-auto-port",
+            "--style",
+            "ci",
+        ],
+        cwd=str(root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    base_url = f"http://localhost:{port}"
+    try:
+        _wait_until_ready(proc, base_url)
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+def _wait_until_ready(proc: subprocess.Popen, base_url: str) -> None:
+    """Poll the root URL until the server answers 200/304 or we time out."""
+    deadline = time.monotonic() + _READY_TIMEOUT_SEC
+    last_err: str = "no response"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            output = proc.stdout.read() if proc.stdout else ""
+            raise AssertionError(f"bengal serve exited early (rc={proc.returncode}):\n{output}")
+        try:
+            with urlopen(Request(base_url + "/", method="GET"), timeout=3) as resp:
+                if resp.status in (200, 304):
+                    return
+                last_err = f"status {resp.status}"
+        except HTTPError as exc:
+            last_err = f"http {exc.code}"
+        except (URLError, OSError) as exc:
+            last_err = str(getattr(exc, "reason", exc) or exc)
+        time.sleep(_READY_POLL_INTERVAL)
+    raise AssertionError(f"bengal serve never became ready ({last_err})")
+
+
+def _wait_for_content(base_url: str, marker: bytes, *, timeout: float = 60.0) -> bytes:
+    """Poll the home page until it contains ``marker``, returning that body.
+
+    On boot the dev server may serve a transient "Rebuilding" placeholder while
+    the background completion build finishes; this waits for the real rendered
+    content so callers establish a stable last-good baseline.
+    """
+    deadline = time.monotonic() + timeout
+    last_body = b""
+    while time.monotonic() < deadline:
+        status, body = _http_get(base_url + "/")
+        if status == 200 and marker in body:
+            return body
+        last_body = body
+        time.sleep(0.25)
+    raise AssertionError(
+        f"home page never rendered marker {marker!r}; last body head: {last_body[:200]!r}"
+    )
+
+
+def _extract_asset_urls(html: str) -> list[str]:
+    """Return same-origin CSS/JS asset URLs referenced by the rendered HTML."""
+    matches = re.finditer(r'(?:href|src)="(/assets/[^"]+\.(?:css|js))"', html)
+    urls = [match.group(1) for match in matches]
+    # De-duplicate, preserve order.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for url in urls:
+        if url not in seen:
+            seen.add(url)
+            ordered.append(url)
+    return ordered
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+class TestLiveDevServerHTTP:
+    """Live HTTP serve-path regression coverage (#399)."""
+
+    def test_referenced_assets_stay_200_under_concurrent_edits(self, tmp_path: Path) -> None:
+        root = tmp_path / "live_site"
+        _make_site(root)
+        port = _find_free_port()
+
+        with _live_server(root, port) as base_url:
+            # Wait for the real rendered home page (not the boot "Rebuilding" page)
+            # so the asset references we extract are the genuine ones.
+            body = _wait_for_content(base_url, b"LIVE_SERVE_MARKER")
+
+            asset_urls = _extract_asset_urls(body.decode("utf-8", errors="replace"))
+            # Pull the home CSS reference explicitly so we always probe a CSS asset
+            # (the canonical #392 symptom). The default theme links its own CSS.
+            assert asset_urls, "rendered HTML should reference at least one CSS/JS asset"
+
+            # Sanity: each referenced asset serves 200 before we start churning.
+            for url in asset_urls:
+                code, _ = _http_get(base_url + url)
+                assert code == 200, f"asset {url} should be 200 before edits"
+
+            failures: list[tuple[str, int]] = []
+            stop = threading.Event()
+
+            def hammer_assets() -> None:
+                while not stop.is_set():
+                    for url in asset_urls:
+                        code, _ = _http_get(base_url + url, timeout=5.0)
+                        # 200 (served) or 304 (not modified) are both fine. Anything
+                        # else — notably 404 for an on-disk asset — is a serve-path bug.
+                        if code not in (200, 304):
+                            failures.append((url, code))
+                    time.sleep(0.02)
+
+            hammer = threading.Thread(target=hammer_assets, daemon=True)
+            hammer.start()
+
+            css_src = root / "assets" / "css" / "style.css"
+            content_src = root / "content" / "index.md"
+            try:
+                for i in range(8):
+                    css_src.write_text(
+                        f"body {{ color: rgb({i * 10 % 255}, 0, 0); }}\n", encoding="utf-8"
+                    )
+                    content_src.write_text(
+                        f"---\ntitle: Home\n---\n\n# Heading {i}\n\nLIVE_SERVE_MARKER edit {i}.\n",
+                        encoding="utf-8",
+                    )
+                    time.sleep(0.4)
+                # Let the hammer observe the final swapped state.
+                time.sleep(1.5)
+            finally:
+                stop.set()
+                hammer.join(timeout=10)
+
+            assert not failures, (
+                "assets must stay reachable across rebuilds/buffer swaps; "
+                f"got non-200 responses: {failures[:10]}"
+            )
+
+    def test_broken_save_preserves_last_good_output(self, tmp_path: Path) -> None:
+        root = tmp_path / "broken_site"
+        _make_site(root)
+        port = _find_free_port()
+
+        with _live_server(root, port) as base_url:
+            # Establish a stable last-good baseline (wait past the boot placeholder).
+            good_body = _wait_for_content(base_url, b"LIVE_SERVE_MARKER")
+            assert b"LIVE_SERVE_MARKER" in good_body
+
+            # Trigger a save that makes the rebuild *fail*: corrupt bengal.toml so
+            # the next build cannot even construct the Site (S003 config parse
+            # error). Bengal tolerates most malformed content, so a config break is
+            # the reliable way to exercise the build-failure path. The dev server
+            # must keep serving the last-good output rather than dropping to a
+            # broken/blank/5xx page.
+            (root / "bengal.toml").write_text(
+                "this is not valid toml = = = [[[\n", encoding="utf-8"
+            )
+            time.sleep(4.0)
+
+            # Across several polls the server must stay 200 and never serve a page
+            # that lost the last-good content.
+            for _ in range(5):
+                status_after, body_after = _http_get(base_url + "/")
+                assert status_after == 200, "server must keep serving after a broken save"
+                assert b"LIVE_SERVE_MARKER" in body_after, (
+                    "broken save must preserve last-good output, not serve a broken page"
+                )
+                time.sleep(0.3)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/server/test_buffer_manager.py
+++ b/tests/unit/server/test_buffer_manager.py
@@ -277,3 +277,66 @@ class TestBufferManager:
         assert (mgr.active_dir / "index.html").read_text() == "<html>v2</html>"
         # Old buffer still has v1
         assert (mgr.staging_dir / "index.html").read_text() == "<html>v1</html>"
+
+
+class TestHiddenBufferGuard:
+    """Hidden-path constraint guard at the integration boundary (#400)."""
+
+    def test_hidden_path_component_detects_dot_bengal(self, tmp_path: Path) -> None:
+        from bengal.server.buffer_manager import _hidden_path_component
+
+        staging = tmp_path / ".bengal" / "staging"
+        assert _hidden_path_component(staging) == ".bengal"
+
+    def test_hidden_path_component_none_for_plain_path(self, tmp_path: Path) -> None:
+        from bengal.server.buffer_manager import _hidden_path_component
+
+        # tmp_path itself must not be under a hidden dir for this assertion to hold.
+        public = tmp_path / "public"
+        assert _hidden_path_component(public) is None
+
+    def test_hidden_path_component_exempts_well_known(self, tmp_path: Path) -> None:
+        from bengal.server.buffer_manager import _hidden_path_component
+
+        wk = tmp_path / ".well-known"
+        assert _hidden_path_component(wk) is None
+
+    def test_setup_warns_loudly_on_hidden_staging_buffer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import bengal.server.buffer_manager as bm
+
+        calls: list[tuple[str, dict]] = []
+
+        def _capture_warning(event: str, **kwargs: object) -> None:
+            calls.append((event, kwargs))
+
+        # bm.logger is a LazyLogger proxy; patch the resolved BengalLogger.
+        monkeypatch.setattr(bm.logger._logger, "warning", _capture_warning)
+
+        mgr = BufferManager.for_dev_server(
+            output_dir=tmp_path / "public",
+            staging_dir=tmp_path / ".bengal" / "staging",
+        )
+        mgr.setup()
+
+        hidden_warnings = [c for c in calls if c[0] == "buffer_path_hidden_component"]
+        # Exactly the staging buffer (under .bengal) is hidden; public is not.
+        assert len(hidden_warnings) == 1
+        _event, kwargs = hidden_warnings[0]
+        assert kwargs["buffer"] == "staging"
+        assert kwargs["hidden_component"] == ".bengal"
+        assert kwargs["ref"] == "lbliii/pounce#74"
+
+    def test_setup_no_warning_for_plain_buffers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import bengal.server.buffer_manager as bm
+
+        calls: list[str] = []
+        monkeypatch.setattr(bm.logger._logger, "warning", lambda event, **_kw: calls.append(event))
+
+        mgr = BufferManager(dir_a=tmp_path / "a", dir_b=tmp_path / "b")
+        mgr.setup()
+
+        assert "buffer_path_hidden_component" not in calls

--- a/tests/unit/server/test_dev_server_live_reload.py
+++ b/tests/unit/server/test_dev_server_live_reload.py
@@ -44,6 +44,7 @@ class TestDevServerContentHashCacheSeeding:
             patch.object(DevServer, "_has_cached_output", return_value=False),
             patch.object(DevServer, "_prepare_dev_config", return_value=False),
             patch.object(DevServer, "_create_server") as mock_create,
+            patch.object(DevServer, "_run_serve_probe", return_value=True),
             patch.object(DevServer, "_create_watcher") as mock_create_watcher,
             patch.object(DevServer, "_init_reload_controller"),
             patch.object(DevServer, "_start_background_completion_build") as mock_background,
@@ -134,6 +135,7 @@ class TestDevServerContentHashCacheSeeding:
             patch.object(DevServer, "_prepare_dev_config", return_value=False),
             patch.object(DevServer, "_run_build_via_executor", return_value=stats) as mock_build,
             patch.object(DevServer, "_create_server") as mock_create,
+            patch.object(DevServer, "_run_serve_probe", return_value=True),
             patch.object(DevServer, "_create_watcher") as mock_create_watcher,
             patch.object(DevServer, "_init_reload_controller"),
             patch.object(DevServer, "_start_background_completion_build") as mock_background,
@@ -194,6 +196,7 @@ class TestDevServerServeFirstWatcherOrder:
             patch.object(DevServer, "_has_cached_output", return_value=True),
             patch.object(DevServer, "_prepare_dev_config", return_value=False),
             patch.object(DevServer, "_create_server") as mock_create,
+            patch.object(DevServer, "_run_serve_probe", return_value=True),
             patch.object(DevServer, "_create_watcher") as mock_create_watcher,
             patch.object(DevServer, "_run_validation_build", tracked_validation),
             patch(
@@ -237,6 +240,7 @@ class TestDevServerServeFirstWatcherOrder:
             patch.object(DevServer, "_run_build_via_executor", return_value=stats) as mock_build,
             patch.object(DevServer, "_run_validation_build") as mock_validation,
             patch.object(DevServer, "_create_server") as mock_create,
+            patch.object(DevServer, "_run_serve_probe", return_value=True),
             patch.object(DevServer, "_init_reload_controller"),
             patch(
                 "bengal.server.dev_server.PIDManager.get_pid_file", return_value=tmp_path / "pid"

--- a/tests/unit/server/test_serve_probe.py
+++ b/tests/unit/server/test_serve_probe.py
@@ -1,0 +1,182 @@
+"""Unit tests for the dev-server serve-ability smoke check (#398).
+
+Covers asset selection from the manifest, the HTTP probe decision logic
+(200 passes, 404 fails loudly, empty manifest falls back to index), and the
+loud failure-message formatting that references #392 / pounce#74.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bengal.assets.manifest import select_smoke_probe_asset
+from bengal.server.serve_probe import (
+    ProbeResult,
+    choose_probe_path,
+    format_probe_failure,
+    probe_serve_ability,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_manifest(output_dir: Path, assets: dict[str, str], *, create_files: bool = True) -> None:
+    """Write an asset-manifest.json (and optionally the referenced files)."""
+    payload = {
+        "version": 1,
+        "generated_at": "2026-01-01T00:00:00Z",
+        "assets": {logical: {"output_path": out} for logical, out in assets.items()},
+    }
+    (output_dir / "asset-manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+    if create_files:
+        for out in assets.values():
+            file_path = output_dir / out
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_text("/* asset */", encoding="utf-8")
+
+
+class TestSelectSmokeProbeAsset:
+    def test_prefers_css_entry(self, tmp_path: Path) -> None:
+        _write_manifest(
+            tmp_path,
+            {
+                "js/app.js": "assets/js/app.js",
+                "css/style.css": "assets/css/style.css",
+            },
+        )
+        assert select_smoke_probe_asset(tmp_path) == "/assets/css/style.css"
+
+    def test_falls_back_to_any_on_disk_entry_when_no_css(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"js/app.js": "assets/js/app.js"})
+        assert select_smoke_probe_asset(tmp_path) == "/assets/js/app.js"
+
+    def test_skips_manifest_entries_missing_on_disk(self, tmp_path: Path) -> None:
+        # CSS referenced but not written; JS present → JS chosen, not the absent CSS.
+        _write_manifest(tmp_path, {"js/app.js": "assets/js/app.js"}, create_files=True)
+        _write_manifest(
+            tmp_path,
+            {"js/app.js": "assets/js/app.js", "css/style.css": "assets/css/missing.css"},
+            create_files=False,
+        )
+        # Re-create only the JS file (manifest now references a missing CSS).
+        (tmp_path / "assets" / "js").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "assets" / "js" / "app.js").write_text("x", encoding="utf-8")
+        assert select_smoke_probe_asset(tmp_path) == "/assets/js/app.js"
+
+    def test_returns_none_when_no_manifest(self, tmp_path: Path) -> None:
+        assert select_smoke_probe_asset(tmp_path) is None
+
+    def test_returns_none_when_manifest_entries_all_missing(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"css/style.css": "assets/css/style.css"}, create_files=False)
+        assert select_smoke_probe_asset(tmp_path) is None
+
+
+class TestChooseProbePath:
+    def test_uses_manifest_asset(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"css/style.css": "assets/css/style.css"})
+        assert choose_probe_path(tmp_path) == "/assets/css/style.css"
+
+    def test_falls_back_to_root_when_empty_manifest(self, tmp_path: Path) -> None:
+        # Empty-manifest fallback: probe index.html at "/".
+        assert choose_probe_path(tmp_path) == "/"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Tiny HTTP server returning a configurable status for any GET."""
+
+    status_code = 200
+
+    def do_GET(self) -> None:
+        self.send_response(type(self).status_code)
+        self.send_header("Content-Type", "text/css")
+        self.end_headers()
+        self.wfile.write(b"/* ok */")
+
+    def log_message(self, *_args: object) -> None:  # silence test server logging
+        pass
+
+
+class _LiveServer:
+    """Context manager running a real HTTP server on an ephemeral port."""
+
+    def __init__(self, status_code: int) -> None:
+        self._status = status_code
+
+    def __enter__(self) -> int:
+        handler = type("_H", (_Handler,), {"status_code": self._status})
+        self._httpd = HTTPServer(("127.0.0.1", 0), handler)
+        self._port = self._httpd.server_address[1]
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self._port
+
+    def __exit__(self, *_exc: object) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+
+
+class TestProbeServeAbility:
+    def test_returns_ok_on_200(self, tmp_path: Path) -> None:
+        with _LiveServer(200) as port:
+            result = probe_serve_ability("127.0.0.1", port, tmp_path, attempts=3)
+        assert result.ok is True
+        assert result.status == 200
+
+    def test_fails_loudly_on_404(self, tmp_path: Path) -> None:
+        with _LiveServer(404) as port:
+            result = probe_serve_ability("127.0.0.1", port, tmp_path, attempts=3)
+        assert result.ok is False
+        assert result.status == 404
+        assert result.reason is not None
+        assert "404" in result.reason
+
+    def test_probes_manifest_asset_path(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, {"css/style.css": "assets/css/style.css"})
+        with _LiveServer(200) as port:
+            result = probe_serve_ability("127.0.0.1", port, tmp_path, attempts=3)
+        assert result.probe_path == "/assets/css/style.css"
+
+    def test_empty_manifest_falls_back_to_root(self, tmp_path: Path) -> None:
+        with _LiveServer(200) as port:
+            result = probe_serve_ability("127.0.0.1", port, tmp_path, attempts=3)
+        assert result.probe_path == "/"
+
+    def test_unreachable_server_reports_connection_failure(self, tmp_path: Path) -> None:
+        # Nothing listening on this port: probe exhausts retries and reports cleanly.
+        with _LiveServer(200) as port:
+            pass  # server now shut down; reuse its (now-free) port number
+        result = probe_serve_ability(
+            "127.0.0.1", port, tmp_path, attempts=2, retry_interval=0.01, timeout=0.2
+        )
+        assert result.ok is False
+        assert result.status is None
+        assert result.reason is not None
+
+
+class TestFormatProbeFailure:
+    def test_mentions_paths_and_pounce_reference(self, tmp_path: Path) -> None:
+        result = ProbeResult(
+            ok=False,
+            url="http://localhost:5173/assets/css/style.css",
+            probe_path="/assets/css/style.css",
+            status=404,
+            reason="server returned HTTP 404 for a known asset",
+        )
+        serving = tmp_path / ".bengal" / "staging"
+        staging = tmp_path / "public"
+        message = format_probe_failure(result, serving_dir=serving, staging_dir=staging)
+        assert "404" in message
+        assert str(serving) in message
+        assert str(staging) in message
+        assert "pounce#74" in message
+        assert "#392" in message
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Three related dev-server serve-path hardening items, follow-ups to #392 (upstream lbliii/pounce#74). Build-time checks verify output bytes exist on disk but never that they are reachable over HTTP — the hidden-buffer 404 bug proved that gap.

## What changed

- **Serve-ability smoke check (#398):** once the dev server is listening, it probes a known asset (chosen from `asset-manifest.json`, preferring CSS — the #392 symptom — and falling back to `index.html`) against the real serving setup and asserts a 200. A definitive non-200 HTTP response fails startup loudly with the probe URL, serving dir, staging dir, and reason; a no-response (connection-refused) result is non-fatal (that is a server-start failure handled by the existing error path, not a serve-path bug). Wired into both the serve-first path (inline after the server thread starts) and the build-first path (daemon thread, since `backend.start()` blocks). New helpers: `bengal/assets/manifest.py:select_smoke_probe_asset`, the `bengal/server/serve_probe.py` module, and `bengal/server/backend.py:probe_backend_serve_ability`.
- **Live `bengal serve` HTTP fixture (#399):** new self-contained `tests/integration/test_live_dev_server_http.py` boots a real `bengal serve` subprocess on a temp site (fingerprinting off, matching dev), finds a free ephemeral port and waits for readiness via `localhost`, drives rapid concurrent content+CSS edits while continuously GETting the referenced CSS/JS assets and asserting they stay 200 across rebuilds/buffer swaps, and verifies a build-failing save (corrupt `bengal.toml`) preserves the last-good served output. Uses a context manager for clean subprocess teardown; marked `slow` (does not run in fast-check).
- **Hidden-buffer guard, Part 1 only (#400):** `BufferManager.setup()` now warns loudly (referencing lbliii/pounce#74) when a served buffer path contains a hidden (dot-prefixed) component, pinning the Pounce static-handler constraint at the integration boundary so a future hidden serving path fails visibly at construction rather than as runtime 404s. The #392 `_has_hidden_path_component` serving fallback is left intact.
- Added unit tests for the probe (200 passes / 404 fails loudly / empty-manifest falls back to index.html / unreachable reports connection failure) and the hidden-path guard; updated four pre-existing mocked `DevServer.start()` tests to patch out the new probe (they use a `MagicMock` backend that never listens).

Part 2 of #400 (relocating `.bengal/staging` to a non-hidden sibling) is intentionally deferred — it is upstream-gated on pounce#74.

Closes #398
Closes #399
Refs #400 (Part 1 guard; Part 2 relocation upstream-gated on pounce#74)

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: Adds a one-time startup serve probe (one HTTP round-trip) and a construction-time hidden-path guard; no per-request or per-page cost.
