### PR TITLE
fix(rendering): wire data_table into register_all() (#434)

### DIFF
--- a/bengal/rendering/template_functions/__init__.py
+++ b/bengal/rendering/template_functions/__init__.py
@@ -119,6 +119,7 @@ from . import (
     seo,
     sharing,
     strings,
+    tables,
     taxonomies,
     theme,
     urls,
@@ -203,6 +204,10 @@ def register_all(
     changelog.register(env, site)
     authors.register(env, site)
 
+    # Phase 7d: Data table function (data_table) -- registered before plugin
+    # extensions (Phase 11) so it stays a default global without clobbering them.
+    tables.register(env, site)
+
     # Phase 8: Template tests (match, draft, featured, etc.)
     template_tests.register(env, site)
 
@@ -253,6 +258,7 @@ __all__ = [
     "seo",
     "sharing",
     "strings",
+    "tables",
     "taxonomies",
     "template_tests",
     "theme",

--- a/changelog.d/434.fixed.md
+++ b/changelog.d/434.fixed.md
@@ -1,0 +1,1 @@
+Wire the `data_table` template function into `register_all()` so templates calling `{{ data_table(...) }}` no longer raise an `UndefinedError` at render time. The function existed and was tested in isolation, but was never registered through the production rendering path. (#434)

--- a/site/content/docs/reference/template-functions/reference-generated.md
+++ b/site/content/docs/reference/template-functions/reference-generated.md
@@ -178,6 +178,7 @@ Call directly: `{{ function_name() }}` or `{{ function_name(arg) }}`
 | `commands` | `commands_filter` |
 | `current_lang` | `current_lang` |
 | `cursor_mcp_install_url` | `cursor_mcp_install_url_with_site` |
+| `data_table` | `_data_table` |
 | `doc` | `doc_with_site` |
 | `email_share_url` | `email_share_url` |
 | `ensure_trailing_slash` | `ensure_trailing_slash` |

--- a/tests/unit/template_functions/test_tables.py
+++ b/tests/unit/template_functions/test_tables.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 from kida import Environment, Markup
 
+from bengal.rendering.template_functions import register_all
 from bengal.rendering.template_functions.tables import data_table, register
 
 
@@ -89,6 +90,56 @@ class TestRegister:
         register(env, site)
 
         assert callable(env.globals["data_table"])
+
+
+class TestRegisterAllWiring:
+    """Guard that data_table is reachable through the production wiring path.
+
+    The TestRegister tests above call tables.register() in isolation, which
+    passes even when tables is never wired into register_all() -- that vacuity
+    hid issue #434, where {{ data_table(...) }} raised UndefinedError at render
+    time because register_all() (the only production registration path) never
+    called tables.register(). These tests exercise register_all() directly so
+    they fail if the wiring is dropped again.
+    """
+
+    def test_register_all_exposes_data_table(self):
+        """register_all() must expose data_table in env.globals (#434)."""
+        env = Environment()
+        site = MagicMock()
+        site.root_path = Path(".")
+
+        register_all(env, site)
+
+        assert "data_table" in env.globals, (
+            "data_table missing from env.globals after register_all() -- "
+            "tables.register() is not wired into register_all() (#434)"
+        )
+
+    def test_register_all_data_table_is_callable(self):
+        """The data_table global wired by register_all() must be callable (#434)."""
+        env = Environment()
+        site = MagicMock()
+        site.root_path = Path(".")
+
+        register_all(env, site)
+
+        assert callable(env.globals.get("data_table")), (
+            "data_table registered by register_all() is not callable (#434)"
+        )
+
+    def test_register_all_data_table_renders_in_template(self, mock_env, yaml_data_file):
+        """data_table wired by register_all() renders a real table (#434)."""
+        site = MagicMock()
+        site.root_path = mock_env.globals["site"].root_path
+
+        register_all(mock_env, site)
+
+        template = mock_env.from_string("{{ data_table(path) }}")
+        result = template.render(path=f"data/{yaml_data_file.name}")
+
+        assert "bengal-data-table" in result
+        assert "Alice" in result
 
 
 class TestDataTableFunction:


### PR DESCRIPTION
## Summary

- Wire `tables.register()` into `register_all()` so the `data_table` template global is reachable through the production rendering path. Previously the `tables` module was never imported or registered, so any template using `{{ data_table(...) }}` raised an `UndefinedError` at render time even though the function existed, was unit-tested in isolation, and was documented. Closes #434.
- Registration is placed after Phase 7 (content view filters) and before Phase 11 (plugin extensions) so `data_table` joins the default globals without clobbering plugin-provided extensions.
- Added `tables` to the package import block and `__all__`; added the `data_table` row to the generated template-functions reference.

## Proof

- [x] Focused tests: `uv run pytest tests/unit/template_functions/test_tables.py -q` -> 31 passed.
- [x] `poe proof-pr` or scoped equivalent: pre-commit hooks (ruff, ruff format, ty, dep/cycle checks) passed on commit.
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/434.fixed.md` added; `reference-generated.md` updated with the `data_table` row.

Discriminating-test note: the existing `TestRegister` tests call `tables.register()` directly, which passed even with the wiring missing -- that vacuity hid this bug (the #130 lesson). The new `TestRegisterAllWiring` class drives `register_all()` and asserts `data_table` is present, callable, and renders a real table. Verified these three tests FAIL (one with the exact `UndefinedError` symptom) when the `tables.register()` call is removed, and PASS with it restored.

## Performance Evidence

not applicable -- N/A, correctness fix, no perf impact.

## Steward Notes

- Filed by the steward swarm audit (2026-06-12), part of #432. The required fix (wire `register()`, not delete) was the correct branch: `data_table` is a live, documented, distinct capability from `DataTableDirective`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
