### PR TITLE
docs(release): 0.4.0 release page + release-notes distillation workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 - [ ] Focused tests:
 - [ ] `poe proof-pr` or scoped equivalent:
-- [ ] Docs/examples/changelog updated or no-impact noted:
+- [ ] Docs/examples/changelog updated or no-impact noted: <!-- changelog.d/ fragment: lead with one user-facing sentence, then engineering detail (see docs/b-stack-changelog-strategy.md) -->
 
 ## Performance Evidence
 

--- a/docs/b-stack-changelog-strategy.md
+++ b/docs/b-stack-changelog-strategy.md
@@ -46,6 +46,14 @@ Use the same six types everywhere (directory names = Towncrier `directory`):
 
 Body: one line or a short bullet list; **user-facing** wording (what changed for downstream users), not internal refactors.
 
+**Lead-sentence convention.** Start every fragment with a single sentence stating
+what changed *for the user* ("Autodoc now cross-links symbol names to their
+documented pages."), then add engineering detail in following sentences if it's
+worth recording. Two reasons: the first sentence is what a reader skims in
+`CHANGELOG.md`, and it gives the release-page distillation (below) a clean topic
+sentence to lift. The detail stays — fragments are the precise record — it just
+comes *after* the user-facing lead, not instead of it.
+
 ### Shared `[tool.towncrier]` shape
 
 Each repo should mirror this structure; only **`package`**, **`package_dir`**, and **`filename`** vary.
@@ -106,6 +114,35 @@ changelog-draft = { cmd = "towncrier build --draft", help = "Preview changelog f
 - **Performance claims:** Name the benchmark matrix row, exact command, Python
   build, machine/OS, baseline, current result, artifact path, and interpretation
   in the PR before repeating the claim in release notes.
+
+## Release pages (user-facing distillation)
+
+`CHANGELOG.md` is the **engineering record** — every change, in full detail, for
+people debugging or upgrading. It is intentionally dense and should stay that way.
+Repos that ship a documentation site (Bengal) additionally maintain a **distilled,
+user-facing release page** per version at `site/content/releases/<version>.md`:
+a key-theme hook, themed highlights with examples, *condensed* Added/Changed/Fixed
+lists, and upgrade notes. (The releases section auto-lists its children — adding the
+file is enough.)
+
+Keep these as **two artifacts**, do not collapse them. Distillation is a
+release-time, top-down editorial act — the theme and the highlight groupings only
+exist once you can see the whole release, so they cannot be authored fragment by
+fragment weeks apart. Writing the release page is therefore a **required cut step**,
+alongside `poe changelog` and the version bump.
+
+To bootstrap it, `scripts/draft_release_notes.py` turns the compiled `[version]`
+section of `CHANGELOG.md` (plus the previous release page as a style exemplar and,
+optionally, the milestone's closed issues) into a *first draft* you then edit:
+
+```bash
+uv run poe release-notes --version 0.4.0 --theme "Documentation generation grows up"
+# no Anthropic SDK/key? add --bundle to emit a paste-ready prompt instead.
+```
+
+The draft is a starting point, never final copy — review for accuracy and voice
+before shipping. The script never adds `anthropic` to Bengal's dependencies; it's
+an opt-in dev tool.
 
 ## Voice (brand)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -466,6 +466,7 @@ publish = { cmd = "uv publish", help = "Publish to PyPI" }
 changelog = { cmd = "towncrier build --yes", help = "Compile changelog.d fragments into CHANGELOG.md" }
 changelog-draft = { cmd = "towncrier build --draft", help = "Preview changelog from fragments (stdout)" }
 changelog-check = { cmd = "towncrier check --compare-with origin/main", help = "Verify branch adds a fragment (vs main)" }
+release-notes = { cmd = "python scripts/draft_release_notes.py", help = "Draft a user-facing site release page from CHANGELOG.md (--version/--theme/--bundle)" }
 release = { sequence = [
     "changelog",
     "dist",

--- a/scripts/draft_release_notes.py
+++ b/scripts/draft_release_notes.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python
+"""Draft a user-facing doc-site release page from the compiled changelog.
+
+Why this exists
+---------------
+Bengal keeps two release artifacts with two audiences:
+
+  * ``CHANGELOG.md`` — the precise engineering record (every change, in full
+    detail). Compiled from ``changelog.d/`` fragments by Towncrier at cut time.
+  * ``site/content/releases/<version>.md`` — the *distilled, user-facing* story
+    (key theme, themed highlights with examples, condensed lists, upgrade notes).
+
+The distillation is a release-time, top-down editorial act: the theme and the
+highlight groupings only exist once you can see the whole release, so it cannot
+be pushed back into per-fragment authoring. This script produces a *first draft*
+of the release page from the compiled ``[version]`` section of ``CHANGELOG.md``
+(plus an optional milestone issue list and the previous release page as a style
+exemplar), which a human then edits before shipping.
+
+It does NOT add the ``anthropic`` SDK to Bengal's dependencies. Generation is
+opt-in: if ``anthropic`` is importable and a key is configured it calls Claude;
+otherwise (or with ``--bundle``) it writes a ready-to-run prompt + context bundle
+to ``.context/`` that you can paste into Claude Code or any Claude client. Bundle
+mode is pure stdlib.
+
+Usage
+-----
+    # Generate a draft directly (needs `uv pip install anthropic` + ANTHROPIC_API_KEY):
+    uv run python scripts/draft_release_notes.py --version 0.4.0 \
+        --theme "Documentation generation grows up"
+
+    # No API key / no SDK — emit a prompt bundle to run by hand:
+    uv run python scripts/draft_release_notes.py --version 0.4.0 --bundle
+
+    # Pull closed issues for the milestone into the context (needs `gh`):
+    uv run python scripts/draft_release_notes.py --version 0.4.0 --milestone v0.4.0
+
+The default model is Claude Opus 4.8 (``claude-opus-4-8``); override with --model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MODEL = "claude-opus-4-8"
+
+SYSTEM_PROMPT = """\
+You are drafting a user-facing release-notes page for Bengal, a Python static
+site generator. You will be given the compiled CHANGELOG.md section for one
+version (the precise engineering record), an optional list of closed issues, an
+optional release theme, and a previous release page as a STYLE EXEMPLAR.
+
+Your job: distill that dense engineering record into a user-facing release page
+that matches the exemplar's structure and voice EXACTLY. The page must:
+
+  1. Open with YAML frontmatter (title, description, date, draft: false, lang: en,
+     tags, keywords, category: changelog) matching the exemplar's frontmatter keys.
+  2. Have an `# Bengal <version>` H1, then a `**Key theme:**` one-paragraph hook.
+  3. Have a `## Highlights` section with 4-7 `###` subsections, each leading with
+     prose a USER cares about ("you can now ..."), with short code examples where
+     they help. Group related changes into themes; do not list every fragment.
+  4. Follow with CONDENSED `## Added`, `## Changed`, `## Fixed`, and `## Removed`
+     sections — one short bullet per user-meaningful change, referencing issue
+     numbers like (#327) where available. These are a skim layer, NOT the full
+     CHANGELOG text — compress aggressively and omit purely-internal refactors.
+  5. End with an `## Upgrading` section: the install command plus any breaking or
+     opt-in changes a user must act on (config flags, removed features, migrations).
+
+Hard rules:
+  - Be accurate. Every claim must be supported by the changelog input. Do not
+    invent features, numbers, flags, or issue numbers. If a perf number appears
+    in the changelog, you may quote it; never fabricate one.
+  - Write for end users, not contributors. Translate internal mechanism into
+    user-visible benefit. Skip changes that have no user-facing effect.
+  - Match the exemplar's tone: confident, concrete, no marketing fluff.
+  - Output ONLY the markdown file content, starting at the `---` frontmatter.
+    No preamble, no explanation, no surrounding code fences.
+"""
+
+
+def run(cmd: list[str]) -> str:
+    """Run a command from the repo root, returning stdout (empty on failure)."""
+    try:
+        out = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, check=True)
+        return out.stdout
+    except subprocess.CalledProcessError, FileNotFoundError:
+        return ""
+
+
+def read_version_from_pyproject() -> str | None:
+    pyproject = REPO_ROOT / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    for line in pyproject.read_text(encoding="utf-8").splitlines():
+        m = re.match(r'\s*version\s*=\s*"([^"]+)"', line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def extract_changelog_section(changelog: Path, version: str) -> str:
+    """Pull the `## [<version>] ...` block, up to the next `## [` heading."""
+    if not changelog.exists():
+        sys.exit(f"error: {changelog} not found")
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    # Match the heading for this version specifically (escape dots).
+    start_re = re.compile(rf"^## \[{re.escape(version)}\]")
+    next_re = re.compile(r"^## \[")
+    collected: list[str] = []
+    capturing = False
+    for line in lines:
+        if start_re.match(line):
+            capturing = True
+            collected.append(line)
+            continue
+        if capturing and next_re.match(line):
+            break
+        if capturing:
+            collected.append(line)
+    body = "\n".join(collected).strip()
+    if not body:
+        sys.exit(
+            f"error: no '## [{version}]' section found in {changelog}. "
+            "Run `uv run poe changelog` (or `towncrier build --version <v>`) first."
+        )
+    return body
+
+
+def find_style_exemplar(releases_dir: Path, version: str) -> tuple[str, str] | None:
+    """Return (name, text) of the highest-versioned release page that isn't `version`."""
+    if not releases_dir.is_dir():
+        return None
+
+    def version_key(p: Path) -> tuple[int, ...]:
+        return tuple(int(x) for x in re.findall(r"\d+", p.stem))
+
+    candidates = sorted(
+        (p for p in releases_dir.glob("*.md") if p.stem != version and p.stem != "_index"),
+        key=version_key,
+        reverse=True,
+    )
+    if not candidates:
+        return None
+    best = candidates[0]
+    return best.name, best.read_text(encoding="utf-8")
+
+
+def fetch_milestone_issues(milestone: str) -> str:
+    """Best-effort: closed issues for a milestone, via gh. Empty string on failure."""
+    out = run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--milestone",
+            milestone,
+            "--state",
+            "closed",
+            "--limit",
+            "100",
+            "--json",
+            "number,title",
+            "--jq",
+            r'.[] | "- #\(.number): \(.title)"',
+        ]
+    )
+    return out.strip()
+
+
+def build_user_prompt(
+    version: str,
+    theme: str | None,
+    changelog_section: str,
+    issues: str,
+    exemplar: tuple[str, str] | None,
+    date: str | None,
+) -> str:
+    parts: list[str] = [f"Draft the release page for **Bengal {version}**."]
+    if date:
+        parts.append(f"Release date (frontmatter `date:`): {date}")
+    if theme:
+        parts.append(f"Release theme / headline: {theme}")
+    if exemplar:
+        name, text = exemplar
+        parts.append(
+            f"STYLE EXEMPLAR — the previous release page `{name}`. Match its "
+            f"frontmatter keys, section structure, and voice:\n\n{text}"
+        )
+    if issues:
+        parts.append(f"Closed issues in this release (for context):\n\n{issues}")
+    parts.append(
+        "COMPILED CHANGELOG SECTION to distill (the engineering record — "
+        f"compress into the user-facing page):\n\n{changelog_section}"
+    )
+    return "\n\n---\n\n".join(parts)
+
+
+def strip_fences(text: str) -> str:
+    """Remove a leading/trailing markdown code fence and any preamble before `---`."""
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```[a-zA-Z]*\n", "", text)
+        text = re.sub(r"\n```$", "", text).strip()
+    # Drop any chatter before the YAML frontmatter.
+    idx = text.find("---")
+    if idx > 0:
+        text = text[idx:]
+    return text.strip() + "\n"
+
+
+def generate_with_claude(system: str, user_prompt: str, model: str) -> str | None:
+    """Call Claude to produce the draft. Returns None if the SDK isn't available."""
+    try:
+        import anthropic
+    except ImportError:
+        return None
+    try:
+        client = anthropic.Anthropic()  # reads ANTHROPIC_API_KEY / profile from env
+        with client.messages.stream(
+            model=model,
+            max_tokens=16000,
+            thinking={"type": "adaptive"},
+            output_config={"effort": "high"},
+            system=system,
+            messages=[{"role": "user", "content": user_prompt}],
+        ) as stream:
+            message = stream.get_final_message()
+    except anthropic.AuthenticationError:
+        print(
+            "error: no Anthropic credentials (set ANTHROPIC_API_KEY). Falling back to --bundle.",
+            file=sys.stderr,
+        )
+        return None
+    text = "".join(b.text for b in message.content if b.type == "text")
+    return strip_fences(text)
+
+
+def write_bundle(version: str, system: str, user_prompt: str) -> Path:
+    """Write a paste-ready prompt + context bundle for manual Claude use."""
+    out = REPO_ROOT / ".context" / f"release-notes-{version}-prompt.md"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        f"# Release-notes draft prompt for Bengal {version}\n\n"
+        "Paste the SYSTEM and USER blocks below into Claude (Opus 4.8 recommended) "
+        "to draft `site/content/releases/" + version + ".md`, then edit before shipping.\n\n"
+        "## SYSTEM\n\n```\n" + system + "\n```\n\n"
+        "## USER\n\n```\n" + user_prompt + "\n```\n",
+        encoding="utf-8",
+    )
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--version", help="Version to draft (default: read from pyproject.toml)")
+    parser.add_argument("--theme", help="Release theme / headline hook")
+    parser.add_argument("--date", help="Release date for frontmatter (e.g. 2026-06-12)")
+    parser.add_argument("--changelog", default="CHANGELOG.md", help="Path to compiled changelog")
+    parser.add_argument("--milestone", help="GitHub milestone to pull closed issues from (via gh)")
+    parser.add_argument("--out", help="Output path (default: site/content/releases/<version>.md)")
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help=f"Claude model (default: {DEFAULT_MODEL})"
+    )
+    parser.add_argument(
+        "--bundle", action="store_true", help="Emit a prompt bundle instead of calling the API"
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Overwrite the output file if it exists"
+    )
+    args = parser.parse_args()
+
+    version = args.version or read_version_from_pyproject()
+    if not version:
+        sys.exit("error: could not resolve version; pass --version")
+
+    changelog = (
+        (REPO_ROOT / args.changelog)
+        if not Path(args.changelog).is_absolute()
+        else Path(args.changelog)
+    )
+    changelog_section = extract_changelog_section(changelog, version)
+    exemplar = find_style_exemplar(REPO_ROOT / "site" / "content" / "releases", version)
+    issues = fetch_milestone_issues(args.milestone) if args.milestone else ""
+
+    user_prompt = build_user_prompt(
+        version, args.theme, changelog_section, issues, exemplar, args.date
+    )
+
+    if args.bundle:
+        path = write_bundle(version, SYSTEM_PROMPT, user_prompt)
+        print(f"Wrote prompt bundle: {path.relative_to(REPO_ROOT)}")
+        return
+
+    draft = generate_with_claude(SYSTEM_PROMPT, user_prompt, args.model)
+    if draft is None:
+        path = write_bundle(version, SYSTEM_PROMPT, user_prompt)
+        print(
+            "anthropic SDK or credentials unavailable — wrote a prompt bundle instead:\n"
+            f"  {path.relative_to(REPO_ROOT)}\n"
+            "Install with `uv pip install anthropic` and set ANTHROPIC_API_KEY to generate directly.",
+            file=sys.stderr,
+        )
+        return
+
+    out = (
+        Path(args.out)
+        if args.out
+        else REPO_ROOT / "site" / "content" / "releases" / f"{version}.md"
+    )
+    if out.exists() and not args.force:
+        sys.exit(
+            f"error: {out} already exists. Re-run with --force to overwrite, "
+            "or pass --out to write elsewhere."
+        )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(draft, encoding="utf-8")
+    print(f"Wrote release-page draft: {out.relative_to(REPO_ROOT)}")
+    print("Review and edit before shipping — this is a first draft, not final copy.")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/content/releases/0.4.0.md
+++ b/site/content/releases/0.4.0.md
@@ -1,0 +1,113 @@
+---
+title: Bengal 0.4.0
+description: Documentation generation grows up — S-tier Python and OpenAPI autodoc, byte-reproducible parallel builds, a more reliable dev server, a stabilized default theme with versioned theme libraries, and an experimental opt-in render-at-scale backend.
+date: 2026-06-12
+draft: false
+lang: en
+tags: [release, changelog, autodoc, openapi, performance, theme, dev-server]
+keywords: [release, 0.4.0, autodoc, openapi, reproducible-builds, render-isolation, theme-libraries, dev-server]
+category: changelog
+---
+
+# Bengal 0.4.0
+
+**Key theme:** Documentation generation grows up. Bengal 0.4.0 turns autodoc from "it renders" into a real reference experience — Python API docs cross-link symbols, group overloads, and show inheritance; REST/OpenAPI docs become a filterable, navigable explorer. Around that headline, builds are now **byte-reproducible** and meaningfully faster, the `bengal serve` dev loop is more reliable, the bundled theme is stabilized, and there's an early, **opt-in** backend for rendering large sites across separate process heaps.
+
+---
+
+## Highlights
+
+### Python API docs that cross-link, group overloads, and show inheritance
+
+Autodoc output is now genuinely navigable:
+
+- **Symbol cross-linking.** Return types, parameter types, base classes, `See Also` targets, and bare `Name` code spans in docstrings now link to the documented symbol's page. A deterministic resolver maps symbols to page-aware URLs (modules to their page, classes/functions/methods to a stable `#card` anchor), so links never 404. Ambiguous simple names resolve to nothing rather than guessing — a wrong link is worse than no link. The previously-dropped `See Also` section now renders.
+- **`@overload` grouping.** Multiple `typing.overload` stubs plus the implementation collapse into a *single* documented member that lists every signature variant, with an `overload` badge — instead of N+1 duplicate peers colliding on one anchor.
+- **Inherited-member badges.** With `include_inherited` enabled, members synthesized from base classes now render an "inherited from X" attribution badge, visually distinct from native members.
+- Members that don't get their own page (classes, functions, methods, CLI options) now get an on-page anchor `href` instead of a dangling page URL.
+
+### REST / OpenAPI docs become a real explorer
+
+- **Advanced schema rendering.** `oneOf` / `anyOf` / `allOf` render as labeled composition blocks; polymorphic schemas show their `discriminator` and mapping; validation constraints (`format`, `pattern`, numeric and length bounds, `uniqueItems`, …) render as chips; `nullable` / `readOnly` / `writeOnly` / `deprecated` render as badges; and self-referential schemas show a bounded "circular reference" indicator instead of an empty box or runaway recursion.
+- **A page per endpoint, by default.** Every endpoint now gets its own three-column explorer page (the `consolidate` option defaults to `false`), so endpoint cards link to real pages instead of dead anchors. Set `consolidate: true` for the old reference-view.
+- **Catalog navigation.** The API landing catalog and schema index gained client-side filtering, a scroll-spy left rail, and copy buttons on operation paths — one lazy-loaded vanilla-JS enhancement, **no npm**, fully degrading with JS disabled and honoring `prefers-reduced-motion`.
+
+### Faster — and byte-reproducible — builds
+
+- **Reproducible output.** Identical content now produces identical output across repeated builds *and across worker counts*. Related-posts tie-breaks, tag-listing order, and tag accent colors are all deterministic now, making parallel free-threaded output trustworthy for caching, CDNs, and version control.
+- **Render hot path ~27% faster** single-threaded (section-path memoization eliminated ~265k `pathlib` calls on a 300-page docs build).
+- **Related posts ~8× faster** on large sites (4,288 pages: ~24s → ~3s), with byte-identical output.
+- **Asset-dependency extraction ~4× faster** via a single-pass scanner, and the post-render asset audit now parallelizes (autodoc builds ~1.7× overall).
+- **Warm dev-loop saves**: the provenance dependency index now updates incrementally instead of re-reading every record — ~180× cut to that save phase on a 500-page blog.
+
+### A more reliable `bengal serve`
+
+The dev-server "theme drops to unstyled HTML" class of bugs is fixed:
+
+- **Hidden-buffer asset 404s fixed.** When the active output buffer was the hidden `.bengal/staging` directory, Pounce's static handler 404'd *every* CSS/JS/font request while HTML kept loading — the classic fully-rendered-but-unstyled page. A live repro went from 53% of CSS requests 404ing to 0%.
+- **`sendfile` EAGAIN crash fixed** (the `BlockingIOError: [Errno 35]` seen serving static assets on macOS + free-threaded 3.14t).
+- **Asset-manifest buffer drift fixed**, plus a startup HTTP serve-ability smoke check that fails loudly if a known asset can't be fetched — catching serve-path regressions before the first request.
+
+### One stable default theme + versioned theme libraries
+
+- The bundled `default` theme is **stabilized**: dead/demo assets removed, experimental holographic-card CSS is now feature-detected/opt-in (no longer force-loaded), and pagination/TOC glow animations honor `prefers-reduced-motion`.
+- The in-repo `chirpui` bridge theme is **removed** — component-library integration (e.g. Chirp UI) now ships as external theme packages through the same library-provider contract.
+- **Theme-library version governance.** Theme libraries can declare a `contract_version` and a `requires` map of PEP 440 specifiers; Bengal enforces both at build start with a clear `BengalConfigError` (C003) and a fix command, instead of failing on the first rendered page. A `bengal[chirp]` extra pins compatible versions.
+
+### Experimental: render at scale across process heaps (opt-in, off by default)
+
+Bengal 0.4.0 lands the foundation for rendering large cold builds across **separate-heap worker processes**, to recover the free-threading render plateau. It is **off by default** behind `[build] render_isolation`, scoped to cold CLI/CI builds only (the dev server and incremental builds keep the in-process thread path), produces byte-identical output, and falls back to threads on any failure — so it can never break a build. It's not yet a guaranteed end-to-end win on every site, which is exactly why it stays opt-in. Tracking continues in #350.
+
+---
+
+## Added
+
+- Python autodoc: symbol cross-linking, `@overload` grouping, and inherited-member badges (#327, #328, #329).
+- REST/OpenAPI autodoc: advanced schema rendering and first-class catalog navigation (#285, #287).
+- Experimental, opt-in isolated render backend for large cold builds (`render_isolation`, off by default) (#350).
+- Theme-library version governance — `contract_version` + `requires` enforcement and a `bengal[chirp]` extra (#363).
+- Dev-server startup serve-ability smoke check and a live `bengal serve` HTTP integration test (#398, #399).
+- A theming guide ("What Bengal Provides vs What Your Theme Provides"), a REST autodoc visual-QA checklist, `.github/CODEOWNERS`, and a CI import-contract gate.
+
+## Changed
+
+- OpenAPI autodoc Phase 2: a page per endpoint by default, full consolidated tag-page references, cross-endpoint sidebar, and multi-tag cross-listing (#287 and follow-ups).
+- Builds are faster: related-posts (~8×), render hot path (~27%), asset-extraction (~4×), parallel asset audit (~1.7× on autodoc), and incremental provenance save (~180×).
+- The bundled `default` theme is stabilized — dead assets removed, holo CSS feature-detected, reduced-motion respected.
+- Theme-library provider resolution is cached per `(site_root, theme_chain)`, shared across all build paths and shard workers.
+- The experimental shard-render byte-parity tests now run as a nightly signal instead of gating every PR (#376); the functional shard tests stay merge gates.
+- Standardized CLI render-format vocabulary so `json` is the consistent machine-readable token and `--help` shows one format option, not two.
+- Reduced internal coupling to the legacy `Page` class (retired public `bengal.Page` re-exports; deleted the legacy mutable `Page` module).
+
+## Fixed
+
+- **Builds are byte-reproducible** across repeated builds and worker counts (#reproducible-builds).
+- Dev server: hidden-buffer asset 404s (unstyled-page bug), `sendfile` EAGAIN crashes, and asset-manifest buffer drift (#392, #400, #314, #315).
+- Warm/incremental builds now keep `rss.xml`, the Lunr `search-index.json`, and the asset manifest correct (no more shrinking-to-one-entry or stale feeds).
+- The internal taxonomy snapshot is no longer always-empty, restoring the lock-free tag-page fast path and correct per-language tag pages under i18n.
+- Cleared the dogfood-site health blockers (broken nav links, missing icons, unregistered `important` admonition); health rose 60% → 80% (#288).
+- Snapshot parse cache now keys on parser version + config hash; rendered-output cache resolves template deps against the site root.
+- Faster CLI help — `--version` and single-command runs skip full parser construction.
+- Numerous docs-accuracy corrections (parser availability, custom-directives API, benchmark figures) with import/contract guards.
+
+## Removed
+
+- The experimental in-repo `chirpui` bridge theme — Bengal now bundles a single stable `default` theme (#remove-chirpui-bridge).
+- Dead REST/OpenAPI layout CSS (~1450 lines) superseded by the current explorer shell, plus stale skipped tests and dead packages/metadata.
+
+---
+
+## Upgrading
+
+```bash
+uv pip install --upgrade bengal
+# or
+pip install --upgrade bengal
+```
+
+Most changes are additive or internal. A few things to know:
+
+- **OpenAPI endpoint pages** now generate one page per endpoint by default. If you relied on the consolidated reference view, set `consolidate: true` in your OpenAPI autodoc config.
+- **The `chirpui` bridge theme was removed.** If you used it, switch to an external theme package built on the theme-library provider contract.
+- **Theme-library authors:** declare `contract_version` and `requires` in your `get_library_contract()` so version skew fails fast with a clear message at build start.
+- **The isolated render backend is off by default.** It's experimental; opt in with `[build] render_isolation` only for large cold CLI/CI builds, and expect a thread fallback on any failure.


### PR DESCRIPTION
## Summary

The v0.4.0 cut compiled `CHANGELOG.md` but **skipped the doc-site release page** — `site/content/releases/` has a page for every prior version. This PR adds the missing `0.4.0.md` and formalizes the distillation workflow so future cuts don't miss it.

- **`site/content/releases/0.4.0.md`** — distilled, user-facing 0.4.0 notes (key theme → themed highlights w/ examples → condensed Added/Changed/Fixed/Removed → Upgrading), matching the existing release-page pattern. Verified: builds, renders (70KB), and auto-lists in the releases index.
- **`scripts/draft_release_notes.py` + `poe release-notes`** — drafts a release page from the compiled `[version]` section of `CHANGELOG.md`, using the previous release page as a style exemplar (+ optional `--milestone` issues). Opt-in Anthropic call (Opus 4.8); falls back to a paste-ready `--bundle` prompt. **Does not add `anthropic` as a dependency** — lazy import, bundle mode is pure stdlib.
- **`docs/b-stack-changelog-strategy.md`** — documents the two-artifact model (dense `CHANGELOG.md` = engineering record vs distilled release page = user story), the per-fragment **user-facing lead-sentence** convention, and that writing the release page is a **required cut step**.
- **`pull_request_template.md`** — reminds fragment authors to lead with a user-facing sentence.
- Also creates the `skip-changelog` label that `changelog.yml` already checks for (applied here — this PR is docs/tooling, no user-facing Bengal code).

## Proof

- [x] Focused tests: `scripts/draft_release_notes.py --bundle` verified end-to-end (extracts the 0.4.0 changelog section, pulls 0.3.3 as the exemplar, writes the prompt bundle). Full site build green with the new page.
- [x] `poe proof-pr` or scoped equivalent: `ruff check` + `ruff format` clean on the new script; pre-commit hooks pass.
- [x] Docs/examples/changelog updated or no-impact noted: docs updated; no `bengal/` runtime change, so no changelog fragment (skip-changelog).

## Performance Evidence

not applicable — docs + a maintainer-facing dev script; no runtime or hot-path change.

## Steward Notes

- Distillation is deliberately a release-time, top-down act (theme + groupings need the whole release), so it stays a cut step rather than per-fragment authoring.
- The script is a first-draft generator — output is always human-edited before shipping.