### PR TITLE
fix(links): validate relative internal links + stop autodoc linkifying docstring examples (#485, #489)

### DIFF
--- a/bengal/autodoc/utils/text.py
+++ b/bengal/autodoc/utils/text.py
@@ -72,6 +72,31 @@ def _convert_sphinx_roles(text: str) -> str:
     return text
 
 
+# MyST-style inline roles in docstrings (e.g. ``{ref}`target```, ``{doc}`/page```)
+# are illustrative source documentation, not navigation. Autodoc renders docstring
+# descriptions through the full Markdown pipeline, so an un-neutralized role becomes
+# a live (and usually broken) link on the generated API page. Escaping the opening
+# brace makes Patitas treat the token as literal text while the backtick span still
+# renders as inline code.
+_MYST_INLINE_ROLE_RE = re.compile(r"(?<!\\)\{([A-Za-z][\w-]*)\}(`+)")
+
+
+def _neutralize_myst_roles(text: str) -> str:
+    """
+    Escape MyST inline role syntax so docstring examples are not linkified.
+
+    Converts ``{role}`target``` into ``\\{role}`target``` so the role is shown
+    as literal text + inline code instead of being parsed as a live cross-reference.
+
+    Args:
+        text: Text that may contain MyST inline roles
+
+    Returns:
+        Text with inline role braces escaped
+    """
+    return _MYST_INLINE_ROLE_RE.sub(lambda m: rf"\{{{m.group(1)}}}{m.group(2)}", text)
+
+
 def sanitize_text(text: str | None) -> str:
     """
     Clean user-provided text for markdown generation.
@@ -119,6 +144,10 @@ def sanitize_text(text: str | None) -> str:
     # :meth:`method_name` → `method_name()`
     # :mod:`module_name` → `module_name`
     text = _convert_sphinx_roles(text)
+
+    # Neutralize MyST inline roles so illustrative docstring targets are not
+    # rendered as live (often broken) links on generated API pages.
+    text = _neutralize_myst_roles(text)
 
     # Collapse multiple blank lines to maximum of 2
     # (2 blank lines = paragraph break in markdown, more is excessive)

--- a/bengal/health/linkcheck/internal_checker.py
+++ b/bengal/health/linkcheck/internal_checker.py
@@ -198,24 +198,37 @@ class InternalLinkChecker:
 
     def _ref_to_page_url(self, ref: str) -> str:
         """
-        Convert a referencing page file path to its site-relative URL.
+        Convert a referencing page file path to its served (pretty) URL.
 
         ``ref`` is the output-relative path of the HTML file that contains the
         link (e.g. ``docs/guide/index.html`` or ``about.html``). The returned
-        URL is the base against which relative links on that page resolve.
+        URL is the base against which relative links on that page resolve, and
+        it must match how a browser sees the page so ``urljoin`` reproduces the
+        browser's RFC 3986 resolution.
+
+        Bengal serves every page at a trailing-slash pretty URL: a directory
+        index (``docs/guide/index.html``) is served at ``/docs/guide/`` and a
+        flat-output non-index page (``docs/guide.html``) is *also* served at
+        ``/docs/guide/`` (the ``.html`` suffix is stripped and a trailing slash
+        is appended -- see :meth:`URLStrategy.url_from_output_path`). Returning
+        the trailing-slash form is therefore required for relative links to
+        resolve against the page's served directory, exactly as a browser does.
 
         Args:
             ref: Output-relative HTML file path (uses ``/`` separators).
 
         Returns:
-            Site-relative URL ending in ``/`` for index pages, otherwise the
-            clean URL of the page (e.g. ``/about.html``).
+            Served site-relative URL ending in ``/`` (e.g. ``/docs/guide/``),
+            or ``/`` for the root page.
         """
         ref = ref.replace("\\", "/")
         rel = Path(ref)
         if rel.name == "index.html":
             return "/" if rel.parent == Path(".") else f"/{rel.parent.as_posix()}/"
-        return f"/{rel.with_suffix('').as_posix()}"
+        # Non-index (flat output) page: served at the trailing-slash pretty URL
+        # with the ``.html`` suffix stripped, so relative links resolve against
+        # the page's own served directory rather than its parent.
+        return f"/{rel.with_suffix('').as_posix()}/"
 
     def _resolved_path_exists(self, path: str) -> bool:
         """

--- a/bengal/health/linkcheck/internal_checker.py
+++ b/bengal/health/linkcheck/internal_checker.py
@@ -54,8 +54,8 @@ class InternalLinkChecker:
         baseurl_path: Base URL path to strip from links
 
     Note:
-        Relative links are currently passed as OK with a metadata note,
-        as full resolution requires tracking the referencing page context.
+        Relative links are resolved against the referencing page's URL and
+        validated like absolute links.
 
     """
 
@@ -196,6 +196,117 @@ class InternalLinkChecker:
             output_paths_count=len(self._output_paths),
         )
 
+    def _ref_to_page_url(self, ref: str) -> str:
+        """
+        Convert a referencing page file path to its site-relative URL.
+
+        ``ref`` is the output-relative path of the HTML file that contains the
+        link (e.g. ``docs/guide/index.html`` or ``about.html``). The returned
+        URL is the base against which relative links on that page resolve.
+
+        Args:
+            ref: Output-relative HTML file path (uses ``/`` separators).
+
+        Returns:
+            Site-relative URL ending in ``/`` for index pages, otherwise the
+            clean URL of the page (e.g. ``/about.html``).
+        """
+        ref = ref.replace("\\", "/")
+        rel = Path(ref)
+        if rel.name == "index.html":
+            return "/" if rel.parent == Path(".") else f"/{rel.parent.as_posix()}/"
+        return f"/{rel.with_suffix('').as_posix()}"
+
+    def _resolved_path_exists(self, path: str) -> bool:
+        """
+        Check whether a resolved absolute path maps to a built page.
+
+        Normalizes common authoring suffixes (``.md``/``.html``) and trailing
+        slashes so a relative link such as ``../other.md`` validates against the
+        clean URL (``/section/other/``) recorded in the output index.
+
+        Args:
+            path: Absolute site path (already resolved, may include a suffix).
+
+        Returns:
+            True if the path matches a known built page or auxiliary file.
+        """
+        candidates = {path, path.rstrip("/")}
+        if path != "/" and not path.endswith("/"):
+            candidates.add(path + "/")
+
+        # Strip authoring suffixes that the build rewrites to clean URLs so a
+        # link to ``foo.md`` / ``foo.html`` resolves to ``/foo/``.
+        for suffix in (".md", ".html"):
+            if path.endswith(suffix):
+                stem = path[: -len(suffix)]
+                candidates.add(stem)
+                candidates.add(stem + "/")
+                # ``section/index.md`` -> ``/section/``
+                if stem.endswith("/index"):
+                    parent = stem[: -len("index")]
+                    candidates.add(parent)
+                    candidates.add(parent.rstrip("/"))
+
+        return any(c in self._output_paths for c in candidates)
+
+    def _check_relative_link(self, url: str, refs: list[str]) -> LinkCheckResult:
+        """
+        Resolve a relative internal link against each referencing page.
+
+        A relative link (``../other/``, ``./sibling.md``) has no meaning without
+        the page it appears on, so it is resolved against every referencing
+        page's URL via ``urljoin`` and validated like an absolute link. If it
+        fails to resolve for any referencing page, it is reported broken.
+
+        Args:
+            url: Relative internal URL (may include a fragment).
+            refs: Output-relative paths of pages that contain this link.
+
+        Returns:
+            LinkCheckResult — BROKEN for the first page where the link does not
+            resolve, otherwise OK.
+        """
+        from urllib.parse import urljoin
+
+        parsed = urlparse(url)
+        link_path = parsed.path
+
+        checked_refs = refs or [""]
+        for ref in checked_refs:
+            base_url = self._ref_to_page_url(ref) if ref else "/"
+            resolved = urljoin(base_url, link_path)
+
+            # Strip baseurl if the relative link climbed into it.
+            if self.baseurl_path and resolved.startswith(self.baseurl_path):
+                resolved = resolved[len(self.baseurl_path) :] or "/"
+
+            if not self._resolved_path_exists(resolved):
+                logger.debug(
+                    "internal_relative_link_broken",
+                    url=url,
+                    ref=ref,
+                    resolved=resolved,
+                )
+                return LinkCheckResult(
+                    url=url,
+                    kind=LinkKind.INTERNAL,
+                    status=LinkStatus.BROKEN,
+                    reason="Page not found",
+                    first_ref=ref or (refs[0] if refs else None),
+                    ref_count=len(refs),
+                    metadata={"resolved": resolved},
+                )
+
+        logger.debug("internal_relative_link_ok", url=url)
+        return LinkCheckResult(
+            url=url,
+            kind=LinkKind.INTERNAL,
+            status=LinkStatus.OK,
+            first_ref=refs[0] if refs else None,
+            ref_count=len(refs),
+        )
+
     def check_links(self, links: list[tuple[str, str]]) -> dict[str, LinkCheckResult]:
         """
         Check internal links against the output directory index.
@@ -292,23 +403,9 @@ class InternalLinkChecker:
             if not path:  # Handle case where path becomes empty
                 path = "/"
 
-        # Handle relative paths (resolve to absolute)
+        # Handle relative paths by resolving against the referencing page(s).
         if not path.startswith("/"):
-            # For now, treat other relative paths as potentially valid
-            # A full implementation would resolve relative to the referencing page
-            logger.debug(
-                "skipping_relative_internal_link",
-                url=url,
-                reason="relative paths not yet fully supported",
-            )
-            return LinkCheckResult(
-                url=url,
-                kind=LinkKind.INTERNAL,
-                status=LinkStatus.OK,
-                first_ref=refs[0] if refs else None,
-                ref_count=len(refs),
-                metadata={"note": "relative path - validation skipped"},
-            )
+            return self._check_relative_link(url, refs)
 
         # Check if page exists (with or without trailing slash)
         page_exists = path in self._output_paths or path.rstrip("/") in self._output_paths

--- a/bengal/parsing/backends/patitas/directives/__init__.py
+++ b/bengal/parsing/backends/patitas/directives/__init__.py
@@ -2,11 +2,13 @@
 
 Provides extensible block-level markup through the directive syntax:
 
+```text
 :::{directive-name} optional title
 :option-key: option value
 
 Content goes here.
 :::
+```
 
 Key components:
 - DirectiveHandler: Protocol for custom directive implementations

--- a/bengal/parsing/backends/patitas/directives/builtins/cards.py
+++ b/bengal/parsing/backends/patitas/directives/builtins/cards.py
@@ -11,6 +11,8 @@ Use cases:
 - Auto-generated section indexes
 
 Example:
+
+```text
 ::::{cards}
 :columns: 3
 
@@ -28,6 +30,7 @@ Quick introduction to the platform.
 Complete API documentation.
 :::
 ::::
+```
 
 Thread Safety:
 Stateless handlers. Safe for concurrent use across threads.

--- a/changelog.d/485.fixed.md
+++ b/changelog.d/485.fixed.md
@@ -1,0 +1,1 @@
+Autodoc no longer turns illustrative cross-reference and directive examples in docstrings into live (often broken) links, so generated API pages and the broken-link health check stay clean.

--- a/changelog.d/489.fixed.md
+++ b/changelog.d/489.fixed.md
@@ -1,0 +1,1 @@
+The internal link checker now resolves relative links (such as `../other/`) against the page that references them and reports broken ones, instead of silently passing them.

--- a/site/content/docs/extending/shortcodes.md
+++ b/site/content/docs/extending/shortcodes.md
@@ -171,8 +171,8 @@ The default theme ships with these shortcodes. Override any by placing a templat
 | `tip` | `{{% tip %}}Hint{{% /tip %}}` | Tip callout box |
 | `warning` | `{{% warning %}}Caution{{% /warning %}}` | Warning callout box |
 | `danger` | `{{% danger %}}Critical{{% /danger %}}` | Danger callout box |
-| `ref` | `{{< ref "docs/guide/intro" >}}` | Internal page link (absolute URL) |
-| `relref` | `{{< relref "docs/guide/intro" >}}` | Internal page link (relative URL) |
+| `ref` | `{{< ref "docs/get-started/quickstart-writer" >}}` | Internal page link (absolute URL) |
+| `relref` | `{{< relref "docs/get-started/quickstart-writer" >}}` | Internal page link (relative URL) |
 
 ## Strict Mode
 
@@ -214,7 +214,7 @@ Copy-paste snippets for common patterns.
 ### Internal link with custom text
 
 ```markdown
-{{< ref "docs/guide/intro" text="Get started" >}}
+{{< ref "docs/get-started/quickstart-writer" text="Get started" >}}
 ```
 
 ### Typed arguments

--- a/tests/unit/autodoc/test_autodoc_utils.py
+++ b/tests/unit/autodoc/test_autodoc_utils.py
@@ -117,6 +117,26 @@ class TestSanitizeText:
         assert "**bold**" in result
         assert "- Item 1" in result
 
+    def test_sanitize_neutralizes_myst_inline_roles(self):
+        """MyST inline roles are escaped so docstring examples are not linkified (#485).
+
+        ``{ref}`target``` and ``{doc}`/page``` would otherwise be rendered as
+        live (and usually broken) cross-reference links on generated API pages.
+        Escaping the opening brace keeps them as literal text + inline code.
+        """
+        text = "See {ref}`installation-guide` and {doc}`/getting-started` here."
+        result = sanitize_text(text)
+
+        assert r"\{ref}`installation-guide`" in result
+        assert r"\{doc}`/getting-started`" in result
+
+    def test_sanitize_leaves_non_role_braces_untouched(self):
+        """Braces not immediately followed by a backtick are not role syntax."""
+        text = "A {note} admonition and a {placeholder} value."
+        result = sanitize_text(text)
+
+        assert result == "A {note} admonition and a {placeholder} value."
+
 
 class TestTruncateText:
     """Tests for text truncation."""

--- a/tests/unit/health/linkcheck/test_internal_checker.py
+++ b/tests/unit/health/linkcheck/test_internal_checker.py
@@ -203,18 +203,57 @@ class TestInternalLinkCheckerBrokenLinks:
 
 
 class TestInternalLinkCheckerRelativeLinks:
-    """Tests for relative link handling."""
+    """Tests for relative link resolution (#489)."""
 
-    def test_relative_link_skipped(self, mock_site):
-        """Relative links (not starting with /) are currently skipped."""
+    def test_broken_relative_link_detected(self, mock_site):
+        """A relative link to a non-existent page is reported as broken (#489).
+
+        ``docs/guide.html`` lives at ``/docs/guide``; ``../missing/`` resolves
+        to ``/missing/`` which does not exist in the output index.
+        """
         checker = InternalLinkChecker(mock_site)
 
-        result = checker._check_internal_link("sibling-page", ["test.html"])
+        result = checker._check_internal_link("../missing/", ["docs/guide.html"])
 
-        # Relative links return OK with a note (not fully validated)
+        assert result.status == LinkStatus.BROKEN
+        assert result.first_ref == "docs/guide.html"
+        assert result.metadata.get("resolved") == "/missing/"
+
+    def test_valid_relative_link_resolves(self, mock_site):
+        """A relative link that resolves to a real page is OK.
+
+        From ``/docs/guide``, ``../about/`` resolves to ``/about/`` which exists.
+        """
+        checker = InternalLinkChecker(mock_site)
+
+        result = checker._check_internal_link("../about/", ["docs/guide.html"])
+
         assert result.status == LinkStatus.OK
-        assert result.metadata is not None
-        assert "relative" in result.metadata.get("note", "").lower()
+
+    def test_relative_md_link_resolves_to_clean_url(self, mock_site):
+        """A relative ``.md`` link resolves against the build's clean URLs.
+
+        From the home page (``/``), ``about/index.md`` should validate against
+        the built ``/about/`` page rather than being skipped.
+        """
+        checker = InternalLinkChecker(mock_site)
+
+        result = checker._check_internal_link("about/index.md", ["index.html"])
+
+        assert result.status == LinkStatus.OK
+
+    def test_relative_link_broken_for_one_ref(self, mock_site):
+        """A relative link is broken if it fails to resolve for any referrer.
+
+        ``./guide`` resolves to ``/docs/guide`` from ``docs/x.html`` (valid) but
+        to ``/guide`` from the home page (invalid) — the link is reported broken.
+        """
+        checker = InternalLinkChecker(mock_site)
+
+        result = checker._check_internal_link("./guide", ["docs/x.html", "index.html"])
+
+        assert result.status == LinkStatus.BROKEN
+        assert result.first_ref == "index.html"
 
 
 class TestInternalLinkCheckerBaseURL:

--- a/tests/unit/health/linkcheck/test_internal_checker.py
+++ b/tests/unit/health/linkcheck/test_internal_checker.py
@@ -208,8 +208,9 @@ class TestInternalLinkCheckerRelativeLinks:
     def test_broken_relative_link_detected(self, mock_site):
         """A relative link to a non-existent page is reported as broken (#489).
 
-        ``docs/guide.html`` lives at ``/docs/guide``; ``../missing/`` resolves
-        to ``/missing/`` which does not exist in the output index.
+        ``docs/guide.html`` is *served* at the pretty URL ``/docs/guide/``; a
+        browser resolves ``../missing/`` against that served directory to
+        ``/docs/missing/``, which does not exist in the output index.
         """
         checker = InternalLinkChecker(mock_site)
 
@@ -217,16 +218,17 @@ class TestInternalLinkCheckerRelativeLinks:
 
         assert result.status == LinkStatus.BROKEN
         assert result.first_ref == "docs/guide.html"
-        assert result.metadata.get("resolved") == "/missing/"
+        assert result.metadata.get("resolved") == "/docs/missing/"
 
     def test_valid_relative_link_resolves(self, mock_site):
         """A relative link that resolves to a real page is OK.
 
-        From ``/docs/guide``, ``../about/`` resolves to ``/about/`` which exists.
+        ``docs/guide.html`` is served at ``/docs/guide/``; a browser resolves
+        ``../../about/`` against that directory to ``/about/`` which exists.
         """
         checker = InternalLinkChecker(mock_site)
 
-        result = checker._check_internal_link("../about/", ["docs/guide.html"])
+        result = checker._check_internal_link("../../about/", ["docs/guide.html"])
 
         assert result.status == LinkStatus.OK
 
@@ -245,15 +247,65 @@ class TestInternalLinkCheckerRelativeLinks:
     def test_relative_link_broken_for_one_ref(self, mock_site):
         """A relative link is broken if it fails to resolve for any referrer.
 
-        ``./guide`` resolves to ``/docs/guide`` from ``docs/x.html`` (valid) but
-        to ``/guide`` from the home page (invalid) — the link is reported broken.
+        Both ``docs/x.html`` and the home page are served at pretty URLs
+        (``/docs/x/`` and ``/``). ``../guide/`` resolves to ``/docs/guide/``
+        from ``docs/x.html`` (valid) but to ``/guide/`` from the home page
+        (invalid) — the link is reported broken against the home page.
         """
         checker = InternalLinkChecker(mock_site)
 
-        result = checker._check_internal_link("./guide", ["docs/x.html", "index.html"])
+        result = checker._check_internal_link("../guide/", ["docs/x.html", "index.html"])
 
         assert result.status == LinkStatus.BROKEN
         assert result.first_ref == "index.html"
+
+    def test_pretty_url_sibling_link_not_false_positive(self, mock_site, tmp_path):
+        """Reviewer false-positive: ``../<sibling>.md`` from a flat non-index page.
+
+        Bengal serves the non-index file ``section/other.html`` at the pretty
+        URL ``/section/other/``. A browser resolves ``../other.md`` against that
+        served directory to ``/section/other.md`` → ``/section/other/`` (a
+        self-reference that exists). With the off-by-a-segment base (``/section/
+        other``) it wrongly resolved to ``/other/`` and was reported BROKEN.
+        This must now be OK.
+        """
+        section = tmp_path / "section"
+        section.mkdir()
+        # Flat-output non-index pages: served at /section/other/ and /section/sibling/
+        (section / "other.html").write_text("<html><body>Other</body></html>")
+        (section / "sibling.html").write_text("<html><body>Sibling</body></html>")
+
+        checker = InternalLinkChecker(mock_site)
+
+        # Self-referential sibling link authored on section/other.html.
+        result = checker._check_internal_link("../other.md", ["section/other.html"])
+        assert result.status == LinkStatus.OK, (
+            f"expected OK, got {result.status} (resolved="
+            f"{result.metadata.get('resolved') if result.metadata else None})"
+        )
+
+        # A real neighbouring page reached relative to the served directory.
+        result = checker._check_internal_link("../sibling/", ["section/other.html"])
+        assert result.status == LinkStatus.OK
+
+    def test_pretty_url_relative_link_still_catches_broken(self, mock_site, tmp_path):
+        """Discriminator: a genuinely-broken relative link from a flat page is BROKEN.
+
+        From ``section/other.html`` (served ``/section/other/``), ``../ghost.md``
+        resolves to ``/section/ghost.md`` → ``/section/ghost/`` which does not
+        exist — must be reported BROKEN with the browser-accurate resolved path.
+        """
+        section = tmp_path / "section"
+        section.mkdir()
+        (section / "other.html").write_text("<html><body>Other</body></html>")
+
+        checker = InternalLinkChecker(mock_site)
+
+        result = checker._check_internal_link("../ghost.md", ["section/other.html"])
+        assert result.status == LinkStatus.BROKEN
+        assert result.first_ref == "section/other.html"
+        # Browser-accurate base: resolves within the section, not at site root.
+        assert result.metadata.get("resolved") == "/section/ghost.md"
 
 
 class TestInternalLinkCheckerBaseURL:


### PR DESCRIPTION
## Summary

Makes the dogfood docs build warning-clean and closes a hole in broken-link detection.

- **#489** — The internal link checker previously returned `LinkStatus.OK` for any relative internal link *without verifying it*. Relative links are now resolved against the referencing page's URL (`urljoin`) and validated like absolute links, with authoring-suffix (`.md`/`.html`) and trailing-slash normalization. A genuinely-broken relative link is now reported as broken.
- **#485** — The dogfood build reported broken internal links and a spurious `Unknown directive "directive-name"` warning, all originating in autodoc-rendered docstrings:
  - `sanitize_text` now neutralizes MyST inline roles (`` {ref}`target` ``, `` {doc}`/page` ``) so illustrative docstring cross-references render as literal text + inline code instead of live (often broken) links on generated API pages.
  - The Patitas `directives/__init__.py` and `cards.py` module docstrings fence their example blocks, so the example syntax renders as code instead of being parsed as a real directive (the `directive-name` warning source) or emitting live card links.
  - The shortcodes reference doc points its `ref`/`relref` example at a real page (`docs/get-started/quickstart-writer`) instead of the non-existent `docs/guide/intro`.

Closes #485
Closes #489

### Verification note
The patitas autodoc API pages cannot be generated in this isolated worktree because its path contains a `.claude/` component and autodoc skips dotted path segments, so the local dogfood build omits those pages. The autodoc-docstring fixes were therefore verified by running the real `PythonExtractor` + `markdownify` pipeline against a dot-free copy of `bengal/parsing/backends/patitas`: after the fixes it produces 0 live internal hrefs and 0 `Unknown directive` warnings. The shortcodes/relative-link fixes were verified directly in the dogfood build.

## Proof

- [x] Focused tests: `uv run pytest tests -k "internal_checker or linkcheck or link_valid" -q` → 89 passed; `uv run pytest tests/unit/autodoc/test_autodoc_utils.py -q` → 23 passed. New broken-relative-link and MyST-role tests confirmed to fail when the fix is reverted (assertions discriminate).
- [x] `poe proof-pr` or scoped equivalent: `cd site && uv run bengal build --no-incremental` → `Health: 0 error(s), 0 warning(s) | Quality: 100% (Excellent)` (was `[H101] 1 broken internal link(s)` before).
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/485.fixed.md` and `changelog.d/489.fixed.md` added; `poe changelog-lint` clean.

## Performance Evidence

not applicable

## Steward Notes

- The MyST-role neutralizer escapes only `{name}` immediately followed by a backtick span; glossary-style `{term}` references and template `{% %}` tags are left untouched.
- Relative-link resolution reports broken if the link fails to resolve for *any* referencing page (a relative link valid from one page but broken from another is a real authoring bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)