### PR TITLE
fix(postprocess): remove production unittest.mock import from index_generator

### DIFF
--- a/bengal/postprocess/output_formats/index_generator.py
+++ b/bengal/postprocess/output_formats/index_generator.py
@@ -75,7 +75,6 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
-from unittest.mock import Mock
 
 from bengal.postprocess.output_formats.utils import (
     generate_excerpt,
@@ -235,7 +234,7 @@ class SiteIndexGenerator:
         logger.debug("generating_site_index_json", page_count=len(pages))
 
         # Build site metadata (per-locale when i18n is enabled)
-        # Ensure all values are strings, not Mock objects
+        # Coerce all values to strings for stable JSON output
         site_metadata = {
             "title": str(self.site.title or "Bengal Site"),
             "description": str(getattr(self.site, "description", "") or ""),
@@ -246,7 +245,7 @@ class SiteIndexGenerator:
         # Use site.build_time (set once at build start) for deterministic output
         if not self.site.dev_mode:
             build_time = getattr(self.site, "build_time", None)
-            # Verify it's a real datetime (not a Mock) with a working isoformat method
+            # Only emit build_time when it's a real datetime with isoformat()
             if isinstance(build_time, datetime):
                 site_metadata["build_time"] = build_time.isoformat()
 
@@ -414,7 +413,7 @@ class SiteIndexGenerator:
         # Use site.build_time (set once at build start) for deterministic output
         if not self.site.dev_mode:
             build_time = getattr(self.site, "build_time", None)
-            # Verify it's a real datetime (not a Mock) with a working isoformat method
+            # Only emit build_time when it's a real datetime with isoformat()
             if isinstance(build_time, datetime):
                 site_metadata["build_time"] = build_time.isoformat()
 
@@ -610,9 +609,13 @@ class SiteIndexGenerator:
         return summary
 
     def _is_json_serializable(self, value: Any) -> bool:
-        """Check if value is JSON serializable (excluding Mock objects)."""
-        if isinstance(value, Mock):
-            return False
+        """Check if value is JSON serializable.
+
+        Uses a real serialization attempt rather than a type allow-list so
+        that any non-serializable object (datetimes, custom classes, test
+        doubles, etc.) is rejected without coupling production code to a
+        specific implementation.
+        """
         try:
             json.dumps(value)
             return True
@@ -624,22 +627,13 @@ class SiteIndexGenerator:
         value = metadata.get(key)
         if value is None:
             return None
-        # Filter out Mock objects and non-serializable values
-        if isinstance(value, Mock):
-            return None
         if isinstance(value, (list, tuple)):
-            # Filter out Mock objects from lists
-            filtered_list = [
-                v for v in value if not isinstance(v, Mock) and self._is_json_serializable(v)
-            ]
+            # Filter out non-serializable items from lists
+            filtered_list = [v for v in value if self._is_json_serializable(v)]
             return filtered_list if filtered_list else None
         if isinstance(value, dict):
-            # Recursively filter dict values
-            filtered_dict = {
-                k: v
-                for k, v in value.items()
-                if not isinstance(v, Mock) and self._is_json_serializable(v)
-            }
+            # Recursively filter out non-serializable dict values
+            filtered_dict = {k: v for k, v in value.items() if self._is_json_serializable(v)}
             return filtered_dict if filtered_dict else None
         if self._is_json_serializable(value):
             return value

--- a/changelog.d/450.fixed.md
+++ b/changelog.d/450.fixed.md
@@ -1,0 +1,1 @@
+Removed a production `from unittest.mock import Mock` import from the site index generator. The JSON-serialization path no longer references the test library to skip values; non-serializable metadata (custom objects, lists, and dicts) is now dropped via a real `json.dumps`-based serializability check. (#450)

--- a/tests/unit/postprocess/test_output_formats_index_json.py
+++ b/tests/unit/postprocess/test_output_formats_index_json.py
@@ -513,6 +513,74 @@ class TestSiteIndexJsonGeneration:
         assert by_version["v2"][0].version == "v2"
         assert by_version[None][0].version is None
 
+    def test_index_generator_module_does_not_import_unittest_mock(self):
+        """Production code must not import the unittest.mock test library (#450)."""
+        import inspect
+
+        from bengal.postprocess.output_formats import index_generator
+
+        source = inspect.getsource(index_generator)
+        assert "unittest.mock" not in source, (
+            "index_generator.py must not import unittest.mock (a TEST library) "
+            "into production code (#450)."
+        )
+        assert "from unittest" not in source, (
+            "index_generator.py must not import from unittest in production (#450)."
+        )
+        # The module's namespace must not expose a bound Mock symbol.
+        assert not hasattr(index_generator, "Mock"), (
+            "index_generator should not bind a Mock symbol in production (#450)."
+        )
+
+    def test_non_serializable_metadata_value_is_skipped_without_mock(self, tmp_path):
+        """Non-JSON-serializable metadata values must be dropped via a real
+
+        serializability check, not a unittest.mock isinstance check (#450).
+        """
+        from bengal.postprocess.output_formats.index_generator import SiteIndexGenerator
+
+        class NotSerializable:
+            """A plain (non-Mock) object that json cannot serialize."""
+
+        output_dir = tmp_path / "public"
+        output_dir.mkdir()
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        generator = SiteIndexGenerator(mock_site)
+
+        bad = NotSerializable()
+        metadata = {
+            "author": "Real Author",  # serializable -> kept
+            "category": bad,  # non-serializable -> dropped
+            "categories": ["ok", bad],  # list filtered to ["ok"]
+            "related": {"a": "ok", "b": bad},  # dict filtered to {"a": "ok"}
+        }
+        summary: dict = {}
+        generator._add_enhanced_metadata(summary, metadata)
+
+        # The whole summary must remain JSON-serializable (the real contract).
+        json.dumps(summary)
+
+        assert summary["author"] == "Real Author"
+        assert "category" not in summary, "Non-serializable scalar must be dropped"
+        assert summary["categories"] == ["ok"], "Non-serializable list items dropped"
+        assert summary["related"] == {"a": "ok"}, "Non-serializable dict values dropped"
+
+    def test_is_json_serializable_rejects_non_serializable_object(self, tmp_path):
+        """_is_json_serializable must reject arbitrary non-serializable objects (#450)."""
+        from bengal.postprocess.output_formats.index_generator import SiteIndexGenerator
+
+        class NotSerializable:
+            pass
+
+        output_dir = tmp_path / "public"
+        output_dir.mkdir()
+        mock_site = self._create_mock_site(tmp_path, output_dir)
+        generator = SiteIndexGenerator(mock_site)
+
+        assert generator._is_json_serializable("ok") is True
+        assert generator._is_json_serializable({"a": 1}) is True
+        assert generator._is_json_serializable(NotSerializable()) is False
+
     def test_index_generator_generates_per_version_indexes_when_versioning_enabled(self, tmp_path):
         """Test that generate() returns list of paths when versioning is enabled."""
         from bengal.core.version import Version, VersionConfig


### PR DESCRIPTION
## Summary
`bengal/postprocess/output_formats/index_generator.py` imported `from unittest.mock import Mock` — a TEST library pulled into a production module — and used `isinstance(value, Mock)` on the JSON-serialization path to skip values. This removes the import and replaces the Mock-detection with a real `json.dumps`-based serializability check (`_is_json_serializable`), which already rejects `Mock` and any other non-serializable object. Stale "not a Mock" comments were reworded to match. The PEP 758 `except TypeError, ValueError:` line is unchanged.

Closes #450

## Testing
- `test_index_generator_module_does_not_import_unittest_mock` — RED on unfixed code (asserts `"unittest.mock" not in inspect.getsource(module)`; failed on the import line), GREEN after fix.
- `test_non_serializable_metadata_value_is_skipped_without_mock` and `test_is_json_serializable_rejects_non_serializable_object` — behavioral guards proving non-serializable scalars/lists/dicts are dropped via the real serializability check (pass before and after; guard against regression when the Mock branches were removed).
- Broader targeted suites: `tests/unit/postprocess/test_output_formats_index_json.py`, `test_output_formats_config.py`, `test_visibility_filtering.py`, `test_content_signals_enforcement.py`, `test_output_formats_hash.py` — 64 passed.
- Smoke build: `SiteIndexGenerator.generate()` on a small site with non-serializable metadata produces a valid `index.json` (non-serializable scalar dropped, list/dict filtered, `build_time` still emitted).

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable
