### PR TITLE
docs: document supported filter registration; correct --memory-optimized claim

### DIFF
--- a/bengal/cli/milo_commands/build.py
+++ b/bengal/cli/milo_commands/build.py
@@ -22,7 +22,8 @@ def build(
         bool, Description("Force full rebuild ignoring cache (default: auto-detect)")
     ] = False,
     memory_optimized: Annotated[
-        bool, Description("Streaming build for memory efficiency (5K+ pages)")
+        bool,
+        Description("[Experimental] Streaming build for 5K+ pages; memory benefit unverified"),
     ] = False,
     environment: Annotated[
         str,

--- a/changelog.d/487.changed.md
+++ b/changelog.d/487.changed.md
@@ -1,0 +1,1 @@
+`bengal build --memory-optimized` is now labeled experimental, and its help text and docs no longer promise a fixed memory saving — measure peak memory with and without the flag on your own site before relying on it.

--- a/site/content/docs/building/performance/large-sites.md
+++ b/site/content/docs/building/performance/large-sites.md
@@ -50,7 +50,11 @@ bengal build --incremental --fast
 
 ## 1. Memory-Optimized Builds (Streaming Mode)
 
-For sites with 5K+ pages, enable streaming mode:
+:::{warning}
+**Experimental.** `--memory-optimized` is an experimental streaming mode. Its memory benefit is **not yet verified** by Bengal's benchmarks, and on the workloads measured so far it has not reduced peak memory below a standard build. Treat it as a tuning knob to try and measure on your own site, not a guaranteed win. Profile your build (see [Build Profiling](#6-build-profiling)) before and after to confirm any improvement.
+:::
+
+For sites with 5K+ pages, you can try streaming mode:
 
 ```bash
 bengal build --memory-optimized
@@ -61,14 +65,15 @@ bengal build --memory-optimized
 1. **Builds knowledge graph** to understand page connectivity
 2. **Renders hubs first** (highly connected pages) and keeps them in memory
 3. **Streams leaves** in batches and releases memory immediately
-4. **Result**: 80-90% memory reduction
 
-### When to Use
+The intent is to keep memory closer to constant as page count grows by releasing leaf pages after they render. Whether this lowers peak memory on a given site depends on its content and link structure — measure to confirm.
 
-- Sites with 5K+ pages
-- CI runners with limited memory
-- Docker containers with memory limits
-- Local machines with limited RAM
+### When to Try It
+
+- Very large sites (5K+ pages) where a standard build runs out of memory
+- CI runners or containers with strict memory limits
+
+In each case, compare peak memory with and without the flag before relying on it.
 
 :::{warning}
 `--memory-optimized` and `--perf-profile` cannot be used together (profiler doesn't work with batched rendering).
@@ -387,9 +392,9 @@ bengal clean --all
 
 ### Build runs out of memory
 
-1. Enable streaming: `--memory-optimized`
-2. Use `bengal build --dev --verbose` to see memory usage
-3. Increase swap space
+1. Increase available memory or swap space
+2. Use `bengal build --dev --verbose` to watch memory usage
+3. Try the experimental streaming mode (`--memory-optimized`) and measure peak memory with and without it — it is not guaranteed to help on every site
 
 ### Build is slow despite caching
 

--- a/site/content/docs/theming/templating/kida/add-custom-filter.md
+++ b/site/content/docs/theming/templating/kida/add-custom-filter.md
@@ -69,69 +69,57 @@ def currency(value: float, symbol: str = "$") -> str:
 ```
 
 :::{/step}
-:::{step} Register Filter
+:::{step} Register the Filter in a Plugin
 
-Create a registration function to add your filter to the template environment:
-
-```bash
-mkdir -p python
-touch python/filter_registration.py
-```
-
-Register the filter:
+Register filters through the supported [plugin API](/docs/extending/plugins/).
+A plugin implements the `Plugin` protocol and calls
+`registry.add_template_filter()` in its `register()` method:
 
 ```python
-# python/filter_registration.py
-from bengal.core import Site
+# my_bengal_plugin/__init__.py
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
+
 from .filters import currency
 
-def register_filters(site: Site) -> None:
-    """Register custom Kida filters.
 
-    Note: This uses internal APIs that may change in future versions.
-    A stable plugin API is planned for v0.4.0.
-    """
-    # Access the template engine environment
-    # The template engine is created during the build process
-    if hasattr(site, '_template_engine') and site._template_engine:
-        env = site._template_engine._env
-        env.add_filter("currency", currency)
+class MyFiltersPlugin(Plugin):
+    name = "my-filters"
+    version = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_template_filter("currency", currency)
 ```
+
+`add_template_filter` is a stable, supported entry point: registered filters
+are applied to every template environment during the build, and the frozen
+registry is safe to share across parallel render workers.
 
 :::{/step}
-:::{step} Call Registration Function
+:::{step} Declare the Entry Point and Install
 
-You need to call this function during the build process. Currently, this requires accessing internal APIs. Two approaches:
+Expose the plugin through the `bengal.plugins` entry point group so Bengal
+discovers it automatically:
 
-**Option A: Programmatic Build (Recommended)**
-
-Create a custom build script that calls your registration function:
-
-```python
-# build.py
-from pathlib import Path
-from bengal.core import Site
-from bengal.orchestration.build import BuildOptions
-from python.filter_registration import register_filters
-
-# Load site
-site = Site.from_config(Path("."))
-
-# Register filters before building
-register_filters(site)
-
-# Build site
-options = BuildOptions()
-site.build(options)
+```toml
+# pyproject.toml
+[project.entry-points."bengal.plugins"]
+my-filters = "my_bengal_plugin:MyFiltersPlugin"
 ```
 
-**Option B: Internal API Access (Advanced)**
+Install the plugin into the same environment as Bengal:
 
-:::{caution}
-This approach uses internal APIs (`site._template_engine`) that may change. Use with caution and test after Bengal updates.
-:::
+```bash
+uv pip install -e ./my-bengal-plugin
+```
 
-If you need to register filters during the build process, you can access the template engine after it's created. The template engine is typically available during the rendering phase of the build.
+On the next build, Bengal discovers the plugin and registers your filter — no
+build script or internal-attribute access required. Verify it is picked up with:
+
+```bash
+bengal plugin list
+bengal plugin info my-filters
+```
 
 :::{/step}
 :::{step} Use Filter in Template
@@ -179,18 +167,11 @@ def truncate_words(value: str, length: int = 50, suffix: str = "...") -> str:
     return " ".join(words[:length]) + suffix
 ```
 
-Register and use:
+Register it in your plugin:
 
 ```python
-# python/filter_registration.py
-from bengal.core import Site
-from .filters import truncate_words
-
-def register_filters(site: Site) -> None:
-    """Register custom Kida filters."""
-    if hasattr(site, '_template_engine') and site._template_engine:
-        env = site._template_engine._env
-        env.add_filter("truncate_words", truncate_words)
+# my_bengal_plugin/__init__.py (inside register())
+registry.add_template_filter("truncate_words", truncate_words)
 ```
 
 ```kida
@@ -239,17 +220,9 @@ def relative_date(value, context=None):
 ```
 
 ```python
-# python/filter_registration.py
-from bengal.core import Site
-from .filters import relative_date
-
-def register_filters(site: Site) -> None:
-    """Register custom Kida filters."""
-    if hasattr(site, '_template_engine') and site._template_engine:
-        env = site._template_engine._env
-        # Note: Context passing depends on filter implementation
-        # Kida passes context when filters accept it as a parameter
-        env.add_filter("relative_date", relative_date)
+# my_bengal_plugin/__init__.py (inside register())
+# Kida passes template context when the filter accepts it as a parameter.
+registry.add_template_filter("relative_date", relative_date)
 ```
 
 ```kida
@@ -284,15 +257,8 @@ def where_contains(items, key, value):
 ```
 
 ```python
-# python/filter_registration.py
-from bengal.core import Site
-from .filters import where_contains
-
-def register_filters(site: Site) -> None:
-    """Register custom Kida filters."""
-    if hasattr(site, '_template_engine') and site._template_engine:
-        env = site._template_engine._env
-        env.add_filter("where_contains", where_contains)
+# my_bengal_plugin/__init__.py (inside register())
+registry.add_template_filter("where_contains", where_contains)
 ```
 
 ```kida
@@ -301,31 +267,26 @@ def register_filters(site: Site) -> None:
   |> where_contains('title', 'python') %}
 ```
 
-## Using Decorator Syntax
+## Registering Multiple Filters
 
-You can also use decorator syntax for cleaner registration:
+A single plugin can register any number of filters in one `register()` call:
 
 ```python
-# python/filter_registration.py
-from bengal.core import Site
+# my_bengal_plugin/__init__.py
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
 
-def register_filters(site: Site) -> None:
-    """Register all custom filters."""
-    if hasattr(site, '_template_engine') and site._template_engine:
-        env = site._template_engine._env
+from .filters import currency, truncate_words, where_contains
 
-        @env.filter()
-        def currency(value: float, symbol: str = "$") -> str:
-            """Format a number as currency."""
-            return f"{symbol}{value:,.2f}"
 
-        @env.filter()
-        def truncate_words(value: str, length: int = 50) -> str:
-            """Truncate text to a specific word count."""
-            words = value.split()
-            if len(words) <= length:
-                return value
-            return " ".join(words[:length]) + "..."
+class MyFiltersPlugin(Plugin):
+    name = "my-filters"
+    version = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_template_filter("currency", currency)
+        registry.add_template_filter("truncate_words", truncate_words)
+        registry.add_template_filter("where_contains", where_contains)
 ```
 
 ## Testing Filters
@@ -354,7 +315,7 @@ def test_truncate_words():
 3. **None handling**: Handle None values gracefully
 4. **Error handling**: Provide sensible defaults
 5. **Naming**: Use descriptive, lowercase names with underscores
-6. **API access**: Use `env.add_filter()` method (preferred) over `env.filters['name'] = func`
+6. **Registration**: Register filters through a plugin's `registry.add_template_filter()` — the supported, thread-safe entry point
 
 ## Troubleshooting
 
@@ -362,31 +323,35 @@ def test_truncate_words():
 
 If your filter isn't available in templates:
 
-:::{dropdown} Check registration timing
-:icon: clock
+:::{dropdown} Verify the plugin is discovered
+:icon: search
 
-Ensure `register_filters()` is called before templates are rendered.
+Run `bengal plugin list` and `bengal plugin info <name>`. If your plugin is
+missing, confirm it is installed in the same environment as Bengal and that the
+`bengal.plugins` entry point in `pyproject.toml` points at your plugin class.
 :::
 
-:::{dropdown} Verify template engine
+:::{dropdown} Check the filter is registered
 :icon: settings
 
-Confirm `site._template_engine` exists and has `_env` attribute.
+Confirm `register()` calls `registry.add_template_filter("name", fn)` and that
+`bengal plugin info <name>` reports a non-zero `template_filters` count.
 :::
 
 :::{dropdown} Check filter name
 :icon: tag
 
-Filter names are case-sensitive and must match exactly.
+Filter names are case-sensitive and must match the name passed to
+`add_template_filter` exactly.
 :::
 
-### Template Engine Not Available
+### Plugin Not Discovered
 
-If `site._template_engine` is `None`:
+If `bengal plugin list` does not show your plugin:
 
-- The template engine is created during the rendering phase
-- Ensure you're calling `register_filters()` after the engine is initialized
-- Consider using a custom build script that registers filters before building
+- Reinstall the plugin after editing `pyproject.toml`: `uv pip install -e ./my-bengal-plugin`
+- Confirm the entry point group is exactly `bengal.plugins`
+- Make sure the class implements `name`, `version`, and `register()`
 
 ### Context Not Passed to Filters
 
@@ -410,8 +375,10 @@ Access context variables through the context parameter when provided.
 Context passing behavior may vary depending on how the filter is called.
 :::
 
-:::{caution}
-**Internal API Usage**: Accessing `site._template_engine._env` uses internal APIs that may change in future versions. A stable plugin API for filter registration is planned for v0.4.0. Test your filter registration after Bengal updates.
+:::{tip}
+**Supported API**: `registry.add_template_filter()` is the stable, supported way
+to register filters. Avoid reaching into internal attributes such as
+`site._template_engine._env` — those are private and may change between releases.
 :::
 
 ## Complete Example
@@ -462,35 +429,38 @@ def relative_date(value, context=None) -> str:
 ```
 
 ```python
-# python/filter_registration.py
-"""Filter registration for custom Kida filters."""
-from bengal.core import Site
+# my_bengal_plugin/__init__.py
+"""Plugin that registers custom Kida filters."""
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
+
 from .filters import currency, truncate_words, relative_date
 
-def register_filters(site: Site) -> None:
-    """Register custom Kida filters.
 
-    Call this function before building your site to register all custom filters.
-    """
-    if hasattr(site, '_template_engine') and site._template_engine:
-        env = site._template_engine._env
-        env.add_filter("currency", currency)
-        env.add_filter("truncate_words", truncate_words)
-        env.add_filter("relative_date", relative_date)
+class MyFiltersPlugin(Plugin):
+    name = "my-filters"
+    version = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_template_filter("currency", currency)
+        registry.add_template_filter("truncate_words", truncate_words)
+        registry.add_template_filter("relative_date", relative_date)
 ```
 
-**Using in a build script:**
+**Declaring the entry point:**
 
-```python
-# build.py
-from pathlib import Path
-from bengal.core import Site
-from bengal.orchestration.build import BuildOptions
-from python.filter_registration import register_filters
+```toml
+# pyproject.toml
+[project.entry-points."bengal.plugins"]
+my-filters = "my_bengal_plugin:MyFiltersPlugin"
+```
 
-site = Site.from_config(Path("."))
-register_filters(site)
-site.build(BuildOptions())
+Install the plugin and build — Bengal discovers it automatically and your
+filters are available in every template:
+
+```bash
+uv pip install -e ./my-bengal-plugin
+bengal build
 ```
 
 ## Next Steps
@@ -501,5 +471,5 @@ site.build(BuildOptions())
 
 :::{seealso}
 - [Template Functions Reference](/docs/reference/template-functions/) — Built-in filters
-- [Build Hooks](/docs/extending/build-hooks/) — More customization options
+- [Writing Plugins](/docs/extending/plugins/) — Full plugin authoring guide
 :::

--- a/site/content/docs/theming/templating/kida/syntax/functions.md
+++ b/site/content/docs/theming/templating/kida/syntax/functions.md
@@ -167,35 +167,41 @@ Use with `{% call %}` to pass content:
 
 ## Custom Filters
 
-Add custom filters using a build hook:
+Add custom filters through a [plugin](/docs/extending/plugins/) by calling
+`registry.add_template_filter()` in its `register()` method:
 
 ```python
-# python/build_hooks.py
-from bengal.core import Site
+# my_bengal_plugin/__init__.py
+from bengal.plugins.protocol import Plugin
+from bengal.plugins.registry import PluginRegistry
+
 
 def reading_time(content: str, wpm: int = 200) -> int:
     """Calculate reading time in minutes."""
     words = len(content.split())
     return max(1, round(words / wpm))
 
+
 def format_number(value: int) -> str:
     """Format number with commas."""
     return f"{value:,}"
 
-def register_filters(site: Site) -> None:
-    """Register custom Kida filters."""
-    # Get the Kida environment from the template engine
-    if hasattr(site, '_template_engine') and site._template_engine:
-        env = site._template_engine._env
-        env.add_filter("reading_time", reading_time)
-        env.add_filter("format_number", format_number)
+
+class MyFiltersPlugin(Plugin):
+    name = "my-filters"
+    version = "1.0.0"
+
+    def register(self, registry: PluginRegistry) -> None:
+        registry.add_template_filter("reading_time", reading_time)
+        registry.add_template_filter("format_number", format_number)
 ```
 
-Add the build hook to `bengal.toml`:
+Declare the entry point so Bengal discovers the plugin automatically:
 
-```yaml
-build_hooks:
-  - python.build_hooks.register_filters
+```toml
+# pyproject.toml
+[project.entry-points."bengal.plugins"]
+my-filters = "my_bengal_plugin:MyFiltersPlugin"
 ```
 
 Use in templates:
@@ -205,7 +211,7 @@ Use in templates:
 <span>{{ view_count | format_number }} views</span>
 ```
 
-**Note**: `page.reading_time` is already available as a built-in Page property, so you may not need a custom filter for reading time. See [Add a Custom Filter](/docs/theming/templating/kida/add-custom-filter/) for more details.
+**Note**: `page.reading_time` is already available as a built-in Page property, so you may not need a custom filter for reading time. See [Add a Custom Filter](/docs/theming/templating/kida/add-custom-filter/) for the full walkthrough.
 
 ## Functions vs Partials
 


### PR DESCRIPTION
## Summary

- Documents the **supported** custom-filter registration path: a plugin that implements the `Plugin` protocol and calls `registry.add_template_filter()` in `register()`. (#486)
- Removes the stale "stable plugin API is planned for v0.4.0" promise and stops steering users at the private `site._template_engine._env`. The supported entry point already ships and is wired into builds (status `ready` in `bengal/plugins/inspection.py`), so no new public surface was needed — the gap was purely in the docs. Updated `add-custom-filter.md` and the "Custom Filters" section of `kida/syntax/functions.md`.
- Corrects the `--memory-optimized` docs: removes the unbacked "80-90% memory reduction" claim from `large-sites.md`, marks the flag experimental, and tells users to measure peak memory before relying on it. (#487)
- Marks the flag experimental in its CLI help text too (`--memory-optimized` now reads "[Experimental] Streaming build for 5K+ pages; memory benefit unverified"). The project's own measurement (epic-performance T17) did not reproduce a memory benefit.

Closes #486
Closes #487

## Proof

- [x] Focused tests: `uv run pytest tests -k "cli or config" -q` → 1450 passed, 20 skipped
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/487.changed.md` added (the user-observable change is the flag's new experimental label/help text). #486 is docs-only with no observable code surface, so it carries no fragment. `uv run poe changelog-lint` → clean (1 file scanned). Re-grep confirms the stale strings are gone: `grep -rn "planned for v0.4.0\|80-90% memory" site/content` returns nothing.

## Performance Evidence

not applicable

## Steward Notes

- #487's fragment is `changed`, not `deprecated`: the flag is demoted to experimental and the claim corrected, but the flag is not being removed.
- Verified the documented `bengal plugin list` / `bengal plugin info` commands exist (`bengal plugin --help`).
- The remaining `site._template_engine._env` mention in `reference/architecture/meta/extension-points.md` is migration guidance steering users *away* from internal attributes, so it was left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
