### PR TITLE
Codify changelog/release-notes voice to stop internal/meta leaks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Sync dev dependencies
         run: uv sync --group dev
 
+      - name: Lint fragments for internal/meta leaks
+        run: uv run python scripts/lint_changelog_voice.py
+
       - name: Verify news fragment
         env:
           SKIP: ${{ contains(join(github.event.pull_request.labels.*.name, ','), 'skip-changelog') }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,12 @@ This applies to `pyproject.toml`, `uv.lock`, `.github/workflows/`,
 - Package-data changes need source-tree and installed-wheel proof.
 - User-facing changes under `bengal/` need a `changelog.d/` fragment unless a
   maintainer marks the change exempt.
+- Changelog fragments and release pages are written for **third-party consumers**,
+  not maintainers: no internal coinage (phase/sprint/saga/epic/plan-file/branch
+  slug), no process narration, no contributor-only churn — translate mechanism to
+  user-visible effect. Rules live in `docs/b-stack-changelog-strategy.md`; stewards
+  in `changelog.d/AGENTS.md` and the "Release Pages" section of `site/AGENTS.md`;
+  `poe changelog-lint` enforces the high-precision subset.
 
 ## Cross-Cutting: Documentation Accuracy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,7 @@ User-facing changes under `bengal/` should include a **news fragment** in `chang
 - **Preview:** `poe changelog-draft` (stdout only).
 - **Compile (maintainers, usually before tagging):** `poe changelog` runs `towncrier build --yes`.
 - **Local check vs `main`:** `poe changelog-check`.
+- **Voice/leak lint:** `poe changelog-lint` (fragments; add `--releases` for site release pages). Fragments are written for third-party consumers — no internal coinage (phase/sprint/saga/epic/plan-file/branch slug), counts, or contributor-only churn; translate mechanism to user-visible effect.
 - **Skip in CI:** Apply the **`skip-changelog`** label when no fragment fits (e.g. docs-only outside the package, or internal refactors with no release note).
 
 ## Pull Request Process

--- a/changelog.d/AGENTS.md
+++ b/changelog.d/AGENTS.md
@@ -1,0 +1,75 @@
+<!-- markdownlint-disable MD013 -->
+
+# Steward: Changelog Fragments
+
+This tree holds unreleased Towncrier news fragments (`<issue>.<type>.md`). Each
+fragment is one line a **third-party consumer** reads — first in `CHANGELOG.md`,
+then lifted into a user-facing release page. You represent that reader.
+
+Related: root `../AGENTS.md`, the canonical cross-repo spec
+`../docs/b-stack-changelog-strategy.md`, `../CONTRIBUTING.md`, and the
+release-page steward (the "Release Pages" section of `../site/AGENTS.md`). The full rules,
+taxonomy, and before/after examples live in the strategy doc; this file is the
+point-of-work reminder.
+
+## Point Of View
+
+You are the reader steward. You defend the fragment against engineer-voice: the
+internal coinage, process narration, and untranslated mechanism that creep in
+when the person closing a PR writes the note for themselves instead of the user.
+
+## Protect
+
+- **Lead with the user-visible change.** First sentence states what changed *for
+  the user* ("Autodoc now cross-links symbol names to their pages."); engineering
+  detail, if worth recording, comes after. The release-page distillation lifts
+  this first sentence, so it must stand alone.
+- **The user-facing test.** A fragment exists only if the user can observe the
+  change: they **type / import / call / unpack** it (CLI, flag, config key,
+  template function, public import, return contract), **see / grep / find** it
+  (build output, emitted file, error string, health code), or must **act** on it
+  (migration, default flip, dependency bump). If none apply, the change is
+  internal — use the `skip-changelog` label, not a fragment.
+- **Correct fragment naming.** Issue-less fragments are `+slug.<type>.md` (the
+  leading `+` makes Towncrier render *no* reference). `slug.<type>.md` without the
+  `+` renders a fake `` `#slug` `` token — never do that. With an issue, use the
+  number: `449.fixed.md`.
+- **Translate mechanism to effect.** State the symptom the user saw or the benefit
+  they get, not the internal class/module/log-key that produced it.
+
+## Contract Checklist
+
+When you add or edit a fragment, confirm:
+
+- The type suffix is one of `added`, `changed`, `deprecated`, `removed`, `fixed`,
+  `security` (matches `[tool.towncrier]` in `../pyproject.toml`).
+- Any issue reference is **numeric** and worth a reader's click — not a branch
+  slug, not a plan-file path, not a per-line reflex.
+- Behavior changes carry a one-line **migration hint**.
+- `uv run poe changelog-draft` reads cleanly, and `uv run poe changelog-lint`
+  passes.
+
+## Advocate
+
+- **Write it in the same PR as the change**, while the user-facing effect is fresh.
+- **One user-meaningful change per fragment**; split unrelated changes.
+- **Borrow the brand voice**: confident, plain, present-tense, benefit-first.
+
+## Do Not
+
+- Cite **internal coinage**: "Phase 2", "Sprint", "saga S13.4", "epic #350", RFC
+  or `plan/*.md` names, branch slugs, codenames.
+- Narrate **process or journey**: "repo-wide audit", "surfaced after the cut",
+  "discovered in CI", "largest change in X's history".
+- Record **project bookkeeping**: fix/file/line counts, ty-diagnostic floors,
+  health scores, test counts.
+- Dress up **contributor-only work** (tests, guards, CI gates, import-linter,
+  behavior-preserving refactors, dead-code removal, release/build tooling) as a
+  user-facing note. It belongs in the commit, not the changelog.
+
+## Own
+
+**Code:** the fragments in this directory until `towncrier build` consumes them.
+**Docs:** fragment-authoring rules here; the canonical spec is the strategy doc.
+**Checks:** `poe changelog-draft`, `poe changelog-check`, `poe changelog-lint`.
+**CODEOWNERS:** codeowners-routed via `.github/CODEOWNERS` (release/changelog).

--- a/docs/b-stack-changelog-strategy.md
+++ b/docs/b-stack-changelog-strategy.md
@@ -144,11 +144,209 @@ The draft is a starting point, never final copy — review for accuracy and voic
 before shipping. The script never adds `anthropic` to Bengal's dependencies; it's
 an opt-in dev tool.
 
-## Voice (brand)
+## The audience boundary (what belongs in user-facing notes)
 
-- Prefer **clear, present-tense or concise past** descriptions: "Add …", "Fix …", "Deprecate … in favor of …".
-- Mention **migration hints** when behavior changes (one line in the fragment).
-- Keep Bengal-ecosystem packages **visually aligned**: same heading level (`## [version] - date`), same section order (Added → … → Security).
+The reader of a release note is a **user of the tool**, not a maintainer of it.
+They did not sit in our planning, do not run our tests, and will never read our
+CHANGELOG looking for the audit that found a bug. They want one thing: **what
+changed for me, and what do I do about it.** Two filters get you there.
+
+### The user-facing test
+
+A change earns a place in user-facing notes only if the user can *observe* it.
+Apply this test to every line:
+
+1. Does the user **type / import / call / unpack** it? — a CLI command or flag, a
+   config key or value, a frontmatter key, a template function, a public import
+   path, a factory parameter, a documented return-tuple contract.
+2. Does the user **see / grep / find** it? — text in build output, an emitted
+   file, an error string, a fingerprinted filename, a surfaced health/error code.
+3. Does the user have to **act** on it? — a migration, a dependency-floor bump, a
+   default flip, a removed import, an opt-in flag they can now set.
+
+If a change answers **none** of these, it is internal. It belongs in `CHANGELOG.md`
+at most, and usually **nowhere** in user-facing notes.
+
+The test cuts both ways — it also *protects* internal-looking detail that is
+genuinely user-facing. Do **not** strip these just because they look like code:
+
+- Public surface the user codes against: `Site.from_config(config_path=...)`,
+  `from bengal.content_types import register_strategy`, `{{ data_table(...) }}`,
+  `minify = false` under `[assets]`, a `parse_with_toc` 4-tuple contract.
+- Output the user sees on disk or in the terminal: `atom.xml`, `versions.json`,
+  a fingerprinted `style.95230091.css`, health codes like `H621`.
+- An internal symbol that **is the literal symptom** the user saw and could grep:
+  *"the error `'PageProxy' object has no attribute 'meta_description'` no longer
+  occurs"* keeps `PageProxy` because the user saw that exact string — whereas
+  "`PageProxy` now wraps `PageCore`" leaks, because the user never sees that.
+- Numbers that measure the **user's** outcome: "caches are 12–14× smaller, load
+  10× faster", "rebuilds 50 pages instead of 1,000".
+
+### Never leak: internal coinage and process meta
+
+User-facing notes **never** reference how the work was organized, discovered,
+tested, counted, or shipped. This is a hard rule, not a preference. Specifically,
+never write:
+
+- **Internal coinage.** "Phase 2", "Phase 1A", "Sprint B3", "saga S13.4",
+  "epic #350", RFC / plan-file names (`plan/epic-agent-dx-polish.md`), branch
+  slugs, codenames ("barrier-owns-globals"). These name *our* process; the reader
+  has no model for them.
+- **Process / journey narration.** "a repo-wide audit", "the audit's expansion
+  pass", "surfaced right after the cut", "discovered in CI", "the largest
+  structural change in X's history", "the first/second patch off Y".
+- **Project bookkeeping.** Fix/file/line counts ("thirteen fixes", "205 lines of
+  dead code removed"), ty-diagnostic floors ("2207 → 2204"), health-score
+  percentages, test counts ("11,600+ examples").
+- **Contributor-only churn.** Test additions, guard tests, de-vacuumed
+  assertions, CI gates, import-linter contracts, behavior-preserving refactors,
+  dead-code removal, type/lint hygiene, and **our own release/build tooling**
+  (`make gh-release`, Towncrier adoption, `python-publish.yml`). A user installs
+  the package; they never run any of it.
+- **Untranslated mechanism.** An internal class, module path, or log-event key as
+  the *subject* of a change ("the `WriteBehind` collector is gated on parallel
+  builds", "`cached_links_restore_failed` is logged"). State the **effect**, not
+  the plumbing.
+- **Off-by-default scaffolding with no caller.** A module added for an in-progress
+  effort that is wired off and leaves the build byte-identical has nothing for a
+  user to observe yet.
+
+| Don't write (leak) | Write (user-facing) |
+|---|---|
+| "0.4.2 is the second patch off 0.4.0 — thirteen fixes from the same repo-wide audit." | "0.4.2 makes failures honest: errors that used to vanish now surface as build warnings, and writes are crash-safe. No breaking changes." |
+| "### Tooling — `make gh-release` built the title from a greedy `grep`…" | *(delete — maintainer release tooling)* |
+| "De-vacuumed a `hasattr(...)` assertion and added validators to the contract suite." | *(delete — contributor-only test change)* |
+| "lazy Kida context is preserved, fingerprint fast paths are reused, version membership is memoized." | "Incremental builds are faster and rebuild fewer pages." |
+| "### i18n Gettext Workflow (Phase 1A)" | "### i18n Gettext Workflow" |
+| "Re-armed the composition-over-inheritance guard tests so they inspect `RuntimePage`." | *(delete — list the user-visible bug it now guards, if any, under Fixed)* |
+
+### Citing issues
+
+A GitHub issue is the **one sanctioned outward pointer** — and only when the link
+earns its place for the reader:
+
+- **Cite a real, numeric issue or PR** (`#449`) when a user would actually click
+  it: to track a known limitation, see a reproduction, or follow remaining work.
+- **Don't make `(#NNN)` a per-bullet reflex.** If the link adds nothing for the
+  reader, drop it. Traceability is the CHANGELOG's job, not the release page's.
+- **Never cite a non-numeric branch slug** (`#reproducible-builds`) or a plan-file
+  path — they resolve to nothing for an outside reader. Prevent this at the
+  source: name issue-less fragments `+slug.<type>.md` (the leading `+` tells
+  Towncrier there is no issue, so it renders no reference) rather than
+  `slug.<type>.md` (which renders as a fake `` `#slug` ``).
+
+## Progressive disclosure (release-page structure)
+
+The release page tells the release's story in **layers**. Each layer is
+self-sufficient; detail is *available* but never *front-loaded*. A reader who
+stops after the first line still understands the release; a reader who needs
+specifics keeps descending; the exhaustive record always lives in `CHANGELOG.md`.
+
+1. **Theme hook** — one paragraph naming the bigger picture of this release. If a
+   reader reads only this, they should get it.
+2. **Highlights** — 4–7 themed `###` subsections, each led by what a *user* can
+   now do ("you can now …"), with short examples where they help. Group related
+   changes; do not transcribe every fragment.
+3. **Condensed lists** — Added / Changed / Fixed / Removed as a skim layer: one
+   short bullet per *user-meaningful* change. Compress aggressively; omit
+   internal-only work entirely.
+4. **Upgrading** — the install command plus any action the user must take
+   (migrations, default flips, removed imports, dependency bumps).
+
+## B-Stack release voice
+
+One voice across every ecosystem package (Kida, Patitas, Rosettes, Bengal, Chirp,
+Pounce, chirp-ui) so a reader of any changelog feels the same hand. The voice is
+**confident, plain, concrete, and benefit-first — and a little delightful.** The
+reader should *enjoy* reading it and *trust* it.
+
+- **Lead with the outcome.** First the user-visible benefit, then the detail:
+  "Autodoc now cross-links symbol names to their pages" before any mechanism.
+- **Present tense, active voice.** "Add …", "Fix …", "Deprecate … in favor of …".
+- **Concrete over abstract.** Name the real command, key, or effect — never
+  "improvements", "various fixes", or "better architecture".
+- **No marketing fluff and no hedging.** Cut "blazing", "massive", "seamless",
+  "the largest … ever"; cut "should now", "we believe". Say what is true, plainly.
+- **Delight is clarity plus a little warmth.** A confident, well-chosen sentence
+  that respects the reader's time *is* the delight — not exclamation points. The
+  bar: the reader finishes a note and knows exactly what changed and why it's good.
+- **Stay visually aligned across repos.** Same heading level (`## [version] -
+  date`), same section order (Added → Changed → Deprecated → Removed → Fixed →
+  Security), same release-page shape.
+
+## Release titles and themes
+
+A release theme should describe **what the release contains or enables for the
+user** — a durable, content-anchored phrase — not pronounce a **verdict on the
+project's quality, maturity, or past behavior.** Verdict-themes read as either
+self-congratulation or confession, and they age badly: the moment the same class
+of work recurs (and correctness, observability, performance, docs-accuracy, and
+security *always* recur — they are perennial, never "done"), the triumphant title
+looks naive or repetitive, and you are stuck writing "Honest internals 2".
+
+**The test:** *could a future release plausibly need this same theme again?* If
+yes, the theme is overclaiming — reframe it to the concrete content.
+
+Avoid:
+
+- **Maturity / coming-of-age declarations** — "grows up", "production-ready",
+  "all grown up", "enterprise-grade".
+- **Virtue-achieved claims** for perennial qualities — "Honest internals", "Rock
+  solid", "Bulletproof", "Correct now".
+- **Confessions** — "Stop shipping wrong output" advertises that you *were*
+  shipping wrong output. State the win, not the prior sin.
+- **Release-to-release arcs** — "Where 0.4.1 stopped X, 0.4.2 stops Y".
+
+Prefer content/capability anchors, and scale boldness to release size — a major
+(`X.0`) can carry a confident *capability* headline; a patch should stay plainly
+descriptive (there is no shame in a repeatable theme like "Correctness and
+data-safety fixes"):
+
+| Verdict-theme (avoid) | Content theme (prefer) |
+|---|---|
+| "Documentation generation grows up" | "Cross-linked autodoc and richer OpenAPI models" |
+| "Stop shipping wrong output" | "Valid structured data and honored configuration" |
+| "Honest internals" | "Visible build failures and crash-safe writes" |
+
+Titles are a judgment call, not a lint target — the steward and this section own
+them.
+
+## Enforcement (so it gets applied automatically)
+
+These rules are carried to the point of work, not left in a doc nobody opens:
+
+- **`changelog.d/AGENTS.md`** — steward for *fragment authoring*. Auto-loaded when
+  an agent works in the fragment folder (i.e. every time a fragment is written).
+- **`site/content/releases/AGENTS.md`** — steward for *release-page distillation*.
+  Auto-loaded when an agent edits a release page.
+- **`scripts/draft_release_notes.py`** — encodes the audience boundary and voice in
+  the generator's system prompt, so the *first draft* is clean rather than scrubbed
+  after the fact.
+- **`poe changelog-lint`** (`scripts/lint_changelog_voice.py`) — deterministically
+  blocks the highest-precision leaks (internal-coinage tokens, non-numeric `(#…)`
+  issue references, plan-file / saga-step references) in fragments and release
+  pages. Wired into the Changelog CI workflow for fragments.
+
+Other ecosystem repos adopt the same set: copy this doc, the two `AGENTS.md`
+stewards, the draft-script system prompt, and the lint. They are written
+repo-agnostically for exactly that.
+
+## Pre-publish checklist
+
+Run this skim-gate before shipping any fragment or release page:
+
+- [ ] Every line passes the **user-facing test** (type / import / see / act).
+- [ ] No **internal coinage** (phase / sprint / saga / epic / plan-file / branch
+      slug / codename) and no process-journey narration.
+- [ ] No **counts, scores, or release-arc** framing ("Nth patch off …", "N fixes").
+- [ ] No **contributor-only** test / CI / refactor / tooling entries.
+- [ ] Mechanism is **translated to a user-visible effect**.
+- [ ] Issue references are **numeric** and **earn the click**.
+- [ ] (Release page) reads **top-down** — hook → highlights → lists → upgrade — and
+      the hook alone tells the story.
+- [ ] (Release page) the **theme describes content**, not a verdict on quality or
+      maturity (no "grows up", "Honest internals", "Stop shipping wrong output").
+- [ ] `poe changelog-lint` is clean.
 
 ## Rollout order (suggested)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -466,6 +466,7 @@ publish = { cmd = "uv publish", help = "Publish to PyPI" }
 changelog = { cmd = "towncrier build --yes", help = "Compile changelog.d fragments into CHANGELOG.md" }
 changelog-draft = { cmd = "towncrier build --draft", help = "Preview changelog from fragments (stdout)" }
 changelog-check = { cmd = "towncrier check --compare-with origin/main", help = "Verify branch adds a fragment (vs main)" }
+changelog-lint = { cmd = "python scripts/lint_changelog_voice.py", help = "Lint fragments for internal/meta leaks (coinage, branch-slugs); add --releases for site pages" }
 release-notes = { cmd = "python scripts/draft_release_notes.py", help = "Draft a user-facing site release page from CHANGELOG.md (--version/--theme/--bundle)" }
 gh-release = { cmd = "python scripts/publish_github_release.py", help = "Create/update the GitHub release from the site release page (--version/--theme/--create)" }
 release = { sequence = [

--- a/scripts/draft_release_notes.py
+++ b/scripts/draft_release_notes.py
@@ -55,29 +55,89 @@ site generator. You will be given the compiled CHANGELOG.md section for one
 version (the precise engineering record), an optional list of closed issues, an
 optional release theme, and a previous release page as a STYLE EXEMPLAR.
 
-Your job: distill that dense engineering record into a user-facing release page
-that matches the exemplar's structure and voice EXACTLY. The page must:
+The reader is a USER of Bengal, not a maintainer of it. They did not sit in our
+planning, do not run our tests, and will never read the CHANGELOG looking for the
+audit that found a bug. They want one thing: what changed for me, and what do I
+do about it. Your job is to distill the dense engineering record into that.
 
-  1. Open with YAML frontmatter (title, description, date, draft: false, lang: en,
-     tags, keywords, category: changelog) matching the exemplar's frontmatter keys.
-  2. Have an `# Bengal <version>` H1, then a `**Key theme:**` one-paragraph hook.
-  3. Have a `## Highlights` section with 4-7 `###` subsections, each leading with
-     prose a USER cares about ("you can now ..."), with short code examples where
-     they help. Group related changes into themes; do not list every fragment.
-  4. Follow with CONDENSED `## Added`, `## Changed`, `## Fixed`, and `## Removed`
-     sections — one short bullet per user-meaningful change, referencing issue
-     numbers like (#327) where available. These are a skim layer, NOT the full
-     CHANGELOG text — compress aggressively and omit purely-internal refactors.
-  5. End with an `## Upgrading` section: the install command plus any breaking or
-     opt-in changes a user must act on (config flags, removed features, migrations).
+STRUCTURE (progressive disclosure — each layer reads on its own):
+  1. YAML frontmatter (title, description, date, draft: false, lang: en, tags,
+     keywords, category: changelog) matching the exemplar's frontmatter keys.
+  2. An `# Bengal <version>` H1, then a `**Key theme:**` one-paragraph hook. A
+     reader who reads only this paragraph should understand the release.
+  3. A highlights section: 4-7 `###` subsections, each leading with what a USER
+     can now do ("you can now ..."), with short code examples where they help.
+     Group related changes into themes; do NOT list every fragment.
+  4. CONDENSED `## Added` / `## Changed` / `## Fixed` / `## Removed` lists — a
+     skim layer, one short bullet per USER-MEANINGFUL change. Compress hard.
+  5. An `## Upgrading` section: the install command plus any action the user must
+     take (migrations, default flips, removed imports, dependency bumps).
 
-Hard rules:
+THE USER-FACING TEST — keep a change only if the user can OBSERVE it:
+  - They type / import / call / unpack it (CLI command/flag, config key,
+    frontmatter key, template function, public import path, factory parameter,
+    documented return-tuple contract), OR
+  - They see / grep / find it (build-output text, an emitted file, an error
+    string, a fingerprinted filename, a surfaced health/error code), OR
+  - They must act on it (migration, default flip, removed import, dependency bump).
+  If a change answers NONE of these, it is internal: OMIT it entirely.
+  This test also PROTECTS internal-looking detail that is genuinely user-facing
+  (a real public API, a config key, an error string the user saw) — keep those.
+
+NEVER INCLUDE (these are leaks — drop them, do not rephrase them):
+  - Internal coinage: "Phase 2", "Phase 1A", "Sprint", "saga S13.4", "epic #350",
+    RFC / plan-file names, branch slugs, codenames.
+  - Process / journey narration: "a repo-wide audit", "surfaced after the cut",
+    "discovered in CI", "the largest change in X's history", "Nth patch off Y".
+  - Project bookkeeping: fix/file/line counts, ty-diagnostic floors, health-score
+    percentages, test counts.
+  - Contributor-only churn: test additions, guard tests, de-vacuumed assertions,
+    CI gates, import-linter contracts, behavior-preserving refactors, dead-code
+    removal, type/lint hygiene, and our own release/build tooling (gh-release,
+    Towncrier, publish workflows). A user never runs any of it.
+  - Untranslated mechanism: an internal class/module/log-key as the SUBJECT of a
+    change. State the user-visible EFFECT instead (e.g. "incremental builds are
+    faster and rebuild fewer pages", not "fingerprint fast paths are reused").
+  - Off-by-default scaffolding with no caller (byte-identical default build).
+
+TRANSLATION EXAMPLES (record -> release page):
+  - "lazy Kida context is preserved, fingerprint fast paths are reused, version
+    membership is memoized" -> "Incremental builds are faster and rebuild fewer
+    pages."
+  - "Removed the never-called `phase_cache_save` helper" -> OMIT.
+  - "### i18n Gettext Workflow (Phase 1A)" -> "### i18n Gettext Workflow".
+  - "unified the two `RebuildReasonCode`/`RebuildReason` definitions" -> "Rebuild
+    reasons are now reported consistently."
+
+ISSUE REFERENCES:
+  - Cite a NUMERIC issue/PR like (#449) only when a reader would actually click it
+    (track a limitation, see a repro, follow remaining work). Not a per-bullet
+    reflex — drop it if it adds nothing for the reader.
+  - NEVER emit a non-numeric token like (#some-branch-slug) or a plan-file path.
+
+VOICE (one B-Stack voice across all repos):
+  - Confident, plain, concrete, benefit-first, present tense.
+  - No marketing fluff ("blazing", "massive", "seamless", "the largest ... ever")
+    and no hedging ("should now", "we believe"). Say what is true, plainly.
+  - Delight is clarity plus a little warmth, not exclamation points. The reader
+    should finish a note knowing exactly what changed and why it's good.
+
+THEME / KEY-THEME HOOK:
+  - The theme describes WHAT THE RELEASE CONTAINS OR ENABLES for the user, not a
+    verdict on the project's quality, maturity, or past behavior. Test: if a
+    future release could plausibly need the same theme again, it's overclaiming.
+  - Avoid maturity claims ("grows up", "production-ready"), virtue-achieved claims
+    for perennial qualities ("Honest internals", "Rock solid"), confessions ("Stop
+    shipping wrong output"), and release-to-release arcs ("Where 0.4.1 did X...").
+  - Prefer a content/capability anchor: "Visible build failures and crash-safe
+    writes" over "Honest internals"; for a patch, a plain repeatable theme like
+    "Correctness and data-safety fixes" is fine. Honor an explicit --theme, but if
+    it is a verdict-theme, reframe it to the concrete user-facing content.
+
+HARD RULES:
   - Be accurate. Every claim must be supported by the changelog input. Do not
-    invent features, numbers, flags, or issue numbers. If a perf number appears
-    in the changelog, you may quote it; never fabricate one.
-  - Write for end users, not contributors. Translate internal mechanism into
-    user-visible benefit. Skip changes that have no user-facing effect.
-  - Match the exemplar's tone: confident, concrete, no marketing fluff.
+    invent features, numbers, flags, or issue numbers. You may quote a perf number
+    that appears in the changelog; never fabricate one.
   - Output ONLY the markdown file content, starting at the `---` frontmatter.
     No preamble, no explanation, no surrounding code fences.
 """

--- a/scripts/lint_changelog_voice.py
+++ b/scripts/lint_changelog_voice.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Lint changelog fragments and release pages for internal/meta leaks.
+
+Enforces the highest-precision rules from ``docs/b-stack-changelog-strategy.md``:
+
+  * No non-numeric ``(#slug)`` issue references — a reader cannot resolve a branch
+    slug. (At the fragment level, issue-less fragments must be named
+    ``+slug.<type>.md`` so Towncrier renders no reference at all.)
+  * No internal coinage: ``Phase N``, ``Sprint``, ``saga``/saga-step codes
+    (``S13.4a``), ``epic #N``, and ``plan/`` or ``benchmarks/`` file references.
+  * No release-arc bookkeeping (``Nth patch off X``) or audit-process narration.
+
+Fuzzy voice — signal-vs-noise, mechanism-vs-effect, counts, contributor-only
+churn — stays a human/steward judgment. This lint blocks ONLY unambiguous
+structural leaks, so it never nags about legitimate prose and is safe as a CI
+gate. The narrow scope is deliberate.
+
+Usage:
+    python scripts/lint_changelog_voice.py              # fragments (the CI gate)
+    python scripts/lint_changelog_voice.py --releases   # + site release pages
+    python scripts/lint_changelog_voice.py --paths a.md b.md
+
+Exit codes:
+    0 - clean
+    1 - leaks found
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FRAGMENT_DIR = REPO_ROOT / "changelog.d"
+RELEASES_DIR = REPO_ROOT / "site" / "content" / "releases"
+
+FRAGMENT_TYPES = {"added", "changed", "deprecated", "removed", "fixed", "security"}
+
+# (compiled pattern, rule label, fix hint). Each is high-precision: it should not
+# match legitimate user-facing prose. Patterns run line-by-line on text with
+# fenced code blocks blanked out (see strip_code_fences).
+BODY_RULES: list[tuple[re.Pattern[str], str, str]] = [
+    (
+        # A parenthesized #token that is NOT a numeric issue and NOT a hex color:
+        # require a hyphen or a non-hex letter (g-z) so (#FF9D00) / (#449) don't match.
+        re.compile(r"\(`?#(?=[\w./-]*(?:-|[G-Zg-z]))[\w./-]+`?\)"),
+        "non-numeric issue reference",
+        "Cite a numeric issue like (#449), or drop it. Name issue-less fragments "
+        "+slug.<type>.md so Towncrier renders no fake (#slug) reference.",
+    ),
+    (
+        re.compile(r"\bphases?\s+\d", re.IGNORECASE),
+        "internal phase coinage",
+        "Drop the phase label; present the content directly.",
+    ),
+    (
+        re.compile(r"\bsprint\b", re.IGNORECASE),
+        "internal sprint coinage",
+        "Drop sprint / process references.",
+    ),
+    (
+        re.compile(r"\bsaga\b", re.IGNORECASE),
+        "internal saga coinage",
+        "Drop saga references.",
+    ),
+    (
+        re.compile(r"\bepic\s+#?\d", re.IGNORECASE),
+        "internal epic reference",
+        "Drop the epic reference; describe the user-facing change.",
+    ),
+    (
+        re.compile(r"\bS\d+\.\d+[a-z]?\b"),
+        "saga-step code",
+        "Drop the saga-step code (e.g. S13.4a).",
+    ),
+    (
+        re.compile(r"\b(?:plan|benchmarks)/[\w./-]+\.(?:md|rst)\b"),
+        "internal plan/benchmark file reference",
+        "Don't reference internal plan or investigation files.",
+    ),
+    (
+        re.compile(r"\brepo-wide audit\b", re.IGNORECASE),
+        "process narration",
+        "Describe what changed, not the audit that found it.",
+    ),
+    (
+        re.compile(r"\bthe audit'?s\b", re.IGNORECASE),
+        "process narration",
+        "Describe what changed, not the audit process.",
+    ),
+    (
+        re.compile(
+            r"\b(?:first|second|third|fourth|fifth|sixth|\d+(?:st|nd|rd|th))\s+patch\s+off\b",
+            re.IGNORECASE,
+        ),
+        "release-arc bookkeeping",
+        "Drop the 'Nth patch off X' framing; state the release's character directly.",
+    ),
+]
+
+
+class Finding(NamedTuple):
+    path: Path
+    line: int  # 0 == the filename itself, not a body line
+    rule: str
+    text: str
+    hint: str
+
+
+def strip_code_fences(text: str) -> str:
+    """Blank out lines inside ``` fenced code blocks, preserving line numbers."""
+    out: list[str] = []
+    in_fence = False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        out.append("" if in_fence else line)
+    return "\n".join(out)
+
+
+def scan_body(path: Path) -> list[Finding]:
+    """Run every body rule line-by-line over a file's prose."""
+    findings: list[Finding] = []
+    text = strip_code_fences(path.read_text(encoding="utf-8"))
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for pattern, rule, hint in BODY_RULES:
+            m = pattern.search(line)
+            if m:
+                findings.append(Finding(path, lineno, rule, m.group(0), hint))
+    return findings
+
+
+def fragment_type(path: Path) -> str | None:
+    """Return the Towncrier type of a fragment file, or None if it isn't one."""
+    name = path.name
+    for ext in (".md", ".markdown"):
+        if name.endswith(ext):
+            stem = name[: -len(ext)]
+            break
+    else:
+        return None
+    parts = stem.split(".")
+    if len(parts) < 2:
+        return None
+    ftype = parts[-1]
+    return ftype if ftype in FRAGMENT_TYPES else None
+
+
+def scan_fragment_filename(path: Path) -> Finding | None:
+    """Flag a fragment whose issue token is non-numeric and lacks a leading '+'."""
+    ftype = fragment_type(path)
+    if ftype is None:
+        return None
+    stem = path.name.rsplit(".", 1)[0] if path.name.endswith(".md") else path.name
+    issue = stem[: -(len(ftype) + 1)]  # drop ".<type>"
+    if issue.startswith("+") or issue.isdigit():
+        return None
+    return Finding(
+        path,
+        0,
+        "non-numeric fragment name",
+        path.name,
+        f"Rename to +{issue}.{ftype}.md (the leading '+' tells Towncrier there is "
+        "no issue), or use a numeric issue number.",
+    )
+
+
+def collect_fragment_files() -> list[Path]:
+    if not FRAGMENT_DIR.is_dir():
+        return []
+    return sorted(p for p in FRAGMENT_DIR.glob("*.md") if fragment_type(p) is not None)
+
+
+def collect_release_files() -> list[Path]:
+    if not RELEASES_DIR.is_dir():
+        return []
+    return sorted(p for p in RELEASES_DIR.glob("*.md") if p.stem != "_index")
+
+
+def lint(paths: list[Path], *, check_fragment_names: bool) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in paths:
+        if not path.is_file():
+            print(f"warning: {path} not found, skipping", file=sys.stderr)
+            continue
+        if check_fragment_names:
+            name_finding = scan_fragment_filename(path)
+            if name_finding is not None:
+                findings.append(name_finding)
+        findings.extend(scan_body(path))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--releases",
+        action="store_true",
+        help="Also lint site/content/releases/*.md (off by default to avoid "
+        "failing on already-shipped pages; use at cut time).",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        type=Path,
+        help="Lint exactly these files instead of the defaults.",
+    )
+    args = parser.parse_args()
+
+    if args.paths:
+        files = [p if p.is_absolute() else REPO_ROOT / p for p in args.paths]
+        findings = lint(files, check_fragment_names=True)
+        scanned = files
+    else:
+        files = collect_fragment_files()
+        if args.releases:
+            files = files + collect_release_files()
+        findings = lint(files, check_fragment_names=True)
+        scanned = files
+
+    if not findings:
+        n = len(scanned)
+        print(f"changelog-lint: clean ({n} file{'s' if n != 1 else ''} scanned)")
+        return 0
+
+    by_path: dict[Path, list[Finding]] = {}
+    for f in findings:
+        by_path.setdefault(f.path, []).append(f)
+
+    for path, items in by_path.items():
+        try:
+            rel = path.relative_to(REPO_ROOT)
+        except ValueError:
+            rel = path
+        print(f"\n{rel}")
+        for f in items:
+            where = f"line {f.line}" if f.line else "filename"
+            print(f"  {where}: [{f.rule}] {f.text!r}")
+            print(f"      -> {f.hint}")
+
+    print(
+        f"\nchangelog-lint: {len(findings)} leak(s) in {len(by_path)} file(s). "
+        "See docs/b-stack-changelog-strategy.md.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -57,6 +57,37 @@ When site docs change, check:
 - Use generated output as authored truth.
 - Mention internal people, private customers, or private infrastructure.
 
+## Release Pages (changelog distillation)
+
+`content/releases/<version>.md` is the distilled, user-facing story of a release
+— the second of two artifacts (the dense engineering record is `../CHANGELOG.md`).
+Do not collapse them. Canonical rules, leak taxonomy, and before/after examples:
+`../docs/b-stack-changelog-strategy.md`. When you write or edit a release page:
+
+- **Distill, don't transcribe.** Find the bigger picture and cut true-but-internal
+  detail. The page is a top-down editorial act, not a reformatted CHANGELOG.
+- **Progressive disclosure.** Layer it: theme hook (one paragraph; reads alone) →
+  4–7 user-facing highlights ("you can now …") → condensed Added/Changed/Fixed
+  skim lists → Upgrading. Detail is available, never front-loaded.
+- **The user-facing test.** Keep a line only if the user can observe it — they
+  **type / import / call / unpack** it, **see / grep / find** it, or must **act**
+  on it. This protects real public API and grep-able error strings as much as it
+  cuts internal churn.
+- **Never internal coinage.** No "Phase 2", "saga S13.4", "epic #350", `plan/*.md`
+  names, branch slugs, codenames; no process narration ("repo-wide audit",
+  "surfaced after the cut"); no counts / scores / "Nth patch off …"; no
+  contributor-only test/CI/refactor/tooling entries. Translate mechanism to effect.
+- **Issue refs are conditional.** Cite a **numeric** issue/PR only when a reader
+  would click it; never a non-numeric slug. Not a per-bullet reflex.
+- **Theme describes content, not a verdict.** Name what the release enables, not
+  the project's maturity or past sins. Avoid "grows up", "Honest internals", "Stop
+  shipping wrong output". Test: if a future release could need the same theme
+  again, reframe it to the concrete user-facing change.
+- **Brand voice.** Confident, plain, concrete, benefit-first, present tense, no
+  marketing fluff — and a little delightful. The same voice across every repo.
+- **Tooling.** Bootstrap with `uv run poe release-notes --version <v> --theme "…"`
+  (first draft, always edited before shipping); check with `poe changelog-lint`.
+
 ## Own
 
 **Code:** `site/content/`, `site/config/`, `site/data/`, hand-maintained assets.


### PR DESCRIPTION
## Summary

- Codifies a third-party-facing voice for changelog fragments and release pages so internal coinage, process/journey narration, project bookkeeping, and contributor-only churn stop leaking into user docs — grounded in an audit of all release pages + CHANGELOG (171 leak instances, 10 categories).
- `docs/b-stack-changelog-strategy.md` is the cross-repo source of truth (user-facing test, never-leak taxonomy, conditional issue-citation, progressive disclosure, B-Stack voice, a release-titling rule, pre-publish checklist); enforced at the point of work by two `AGENTS.md` stewards (`changelog.d/` and a "Release Pages" section in `site/AGENTS.md`), the `draft_release_notes.py` system prompt, and a deterministic `poe changelog-lint`.
- All artifacts are repo-agnostic so other B-Stack repos adopt them by copying.

## Proof

- [x] Focused tests: lint truth-table + full back-catalog scan — catches real leaks (`Phase N`, branch-slugs like `#reproducible-builds`, `repo-wide audit` / `Nth patch off`) and spares legitimate content (hex `#FF9D00`, numeric `#449`, `` `#Card` `` anchors). CI-gate run on fragments is clean.
- [x] `poe proof-pr` or scoped equivalent: pre-commit passed on commit (ruff, ruff-format, ty, cycles, deps); `py_compile` + `ruff`/`ruff format --check` clean on both scripts; `towncrier build --draft` confirms the fragment dir (incl. new `AGENTS.md`) still parses.
- [x] Docs/examples/changelog updated or no-impact noted: docs updated; no changelog fragment — maintainer tooling/docs only (apply `skip-changelog`). The `pyproject.toml` change adds only a `poe` task.

## Performance Evidence

Not applicable — no performance claim, hot path, or free-threaded/concurrent behavior changed.

## Steward Notes

- Site Documentation (`site/AGENTS.md`): added a "Release Pages" distillation steward. Placed here, not at `site/content/releases/AGENTS.md`, because `directory_walker.should_skip_item` only skips `.`/`_` names — an `AGENTS.md` under `site/content/` would be discovered and published as a `/releases/agents/` page.
- Release & Dependency Risk (root `AGENTS.md`, `changelog.d/`, `.github/workflows/`): new `changelog.d/AGENTS.md` steward + a Changelog CI lint step. The CI gate lints fragments only (clean today); `--releases` is opt-in to avoid failing on the already-shipped back-catalog (16 findings / 7 pages, surfaced for a follow-up editorial pass).
- No `bengal/` runtime code changed; behavior is unchanged.
