### PR TITLE
fix(errors): make ErrorSession reader methods thread-safe under free-threading (#439)

### DIFF
--- a/bengal/concurrency.py
+++ b/bengal/concurrency.py
@@ -215,8 +215,8 @@ Locks for error recording, always acquired last.
 +-----------------------------------------------+--------+--------------------------------------------+
 | Lock                                          | Type   | Protects                                   |
 +===============================================+========+============================================+
-| ErrorSession._lock                            | Lock   | _patterns, _errors_by_*, _total_errors     |
-|   errors/session.py:180                       |        |                                            |
+| ErrorSession._lock                            | RLock  | _patterns, _errors_by_*, _total_errors     |
+|   errors/session.py:180                       |        | (reentrant: get_summary() calls readers)   |
 +-----------------------------------------------+--------+--------------------------------------------+
 | SingletonContainer._lock                      | Lock   | _instance (lazy singleton creation)        |
 |   errors/utils.py:531                         |        |                                            |
@@ -265,7 +265,8 @@ Design Principles
   serialization (templates, nav versions), use PerKeyLockManager instead
   of a single global lock.
 - **RLock for reentrant paths**: TaxonomyIndex, QueryIndex, ContentHashRegistry,
-  and LRUCache use RLock because their public methods may call each other.
+  LRUCache, and ErrorSession use RLock because their public methods may call
+  each other (e.g. ``ErrorSession.get_summary()`` calls other locked readers).
 - **ContextVar over locks**: Where possible, use ``contextvars.ContextVar``
   for per-task state instead of shared mutable state + locks. Note: For
   ThreadPoolExecutor workers, ``threading.local()`` is appropriate for

--- a/bengal/errors/session.py
+++ b/bengal/errors/session.py
@@ -72,7 +72,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
-from threading import Lock
+from threading import RLock
 from typing import TYPE_CHECKING, Any
 
 from bengal.errors.utils import ThreadSafeSingleton, generate_error_signature
@@ -114,6 +114,15 @@ class ErrorPattern:
         occurrences: List of all occurrences
         first_file: File where error first occurred
         affected_files: Set of all affected files
+
+    Thread-safety:
+        This is a ``frozen`` *shell* — its fields cannot be reassigned — but
+        ``occurrences`` and ``affected_files`` are mutable containers that
+        :class:`ErrorSession` appends to in place while holding its lock.
+        The derived ``count`` / ``is_recurring`` / ``is_systemic`` properties
+        must therefore be read through :class:`ErrorSession`'s locked
+        accessors; iterating or mutating these fields outside that lock is a
+        data race on free-threaded Python.
 
     """
 
@@ -176,7 +185,10 @@ class ErrorSession:
         self._errors_by_file: dict[str, list[ErrorOccurrence]] = defaultdict(list)
         self._errors_by_code: dict[str, list[ErrorOccurrence]] = defaultdict(list)
         self._errors_by_phase: dict[str, list[ErrorOccurrence]] = defaultdict(list)
-        self._lock = Lock()
+        # Re-entrant: get_summary()/get_investigation_hints() call other locked
+        # readers, so a plain Lock would self-deadlock. All readers and writers
+        # below acquire this lock — the class's thread-safety claim depends on it.
+        self._lock = RLock()
         self._start_time = datetime.now()
         self._total_errors = 0
 
@@ -294,7 +306,8 @@ class ErrorSession:
             ErrorPattern if found, None otherwise
         """
         signature = self._generate_signature(error)
-        return self._patterns.get(signature)
+        with self._lock:
+            return self._patterns.get(signature)
 
     def get_errors_for_file(self, file_path: str) -> list[ErrorOccurrence]:
         """
@@ -306,7 +319,9 @@ class ErrorSession:
         Returns:
             List of ErrorOccurrence for that file
         """
-        return self._errors_by_file.get(file_path, [])
+        with self._lock:
+            # Copy: the caller must not iterate a list record() may append to.
+            return list(self._errors_by_file.get(file_path, []))
 
     def get_errors_by_code(self, code: str | ErrorCode) -> list[ErrorOccurrence]:
         """
@@ -319,7 +334,9 @@ class ErrorSession:
             List of ErrorOccurrence with that code
         """
         code_str = str(code)
-        return self._errors_by_code.get(code_str, [])
+        with self._lock:
+            # Copy: the caller must not iterate a list record() may append to.
+            return list(self._errors_by_code.get(code_str, []))
 
     def get_systemic_issues(self) -> list[ErrorPattern]:
         """
@@ -328,7 +345,8 @@ class ErrorSession:
         Returns:
             List of ErrorPattern that are systemic
         """
-        return [p for p in self._patterns.values() if p.is_systemic]
+        with self._lock:
+            return [p for p in self._patterns.values() if p.is_systemic]
 
     def get_most_common_errors(self, limit: int = 5) -> list[tuple[str, int]]:
         """
@@ -340,12 +358,13 @@ class ErrorSession:
         Returns:
             List of (signature, count) tuples, sorted by count
         """
-        sorted_patterns = sorted(
-            self._patterns.items(),
-            key=lambda x: x[1].count,
-            reverse=True,
-        )
-        return [(sig, pattern.count) for sig, pattern in sorted_patterns[:limit]]
+        with self._lock:
+            sorted_patterns = sorted(
+                self._patterns.items(),
+                key=lambda x: x[1].count,
+                reverse=True,
+            )
+            return [(sig, pattern.count) for sig, pattern in sorted_patterns[:limit]]
 
     def get_summary(self) -> dict[str, Any]:
         """
@@ -354,34 +373,35 @@ class ErrorSession:
         Returns:
             Dictionary with session statistics
         """
-        duration = (datetime.now() - self._start_time).total_seconds()
+        with self._lock:
+            duration = (datetime.now() - self._start_time).total_seconds()
 
-        # Get phase distribution
-        phase_counts = {phase: len(errors) for phase, errors in self._errors_by_phase.items()}
+            # Get phase distribution
+            phase_counts = {phase: len(errors) for phase, errors in self._errors_by_phase.items()}
 
-        # Get code distribution
-        code_counts = {code: len(errors) for code, errors in self._errors_by_code.items()}
+            # Get code distribution
+            code_counts = {code: len(errors) for code, errors in self._errors_by_code.items()}
 
-        # Get most affected files
-        file_counts = sorted(
-            [(f, len(e)) for f, e in self._errors_by_file.items()],
-            key=lambda x: x[1],
-            reverse=True,
-        )[:5]
+            # Get most affected files
+            file_counts = sorted(
+                [(f, len(e)) for f, e in self._errors_by_file.items()],
+                key=lambda x: x[1],
+                reverse=True,
+            )[:5]
 
-        return {
-            "total_errors": self._total_errors,
-            "unique_patterns": len(self._patterns),
-            "affected_files": len(self._errors_by_file),
-            "session_duration_seconds": duration,
-            "errors_per_minute": (self._total_errors / duration * 60) if duration > 0 else 0,
-            "systemic_issues": len(self.get_systemic_issues()),
-            "most_common_errors": self.get_most_common_errors(),
-            "errors_by_phase": phase_counts,
-            "errors_by_code": code_counts,
-            "most_affected_files": file_counts,
-            "recurring_errors": sum(1 for p in self._patterns.values() if p.is_recurring),
-        }
+            return {
+                "total_errors": self._total_errors,
+                "unique_patterns": len(self._patterns),
+                "affected_files": len(self._errors_by_file),
+                "session_duration_seconds": duration,
+                "errors_per_minute": (self._total_errors / duration * 60) if duration > 0 else 0,
+                "systemic_issues": len(self.get_systemic_issues()),
+                "most_common_errors": self.get_most_common_errors(),
+                "errors_by_phase": phase_counts,
+                "errors_by_code": code_counts,
+                "most_affected_files": file_counts,
+                "recurring_errors": sum(1 for p in self._patterns.values() if p.is_recurring),
+            }
 
     def get_investigation_hints(self) -> list[str]:
         """
@@ -390,46 +410,47 @@ class ErrorSession:
         Returns:
             List of actionable investigation hints
         """
-        hints: list[str] = []
+        with self._lock:
+            hints: list[str] = []
 
-        # Check for systemic issues
-        systemic = self.get_systemic_issues()
-        if systemic:
-            hints.append(
-                f"🔍 Found {len(systemic)} systemic issue(s) affecting multiple files. "
-                "Consider checking shared templates or configuration."
-            )
-
-        # Check for phase concentration
-        phase_counts = {p: len(e) for p, e in self._errors_by_phase.items()}
-        if phase_counts:
-            max_phase = max(phase_counts, key=lambda k: phase_counts[k])
-            if phase_counts[max_phase] > self._total_errors * 0.5:
+            # Check for systemic issues
+            systemic = self.get_systemic_issues()
+            if systemic:
                 hints.append(
-                    f"🎯 {phase_counts[max_phase]}/{self._total_errors} errors occurred in "
-                    f"{max_phase} phase. Focus investigation there."
+                    f"🔍 Found {len(systemic)} systemic issue(s) affecting multiple files. "
+                    "Consider checking shared templates or configuration."
                 )
 
-        # Check for high recurrence
-        recurring = [p for p in self._patterns.values() if p.count >= 3]
-        if recurring:
-            top = recurring[0]
-            hints.append(
-                f"⚠️ Error pattern '{top.signature[:50]}...' occurred {top.count} times. "
-                f"First in: {top.first_file}"
-            )
+            # Check for phase concentration
+            phase_counts = {p: len(e) for p, e in self._errors_by_phase.items()}
+            if phase_counts:
+                max_phase = max(phase_counts, key=lambda k: phase_counts[k])
+                if phase_counts[max_phase] > self._total_errors * 0.5:
+                    hints.append(
+                        f"🎯 {phase_counts[max_phase]}/{self._total_errors} errors occurred in "
+                        f"{max_phase} phase. Focus investigation there."
+                    )
 
-        # Check for code concentration
-        code_counts = {c: len(e) for c, e in self._errors_by_code.items()}
-        if code_counts:
-            max_code = max(code_counts, key=lambda k: code_counts[k])
-            if code_counts[max_code] >= 3:
+            # Check for high recurrence
+            recurring = [p for p in self._patterns.values() if p.count >= 3]
+            if recurring:
+                top = recurring[0]
                 hints.append(
-                    f"📋 Error code {max_code} occurred {code_counts[max_code]} times. "
-                    "Check documentation for this error code."
+                    f"⚠️ Error pattern '{top.signature[:50]}...' occurred {top.count} times. "
+                    f"First in: {top.first_file}"
                 )
 
-        return hints
+            # Check for code concentration
+            code_counts = {c: len(e) for c, e in self._errors_by_code.items()}
+            if code_counts:
+                max_code = max(code_counts, key=lambda k: code_counts[k])
+                if code_counts[max_code] >= 3:
+                    hints.append(
+                        f"📋 Error code {max_code} occurred {code_counts[max_code]} times. "
+                        "Check documentation for this error code."
+                    )
+
+            return hints
 
     def clear(self) -> None:
         """Clear all recorded errors and reset session."""

--- a/changelog.d/439.fixed.md
+++ b/changelog.d/439.fixed.md
@@ -1,0 +1,1 @@
+Build error summaries and investigation hints no longer crash or report wrong counts during parallel builds on free-threaded Python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,6 +357,8 @@ package_dir = "."
 title_format = "## [{version}] - {project_date}"
 issue_format = "`#{issue}`"
 underlines = ["", "", ""]
+# Steward docs / placeholders that live in changelog.d/ but are not fragments.
+ignore = ["AGENTS.md", ".gitkeep"]
 
 [[tool.towncrier.type]]
 directory = "added"

--- a/tests/unit/errors/test_session_thread_safety.py
+++ b/tests/unit/errors/test_session_thread_safety.py
@@ -1,0 +1,128 @@
+"""Free-threading data-race coverage for :class:`ErrorSession` (issue #439).
+
+The session docstring claims thread-safety, but only ``record()`` and
+``clear()`` hold ``self._lock``; the read methods iterate the shared
+``_patterns`` / ``_errors_by_*`` dicts unlocked. Under free-threaded CPython
+(``python3.14t``, GIL disabled) a reader iterating a dict while ``record()``
+mutates it raises ``RuntimeError: dictionary changed size during iteration``.
+
+These tests are **discriminating**: on the unfixed code they reproduce that
+race (the assertions fail), and they pass only once every reader holds the
+lock. They are no-ops on a GIL build (the GIL serialises access), which is
+why the #439 milestone requires verifying under ``python3.14t``.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from bengal.errors.session import ErrorSession
+
+pytestmark = pytest.mark.parallel_unsafe
+
+# High write pressure with *distinct* signatures so ``_patterns`` keeps growing
+# (and therefore resizes) *during* a reader's iteration — a gentle driver with
+# few patterns is vacuously green because the dicts never change size mid-read.
+_WRITERS = 6
+_READERS = 6
+_RECORDS_PER_WRITER = 4000
+
+
+def _unique_error(writer: int, index: int) -> ValueError:
+    # The signature is derived from the (normalised) message, so a unique
+    # message per call yields a unique pattern -> the pattern dict grows.
+    return ValueError(f"boom w{writer} n{index}")
+
+
+def test_error_session_readers_are_race_free_under_free_threading() -> None:
+    """Concurrent record() + read methods must never tear or raise.
+
+    Drives ``record()`` from many threads while other threads hammer every
+    reader (``get_summary`` / ``get_investigation_hints`` /
+    ``get_systemic_issues`` / ``get_most_common_errors`` / the per-key
+    getters). Asserts no exception escaped any thread and the final totals
+    are internally consistent.
+    """
+    session = ErrorSession()
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+    stop = threading.Event()
+    start = threading.Barrier(_WRITERS + _READERS)
+
+    def writer(writer_id: int) -> None:
+        start.wait()
+        try:
+            for index in range(_RECORDS_PER_WRITER):
+                session.record(
+                    _unique_error(writer_id, index),
+                    file_path=f"content/w{writer_id}/post{index % 50}.md",
+                    build_phase=("render", "parse", "postprocess")[index % 3],
+                )
+        except BaseException as exc:
+            with errors_lock:
+                errors.append(exc)
+        finally:
+            stop.set()
+
+    def reader() -> None:
+        start.wait()
+        try:
+            while not stop.is_set():
+                session.get_summary()
+                session.get_investigation_hints()
+                session.get_systemic_issues()
+                session.get_most_common_errors()
+                session.get_errors_for_file("content/w0/post0.md")
+                session.get_errors_by_code("X")
+        except BaseException as exc:
+            with errors_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=writer, args=(w,)) for w in range(_WRITERS)]
+    threads += [threading.Thread(target=reader) for _ in range(_READERS)]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, (
+        f"ErrorSession raced under free-threading: {len(errors)} thread(s) failed, "
+        f"first = {type(errors[0]).__name__}: {errors[0]}"
+    )
+
+    summary = session.get_summary()
+    assert summary["total_errors"] == _WRITERS * _RECORDS_PER_WRITER
+    # Every record had a unique message -> a unique pattern.
+    assert summary["unique_patterns"] == _WRITERS * _RECORDS_PER_WRITER
+
+
+def test_get_summary_does_not_deadlock_when_readers_are_locked() -> None:
+    """``get_summary`` calls two other readers, so a plain ``Lock`` self-deadlocks.
+
+    This guards the reentrancy trap: the fix must use a re-entrant lock (or a
+    snapshot-then-release strategy). A plain ``Lock`` wrapping every reader
+    would hang here; the test asserts the call returns promptly.
+    """
+    session = ErrorSession()
+    for index in range(200):
+        session.record(_unique_error(0, index), file_path=f"f{index % 5}.md")
+
+    done = threading.Event()
+    result: dict[str, object] = {}
+
+    def call_summary() -> None:
+        result["summary"] = session.get_summary()
+        result["hints"] = session.get_investigation_hints()
+        done.set()
+
+    thread = threading.Thread(target=call_summary)
+    thread.start()
+    thread.join(timeout=10.0)
+
+    assert done.is_set(), (
+        "get_summary()/get_investigation_hints() deadlocked (reentrant reader calls)"
+    )
+    assert result["summary"]["total_errors"] == 200  # type: ignore[index]


### PR DESCRIPTION
## Summary

- Fixes #439. The seven `ErrorSession` read methods iterated the shared `_patterns` / `_errors_by_*` dicts without holding `self._lock`, while `record()` mutated them under it. On free-threaded CPython a reader iterating a dict during a concurrent `record()` raised `RuntimeError: dictionary changed size during iteration`, producing crashing or wrong build error summaries.
- `Lock` → `RLock` (`get_summary()` / `get_investigation_hints()` call other locked readers, so a plain `Lock` self-deadlocks), wrap all seven readers under the lock, and return list copies from the per-key getters so callers can't iterate a list `record()` may append to.
- Document the frozen-`ErrorPattern`-with-mutable-fields contract and update the canonical lock-ordering inventory in `concurrency.py`.

## Proof

- [x] Focused tests: `tests/unit/errors/test_session_thread_safety.py` (new, `parallel_unsafe`) — discriminating: reproduces the race on the unfixed code under free-threaded CPython (`RuntimeError: dictionary changed size during iteration` across 6 threads), passes after the fix; plus a reentrancy guard that fails against a plain-`Lock` deadlock.
- [x] Verified RED-on-unfixed / GREEN-on-fixed on a genuine free-threaded build (CPython 3.14.2, GIL disabled); `tests/unit/errors/` (257) + cache/config/themes session-tracking suites all green.
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/439.fixed.md`

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

Correctness-only change to concurrent behavior (adds locking); makes no performance claim.

## Steward Notes

- `bengal/concurrency.py` lock inventory updated to reflect `ErrorSession._lock` is now an `RLock` (reentrant readers).
