### PR TITLE
chore(governance): add CODEOWNERS + update ownership routing status

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,52 @@
+# CODEOWNERS — review routing for Bengal
+#
+# Bengal is currently a solo-maintained project. All paths route to @lbliii,
+# who owns and approves changes across every area below. The area-specific
+# lines exist so that ownership of high-risk surfaces (public API, release,
+# dependencies, security-sensitive code) is recorded explicitly rather than
+# left implicit, and so that routing can be split among additional maintainers
+# without rewriting this file from scratch.
+#
+# Later entries take precedence over earlier ones (last match wins), so the
+# global fallback comes first and the area-specific rules follow.
+# Syntax reference: https://docs.github.com/articles/about-code-owners
+
+# Global fallback — anything not matched below.
+*                               @lbliii
+
+# Public API, protocols, plugins, and hook surfaces (public contracts).
+/bengal/__init__.py             @lbliii
+/bengal/protocols/              @lbliii
+/bengal/plugins/                @lbliii
+/bengal/core/                   @lbliii
+
+# CLI and configuration (user-facing contracts: flags, commands, config keys).
+/bengal/cli/                    @lbliii
+/bengal/config/                 @lbliii
+
+# Rendering, templates, and themes (presentation layer).
+/bengal/rendering/              @lbliii
+/bengal/parsing/                @lbliii
+/bengal/themes/                 @lbliii
+
+# Orchestration, cache, incremental builds, and dev server.
+/bengal/orchestration/          @lbliii
+/bengal/cache/                  @lbliii
+/bengal/server/                 @lbliii
+/bengal/snapshots/              @lbliii
+
+# Docs, site content, and scaffolds.
+/docs/                          @lbliii
+/site/                          @lbliii
+/bengal/scaffolds/              @lbliii
+*.md                            @lbliii
+
+# Release, dependencies, and CI workflows (release/security governance).
+/pyproject.toml                 @lbliii
+/uv.lock                        @lbliii
+/requirements.lock              @lbliii
+/renovate.json                  @lbliii
+/.github/                       @lbliii
+/.github/workflows/             @lbliii
+/.github/dependabot.yml         @lbliii
+/.github/CODEOWNERS             @lbliii

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,15 @@ are public contracts.
 
 ## Governance Alignment
 
-- `CODEOWNERS`, `OWNERS`, and `MAINTAINERS` were not found in `.github/` or the
-  repo root during bootstrap. Human approval routing is therefore
-  `manual-confirmation-needed` until ownership is recorded.
+- `.github/CODEOWNERS` records review routing. Bengal is solo-maintained, so a
+  global `*` fallback plus area-specific lines all route to `@lbliii` (the owner
+  who approves changes). Ownership of high-risk surfaces — public API/protocols/
+  plugins, CLI and config, rendering/templates/themes, orchestration/cache/
+  incremental/dev server, docs/site/scaffolds, and release/dependencies/
+  workflows — is recorded explicitly rather than left implicit. Human approval
+  routing is therefore `codeowners-routed` (last-match-wins). Some scoped
+  `AGENTS.md` files in subdirectories may still describe the older
+  `manual-confirmation-needed` state until they are swept separately.
 - Canonical public knowledge lives in `README.md`, `CONTRIBUTING.md`,
   `CHANGELOG.md`, `site/content/`, `tests/README.md`, and `.importlinter`.
 - CI and release governance lives in `.github/workflows/`, `pyproject.toml`,

--- a/changelog.d/394.added.md
+++ b/changelog.d/394.added.md
@@ -1,0 +1,1 @@
+Added `.github/CODEOWNERS` to record review routing and approval ownership across public API, CLI/config, rendering/themes, orchestration, docs, and release/dependency surfaces.


### PR DESCRIPTION
Adds first-pass ownership metadata so review routing is recorded explicitly instead of left implicit. Bengal is solo-maintained, so every area routes to `@lbliii`, but the area-specific lines make ownership of high-risk surfaces (public API, release, dependencies, security-sensitive paths) explicit and let routing be split among future maintainers without rewriting the file.

## What changed

- Added `.github/CODEOWNERS` with valid GitHub CODEOWNERS syntax: a global `*` fallback plus area-specific lines for public API/protocols/plugins (`/bengal/__init__.py`, `/bengal/protocols/`, `/bengal/plugins/`, `/bengal/core/`), CLI and config (`/bengal/cli/`, `/bengal/config/`), rendering/templates/themes (`/bengal/rendering/`, `/bengal/parsing/`, `/bengal/themes/`), orchestration/cache/incremental/dev server (`/bengal/orchestration/`, `/bengal/cache/`, `/bengal/server/`, `/bengal/snapshots/`), docs/site/scaffolds (`/docs/`, `/site/`, `/bengal/scaffolds/`, `*.md`), and release/dependencies/workflows (`/pyproject.toml`, `/uv.lock`, `/requirements.lock`, `/renovate.json`, `/.github/`).
- Updated the `AGENTS.md` Governance Alignment section so it no longer claims `manual-confirmation-needed`; it now describes the concrete `codeowners-routed` (last-match-wins) policy and notes that scoped subdir `AGENTS.md` files may still describe the older state until swept separately.
- Added changelog fragment `changelog.d/394.added.md`.

No runtime behavior changes.

Closes #394