### PR TITLE
chore(release): v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.4.3] - 2026-06-15
+
+### Fixed
+
+- Build error summaries and investigation hints no longer crash or report wrong counts during parallel builds on free-threaded Python. (`#439`)
+
+
 ## [0.4.2] - 2026-06-15
 
 ### Removed

--- a/changelog.d/439.fixed.md
+++ b/changelog.d/439.fixed.md
@@ -1,1 +1,0 @@
-Build error summaries and investigation hints no longer crash or report wrong counts during parallel builds on free-threaded Python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bengal"
-version = "0.4.2"
+version = "0.4.3"
 description = "Python static site generator built on free-threading — every layer pure Python, scales with your cores, zero npm"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/site/content/releases/0.4.3.md
+++ b/site/content/releases/0.4.3.md
@@ -1,0 +1,34 @@
+---
+title: Bengal 0.4.3
+description: Free-threading hardening — build error reporting is now race-free on free-threaded Python, so parallel builds no longer crash or report wrong error counts in their summaries.
+date: 2026-06-15
+draft: false
+lang: en
+tags: [release, changelog, patch, bugfix]
+keywords: [release, 0.4.3, patch, free-threading, thread-safety, correctness]
+category: changelog
+---
+
+# Bengal 0.4.3
+
+**Key theme:** Free-threading hardening. 0.4.3 closes a free-threading correctness gap in how Bengal reports build errors. On free-threaded CPython (3.14t) Bengal runs your build across cores — and the session that tracks errors across that build recorded them safely but *read* them without the same protection. This patch makes the reads safe too. No new features, no breaking changes.
+
+## What's fixed
+
+### Build error reporting is race-free under free-threading
+
+- **Error summaries no longer crash or miscount on free-threaded Python.** The build-error session indexed errors under a lock when recording them, but its readers — the end-of-build summary, the investigation hints, and the systemic-issue / most-common-error views — walked those shared indexes without one. On free-threaded CPython (`python3.14t`), a reader iterating an index while another thread recorded an error could raise `RuntimeError: dictionary changed size during iteration` or report wrong counts. Every reader now takes the session's re-entrant lock, and the per-file / per-code lookups return copies, so concurrent builds produce correct, stable error summaries (`#439`).
+
+## Changes at a glance
+
+**Fixed**
+
+- Race-free error tracking: build error summaries and investigation hints no longer crash or report wrong counts during parallel builds on free-threaded Python (`#439`).
+
+## Upgrading
+
+```bash
+pip install --upgrade bengal-ssg
+```
+
+0.4.3 is a drop-in patch: no breaking changes and no config migration. The fix only affects builds running on free-threaded CPython (`python3.14t`); on the standard GIL build the behavior is unchanged.

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "bengal"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "bengal-pounce" },


### PR DESCRIPTION
## Summary

- Cuts **v0.4.3** — the free-threading hardening patch. Ships the one fully-validated fix from the v0.4.3 milestone: #439 (`ErrorSession` reader methods are now race-free under free-threaded CPython).
- Bumps `pyproject.toml` 0.4.2 → 0.4.3, refreshes `uv.lock`, compiles `changelog.d/439.fixed.md` into `CHANGELOG.md` under `## [0.4.3]`, and adds the site release page `site/content/releases/0.4.3.md`.
- #438 (the other former v0.4.3 issue) was re-homed to v0.5.0 — its prescribed fix has a latent correctness regression and its proofs are non-discriminating on 3.14t; it belongs with the warm-build work where a deterministic proof can be designed.

## Proof

- [x] Focused tests: #439's fix landed in #483 with a discriminating `parallel_unsafe` test (RED on unfixed under `python3.14t`, GREEN after) and an independent adversarial verification (SHIP).
- [x] `towncrier build` compiled cleanly; `changelog-lint` (fragments) and `changelog-lint --releases` (this page) pass; doc-reality-drift guard passes (`releases/` exempt).
- [x] Docs/examples/changelog updated: `CHANGELOG.md` + `site/content/releases/0.4.3.md`.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

Release bookkeeping only (version bump + changelog compile + release page); no code paths changed.

## Steward Notes

- GitHub release title will render as `v0.4.3 — Free-threading hardening` (dry-run verified via `scripts/publish_github_release.py`).
