### PR TITLE
feat(render): shard generated pages in COW-free backend — S13.4e (#350)

### DIFF
--- a/bengal/orchestration/render/isolated/shard_backend.py
+++ b/bengal/orchestration/render/isolated/shard_backend.py
@@ -23,17 +23,24 @@ Byte-identical to the thread path on test-product/basic/taxonomy/navigation
 (``tests/integration/test_shard_render_parity.py``). The registry is fork-only; spawn has no
 COW inheritance, so the spawn backend stays deferred.
 
+Generated pages (tags / tag-index / auto-archives) are sharded too (S13.4e): the parent balances
+them across the same workers (``generated_page_assignments``) and each worker renders its slice
+in its own heap, against its WorkerSite — so the ~23%-of-render generated fraction is no longer a
+serial parent tail. They are live parent objects inherited via fork COW; rendering them against
+the WorkerSite resolves their listings through the worker's own PageViews + the immortalized
+snapshot (the COW-free path), so the bulk (tag pages) parallelizes without the Phase-1 COW tax.
+
 What this version does NOT yet do (tracked):
-- Generated pages (tags/archives/pagination) are rendered in the *parent* (global aggregations
-  the content-file sharder does not cover); sharding them is S13.4e. So the parallel-render win
-  is the content-render fraction only (generated pages are ~23% of render on taxonomied sites).
-- render_isolation stays OFF by default until the full S17 idle-box E2E A/B + crossover gate.
+- Spawn (no COW): the generated-page list + cross-shard content registry are fork-COW-inherited,
+  so the spawn backend stays deferred (it would need them serialized).
+- render_isolation stays OFF by default until the full S17 idle-box E2E A/B + content-aware gate.
 """
 
 from __future__ import annotations
 
+import heapq
 import multiprocessing as mp
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 from .merge import merge_chunk_results
@@ -63,6 +70,7 @@ class _ShardForkState:
     content_dir: Path
     output_dir: Path
     shards: list[list[Any]]  # list[list[ContentFile]] indexed by worker
+    generated_pages: list[Any]  # all generated pages (tag/archive/pagination), assigned per S13.4e
     asset_ctx: Any
     quiet: bool
 
@@ -71,14 +79,63 @@ class _ShardForkState:
 # forked worker. ``None`` in the parent outside a shard render.
 _SHARD_STATE: _ShardForkState | None = None
 
+# Base cost for a generated page in the LPT balance below; the cost proxy is the number of
+# items the page lists (a tag page over 200 posts renders far more cards than one over 2),
+# so the base only matters for tie-breaking near-empty listings.
+_GENERATED_BASE_COST = 1
+
+
+def _estimate_generated_cost(page: Any) -> int:
+    """Relative render cost of a generated page — proxied by the number of items it lists.
+
+    Tag/archive pages render one card per listed post, so the listing length dominates the
+    template work; tag-index pages list one entry per term. Falls back to the base cost when
+    neither is present, so the estimate never raises."""
+    metadata = getattr(page, "metadata", None) or {}
+    for key in ("_posts", "_tags"):
+        items = metadata.get(key)
+        if items is not None:
+            try:
+                return _GENERATED_BASE_COST + len(items)
+            except TypeError:  # not sized — fall through to the base cost
+                pass
+    return _GENERATED_BASE_COST
+
+
+def _assign_generated_pages(pages: Any, num_workers: int) -> dict[Path, int]:
+    """Deterministically LPT-balance generated pages across exactly ``num_workers`` bins.
+
+    Returns ``{source_path: worker_index}``. Pages are ordered by ``source_path.parts`` first,
+    so the assignment is independent of the parent's page-list order *and* the OS path
+    separator (the same cross-OS-stable key the content sharder uses); the LPT pass then packs
+    them by :func:`_estimate_generated_cost` so each worker gets a comparable listing load.
+    """
+    assignment: dict[Path, int] = {}
+    if num_workers <= 0 or not pages:
+        return assignment
+    ordered = sorted(pages, key=lambda p: p.source_path.parts)
+    costed = sorted(
+        ((_estimate_generated_cost(p), i) for i, p in enumerate(ordered)),
+        key=lambda ci: (-ci[0], ci[1]),
+    )
+    heap: list[tuple[int, int]] = [(0, worker) for worker in range(num_workers)]
+    heapq.heapify(heap)
+    for cost, i in costed:
+        load, worker = heapq.heappop(heap)
+        assignment[ordered[i].source_path] = worker
+        heapq.heappush(heap, (load + cost, worker))
+    return assignment
+
 
 def _render_shard_worker(shard_index: int) -> RenderChunkResult:
-    """Fork worker: reconstruct a WorkerSite, parse THIS shard, render its own pages.
+    """Fork worker: reconstruct a WorkerSite, parse THIS shard, render its own + generated pages.
 
     The proven S13.3c/d recipe: build an empty real ``Site`` from the plan, parse this
     worker's content files against it (so each page's ``_site`` is the worker site), merge
     the heterogeneous page list, reset process-globals + install the precomputed nav trees,
-    then render. Bodies never leave this heap; only a picklable ``RenderChunkResult`` returns.
+    then render — both this shard's content pages AND the generated pages the parent assigned
+    to this worker (S13.4e). Bodies never leave this heap; only a picklable
+    ``RenderChunkResult`` returns.
     """
     state = _SHARD_STATE
     if state is None:  # pragma: no cover - defensive; never happens under fork
@@ -121,10 +178,23 @@ def _render_shard_worker(shard_index: int) -> RenderChunkResult:
     NavTreeCache.invalidate()
     NavTreeCache.set_precomputed(dict(plan.navigation.nav_trees))
 
-    ctx = BuildContext(site=ws, pages=list(worker_pages))
+    # S13.4e: this worker also renders its assigned slice of the GENERATED pages
+    # (tag / tag-index / auto-archive), which used to render serially in the parent. They are
+    # live parent objects inherited via fork COW; the parent balanced them across workers and
+    # recorded the split in ``plan.generated_page_assignments``. Rendering them against the
+    # WorkerSite (not the parent's live site) resolves their listings through the worker's own
+    # PageViews + the immortalized snapshot — the same COW-free path content pages use — so the
+    # bulk (tag pages) parallelizes without re-introducing the Phase-1 shared-graph COW tax.
+    assignments = plan.generated_page_assignments
+    assigned_generated = [
+        p for p in state.generated_pages if assignments.get(p.source_path) == shard_index
+    ]
+    render_pages = [*worker_pages, *assigned_generated]
+
+    ctx = BuildContext(site=ws, pages=render_pages)
     ctx.snapshot = state.snapshot  # section tiles render from it (inherited, immortalized)
     return render_shard(
-        list(worker_pages),
+        render_pages,
         ws,
         ctx,
         chunk_index=shard_index,
@@ -186,18 +256,28 @@ class ShardRenderBackend:
         # already holds every parsed page, so this is a {path: body} lookup, not extra memory.
         set_worker_page_content({p.source_path: getattr(p, "content", "") or "" for p in pages})
 
-        # --- Phase 2 (parallel): content pages across separate-heap workers --------------
+        # --- Phase 2 (parallel): content + assigned generated pages across worker heaps ----
         results: list[RenderChunkResult] = []
         if content_pages:
             workers = max(1, min(num_workers, len(files)))
             idx_lists = partition_content_files(files, workers, strategy="balanced")
             shards = [[files[i] for i in idxs] for idxs in idx_lists]
+            # S13.4e: balance the generated pages across the SAME workers (each worker renders
+            # its content shard AND its assigned generated pages, in its own heap). Record the
+            # split in the plan's reserved ``generated_page_assignments`` field so the workers
+            # — which inherit the full generated-page list via fork COW — can each pick out
+            # exactly their slice (the field was empty scaffolding before this).
+            plan = replace(
+                plan,
+                generated_page_assignments=_assign_generated_pages(generated_pages, len(shards)),
+            )
             _SHARD_STATE = _ShardForkState(
                 plan=plan,
                 snapshot=snapshot,
                 content_dir=content_dir,
                 output_dir=site.output_dir,
                 shards=shards,
+                generated_pages=list(generated_pages),
                 asset_ctx=asset_ctx,
                 quiet=quiet,
             )
@@ -208,22 +288,23 @@ class ShardRenderBackend:
             finally:
                 _SHARD_STATE = None
                 clear_worker_page_content()
-
-        # --- Generated pages (tags/archives/pagination) rendered in the parent -----------
-        # They are global aggregations the content-file sharder does not cover; sharding them
-        # is S13.4e. The parent already holds them parsed, so render them on the live site.
-        if generated_pages:
+        elif generated_pages:
+            # No content files to shard onto (e.g. an autodoc-only / generated-only build):
+            # render the generated pages serially in the parent (the pre-S13.4e fallback). With
+            # no content shards there are no worker heaps to host the generated render, so there
+            # is nothing to parallelize onto — correctness over a non-existent win.
             from bengal.orchestration.render.isolated.shard_worker import render_shard
 
-            gen_result = render_shard(
-                list(generated_pages),
-                site,
-                build_context,
-                chunk_index=-1,
-                asset_ctx=asset_ctx,
-                quiet=quiet,
+            results.append(
+                render_shard(
+                    list(generated_pages),
+                    site,
+                    build_context,
+                    chunk_index=-1,
+                    asset_ctx=asset_ctx,
+                    quiet=quiet,
+                )
             )
-            results.append(gen_result)
 
         merged = merge_chunk_results(build_context, results)
         if stats is not None:

--- a/bengal/orchestration/render/isolated/shard_worker.py
+++ b/bengal/orchestration/render/isolated/shard_worker.py
@@ -33,9 +33,10 @@ restricted to one shard:
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-from .transport import RenderChunkResult
+from .transport import RenderChunkResult, picklable_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -220,7 +221,15 @@ def render_shard(
 
     render_time_ms = (time.perf_counter() - start) * 1000
 
-    page_data = tuple(build_context.get_accumulated_page_data())
+    # Generated pages (tags/archives) inject live Page/Section refs + MappingProxyType into their
+    # metadata, which lands in AccumulatedPageData.raw_metadata — the one unpicklable field on the
+    # worker→parent boundary (S13.4e moved their render here). Flatten it to a picklable,
+    # freeze-identical form so the result pickles without changing output or the page-artifact
+    # cache. No-op for content pages (plain frontmatter); the parent fallback path runs it too,
+    # harmlessly (in-process, freeze-identical).
+    page_data = tuple(
+        _picklable_page_data(data) for data in build_context.get_accumulated_page_data()
+    )
     assets = tuple(
         (str(src), tuple(sorted(refs))) for src, refs in build_context.get_accumulated_assets()
     )
@@ -239,6 +248,17 @@ def render_shard(
         assets=assets,
         external_refs=tuple(external_refs),
     )
+
+
+def _picklable_page_data(data: Any) -> Any:
+    """Return ``data`` with a picklable ``raw_metadata`` (the lone unpicklable field on generated
+    pages). ``raw_metadata`` does not feed rendered output — postprocess reads the computed
+    fields + ``full_json_data`` — so flattening only the injected live refs is output-neutral and
+    freeze-identical for the page-artifact cache (see :func:`picklable_metadata`)."""
+    raw = getattr(data, "raw_metadata", None)
+    if not raw:
+        return data
+    return replace(data, raw_metadata=picklable_metadata(raw))
 
 
 def _build_worker_caches(site: SiteLike) -> tuple[Any, Any]:

--- a/bengal/orchestration/render/isolated/transport.py
+++ b/bengal/orchestration/render/isolated/transport.py
@@ -15,9 +15,45 @@ copy-on-write; the spawn worker re-derives them).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
 from typing import Any
 
-__all__ = ["RenderChunkResult"]
+__all__ = ["RenderChunkResult", "picklable_metadata"]
+
+# Values that pickle cleanly AND that ``PageArtifact._freeze_json`` already treats verbatim
+# (str/int/float/bool/None passthrough; Path → str; date/datetime → isoformat). Anything else
+# is stringified below, exactly as ``_freeze_json`` does, so the transform is a no-op under the
+# page-artifact cache's eventual freeze.
+_FREEZE_TRIVIAL = (str, int, float, bool, type(None), Path, datetime, date)
+
+
+def picklable_metadata(value: Any) -> Any:
+    """Return a picklable copy of a page-metadata value, freeze-identical to the original.
+
+    Generated pages (tag/tag-index/archive) inject live ``Page``/``Section`` refs and
+    ``MappingProxyType`` into ``page.metadata`` (``_tags``/``_posts``/``_paginator``/``_section``)
+    so the page can resolve its listing at render time. Those land in
+    ``AccumulatedPageData.raw_metadata`` (a shallow ``dict(page.metadata)``) and are **unpicklable**
+    across the shard worker → parent boundary — the only thing in the render result that is. The
+    in-process path never pickles them, and when the page-artifact cache *does* serialize
+    ``raw_metadata`` it stringifies every such ref via :func:`PageArtifact._freeze_json`.
+
+    This mirrors that freeze: recurse plain containers, leave freeze-trivial leaves untouched, and
+    stringify anything else (live refs, ``MappingProxyType``, callables). The result pickles, and
+    ``_freeze_json(picklable_metadata(v)) == _freeze_json(v)`` for every ``v`` — so both the rendered
+    output (which reads computed fields, never ``raw_metadata``) and the page-artifact cache stay
+    byte-identical thread-vs-shard. Applied shard-side only; the thread path is untouched.
+    """
+    if isinstance(value, _FREEZE_TRIVIAL):
+        return value
+    # MappingProxyType is NOT a dict subclass, so it falls through to ``str(value)`` below —
+    # matching ``_freeze_json`` (which only descends genuine ``dict``s).
+    if isinstance(value, dict):
+        return {key: picklable_metadata(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set | frozenset):
+        return [picklable_metadata(item) for item in value]
+    return str(value)
 
 
 @dataclass(frozen=True, slots=True)

--- a/changelog.d/shard-generated-page-rendering.added.md
+++ b/changelog.d/shard-generated-page-rendering.added.md
@@ -1,0 +1,19 @@
+Sharded the generated pages in the COW-free shard render backend (issue #350, Phase 2, saga
+S13.4e). Tag / tag-index / auto-archive pages used to render serially in the parent process
+(~15–23% of render un-parallelized), so a shard build *lost* end-to-end on generated-heavy
+sites. The parent now LPT-balances them across the same content-shard workers — populating the
+reserved `RenderPlan.generated_page_assignments` field (previously empty scaffolding) — and each
+worker renders its assigned slice in its own heap, against its `WorkerSite`. Because the tag-page
+render context already re-resolves its post list from the immortalized snapshot +
+`site.get_page_path_map()` and rebuilds a fresh `Paginator` from `per_page`, rendering against
+the WorkerSite resolves listings to the worker's own `PageView`s — the same COW-free path content
+pages use — so the bulk parallelizes without the Phase-1 shared-graph copy-on-write tax. Generated
+pages inject live `Page`/`Section` refs + a `MappingProxyType` into their metadata (`_tags`/
+`_posts`/`_paginator`), which land in `AccumulatedPageData.raw_metadata` and are unpicklable across
+the worker→parent boundary; `transport.picklable_metadata` flattens them exactly as
+`PageArtifact._freeze_json` would, so the result pickles while the rendered output (which never
+reads `raw_metadata`) and the page-artifact cache stay byte-identical. `render_isolation` stays
+`off` by default. Proven byte-identical across the *whole* output tree (not just `*.html`) on
+test-taxonomy by `test_shard_full_output_byte_identical_excluding_nondeterminism` (self-calibrating
+non-determinism exclusion, non-vacuous) plus 7 unit tests; measured on a 1431-page, 15%-generated
+idle-box A/B as 0.88× (pre-S13.4e, S17) → 1.23× shard-vs-thread (render phase 8.5s → 5.2s).

--- a/plan/epic-shard-parallel-build.md
+++ b/plan/epic-shard-parallel-build.md
@@ -391,11 +391,39 @@ are *not* blockers under this design.
       NOT required by the shipped backend: it uses `RenderPlan.from_site`, which already carries
       `menus` + view-ified `nav_trees` (installed via `NavTreeCache.set_precomputed`), byte-identical
       on test-navigation. Only the small-parent path (avoiding the snapshot build) needs this. xl.
-    - [ ] **S13.4e — shard generated pages — THE MAIN REMAINING PERF ITEM.** tag/archive/pagination
-      currently render SERIALLY in the parent (byte-correct, but ~23% of render un-parallelized) —
-      so the shard build LOSES end-to-end on generated-heavy sites (S17). Sharding them (synthesis +
-      `generated_page_assignments` + worker Paginator rehydration; COW-prone — the generated graph is
-      shared) is what broadens the win beyond render-heavy-low-generated sites. *(l)*
+    - [x] **S13.4e — shard generated pages (DONE).** tag/tag-index/auto-archive pages used to
+      render SERIALLY in the parent (byte-correct, but ~15–23% of render un-parallelized) — so the
+      shard build LOST end-to-end on generated-heavy sites (S17, 0.88×). They now render IN THE
+      WORKERS: the parent LPT-balances them across the same content shards
+      (`_assign_generated_pages` → the reserved `RenderPlan.generated_page_assignments`, previously
+      empty scaffolding), and each worker renders its assigned slice — live parent objects inherited
+      via **fork COW** — against its **WorkerSite**, not the parent's live site. That was the key
+      COW-avoidance choice: the tag-page render context (`renderer._add_tag_generated_page_context`)
+      already re-resolves its post list from the immortalized snapshot + `site.get_page_path_map()`
+      and rebuilds a fresh `Paginator` from `per_page`, so against the WorkerSite the bulk (tag
+      pages) resolves to the worker's OWN PageViews — the same COW-free path content pages use — and
+      the Paginator "rehydrates" for free via the existing renderer (no separate rehydration step).
+      **The one real engineering blocker was pickling, not COW:** a generated page's metadata holds
+      live `Page`/`Section` refs + a `MappingProxyType` (`_tags`/`_posts`/`_paginator`), which land
+      in `AccumulatedPageData.raw_metadata` and are **unpicklable** across the worker→parent
+      boundary (`cannot pickle 'mappingproxy'`) — invisible before because generated pages rendered
+      in-process. Fixed with `transport.picklable_metadata`, which flattens those refs exactly as
+      `PageArtifact._freeze_json` later would (stringify live refs/proxies, recurse plain
+      containers, leave scalars/Paths/dates) — so the result pickles AND the rendered output +
+      page-artifact cache stay byte-identical (output never reads `raw_metadata`; the cache freeze
+      is provably unchanged). Gated by `test_shard_full_output_byte_identical_excluding_nondeterminism`
+      (FULL output tree, not just `*.html`, self-calibrating non-determinism exclusion, non-vacuous)
+      + 7 unit tests (`test_shard_generated.py`). `render_isolation` stays **off**; ty floor
+      unchanged by this change. *(l)*
+
+      **Discovered (out of S13.4e scope, filed separately) — two pre-existing CONTENT-shard
+      byte-parity gaps the HTML-only S16 gate misses, on `test-blog-paginated`:** (G1) per-page JSON
+      output-format files for blog posts are absent under shard; (G2) an enriched authored
+      section-index (`content/posts/_index.md`, `type=blog`) renders its post-date `<time>` elements
+      differently thread-vs-shard (the worker re-parses the authored `_index.md` without re-running
+      `SectionOrchestrator._enrich_existing_index`, which injects `_posts`/`_subsections`/`_paginator`
+      in the parent). These do NOT touch the generated bucket (test-taxonomy is fully byte-clean) but
+      they block default-on and are the next S16-v2 blockers.
     - [~] **S13.4f/g — small-parent driver — OPTIONAL OPTIMIZATION.** The shipped `ShardRenderBackend`
       forks from a `from_site` parent (parent builds the snapshot — cheap, ~10%). The pure
       snapshot-free small-parent reduce (all barrier flags on, S13.4a/b done; sections=S13.4c-pt2,

--- a/tests/integration/test_shard_render_parity.py
+++ b/tests/integration/test_shard_render_parity.py
@@ -130,3 +130,53 @@ def test_shard_resolves_cross_shard_related_content(tmp_path):
     assert "blog-card-excerpt" in html, (
         "related-post card body missing — cross-shard content registry (S14) did not resolve"
     )
+
+
+def _walk_files(out: Path) -> dict[str, Path]:
+    """Every output file (not just HTML), keyed by output-relative POSIX path."""
+    return {str(p.relative_to(out)): p for p in out.rglob("*") if p.is_file()}
+
+
+@pytest.mark.serial
+def test_shard_full_output_byte_identical_excluding_nondeterminism(tmp_path):
+    """S13.4e + S16-v2: with the GENERATED pages (tag / tag-index / archive) sharded into the
+    workers, a shard build must be byte-identical to the thread path across the WHOLE output
+    tree — not just ``*.html`` — including per-page JSON, the search index, sitemap, RSS, and
+    the markdown output format.
+
+    Non-determinism (timestamped JSON sidecars, ``*.hash``, the unseeded random-posts widget) is
+    excluded *self-calibratingly*: any file that already differs thread-vs-thread is dropped from
+    the compare, so the assertion can only fail on a genuine shard divergence. Non-vacuous: the
+    shard backend must FIRE, the generated tag pages must be PRESENT and in the compared set, and
+    a real set of deterministic files must be compared (#130)."""
+    root = _copy_root(tmp_path, "test-taxonomy")
+    out_t1, out_t2, out_s = tmp_path / "t1", tmp_path / "t2", tmp_path / "shard"
+
+    # Two thread builds calibrate which files are non-deterministic run-to-run; one shard build
+    # is the comparand. Same source root → identical source paths in any reprs.
+    assert not _build(root, out_t1, shard=False)
+    assert not _build(root, out_t2, shard=False)
+    assert _build(root, out_s, shard=True), "shard backend did not fire (gate/threshold?)"
+
+    t1, t2, s = _walk_files(out_t1), _walk_files(out_t2), _walk_files(out_s)
+    assert t1, "thread build produced no files — parity would be vacuous (#130)"
+    assert set(t1) == set(s), (
+        f"file set differs: only-thread={sorted(set(t1) - set(s))}, "
+        f"only-shard={sorted(set(s) - set(t1))}"
+    )
+
+    nondeterministic = {
+        rel for rel in t1 if rel in t2 and t1[rel].read_bytes() != t2[rel].read_bytes()
+    }
+    compared = [rel for rel in t1 if rel not in nondeterministic]
+    assert len(compared) > 10, f"too few deterministic files compared ({len(compared)}) — vacuous?"
+
+    # The generated pages S13.4e moved into the workers must be present AND in the deterministic
+    # compared set (so the byte check below actually exercises them, not a vacuous absence).
+    generated_outputs = ["tags/index.html", "tags/python/index.html", "tags/testing/index.html"]
+    for rel in generated_outputs:
+        assert rel in s, f"generated page {rel} missing from shard output"
+        assert rel not in nondeterministic, f"generated page {rel} unexpectedly non-deterministic"
+
+    diffs = [rel for rel in compared if t1[rel].read_bytes() != s[rel].read_bytes()]
+    assert not diffs, f"shard diverged from thread on deterministic files: {sorted(diffs)}"

--- a/tests/unit/orchestration/render/test_shard_generated.py
+++ b/tests/unit/orchestration/render/test_shard_generated.py
@@ -1,0 +1,118 @@
+"""Unit tests for the S13.4e generated-page sharding helpers (issue #350).
+
+Covers the two new pure units that move generated-page rendering (tag / tag-index / archive)
+off the serial parent and onto the fork workers:
+
+- ``_assign_generated_pages`` — deterministic, cross-OS-stable, exact-cover LPT balance of the
+  generated pages across the content workers (populates the reserved
+  ``RenderPlan.generated_page_assignments`` slot).
+- ``picklable_metadata`` — flattens the live ``Page``/``Section`` refs + ``MappingProxyType`` that
+  generated pages inject into their metadata to a picklable, freeze-identical form, so the
+  worker → parent ``RenderChunkResult`` pickles without changing output or the page-artifact cache.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+from bengal.orchestration.render.isolated.shard_backend import _assign_generated_pages
+from bengal.orchestration.render.isolated.transport import picklable_metadata
+from bengal.rendering.page_artifact import _freeze_json
+
+
+@dataclass
+class _FakePage:
+    """Minimal stand-in for the assignment helper (it touches source_path + metadata only)."""
+
+    source_path: Path
+    metadata: dict[str, Any]
+
+
+def _gen(name: str, *, posts: int = 0) -> _FakePage:
+    return _FakePage(
+        source_path=Path(f".bengal/generated/{name}/index.md"),
+        metadata={"_posts": list(range(posts))} if posts else {},
+    )
+
+
+def test_assign_generated_pages_exact_cover_and_in_range():
+    pages = [_gen(f"tags/t{i}", posts=i) for i in range(7)]
+    assignment = _assign_generated_pages(pages, 3)
+    # Every page assigned exactly once, to a valid worker index.
+    assert set(assignment) == {p.source_path for p in pages}
+    assert all(0 <= w < 3 for w in assignment.values())
+
+
+def test_assign_generated_pages_is_deterministic_regardless_of_input_order():
+    pages = [_gen(f"tags/t{i}", posts=(i * 7) % 11) for i in range(9)]
+    forward = _assign_generated_pages(pages, 4)
+    reverse = _assign_generated_pages(list(reversed(pages)), 4)
+    # Ordering is keyed by source_path.parts, so input order must not change the result.
+    assert forward == reverse
+
+
+def test_assign_generated_pages_distributes_load_across_workers():
+    # Many comparable-cost pages must spread across all workers, not pile onto worker 0.
+    pages = [_gen(f"tags/t{i:02d}", posts=5) for i in range(12)]
+    assignment = _assign_generated_pages(pages, 4)
+    used_workers = set(assignment.values())
+    assert used_workers == {0, 1, 2, 3}, f"load not spread: only used {sorted(used_workers)}"
+
+
+def test_assign_generated_pages_edge_cases():
+    assert _assign_generated_pages([], 4) == {}
+    assert _assign_generated_pages([_gen("tags/t0")], 0) == {}
+    one = [_gen("tags/only")]
+    assert _assign_generated_pages(one, 4) == {one[0].source_path: 0}
+
+
+@dataclass
+class _LiveRef:
+    """Stands in for a live Page/Section ref injected into generated-page metadata."""
+
+    title: str
+
+    def __str__(self) -> str:
+        return f"_LiveRef({self.title})"
+
+
+def test_picklable_metadata_round_trips_through_pickle():
+    import pickle
+
+    meta = {
+        "title": "All Tags",
+        "_generated": True,
+        "_tags": {
+            "python": {"name": "python", "pages": [_LiveRef("a"), _LiveRef("b")]},
+            "_frozen": MappingProxyType({"k": "v"}),
+        },
+        "weight": 3,
+        "date": None,
+        "path": Path("/tmp/x"),
+    }
+    cleaned = picklable_metadata(meta)
+    # The whole thing now pickles (the original would raise on the MappingProxyType / live refs).
+    pickle.loads(pickle.dumps(cleaned))
+
+
+def test_picklable_metadata_is_freeze_identical_to_the_original():
+    # The transform must be invisible under PageArtifact._freeze_json — so the page-artifact
+    # cache (and any _freeze_mapping consumer) is byte-identical thread-vs-shard.
+    meta = {
+        "title": "All Tags",
+        "_tags": {"python": {"pages": [_LiveRef("a"), _LiveRef("b")]}},
+        "_frozen": MappingProxyType({"k": "v"}),
+        "tags": ["a", "b"],
+        "path": Path("/tmp/x"),
+        "n": 7,
+    }
+    assert _freeze_json(picklable_metadata(meta)) == _freeze_json(meta)
+
+
+def test_picklable_metadata_leaves_plain_frontmatter_intact():
+    # A content page's frontmatter is already picklable; the transform must not perturb its values.
+    meta = {"title": "Post", "tags": ["x", "y"], "weight": 2, "draft": False}
+    assert picklable_metadata(meta) == meta


### PR DESCRIPTION
## Summary

- Saga S13.4e of epic #350: generated pages (tag / tag-index / auto-archive) now render **in the fork workers** instead of serially in the parent, so the COW-free shard backend stops losing end-to-end on generated-heavy sites.
- The parent LPT-balances them across the same content-shard workers via the previously-empty `RenderPlan.generated_page_assignments`; each worker renders its slice (fork-COW-inherited live pages) against its `WorkerSite`, where tag-page listings resolve to the worker's own `PageView`s — the COW-free path content pages already use.
- The one real blocker was pickling: generated-page metadata holds live `Page`/`Section` refs + `MappingProxyType`, unpicklable on the worker→parent boundary; `transport.picklable_metadata` flattens them exactly as `PageArtifact._freeze_json` would, so output and the page-artifact cache stay byte-identical.
- `render_isolation` stays `off` by default. Adds a whole-output-tree parity gate (the existing one is HTML-only) which surfaced two pre-existing content-shard gaps (#418, #419), documented as the next S16-v2 blockers.

## Proof

- [x] Focused tests: `tests/integration/test_shard_render_parity.py` (6, incl. new `test_shard_full_output_byte_identical_excluding_nondeterminism`) + `tests/unit/orchestration/render/test_shard_generated.py` (7 new) + `test_shard_worker.py` + fork-backend `test_isolated_render_parity.py` — all green.
- [x] `poe proof-pr` or scoped equivalent: `ty check` on the three edited modules unchanged (9 pre-existing structural warnings, 0 from new code); 138 render/snapshot unit tests pass.
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/shard-generated-page-rendering.added.md` + `plan/epic-shard-parallel-build.md` S13.4e entry.

## Performance Evidence

- Benchmark matrix row: thread vs shard, end-to-end build wall time, generated-heavy and render-heavy
- Command: `PYTHONPATH=. uv run python benchmarks/bench_build_ab.py <site> --runs 3 --modes thread,shard`
- Python build: CPython 3.14.2 free-threaded (3.14t)
- Machine/OS: M3 Pro (5P+6E), macOS — dev box, median-of-3 (directional, not the idle-box materialization gate)
- Baseline commit or saved result: pre-S13.4e generated-serial path = S17's 0.88x on a 15%-generated site
- Current commit or saved result: generated-heavy 1431pg/15%-gen = 1.23x (render phase 8.5s to 5.2s); render-heavy test-large = 1.07x (no regression, render 1.9s to 0.8s)
- Artifact path: ephemeral dev-box runs (reproduce via the command above; generate the fixture with `benchmarks/generate_bench_site.py /tmp/site --pages 1200`)
- Interpretation: each speedup is a same-box thread-vs-shard ratio, so the flip from 0.88x (loss) to 1.23x (win) on generated-heavy content is robust to box contamination. The authoritative absolute magnitudes still come from the idle-box S17 gate; this PR makes the generated-heavy case net-positive, which was the prerequisite for the content-aware crossover gate.

## Steward Notes

- `render_isolation` remains `off`; this is cold-build/CLI/CI machinery only, never the dev loop. Thread path is byte-unchanged (all edits are shard-only modules).
- Out of scope but discovered + filed: two pre-existing content-shard byte-parity gaps the HTML-only gate hid — #418 (per-page JSON absent for blog posts) and #419 (enriched authored `_index.md` date divergence; worker re-parses without re-running `_enrich_existing_index`). These are the next S16-v2 blockers before default-on; test-taxonomy is fully byte-clean.
