### PR TITLE
refactor(orchestration): remove dead divergent phase_cache_save

### DIFF
--- a/bengal/orchestration/build/finalization.py
+++ b/bengal/orchestration/build/finalization.py
@@ -1,7 +1,7 @@
 """
 Finalization phases for build orchestration.
 
-Phases 17-21: Post-processing, cache save, collect stats, health check, finalize build.
+Phases 17-21: Post-processing, collect stats, health check, finalize build.
 """
 
 from __future__ import annotations
@@ -187,46 +187,6 @@ def _record_post_render_timing(
     timings = getattr(orchestrator.stats, "post_render_timings_ms", None)
     if isinstance(timings, dict):
         timings[name] = round(duration_ms, 1)
-
-
-def phase_cache_save(
-    orchestrator: BuildOrchestrator,
-    pages_to_build: list[Any],
-    assets_to_process: list[Any],
-    cli: CLIOutput | None = None,
-) -> None:
-    """
-    Phase 18: Save Cache.
-
-    Persists build cache including URL claims for incremental build safety.
-
-    Saves build cache for future incremental builds.
-
-    Args:
-        orchestrator: Build orchestrator instance
-        pages_to_build: Pages that were built
-        assets_to_process: Assets that were processed
-        cli: CLI output (optional) for timing display
-
-    """
-    with orchestrator.logger.phase("cache_save"):
-        start = time.perf_counter()
-        saved = orchestrator.incremental.save_cache(pages_to_build, assets_to_process)
-        if saved is False:
-            from bengal.errors import BengalCacheError, ErrorCode
-
-            raise BengalCacheError(
-                "Build cache could not be saved.",
-                code=ErrorCode.A004,
-                suggestion=(
-                    "Check disk space and permissions. Incremental builds may be stale "
-                    "until the cache can be saved."
-                ),
-            )
-        duration_ms = (time.perf_counter() - start) * 1000
-        if cli is not None:
-            cli.phase("Cache save", duration_ms=duration_ms)
-        orchestrator.logger.info("cache_saved")
 
 
 def phase_collect_stats(

--- a/changelog.d/451.removed.md
+++ b/changelog.d/451.removed.md
@@ -1,0 +1,1 @@
+Removed the dead `phase_cache_save` build-finalization helper, which was never called and diverged from the live cache-save path by omitting `build_context`; the live build already persists the cache with `build_context` for incremental safety. (#451)

--- a/site/content/docs/reference/architecture/core/orchestration.md
+++ b/site/content/docs/reference/architecture/core/orchestration.md
@@ -92,7 +92,7 @@ flowchart LR
 | Phase | Function | Description |
 |-------|----------|-------------|
 | 17 | `phase_postprocess` | Generate sitemap, RSS, validate links |
-| 18 | `phase_cache_save` | Save cache for incremental builds |
+| 18 | Cache save | Persist the incremental build cache (URL claims, page/asset state) |
 | 19 | `phase_collect_stats` | Collect build statistics |
 | 19.5 | Error session | Track errors for pattern detection |
 | 20 | Health check | Run validators |

--- a/tests/unit/orchestration/build/test_cache_save_build_context.py
+++ b/tests/unit/orchestration/build/test_cache_save_build_context.py
@@ -1,0 +1,70 @@
+"""Regression guard for the live cache-save path passing ``build_context``.
+
+The orchestrator's ``_save_main_cache`` closure must call
+``incremental.save_cache(..., build_context=ctx)`` so the persisted cache stays
+consistent with the build it describes. A previous, dead ``phase_cache_save``
+helper diverged by calling ``save_cache`` *without* ``build_context``; this test
+exercises the real build path and asserts the live behavior.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+from bengal.orchestration.incremental.orchestrator import IncrementalOrchestrator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_tiny_site(tmp_path: Path) -> Path:
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+    (site_dir / "bengal.toml").write_text(
+        """
+[site]
+title = "Cache Save Context Test"
+baseurl = "/"
+
+[build]
+output_dir = "public"
+
+[theme]
+name = "default"
+""",
+        encoding="utf-8",
+    )
+    content_dir = site_dir / "content"
+    content_dir.mkdir()
+    (content_dir / "index.md").write_text(
+        "---\ntitle: Home\n---\n# Home\n\nHello.\n",
+        encoding="utf-8",
+    )
+    return site_dir
+
+
+def test_live_cache_save_passes_build_context(tmp_path: Path, monkeypatch) -> None:
+    """The live build path saves the main cache WITH a non-None build_context."""
+    site_dir = _make_tiny_site(tmp_path)
+    site = Site.from_config(site_dir)
+
+    real_save_cache = IncrementalOrchestrator.save_cache
+    captured: list[dict] = []
+
+    def _recording_save_cache(self, *args, **kwargs):
+        captured.append(dict(kwargs))
+        return real_save_cache(self, *args, **kwargs)
+
+    monkeypatch.setattr(IncrementalOrchestrator, "save_cache", _recording_save_cache)
+
+    site.build(BuildOptions(incremental=False))
+
+    assert captured, "Expected incremental.save_cache to be called during the build"
+    # The main-cache save is the call that carries build_context.
+    context_calls = [c for c in captured if c.get("build_context") is not None]
+    assert context_calls, (
+        "Live cache save must pass a non-None build_context; "
+        f"observed save_cache kwargs were: {captured}"
+    )

--- a/tests/unit/orchestration/build/test_finalization.py
+++ b/tests/unit/orchestration/build/test_finalization.py
@@ -3,7 +3,6 @@ Tests for build finalization phases.
 
 Covers:
 - phase_postprocess(): Post-processing phase
-- phase_cache_save(): Cache saving phase
 - phase_collect_stats(): Statistics collection
 - run_health_check(): Health check execution
 - phase_finalize(): Final cleanup phase
@@ -25,7 +24,6 @@ from bengal.orchestration.build.finalization import (
     _health_report_fingerprint,
     _load_cached_health_report,
     _store_cached_health_report,
-    phase_cache_save,
     phase_collect_stats,
     phase_finalize,
     phase_postprocess,
@@ -167,44 +165,6 @@ class TestPhasePostprocess:
             enabled_task_names={"special pages"},
         )
         assert orchestrator.stats.post_render_timings_ms["asset_audit"] == 0
-
-
-class TestPhaseCacheSave:
-    """Tests for phase_cache_save function."""
-
-    def test_saves_cache(self, tmp_path):
-        """Saves build cache."""
-        orchestrator = MockPhaseContext.create_orchestrator(tmp_path)
-        pages_to_build = [MagicMock()]
-        assets_to_process = [MagicMock()]
-
-        phase_cache_save(orchestrator, pages_to_build, assets_to_process)
-
-        orchestrator.incremental.save_cache.assert_called_once_with(
-            pages_to_build, assets_to_process
-        )
-
-    def test_logs_cache_saved(self, tmp_path):
-        """Logs cache saved message."""
-        orchestrator = MockPhaseContext.create_orchestrator(tmp_path)
-
-        phase_cache_save(orchestrator, [], [])
-
-        orchestrator.logger.info.assert_called_with("cache_saved")
-
-    def test_raises_when_cache_save_fails(self, tmp_path):
-        """Cache persistence failures stop the build instead of being hidden."""
-        from bengal.errors import BengalCacheError
-
-        orchestrator = MockPhaseContext.create_orchestrator(tmp_path)
-        orchestrator.incremental.save_cache.return_value = False
-        phase_context = MagicMock()
-        phase_context.__enter__.return_value = None
-        phase_context.__exit__.return_value = False
-        orchestrator.logger.phase.return_value = phase_context
-
-        with pytest.raises(BengalCacheError):
-            phase_cache_save(orchestrator, [], [])
 
 
 class TestPhaseCollectStats:


### PR DESCRIPTION
## Summary
Deletes the dead `phase_cache_save` helper from `bengal/orchestration/build/finalization.py`. It was never called and diverged from the live cache-save path: it invoked `incremental.save_cache(...)` WITHOUT `build_context`, whereas the live `_save_main_cache` closure in `bengal/orchestration/build/__init__.py` correctly passes `build_context=ctx` for incremental-build safety. Removing it eliminates a stale, incorrect code path that could only mislead future maintainers.

Closes #451

## Testing
- `tests/unit/orchestration/build/test_cache_save_build_context.py::test_live_cache_save_passes_build_context` — new regression guard that drives a real `Site.build()` and asserts the live path calls `incremental.save_cache(..., build_context=...)` with a non-None context. Proven non-vacuous: temporarily dropping `build_context=ctx` from `_save_main_cache` turned it RED (`AssertionError: ... observed save_cache kwargs were: [{}]`); restoring made it GREEN.
- Removed the `TestPhaseCacheSave` class (3 tests) that codified the divergent, `build_context`-less behavior, plus the now-unused import.
- `tests/unit/orchestration/build/test_finalization.py` (TestPhasePostprocess + TestPhaseCollectStats) and the new test pass (14 passed). Note: 3 pre-existing failures in `TestPhaseFinalize` (stale `set_console_quiet` / `pygments_cache.log_cache_stats` patch targets) reproduce on pristine `origin/main` and are unrelated to this change.
- `ruff check` clean on all changed files.

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable
