### PR TITLE
chore(arch): contain core->rendering.version_url edge + tighten Contract 1

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -20,7 +20,7 @@ root_package = bengal
 #   bengal.core.site -> bengal.server.dev_server.DevServer (L1505)
 #   bengal.core.site -> bengal.rendering.pipeline.thread_local (L1579)
 #   bengal.core.site -> bengal.rendering.assets (L1583)
-#   bengal.core.site -> bengal.rendering.template_functions.version_url (L866)
+#   bengal.core.site -> bengal.rendering.template_functions.version_url (L1127)
 
 [importlinter:contract:core-does-not-import-upward]
 name = bengal.core must not directly import orchestration, server, or rendering.pipeline/assets
@@ -32,6 +32,7 @@ forbidden_modules =
     bengal.server
     bengal.rendering.pipeline
     bengal.rendering.assets
+    bengal.rendering.template_functions
 # Only direct edges; transitive chains are tolerated (other layers will clean those).
 allow_indirect_imports = True
 # Baseline — known direct violations remaining after Sprint B1.1.
@@ -56,6 +57,19 @@ allow_indirect_imports = True
 #                documented circular-import fragility. This edge replaced the old
 #                feature_detector edge (both touched in #245); the S4-followup note
 #                about feature_detector is now resolved (that import is gone).
+#   Live deferred edge: bengal.core.site -> bengal.rendering.template_functions.version_url —
+#                Site.get_version_target_url() (site/__init__.py) imports the
+#                version-aware URL helper function-locally and delegates to it.
+#                This is a load-bearing public template API: the default theme's
+#                partials/version-selector.html calls site.get_version_target_url(page, v)
+#                at render time, so the method cannot be dropped without a template
+#                rewrite + build-time pre-baking (tracked as #383 Finding 33 option a,
+#                deferred as a larger refactor). The import is deferred precisely
+#                because version_url imports back into core.site transitively
+#                (via bengal.protocols.analysis) — a documented circular-import
+#                hazard; do NOT hoist it to module level. forbidden_modules now
+#                lists bengal.rendering.template_functions so this edge is tracked/
+#                ratcheted instead of silent (it was previously in no contract).
 ignore_imports =
     bengal.core.site -> bengal.orchestration.build.inputs
     bengal.core.site -> bengal.orchestration.build.options
@@ -63,6 +77,7 @@ ignore_imports =
     bengal.core.site -> bengal.orchestration.content
     bengal.core.site -> bengal.orchestration.site_runner
     bengal.core.site -> bengal.orchestration.stats.models
+    bengal.core.site -> bengal.rendering.template_functions.version_url
 
 # -----------------------------------------------------------------------------
 # Contract 2: Page/Section use SiteContext, not Site

--- a/changelog.d/383.changed.md
+++ b/changelog.d/383.changed.md
@@ -1,0 +1,1 @@
+Tightened import-linter Contract 1 to track the `bengal.core.site -> bengal.rendering.template_functions.version_url` edge so the core/rendering boundary can no longer erode without CI signal.


### PR DESCRIPTION
Addresses Finding 33 of #383: the `bengal.core.site -> bengal.rendering.template_functions.version_url` upward edge (`Site.get_version_target_url()` delegating to the version-aware URL helper) was previously caught by no import-linter contract, so the core/rendering boundary could erode silently. Contract 1's `forbidden_modules` listed only `rendering.pipeline` and `rendering.assets`, never `rendering.template_functions`.

I chose the FALLBACK option (b) — baseline-and-ratchet — over option (a) extraction, because option (a) risks template API compat:

- `Site.get_version_target_url()` is a load-bearing public template API. The default theme's `partials/version-selector.html` calls `{{ site.get_version_target_url(page, v) }}` at render time (looping over `versions`), and integration tests (`tests/integration/test_nav_tree_integration.py`, `tests/unit/test_nav_tree.py`) call it. The template invokes it per-version with a runtime loop variable, so the URL cannot be pre-baked into page/snapshot context without a template rewrite — exactly the larger refactor the issue defers under option (a).
- The function-local import is also retained as-is: `grimp` confirms `version_url` imports back into `core.site` transitively (`version_url -> bengal.protocols -> bengal.protocols.analysis -> bengal.core.site`), so hoisting it to module level would introduce a circular import. No Python code was touched.

## What changed
- Added `bengal.rendering.template_functions` to Contract 1 `forbidden_modules` in `.importlinter`, so the previously-uncaught edge is now in a contract.
- Baselined `bengal.core.site -> bengal.rendering.template_functions.version_url` in Contract 1 `ignore_imports`, with a documenting comment block explaining the load-bearing template API, the deferred option-(a) refactor, and the circular-import hazard (do-not-hoist note).
- Fixed the stale `(L866)` line reference in the Contract 1 header comment to `(L1127)` to match the current edge location.
- Added changelog fragment `changelog.d/383.changed.md`.

Verified `uv run lint-imports --config .importlinter` exits 0 with 2 contracts kept, 0 broken, and no "No matches for ignored import" warnings. Confirmed the baseline entry is load-bearing: removing it makes the contract go BROKEN at `l.1127`, proving the forbidden-module addition actually catches the edge.

Finding 4 (`core -> orchestration.content`) is intentionally NOT addressed here — it is already baselined in `ignore_imports` and removing it is a larger refactor (extract `build_discovery(root_path) -> DiscoveryResult` per epic D3). Deferred.

Refs #383