### PR TITLE
fix(rendering): surface JsonAccumulator failures as build warnings, not silent debug

### DIFF
--- a/bengal/rendering/pipeline/json_accumulator.py
+++ b/bengal/rendering/pipeline/json_accumulator.py
@@ -150,11 +150,30 @@ class JsonAccumulator:
             self.build_context.accumulate_page_data(data)
 
         except Exception as e:
-            logger.debug(
+            # Surface accumulation failures as visible build warnings instead of
+            # silently dropping the page from the search index / JSON outputs.
+            # Mirrors the precedent in core.py for link-extraction failures.
+            full_error = str(e)
+            page_path = str(page.source_path)
+            logger.warning(
                 "unified_page_data_accumulation_failed",
-                page=str(page.source_path),
-                error=str(e)[:100],
+                page=page_path,
+                error=full_error,
+                error_type=type(e).__name__,
+                suggestion=(
+                    "This page was omitted from the search index and JSON "
+                    "outputs. Check the page content for malformed markdown, "
+                    "shortcodes, or metadata."
+                ),
             )
+            # Record in build stats so it shows up in the build summary
+            # (build_context and build_context.stats are both Optional).
+            if self.build_context and self.build_context.stats:
+                self.build_context.stats.add_warning(
+                    page_path,
+                    f"Page data accumulation failed: {full_error}",
+                    "json_accumulation",
+                )
 
     def extract_enhanced_metadata(self, page: PageLike) -> dict[str, Any]:
         """

--- a/changelog.d/449.fixed.md
+++ b/changelog.d/449.fixed.md
@@ -1,0 +1,1 @@
+When per-page JSON / search-index data accumulation fails for a page, the failure is now surfaced as a visible build warning (recorded in the build summary) with the full, untruncated error and an actionable suggestion, instead of being silently dropped at debug level. The page is still omitted gracefully and the build completes as before. (#449)

--- a/tests/unit/postprocess/test_json_accumulator.py
+++ b/tests/unit/postprocess/test_json_accumulator.py
@@ -1,0 +1,90 @@
+"""Unit tests for bengal.rendering.pipeline.json_accumulator.JsonAccumulator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from bengal.orchestration.stats import BuildStats
+from bengal.rendering.pipeline.json_accumulator import JsonAccumulator
+
+
+class _ExplodingPage:
+    """Page whose content-derivative access raises a long error.
+
+    URL-shaped attributes resolve cleanly so the first failure inside
+    ``accumulate_unified_page_data`` is the content-derivative access
+    (``plain_text``). The error message is intentionally longer than 100
+    characters so a test can prove the recorded warning is NOT truncated.
+    """
+
+    LONG_ERROR = (
+        "plain_text rendering blew up because of a deeply nested directive that "
+        "could not be resolved and produced an unexpectedly verbose traceback "
+        "well beyond one hundred characters of detail"
+    )
+
+    def __init__(self) -> None:
+        self.source_path = Path("/content/exploding.md")
+        self.title = "Exploding"
+        self.metadata: dict[str, Any] = {}
+        self.tags: list[str] = []
+        # URL-shaped attributes used by get_page_url / get_page_relative_url.
+        self.href = "/exploding/"
+        self._path = "/exploding/"
+
+    @property
+    def plain_text(self) -> str:
+        raise RuntimeError(self.LONG_ERROR)
+
+
+def _make_site() -> Any:
+    site = MagicMock()
+    site.config = {}
+    return site
+
+
+class TestAccumulationFailureSurfacesWarning:
+    """accumulate_unified_page_data must surface failures as build warnings."""
+
+    def test_records_single_untruncated_build_warning_on_failure(self) -> None:
+        """A failing page records exactly one non-truncated build-stats warning.
+
+        RED on unfixed code: the failure is swallowed at logger.debug and the
+        BuildStats warnings list stays empty.
+        """
+        stats = BuildStats()
+        build_context = MagicMock()
+        build_context.stats = stats
+
+        site = _make_site()
+        accumulator = JsonAccumulator(site, build_context)
+
+        page = _ExplodingPage()
+        accumulator.accumulate_unified_page_data(page)
+
+        # Exactly one warning recorded.
+        assert len(stats.warnings) == 1, (
+            f"expected exactly one recorded warning, got {len(stats.warnings)}"
+        )
+
+        warning = stats.warnings[0]
+        # The full error text must be present (not truncated to 100 chars).
+        assert _ExplodingPage.LONG_ERROR in warning.message, (
+            "recorded warning message must contain the full, untruncated error"
+        )
+        assert len(_ExplodingPage.LONG_ERROR) > 100
+        # File path of the offending page is recorded for actionability.
+        assert "exploding.md" in warning.file_path
+
+    def test_build_completes_without_reraising(self) -> None:
+        """The accumulation failure must not propagate (build keeps going)."""
+        stats = BuildStats()
+        build_context = MagicMock()
+        build_context.stats = stats
+
+        accumulator = JsonAccumulator(_make_site(), build_context)
+
+        # Should not raise.
+        accumulator.accumulate_unified_page_data(_ExplodingPage())


### PR DESCRIPTION
## Summary
`JsonAccumulator.accumulate_unified_page_data` caught any failure with a bare `except Exception` and logged it at `logger.debug`, truncating the error to 100 chars. The page was silently dropped from the search index / per-page JSON outputs with no build warning. This converts the silent debug into a visible build warning: it now logs at `logger.warning` with the full untruncated error plus an actionable suggestion, and records a build-stats warning (guarded by the Optional `build_context`/`build_context.stats`) so the failure shows up in the build summary. The build still completes (no new re-raise), matching the link-extraction precedent in `core.py`.

Closes #449

## Testing
- `tests/unit/postprocess/test_json_accumulator.py::TestAccumulationFailureSurfacesWarning::test_records_single_untruncated_build_warning_on_failure` — RED on unfixed code (0 warnings recorded), GREEN after fix (exactly one non-truncated build-stats warning)
- `tests/unit/postprocess/` — 449 passed, 7 skipped (font-only)
- `tests/unit/rendering/ -k "pipeline or accumul or json or core"` — 68 passed
- `ruff check` on changed files — clean

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable
