### PR TITLE
fix(assets): re-export AssetManifest + honor nested [assets] config (#447)

### DIFF
--- a/bengal/assets/__init__.py
+++ b/bengal/assets/__init__.py
@@ -47,3 +47,7 @@ See Also:
 """
 
 from __future__ import annotations
+
+from bengal.assets.manifest import AssetManifest, AssetManifestEntry
+
+__all__ = ["AssetManifest", "AssetManifestEntry"]

--- a/bengal/orchestration/asset.py
+++ b/bengal/orchestration/asset.py
@@ -322,9 +322,15 @@ class AssetOrchestrator:
                 f"{cli.icons.tree_end} Output: {total_output} files {cli.icons.success}", indent=1
             )
 
-        minify = self.site.config.get("minify_assets", True)
-        optimize = self.site.config.get("optimize_assets", True)
-        fingerprint = self.site.config.get("fingerprint_assets", True)
+        # Read the nested ``[assets]`` config (assets.minify / assets.optimize /
+        # assets.fingerprint), as documented. Fall back to the deprecated flat
+        # keys (minify_assets / optimize_assets / fingerprint_assets) for
+        # backward compatibility with older configs.
+        minify = assets_cfg.get("minify", self.site.config.get("minify_assets", True))
+        optimize = assets_cfg.get("optimize", self.site.config.get("optimize_assets", True))
+        fingerprint = assets_cfg.get(
+            "fingerprint", self.site.config.get("fingerprint_assets", True)
+        )
 
         # Log asset processing configuration
         logger.info(

--- a/changelog.d/447.fixed.md
+++ b/changelog.d/447.fixed.md
@@ -1,0 +1,1 @@
+Restored the documented public import `from bengal.assets import AssetManifest` (the package previously re-exported nothing) and made the asset orchestrator honor the nested `[assets]` settings (`minify`, `optimize`, `fingerprint`) instead of the deprecated flat `*_assets` keys, so setting `minify = false` under `[assets]` now actually disables minification. (#447)

--- a/tests/unit/assets/test_assets_pipeline.py
+++ b/tests/unit/assets/test_assets_pipeline.py
@@ -126,3 +126,118 @@ def test_cli_build_flag_overrides_pipeline(tmp_path: Path, monkeypatch):
 
     # Assert: command succeeded
     assert result.exit_code == 0
+
+
+def test_asset_manifest_importable_from_package() -> None:
+    """The documented public import ``from bengal.assets import AssetManifest`` works.
+
+    Regression guard for #447: ``bengal/assets/__init__.py`` previously had no
+    re-export, so the documented import (docstring + theming/assets docs) raised
+    ImportError. This asserts both names are re-exported from the package root
+    and are the same objects as the ones defined in ``bengal.assets.manifest``.
+    """
+    from bengal.assets import AssetManifest as PackageManifest
+    from bengal.assets import AssetManifestEntry as PackageEntry
+    from bengal.assets.manifest import AssetManifest as ModuleManifest
+    from bengal.assets.manifest import AssetManifestEntry as ModuleEntry
+
+    assert PackageManifest is ModuleManifest
+    assert PackageEntry is ModuleEntry
+
+
+def test_orchestrator_honors_nested_assets_minify_false(tmp_path: Path, monkeypatch) -> None:
+    """``[assets] minify = false`` must disable minification.
+
+    Regression guard for #447: the orchestrator used to read the deprecated flat
+    key ``minify_assets`` (which never exists once the loader flattens
+    ``assets.*`` to bare keys), so the documented nested ``[assets] minify``
+    setting was silently ignored and minification stayed on. This spies on the
+    derived ``minify`` flag handed to processing. It is discriminating: if the
+    orchestrator reverted to reading ``minify_assets``, ``captured["minify"]``
+    would be the ``True`` default and the assertion would fail.
+    """
+    from bengal.orchestration.asset import AssetOrchestrator
+
+    # Nested [assets] config as documented; note this is the section dict that
+    # config_service.assets_config returns.
+    site = DummySite(tmp_path, config={"assets": {"minify": False}})
+    orchestrator = AssetOrchestrator(site)
+
+    captured: dict = {}
+
+    def fake_sequential(
+        self,
+        css_entries,
+        other_assets,
+        minify,
+        optimize,
+        fingerprint,
+        progress_manager,
+        css_modules_count=0,
+    ):
+        captured["minify"] = minify
+        captured["optimize"] = optimize
+        captured["fingerprint"] = fingerprint
+
+    monkeypatch.setattr(AssetOrchestrator, "_process_sequentially", fake_sequential)
+
+    class _FakeAsset:
+        def __init__(self) -> None:
+            self.source_path = tmp_path / "app.js"
+
+        def is_css_entry_point(self) -> bool:
+            return False
+
+        def is_css_module(self) -> bool:
+            return False
+
+        def is_js_module(self) -> bool:
+            return False
+
+    orchestrator.process([_FakeAsset()])
+
+    assert captured["minify"] is False
+
+
+def test_orchestrator_minify_defaults_true_without_assets_config(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """With no ``[assets]`` config, minification defaults to on (proves the guard
+    above fails for the right reason, not because the flag is always False)."""
+    from bengal.orchestration.asset import AssetOrchestrator
+
+    site = DummySite(tmp_path, config={})
+    orchestrator = AssetOrchestrator(site)
+
+    captured: dict = {}
+
+    def fake_sequential(
+        self,
+        css_entries,
+        other_assets,
+        minify,
+        optimize,
+        fingerprint,
+        progress_manager,
+        css_modules_count=0,
+    ):
+        captured["minify"] = minify
+
+    monkeypatch.setattr(AssetOrchestrator, "_process_sequentially", fake_sequential)
+
+    class _FakeAsset:
+        def __init__(self) -> None:
+            self.source_path = tmp_path / "app.js"
+
+        def is_css_entry_point(self) -> bool:
+            return False
+
+        def is_css_module(self) -> bool:
+            return False
+
+        def is_js_module(self) -> bool:
+            return False
+
+    orchestrator.process([_FakeAsset()])
+
+    assert captured["minify"] is True


### PR DESCRIPTION
## Summary

Closes #447.

Two documented-contract regressions in the assets layer:

- The documented public import `from bengal.assets import AssetManifest` raised `ImportError` because `bengal/assets/__init__.py` was only a docstring with no re-export. Added `AssetManifest`/`AssetManifestEntry` to the package root.
- The asset orchestrator read deprecated flat config keys (`minify_assets`/`optimize_assets`/`fingerprint_assets`) that never exist once the loader flattens `[assets].*` to bare keys. So a user setting `[assets]\nminify = false` (per the theming/assets docs) still got minification. The orchestrator now reads the nested `config_service.assets_config` section, keeping the flat keys as a backward-compat fallback.

## Proof

- [x] Focused tests: `uv run pytest tests/unit/assets/test_assets_pipeline.py -q` -> 6 passed
- [x] `poe proof-pr` or scoped equivalent: ran the targeted asset-pipeline suite (above); pre-commit ruff/ty/cycle/dep-layer hooks pass.
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/447.fixed.md` added.

Tests are discriminating (verified by reverting each fix):
- Reverting the `__init__.py` re-export makes `test_asset_manifest_importable_from_package` fail.
- Reverting the orchestrator to read `minify_assets` makes `test_orchestrator_honors_nested_assets_minify_false` fail.
- `test_orchestrator_minify_defaults_true_without_assets_config` proves the minify guard fails for the right reason (default stays `True` with no `[assets]` config), not because the flag is always `False`.

## Performance Evidence

- Benchmark matrix row: Not applicable
- Command: Not applicable
- Python build: Not applicable
- Machine/OS: Not applicable
- Baseline commit or saved result: Not applicable
- Current commit or saved result: Not applicable
- Artifact path: Not applicable
- Interpretation: Not applicable — correctness fix, no perf impact.

## Steward Notes

Filed by the steward swarm audit (2026-06-12), part of #432, steward `assets`, severity P1.
