### PR TITLE
fix(parsing): align parse_with_toc base contract to the 4-tuple production returns

### DIFF
--- a/bengal/parsing/__init__.py
+++ b/bengal/parsing/__init__.py
@@ -48,8 +48,8 @@ Usage:
     >>> # Parse content
     >>> html = parser.parse("# Hello World", metadata={})
     >>>
-    >>> # Parse with TOC extraction
-    >>> html, toc = parser.parse_with_toc("## Section 1\n## Section 2", {})
+    >>> # Parse with TOC extraction (html, toc, excerpt, meta_description)
+    >>> html, toc, excerpt, meta = parser.parse_with_toc("## Section 1\n## Section 2", {})
 
 Thread Safety:
 PythonMarkdownParser instances are NOT thread-safe.

--- a/bengal/parsing/backends/patitas/wrapper.py
+++ b/bengal/parsing/backends/patitas/wrapper.py
@@ -6,7 +6,7 @@ This allows Patitas to be used as a drop-in replacement for legacy parsers.
 Usage:
     parser = PatitasParser()
     html = parser.parse("# Hello", {})
-html, toc = parser.parse_with_toc("## Section 1\n## Section 2", {})
+    html, toc, excerpt, meta = parser.parse_with_toc("## Section 1\n## Section 2", {})
 
 Thread Safety:
 PatitasParser is thread-safe. Each parse() call creates independent

--- a/bengal/parsing/base.py
+++ b/bengal/parsing/base.py
@@ -48,7 +48,7 @@ class BaseMarkdownParser(ABC):
         """
 
     @abstractmethod
-    def parse_with_toc(self, content: str, metadata: dict[str, Any]) -> tuple[str, str]:
+    def parse_with_toc(self, content: str, metadata: dict[str, Any]) -> tuple[str, str, str, str]:
         """
         Parse Markdown content and extract table of contents.
 
@@ -57,7 +57,9 @@ class BaseMarkdownParser(ABC):
             metadata: Page metadata
 
         Returns:
-            Tuple of (parsed HTML, table of contents HTML)
+            Tuple of (parsed HTML, table of contents HTML, excerpt,
+            meta description). Parsers that do not derive an excerpt or
+            meta description return empty strings for those fields.
         """
 
     def parse_to_ast(self, content: str, metadata: dict[str, Any]) -> list[dict[str, Any]]:

--- a/bengal/parsing/python_markdown.py
+++ b/bengal/parsing/python_markdown.py
@@ -57,9 +57,14 @@ class PythonMarkdownParser(BaseMarkdownParser):
         return self.md.convert(content)
 
     @override
-    def parse_with_toc(self, content: str, metadata: dict[str, Any]) -> tuple[str, str]:
-        """Parse Markdown content and extract table of contents."""
+    def parse_with_toc(self, content: str, metadata: dict[str, Any]) -> tuple[str, str, str, str]:
+        """Parse Markdown content and extract table of contents.
+
+        Returns a 4-tuple ``(html, toc, excerpt, meta_description)`` to match
+        :meth:`BaseMarkdownParser.parse_with_toc`. python-markdown does not
+        derive an excerpt or meta description here, so both are empty strings.
+        """
         self.md.reset()
         html = self.md.convert(content)
         toc = getattr(self.md, "toc", "")
-        return html, toc
+        return html, toc, "", ""

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -690,7 +690,13 @@ class RenderingPipeline:
             else:
                 # Fallback for parsers without context support (e.g., PythonMarkdownParser)
                 if need_toc:
-                    parsed_content, toc = self.parser.parse_with_toc(source, metadata_for_parser)
+                    result = self.parser.parse_with_toc(source, metadata_for_parser)
+                    parsed_content, toc = result[0], result[1]
+                    result_ext = cast("tuple[str, ...]", result)
+                    if len(result_ext) > 2:
+                        parsed_excerpt = result_ext[2]
+                    if len(result_ext) > 3:
+                        parsed_meta_description = result_ext[3]
                     parsed_content = escape_template_syntax_in_html(parsed_content)
                 else:
                     parsed_content = self.parser.parse(source, metadata_for_parser)
@@ -743,7 +749,8 @@ class RenderingPipeline:
         """Parse content using legacy python-markdown parser."""
         content = self._preprocess_content(page)
         if need_toc and hasattr(self.parser, "parse_with_toc"):
-            parsed_content, toc = self.parser.parse_with_toc(content, page.metadata)
+            result = self.parser.parse_with_toc(content, page.metadata)
+            parsed_content, toc = result[0], result[1]
         else:
             parsed_content = self.parser.parse(content, page.metadata)
             toc = ""

--- a/changelog.d/443.fixed.md
+++ b/changelog.d/443.fixed.md
@@ -1,0 +1,1 @@
+`BaseMarkdownParser.parse_with_toc` now documents and returns the 4-tuple `(html, toc, excerpt, meta_description)` that the parsers actually produce. `PythonMarkdownParser` now returns this 4-tuple (with empty excerpt/meta) instead of a 2-tuple, so custom parser implementations and callers can unpack four values uniformly. (#443)

--- a/site/content/docs/reference/architecture/meta/extension-points.md
+++ b/site/content/docs/reference/architecture/meta/extension-points.md
@@ -90,11 +90,17 @@ class CustomMarkdownParser(BaseMarkdownParser):
         html = self._convert_to_html(content)
         return html
 
-    def parse_with_toc(self, content: str, metadata: dict[str, Any]) -> tuple[str, str]:
-        """Parse markdown and extract table of contents."""
+    def parse_with_toc(
+        self, content: str, metadata: dict[str, Any]
+    ) -> tuple[str, str, str, str]:
+        """Parse markdown and extract TOC, excerpt, and meta description.
+
+        Returns ``(html, toc, excerpt, meta_description)``. Return empty
+        strings for excerpt/meta if your parser does not derive them.
+        """
         html = self.parse(content, metadata)
         toc_html = self._extract_toc(content)
-        return html, toc_html
+        return html, toc_html, "", ""
 
 # Register in parser factory
 # (requires modification of bengal/parsing/__init__.py)

--- a/tests/unit/parsing/test_parser_signatures.py
+++ b/tests/unit/parsing/test_parser_signatures.py
@@ -1,0 +1,43 @@
+"""Tests pinning the parser ``parse_with_toc`` contract to a 4-tuple.
+
+The ``BaseMarkdownParser.parse_with_toc`` contract returns
+``(html, toc, excerpt, meta_description)``. Both concrete parsers must honor
+that 4-tuple shape so callers can unpack four values uniformly (#443).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from bengal.parsing.backends.patitas.wrapper import PatitasParser
+from bengal.parsing.base import BaseMarkdownParser
+from bengal.parsing.python_markdown import PythonMarkdownParser
+
+
+def test_base_parse_with_toc_declares_four_tuple() -> None:
+    """The abstract contract advertises a 4-tuple of strings."""
+    annotation = inspect.signature(BaseMarkdownParser.parse_with_toc).return_annotation
+    assert annotation == "tuple[str, str, str, str]"
+
+
+def test_patitas_parse_with_toc_returns_four_tuple_of_str() -> None:
+    """PatitasParser returns (html, toc, excerpt, meta_description)."""
+    parser = PatitasParser()
+    result = parser.parse_with_toc("# Heading\n\nBody paragraph.", {})
+
+    html, toc, excerpt, meta = result
+    assert len(result) == 4
+    assert all(isinstance(part, str) for part in (html, toc, excerpt, meta))
+
+
+def test_python_markdown_parse_with_toc_returns_four_tuple_of_str() -> None:
+    """PythonMarkdownParser returns a 4-tuple with empty excerpt/meta."""
+    parser = PythonMarkdownParser()
+    result = parser.parse_with_toc("# Heading\n\nBody paragraph.", {})
+
+    html, toc, excerpt, meta = result
+    assert len(result) == 4
+    assert all(isinstance(part, str) for part in (html, toc, excerpt, meta))
+    # python-markdown does not extract excerpt/meta in this path.
+    assert excerpt == ""
+    assert meta == ""

--- a/tests/unit/rendering/test_pipeline_cache_storage.py
+++ b/tests/unit/rendering/test_pipeline_cache_storage.py
@@ -34,10 +34,10 @@ class DummyParser:
         return f"<p>{content}</p>"
 
     def parse_with_toc(self, content, metadata):
-        return f"<p>{content}</p>", "<nav>TOC</nav>"
+        return f"<p>{content}</p>", "<nav>TOC</nav>", "", ""
 
     def parse_with_toc_and_context(self, content, metadata, context):
-        return f"<p>{content}</p>", "<nav>TOC</nav>"
+        return f"<p>{content}</p>", "<nav>TOC</nav>", "", ""
 
     def parse_with_context(self, content, metadata, context):
         return f"<p>{content}</p>"


### PR DESCRIPTION
## Summary
`BaseMarkdownParser.parse_with_toc` declared `-> tuple[str, str]`, but the patitas wrapper already returns a 4-tuple `(html, toc, excerpt, meta_description)` while `PythonMarkdownParser` returned a 2-tuple — so the documented contract matched neither implementation. This aligns the abstract signature/docstring to the 4-tuple, makes `PythonMarkdownParser.parse_with_toc` return `(html, toc, "", "")`, and updates the stale 2-tuple docstrings/example doc and the vacuous test mock. Pipeline callers that hard-unpacked a 2-tuple from the python-markdown path are made tolerant of the 4-tuple (matching the existing pattern in the same module).

Closes #443

## Testing
- `tests/unit/parsing/test_parser_signatures.py` — new; asserts the base signature is `tuple[str, str, str, str]` and that both `PatitasParser` and `PythonMarkdownParser` return 4-tuples of `str`. RED on unfixed code (base `assert 'tuple[str, str]' == 'tuple[str, str, str, str]'`; python-markdown `ValueError: not enough values to unpack (expected 4, got 2)`), GREEN after fix.
- `uv run pytest tests/unit/parsing/ tests/unit/rendering/test_pipeline_cache_storage.py` — 31 passed
- `uv run pytest tests/unit/rendering/` — 2097 passed, 3 skipped (covers the legacy python-markdown parse path)
- `uv run pytest tests/unit/core/test_no_core_mixins.py` — 12 passed (project-contract guard)
- `uv run ruff check` on all changed files — clean

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable
