### PR TITLE
docs(theme): correct EXPERIMENTAL.md to reflect opt-in/feature-detected holo CSS (#360)

### DIFF
--- a/bengal/themes/default/assets/css/experimental/EXPERIMENTAL.md
+++ b/bengal/themes/default/assets/css/experimental/EXPERIMENTAL.md
@@ -6,7 +6,7 @@ Components in this directory are **experimental** and may change or be removed w
 
 **Purpose**: Holographic TCG-style card effects inspired by [pokemon-cards-css](https://github.com/simeydotme/pokemon-cards-css). Uses mouse-tracking via CSS custom properties for dynamic shine and gradient effects.
 
-**Status**: Loaded by default. To scope to specific pages, add `data-style="holo"` to a parent container and ensure card elements use the `.holo-card` class.
+**Status**: Not loaded by default. This file is included **only when the build's CSS feature detector finds a holographic class in rendered content** — the regex `holo[-_]?card|holographic` in `bengal/orchestration/feature_detector.py`, mapped to this file via `FEATURE_CSS["holo_cards"]` in `bengal/themes/default/css_manifest.py`. It is also listed in `CSS_EXPERIMENTAL` (opt-in) in the same manifest. To use it, apply the `.holo-card` class to card elements (which triggers detection); to scope effects, add `data-style="holo"` to a parent container.
 
 **Browser support**: Modern browsers with CSS custom properties and `filter`. Best in Chrome, Firefox, Safari 15+.
 
@@ -27,4 +27,9 @@ Components in this directory are **experimental** and may change or be removed w
 
 ## Enabling Experimental Styles
 
-Experimental components are loaded unconditionally in `style.css`. To make holo effects opt-in site-wide, add `data-experimental="holo"` to the `<html>` element when the theme supports it (e.g., via `theme.yaml`).
+Experimental components are **not** imported unconditionally by `style.css`. Inclusion is driven by the CSS manifest in `bengal/themes/default/css_manifest.py`:
+
+- **Feature-detected** — files in `FEATURE_CSS` (e.g. `holo_cards` → `experimental/holo-cards-advanced.css`) are added automatically when the build's feature detector matches the corresponding pattern in rendered content.
+- **Opt-in** — files in `CSS_EXPERIMENTAL` are available for explicit inclusion and are never emitted unless requested.
+
+This keeps experimental, may-be-removed CSS out of every site's bundle by default.

--- a/changelog.d/360.changed.md
+++ b/changelog.d/360.changed.md
@@ -1,0 +1,1 @@
+Default theme: corrected the experimental-CSS documentation (`EXPERIMENTAL.md`) to describe holo styles as feature-detected/opt-in via the CSS manifest rather than "loaded by default" — matching the opt-in behavior shipped in #367 (documentation only; no behavior change).


### PR DESCRIPTION
## Summary

Doc-accuracy fix for the default theme (one item from #360). `EXPERIMENTAL.md` still claimed the holographic CSS was **"Loaded by default"** and that experimental components are **"loaded unconditionally in `style.css`"**. Since #367 that is no longer true — experimental CSS is gated by the theme's CSS manifest and stays out of every site's bundle by default.

## What changed

Corrected the two stale status notes in `bengal/themes/default/assets/css/experimental/EXPERIMENTAL.md` to describe the real mechanism:
- **Feature-detected** — `FEATURE_CSS["holo_cards"]` in `css_manifest.py` maps to `experimental/holo-cards-advanced.css`, added automatically only when the build's feature detector matches `holo[-_]?card|holographic` (`bengal/orchestration/feature_detector.py`) in rendered content.
- **Opt-in** — files in `CSS_EXPERIMENTAL` are never emitted unless explicitly requested.

Documentation only — no behavior or rendered-output change.

## Scope

This closes out the **documentation tail** of #360's "stop shipping experimental cruft" task. #360 stays **open** as the default-theme debt tracker; verified current state:

- ✅ Delete `icons_backup/` and stop the unconditional experimental `@import` / demo HTML — **done in #367** (zero `experimental` imports in `style.css`; no demo HTML ships).
- ◑ "Stop shipping process `.md` files in `assets/`" — largely moot: `asset_discovery.py` already **skips `.md`** (not shipped to output, not discovered as assets), and several (`COMPONENT-PATTERNS.md`, `MOTION_DESIGN_SYSTEM.md`) are **referenced in-source** by CSS/JS, so relocating them would break live `See: …` references. Recommend not relocating.
- ⬜ Remaining substantive refactors stay tracked in #360: the `!important`/hardcoded-hex → semantic-token audit, always-on `infinite` animation trim, the `TYPOGRAPHY_MIGRATION.md` legacy-alias deprecation window, and large-file splits — each needs byte-stability care.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

Refs #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
