### PR TITLE
test(meta): catch commented assert True forms in weak-assertion guard (#384)

### DIFF
--- a/tests/meta/test_test_quality.py
+++ b/tests/meta/test_test_quality.py
@@ -49,7 +49,8 @@ class TestNoWeakAssertions:
     @pytest.mark.parametrize(
         ("pattern", "description", "threshold"),
         [
-            (r"^\s*assert\s+True\s*$", "assert True", 10),  # Start with baseline, reduce over time
+            # honest true count incl. commented forms; reduce as #384 findings land
+            (r"^\s*assert\s+True\b", "assert True", 10),
             (r"^\s*assert\s+False\s*$", "assert False (always fails)", 0),
         ],
     )


### PR DESCRIPTION
## Summary

Refs #384 — lands **Finding 12 only** of the assertion-hardening saga: the weak-assertion meta-guard was itself vacuous.

The `assert True` meta-guard regex used an `\s*$` end-anchor, so it was **blind to the most idiomatic form** — `assert True  # why` — under-reporting weak assertions ~3× and letting commented `assert True` accrue freely under the threshold. (This is exactly the #130 lesson: a guard that can't fail when the guarded condition is violated.)

## What changed

One-line regex change in `tests/meta/test_test_quality.py`:

- Pattern `r"^\s*assert\s+True\s*$"` → `r"^\s*assert\s+True\b"` — drop the end-anchor, add a `\b` word boundary (the boundary prevents false positives on identifiers like `True_flag`).
- This raises the detected count from 3 to the honest **10** (7 previously-hidden commented forms now counted), exactly matching the unchanged threshold of 10 — so the ratchet now sits at the **real ceiling with zero headroom**.
- Inline comment updated to note 10 is the honest current count that reduces as sibling findings (3/4/5) land. The `assert False` entry (threshold 0) is untouched.

## Test plan

- `uv run pytest 'tests/meta/test_test_quality.py::TestNoWeakAssertions' -q` → 3 passed
- `uv run ruff check tests/meta/test_test_quality.py` → clean
- **Discriminating (verified by simulation):** adding one `assert True  # foo` line pushes the count to 11 (> 10) → guard FAILS. The `\b` boundary correctly does *not* match `True_flag` / `Truething`.

Test-only change — no `bengal/` edits, no import edges, no rendered-output impact.

## Scope

This is **one finding** of the #384 saga. The sibling findings remain open:
- 3 inverted meta-guards (`pytest.skip` on threshold breach → green exactly when worst)
- 4 downstream vacuous guard targets (href smoke tests, the #130 asset-manifest test, two TrackValidator lookup tests)

Do **not** close #384 on merge.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

Refs #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
