### PR TITLE
feat(cli): add --drafts preview to serve and build (#488)

### DIFF
--- a/bengal/cli/milo_commands/build.py
+++ b/bengal/cli/milo_commands/build.py
@@ -38,6 +38,7 @@ def build(
         bool, Description("[Debug] Profile template rendering times")
     ] = False,
     clean_output: Annotated[bool, Description("Delete output directory before building")] = False,
+    drafts: Annotated[bool, Description("Include draft pages (draft: true) in the build")] = False,
     theme_dev: Annotated[bool, Description("Use theme developer profile")] = False,
     dev_profile: Annotated[
         bool, Description("Shorthand for --profile dev (full observability)")
@@ -288,6 +289,10 @@ def build(
             if "build" not in site.config:
                 site.config["build"] = {}
             site.config["build"]["strict_mode"] = True
+        if drafts:
+            if "build" not in site.config:
+                site.config["build"] = {}
+            site.config["build"]["drafts"] = True
         if debug:
             if "build" not in site.config:
                 site.config["build"] = {}

--- a/bengal/cli/milo_commands/serve.py
+++ b/bengal/cli/milo_commands/serve.py
@@ -16,6 +16,9 @@ def serve(
         bool, Description("Find available port if specified port is taken")
     ] = True,
     open_browser: Annotated[bool, Description("Open browser after server starts")] = True,
+    drafts: Annotated[
+        bool, Description("Include draft pages (draft: true) in the preview")
+    ] = False,
     environment: Annotated[str, Description("Environment: local, preview, production")] = "",
     profile: Annotated[str, Description("Config profile: writer, theme-dev, dev")] = "",
     version_scope: Annotated[str, Description("Focus on single version (e.g., v2, latest)")] = "",
@@ -93,6 +96,8 @@ def serve(
         if "build" not in cfg:
             cfg["build"] = {}
         cfg["build"]["strict_mode"] = True
+        if drafts:
+            cfg["build"]["drafts"] = True
         if debug:
             cfg["build"]["debug"] = True
 

--- a/bengal/config/defaults.py
+++ b/bengal/config/defaults.py
@@ -135,6 +135,10 @@ DEFAULTS: dict[str, Any] = {
         "minify_html": True,
         "strict_mode": False,
         "debug": False,
+        # Render draft (and otherwise-hidden) pages in listings/feeds/search.
+        # Off by default; the `bengal serve --drafts` / `bengal build --drafts`
+        # flags flip this for local preview.
+        "drafts": False,
         "validate_build": True,
         "validate_templates": False,  # Proactive template syntax validation during build
         "validate_links": True,

--- a/bengal/config/validators.py
+++ b/bengal/config/validators.py
@@ -181,6 +181,7 @@ class ConfigValidator:
         "fast_writes",
         "fast_mode",
         "stable_section_references",
+        "drafts",  # build.drafts — render draft pages for local preview (#488)
         # Assets (after flattening from assets.*)
         "minify_assets",
         "optimize_assets",

--- a/bengal/core/page_visibility.py
+++ b/bengal/core/page_visibility.py
@@ -117,7 +117,31 @@ def should_render_page_in_environment(page: Any, is_production: bool = False) ->
     return should_render_visibility(get_page_visibility(page), is_production)
 
 
+def _drafts_enabled(page: Any) -> bool:
+    """Return whether draft preview is enabled site-wide for this page-like object.
+
+    Controlled by ``build.drafts`` (set by ``bengal serve --drafts`` /
+    ``bengal build --drafts``). When enabled, draft pages are treated as
+    publishable so authors can preview unpublished content locally.
+    """
+    site = getattr(page, "_site", None)
+    if site is None:
+        return False
+    config = getattr(site, "config", None)
+    if config is None:
+        return False
+    try:
+        build = config.get("build", {})
+        if isinstance(build, Mapping) and build.get("drafts"):
+            return True
+        return bool(config.get("drafts", False))
+    except Exception:
+        return False
+
+
 def _is_page_draft(page: Any) -> bool:
+    if _drafts_enabled(page):
+        return False
     metadata = getattr(page, "metadata", {})
     if isinstance(metadata, Mapping):
         return bool(metadata.get("draft", False))

--- a/bengal/core/section/__init__.py
+++ b/bengal/core/section/__init__.py
@@ -378,11 +378,16 @@ class Section:
 
         return has_index(self)
 
-    def get_all_pages(self, recursive: bool = True) -> list[PageLike]:
-        """Get all pages in this section."""
+    def get_all_pages(
+        self, recursive: bool = True, *, include_drafts: bool = True
+    ) -> list[PageLike]:
+        """Get all pages in this section.
+
+        Set ``include_drafts=False`` to omit pages marked ``draft: true``.
+        """
         from .queries import get_all_pages
 
-        return get_all_pages(self, recursive)
+        return get_all_pages(self, recursive, include_drafts=include_drafts)
 
     @cached_property
     def href(self) -> str:

--- a/bengal/core/section/queries.py
+++ b/bengal/core/section/queries.py
@@ -200,21 +200,41 @@ def has_index(section: Section) -> bool:
     return section.index_page is not None
 
 
-def get_all_pages(section: Section, recursive: bool = True) -> list[PageLike]:
+def get_all_pages(
+    section: Section,
+    recursive: bool = True,
+    *,
+    include_drafts: bool = True,
+) -> list[PageLike]:
     """
     Get all pages in this section.
 
     Args:
         section: Section to read
         recursive: If True, include pages from subsections
+        include_drafts: If False, omit pages marked ``draft: true`` in
+            frontmatter. Defaults to True so existing callers (navigation,
+            cascade, content stats) keep seeing every page; the visibility
+            gate (``is_page_in_listings`` and friends) is what actually hides
+            drafts from public listings/feeds.
 
     Returns:
         List of all pages
     """
-    all_pages = list(section.pages)
+    all_pages = [p for p in section.pages if include_drafts or not _page_is_draft(p)]
 
     if recursive:
         for subsection in section.subsections:
-            all_pages.extend(subsection.get_all_pages(recursive=True))
+            all_pages.extend(
+                subsection.get_all_pages(recursive=True, include_drafts=include_drafts)
+            )
 
     return all_pages
+
+
+def _page_is_draft(page: PageLike) -> bool:
+    """Return whether a page is marked ``draft: true`` in frontmatter."""
+    metadata = getattr(page, "metadata", None)
+    if isinstance(metadata, dict):
+        return bool(metadata.get("draft", False))
+    return False

--- a/bengal/protocols/core.py
+++ b/bengal/protocols/core.py
@@ -628,8 +628,13 @@ class QueryableSection(Protocol):
         """Get pages with filtering and sorting."""
         ...
 
-    def get_all_pages(self, *, include_drafts: bool = False) -> list[PageLike]:
-        """Get all pages including from subsections."""
+    def get_all_pages(
+        self, recursive: bool = True, *, include_drafts: bool = True
+    ) -> list[PageLike]:
+        """Get all pages, optionally recursing into subsections.
+
+        Set ``include_drafts=False`` to omit pages marked ``draft: true``.
+        """
         ...
 
 

--- a/changelog.d/488.added.md
+++ b/changelog.d/488.added.md
@@ -1,0 +1,1 @@
+`bengal serve --drafts` and `bengal build --drafts` (or `drafts = true` under `[build]`) render pages marked `draft: true` so you can preview unpublished content locally; drafts stay hidden by default.

--- a/tests/unit/core/test_page_visibility.py
+++ b/tests/unit/core/test_page_visibility.py
@@ -11,6 +11,7 @@ Tests the hidden/visibility frontmatter and related properties:
 from pathlib import Path
 
 from bengal.core.page_visibility import (
+    _is_page_draft,
     get_page_visibility,
     get_robots_meta,
     is_page_in_ai_input,
@@ -22,6 +23,7 @@ from bengal.core.page_visibility import (
     should_render_page,
     should_render_page_in_environment,
 )
+from tests._testing.mocks import MockSite
 from tests._testing.mocks import make_mock_page as _page
 
 
@@ -417,3 +419,67 @@ class TestVisibilityWithDraft:
         assert is_page_in_rss(page) is False
         assert is_page_in_ai_input(page) is False
         assert is_page_in_ai_train(page) is False
+
+
+class TestDraftsPreview:
+    """Test the build.drafts preview flag (bengal serve/build --drafts).
+
+    The CLI flag sets ``site.config["build"]["drafts"] = True``; the
+    visibility gate then treats draft pages as publishable so authors can
+    preview unpublished content locally. Default behaviour (drafts hidden)
+    must be unchanged.
+    """
+
+    def _draft_page(self, *, drafts_enabled: bool):
+        site = MockSite(config={"build": {"drafts": drafts_enabled}})
+        return _page(
+            source_path=Path("content/draft.md"),
+            _raw_content="Draft",
+            _raw_metadata={"title": "Draft", "draft": True},
+            _site=site,
+        )
+
+    def test_default_hides_drafts(self):
+        """Without --drafts, draft pages are excluded from every output."""
+        page = self._draft_page(drafts_enabled=False)
+
+        assert _is_page_draft(page) is True
+        assert is_page_in_listings(page) is False
+        assert is_page_in_sitemap(page) is False
+        assert is_page_in_search(page) is False
+        assert is_page_in_rss(page) is False
+
+    def test_drafts_flag_includes_drafts(self):
+        """With --drafts (build.drafts=True), draft pages become visible."""
+        page = self._draft_page(drafts_enabled=True)
+
+        assert _is_page_draft(page) is False
+        assert is_page_in_listings(page) is True
+        assert is_page_in_sitemap(page) is True
+        assert is_page_in_search(page) is True
+        assert is_page_in_rss(page) is True
+
+    def test_drafts_flag_does_not_publish_hidden_pages(self):
+        """--drafts only affects draft pages; hidden: true stays hidden."""
+        site = MockSite(config={"build": {"drafts": True}})
+        page = _page(
+            source_path=Path("content/secret.md"),
+            _raw_content="Secret",
+            _raw_metadata={"title": "Secret", "hidden": True},
+            _site=site,
+        )
+
+        assert is_page_in_listings(page) is False
+        assert is_page_in_sitemap(page) is False
+
+    def test_non_draft_page_unaffected_by_flag(self):
+        """Regular pages stay visible whether or not --drafts is set."""
+        for drafts_enabled in (False, True):
+            site = MockSite(config={"build": {"drafts": drafts_enabled}})
+            page = _page(
+                source_path=Path("content/post.md"),
+                _raw_content="Post",
+                _raw_metadata={"title": "Post"},
+                _site=site,
+            )
+            assert is_page_in_listings(page) is True

--- a/tests/unit/core/test_section_sorting.py
+++ b/tests/unit/core/test_section_sorting.py
@@ -562,3 +562,52 @@ def test_weighted_sorting_invariant(pages_data):
         <= sorted_pages[i + 1].metadata.get("weight", float("inf"))
         for i in range(len(sorted_pages) - 1)
     ), "Sorting stable under weights"
+
+
+class TestSectionGetAllPagesIncludeDrafts:
+    """Test Section.get_all_pages(include_drafts=...) draft filtering."""
+
+    def test_default_includes_drafts(self, tmp_path):
+        """get_all_pages() keeps draft pages by default (callers filter via the
+        visibility gate, not here)."""
+        section = Section(name="docs", path=tmp_path / "docs")
+        published = _page(
+            source_path=tmp_path / "docs/a.md",
+            _raw_metadata={"title": "A"},
+        )
+        draft = _page(
+            source_path=tmp_path / "docs/b.md",
+            _raw_metadata={"title": "B", "draft": True},
+        )
+        section.pages = [published, draft]
+
+        titles = {p.title for p in section.get_all_pages()}
+        assert titles == {"A", "B"}
+
+    def test_exclude_drafts(self, tmp_path):
+        """get_all_pages(include_drafts=False) omits draft: true pages, recursively."""
+        root = Section(name="root", path=tmp_path)
+        child = Section(name="child", path=tmp_path / "child")
+        root.subsections = [child]
+
+        published = _page(
+            source_path=tmp_path / "a.md",
+            _raw_metadata={"title": "A"},
+        )
+        draft_top = _page(
+            source_path=tmp_path / "b.md",
+            _raw_metadata={"title": "B", "draft": True},
+        )
+        draft_nested = _page(
+            source_path=tmp_path / "child/c.md",
+            _raw_metadata={"title": "C", "draft": True},
+        )
+        published_nested = _page(
+            source_path=tmp_path / "child/d.md",
+            _raw_metadata={"title": "D"},
+        )
+        root.pages = [published, draft_top]
+        child.pages = [draft_nested, published_nested]
+
+        titles = {p.title for p in root.get_all_pages(include_drafts=False)}
+        assert titles == {"A", "D"}


### PR DESCRIPTION
## Summary

- Adds `bengal serve --drafts` and `bengal build --drafts` (plus a `drafts = true` key under `[build]`) so authors can preview pages marked `draft: true` locally, the way Hugo's `-D` and Eleventy do.
- Wires the previously-dangling `include_drafts` protocol surface: when drafts are enabled, the visibility gate (`_is_page_draft`) treats drafts as publishable, so they flow back into listings, sitemap, search, and RSS for preview. `Section.get_all_pages` now honors the protocol's `include_drafts` keyword.
- Default behavior is unchanged — drafts stay hidden in every output unless the flag/config is set.

Closes #488

## Proof

- [x] Focused tests: `uv run pytest tests -k "draft or visibility or serve" -q` → 786 passed. New tests: `tests/unit/core/test_page_visibility.py::TestDraftsPreview` (default hides drafts; `--drafts` includes them; hidden pages stay hidden; non-draft pages unaffected) and `tests/unit/core/test_section_sorting.py::TestSectionGetAllPagesIncludeDrafts`.
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/488.added.md` (one user-facing sentence; `changelog-lint` clean).

End-to-end smoke (tiny site with a `draft: true` page):
- `bengal build` → draft absent from `sitemap.xml` (count 0).
- `bengal build --drafts` → draft present in `sitemap.xml` (count 1), no unknown-config warning.
- `bengal serve --help` / `bengal build --help` both show `--drafts`.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable — adds a `--drafts` preview flag; no performance-sensitive paths changed.

## Steward Notes

- New config key `build.drafts` registered in `bengal/config/defaults.py` and `bengal/config/validators.py` (BOOLEAN_FIELDS) so it doesn't surface as an unknown-config warning.
- `bengal/protocols/core.py` `QueryableSection.get_all_pages` signature was realigned to the actual implementation (`recursive=True, *, include_drafts=True`); the previous declaration was a dangling, never-implemented signature.
- No new core mixins; PEP 758 unparenthesized `except` syntax left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

