### PR TITLE
fix(autodoc): resolve "View source" links to real GitHub URLs (#441)

### DIFF
--- a/bengal/themes/default/templates/autodoc/partials/header.html
+++ b/bengal/themes/default/templates/autodoc/partials/header.html
@@ -94,12 +94,26 @@ children = element?.children ?? []
   {% end %}
   {% end %}
 
-  {# Source link #}
-  {% with meta?.source_file as source_file %}
-  {% if show_source and source_file %}
-  <a href="{{ meta?.source_url ?? '#' }}" class="autodoc-source" target="_blank" rel="noopener">
+  {# Source link - build the GitHub blob URL inline from `config` (see #441).
+     The old template read `meta?.source_url`, which nothing ever populates, so
+     every link fell back to '#'. We now resolve github_repo / github_branch the
+     same way the autodoc config normalizer does: prefer the [autodoc] section,
+     fall back to the top level, and expand `owner/repo` shorthand to a full URL.
+     `config` may be a Config accessor (use its `.raw` dict for predictable
+     `| get` semantics) or an already-normalized dict. #}
+  {% let _cfg = config?.raw ?? config %}
+  {% let _autodoc = _cfg | get('autodoc', {}) %}
+  {% let _repo = (_autodoc | get('github_repo', '')) or (_cfg | get('github_repo', '')) %}
+  {% let _repo = _repo | string %}
+  {% let source_file = element?.display_source_file ?? element?.source_file %}
+  {% if show_source and source_file and _repo %}
+  {% let github_repo = _repo if _repo.startswith('http') else ('https://github.com/' ~ _repo) %}
+  {% let _branch = (_autodoc | get('github_branch', '')) or (_cfg | get('github_branch', '')) %}
+  {% let branch = (_branch | string) if _branch else 'main' %}
+  {% let line_anchor = '#L' ~ element.line_number if element?.line_number else '' %}
+  {% let source_url = github_repo ~ '/blob/' ~ branch ~ '/' ~ source_file ~ line_anchor %}
+  <a href="{{ source_url }}" class="autodoc-source" target="_blank" rel="noopener">
     View source
   </a>
-  {% end %}
   {% end %}
 </header>

--- a/changelog.d/441.fixed.md
+++ b/changelog.d/441.fixed.md
@@ -1,0 +1,1 @@
+Autodoc "View source" links now resolve to a real GitHub blob URL when `github_repo` is configured (under `[autodoc]` or at the top level), instead of always falling back to `#`. The default-theme autodoc header partial builds the URL from the repository and branch directly, expanding `owner/repo` shorthand and honoring `github_branch`. (#441)

--- a/tests/unit/autodoc/test_header_source_link.py
+++ b/tests/unit/autodoc/test_header_source_link.py
@@ -1,0 +1,147 @@
+"""
+End-to-end render test for the autodoc "View source" link (regression for #441).
+
+The autodoc header partial (``autodoc/partials/header.html``) used to read a
+``source_url`` key that nothing ever writes to ``element.metadata`` and fell
+back to ``#``. As a result, every "View source" link rendered as ``#`` even
+when ``github_repo`` was configured.
+
+These tests render the partial through the real template engine with a
+configured ``github_repo`` and assert a *real* blob URL is produced. They pass
+the live ``Site.config`` object (exactly what the autodoc renderer hands the
+template), so the positive assertion fails if the partial regresses to the
+``#`` fallback -- this is what makes the test discriminating.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bengal.autodoc.base import DocElement
+from bengal.core.site import Site
+from bengal.rendering.template_engine import TemplateEngine
+
+# Render the partial exactly as the page templates do (it inherits `element` and
+# `config` from the surrounding template context, matching production).
+HEADER_INCLUDE = "{% include 'autodoc/partials/header.html' %}"
+
+
+def _make_site(tmp_path: Path, *, github_repo: str | None, branch: str | None = None) -> Site:
+    site_dir = tmp_path / "site"
+    (site_dir / "content").mkdir(parents=True)
+    (site_dir / "public").mkdir(parents=True)
+
+    autodoc_lines = []
+    if github_repo is not None:
+        autodoc_lines.append(f'github_repo = "{github_repo}"')
+    if branch is not None:
+        autodoc_lines.append(f'github_branch = "{branch}"')
+    autodoc_block = "[autodoc]\n" + "\n".join(autodoc_lines) if autodoc_lines else ""
+
+    cfg = site_dir / "bengal.toml"
+    cfg.write_text(
+        f"""
+[site]
+title = "Test"
+
+[build]
+output_dir = "public"
+
+{autodoc_block}
+        """,
+        encoding="utf-8",
+    )
+    (site_dir / "content" / "index.md").write_text(
+        "---\ntitle: Home\n---\n# Home\n", encoding="utf-8"
+    )
+    return Site.from_config(site_dir)
+
+
+def _make_element() -> DocElement:
+    element = DocElement(
+        name="MyClass",
+        qualified_name="mypackage.core.MyClass",
+        description="A documented class.",
+        element_type="class",
+        source_file=Path("/repo/mypackage/core.py"),
+        line_number=42,
+        metadata={"type": "autodoc/python"},
+        children=[],
+        examples=[],
+        see_also=[],
+        deprecated=None,
+    )
+    # page_builders.py sets this repo-relative display path on the element
+    # before rendering; mirror that here.
+    element.display_source_file = "mypackage/core.py"
+    return element
+
+
+def _render(site: Site, element: DocElement) -> str:
+    engine = TemplateEngine(site)
+    # Pass the live Site.config object, mirroring AutodocRenderer's render() call.
+    return engine.render_string(HEADER_INCLUDE, {"element": element, "config": site.config})
+
+
+def test_view_source_renders_real_blob_url_when_github_repo_configured(tmp_path: Path) -> None:
+    """A configured github_repo (in [autodoc]) produces a real blob URL, not '#'."""
+    site = _make_site(tmp_path, github_repo="myorg/myproject")
+    html = _render(site, _make_element())
+
+    expected = "https://github.com/myorg/myproject/blob/main/mypackage/core.py#L42"
+    assert f'href="{expected}"' in html, (
+        f"View source link should point at the GitHub blob URL.\nGot:\n{html}"
+    )
+    # Discriminating guard: the old bug rendered href="#". If the partial
+    # regresses to that fallback, this fails.
+    assert 'href="#"' not in html
+    assert "View source" in html
+
+
+def test_view_source_honors_custom_branch(tmp_path: Path) -> None:
+    """github_branch from [autodoc] is reflected in the blob URL."""
+    site = _make_site(tmp_path, github_repo="myorg/myproject", branch="develop")
+    html = _render(site, _make_element())
+
+    assert 'href="https://github.com/myorg/myproject/blob/develop/mypackage/core.py#L42"' in html
+    assert 'href="#"' not in html
+
+
+def test_view_source_accepts_full_url_repo(tmp_path: Path) -> None:
+    """A repo already given as a full URL is not double-prefixed."""
+    site = _make_site(tmp_path, github_repo="https://github.com/myorg/myproject")
+    html = _render(site, _make_element())
+
+    assert 'href="https://github.com/myorg/myproject/blob/main/mypackage/core.py#L42"' in html
+    assert "https://github.com/https://" not in html
+
+
+def test_view_source_omitted_when_no_github_repo(tmp_path: Path) -> None:
+    """Without a configured repo, no 'View source' link (and no '#' leak) renders."""
+    site = _make_site(tmp_path, github_repo=None)
+    html = _render(site, _make_element())
+
+    # No repo configured -> the source link block is skipped entirely.
+    assert "View source" not in html
+    assert 'href="#"' not in html
+
+
+def test_view_source_omitted_when_element_has_no_source_file(tmp_path: Path) -> None:
+    """Elements without a source file (e.g. some CLI commands) get no link."""
+    site = _make_site(tmp_path, github_repo="myorg/myproject")
+    element = DocElement(
+        name="build",
+        qualified_name="cli.build",
+        description="Build command.",
+        element_type="command",
+        source_file=None,
+        line_number=None,
+        metadata={"type": "autodoc/cli"},
+        children=[],
+        examples=[],
+        see_also=[],
+        deprecated=None,
+    )
+    html = _render(site, element)
+
+    assert "View source" not in html


### PR DESCRIPTION
## Summary

- Closes #441
- The default-theme autodoc header partial (`autodoc/partials/header.html`) read `meta?.source_url`, a key nothing ever writes to `element.metadata`, so every "View source" link on Python/CLI/OpenAPI autodoc pages fell back to `#` even when `github_repo` was configured.
- Fixed in the template path (per the issue's required fix): build the GitHub blob URL inline from `config`, reading `github_repo`/`github_branch` from the `[autodoc]` section (or top level), expanding `owner/repo` shorthand to a full URL, and appending the source path + `#L<line>` anchor. The builder/extraction paths are untouched.
- `config` may be a `Config` accessor or an already-normalized dict; the template uses `config?.raw ?? config` so `| get(...)` has predictable dict semantics in both cases.

## Proof

- [x] Focused tests: `uv run pytest tests/unit/autodoc/test_header_source_link.py tests/unit/autodoc/test_source_links.py -q` -> 18 passed
- [x] `poe proof-pr` or scoped equivalent: scoped to the touched autodoc render path (`test_header_source_link.py` end-to-end render + `test_virtual_page_rendering.py` + `test_source_links.py`), all green
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/441.fixed.md` added

Discriminating-test evidence: reverting `header.html` to the old `meta?.source_url ?? '#'` makes the three positive render assertions fail (they require a real blob URL the old template cannot produce); restoring the fix turns them green.

## Performance Evidence

not applicable — correctness fix, no perf impact, no hot-path or free-threaded behavior change.

## Steward Notes

- Steward: `autodoc`. Filed by the steward swarm audit (part of #432).
- Fix is template-only (`bengal/themes/default/templates/autodoc/partials/header.html`), honoring the guardrail to avoid the autodoc builder so CLI/OpenAPI/Python page-build paths cannot regress.
- Root cause was broader than the cited `source_url` typo: the rendering pipeline's `_normalize_config` no-ops on `Config` accessor objects (its `isinstance(config, dict)` guard fails), so the `config` var the template receives is the raw accessor where `github_repo` lives under `[autodoc]`. The template now resolves the repo/branch defensively rather than assuming a pre-normalized dict.
