### PR TITLE
fix(server): serve hidden-buffer dev assets via fast Pounce static path (#400)

### DIFF
--- a/bengal/server/asgi_app.py
+++ b/bengal/server/asgi_app.py
@@ -133,15 +133,13 @@ def create_bengal_dev_app(
         # within this request use the same buffer (double-buffer consistency).
         serving_dir = _resolve_dir()
 
-        # Pounce's static handler 404s any path with a hidden (dot-prefixed) component.
-        # The double-buffer serves from <root>/.bengal/staging half the time, so route
-        # asset requests around Pounce to _serve_static whenever the active buffer (or any
-        # ancestor) is hidden — otherwise every asset 404s and pages render unstyled.
-        if (
-            method in {"GET", "HEAD"}
-            and _should_delegate_to_pounce_static(path)
-            and not _has_hidden_path_component(serving_dir)
-        ):
+        # Serve cacheable static assets through Pounce's optimized static handler.
+        # The double-buffer serves from <root>/.bengal/staging half the time; Pounce 0.8.0
+        # (lbliii/pounce#74) only treats path components *below* the mount root as hidden,
+        # so the hidden staging buffer uses this fast path too (no #392 _serve_static
+        # detour). BufferManager.setup() still warns if a buffer path is hidden as a
+        # safety net (#400 Part 1).
+        if method in {"GET", "HEAD"} and _should_delegate_to_pounce_static(path):
             served = await _serve_pounce_static_asset(
                 scope,
                 receive,
@@ -237,26 +235,6 @@ def _should_delegate_to_pounce_static(path: str) -> bool:
     if is_deferred_generated_artifact_path(raw_path) or _is_html_path(raw_path):
         return False
     return any(raw_path.endswith(ext) for ext in _POUNCE_STATIC_ASSET_EXTENSIONS)
-
-
-def _has_hidden_path_component(directory: Path) -> bool:
-    """True when the serving directory's resolved path contains a dot-prefixed component.
-
-    Pounce's static handler rejects any path whose *resolved absolute* path contains a
-    hidden component (a part starting with ``.``, except ``.well-known``) — see
-    ``pounce/_static.py`` ``_resolve_file``. The dev server's double-buffer stages builds
-    in ``<root>/.bengal/staging``; whenever that buffer is the active one after a swap,
-    Pounce would 404 *every* asset under it (CSS/JS/fonts/icons), leaving pages unstyled
-    while HTML — served by ``_serve_static`` — still loads. Detecting a hidden serving dir
-    lets us route around Pounce to ``_serve_static`` (which has no such restriction and
-    serves assets with correct content types), so assets keep serving regardless of which
-    buffer is active. Also covers the rarer case of a project rooted under a dot-directory.
-    """
-    try:
-        resolved = directory.resolve()
-    except OSError:
-        resolved = directory
-    return any(part.startswith(".") and part != ".well-known" for part in resolved.parts)
 
 
 def _scope_without_sendfile(scope: dict[str, Any]) -> dict[str, Any]:

--- a/bengal/server/buffer_manager.py
+++ b/bengal/server/buffer_manager.py
@@ -42,9 +42,8 @@ def _hidden_path_component(directory: Path) -> str | None:
     """Return the first hidden (dot-prefixed) component of a resolved path, or None.
 
     ``.well-known`` is exempt: it is a hidden directory the static handler is
-    expected to serve. Mirrors the detection in ``asgi_app._has_hidden_path_component``
-    so the construction-time guard (#400) and the request-time serving fallback
-    (#392) agree on what "hidden" means.
+    expected to serve. Used by the construction-time warning (#400 Part 1), which
+    surfaces a hidden serving path loudly at buffer setup as a safety net.
     """
     try:
         resolved = directory.resolve()
@@ -83,19 +82,19 @@ class BufferManager:
     def _warn_on_hidden_buffer_paths(self) -> None:
         """Pin the hidden-path serving constraint at the integration boundary (#400).
 
-        Pounce's static handler rejects any path whose resolved absolute path
-        contains a hidden (dot-prefixed) component — see ``pounce/_static.py``
-        ``_resolve_file`` and upstream lbliii/pounce#74. The dev server's default
-        staging buffer lives under ``<root>/.bengal/staging``, a hidden directory,
-        so when that buffer is active Pounce 404s every asset under it. #392 works
-        around this by routing those requests through Bengal's own ``_serve_static``,
-        but the underlying constraint is invisible three layers from the cause.
+        Historically Pounce's static handler rejected any path whose *resolved
+        absolute* path contained a hidden (dot-prefixed) component, so the dev
+        server's default staging buffer under ``<root>/.bengal/staging`` made
+        Pounce 404 every asset when that buffer was active (lbliii/pounce#74).
+        Pounce 0.8.0 fixed this — the hidden-file check now only inspects path
+        components *below* the mount root, so a buffer rooted under a dotfile
+        serves correctly through the fast static path.
 
-        This surfaces the constraint loudly at buffer construction so a future
-        change that introduces a *new* hidden serving path fails visibly here
-        rather than as mysterious runtime 404s. We log (not raise) because the
-        #392 mitigation keeps serving working; Part 2 (relocating the staging
-        buffer off ``.bengal/``) is upstream-gated on pounce#74.
+        We keep this warning as a forward-looking safety net: it surfaces a
+        hidden serving-buffer path loudly at construction so a future change
+        (a different static handler, a downgraded Pounce, a new hidden ancestor)
+        fails visibly here instead of as mysterious runtime 404s three layers
+        downstream. We log (not raise) because serving works on Pounce 0.8.0+.
         """
         for label, directory in (("active", self._dirs[0]), ("staging", self._dirs[1])):
             hidden = _hidden_path_component(directory)
@@ -107,11 +106,12 @@ class BufferManager:
                     hidden_component=hidden,
                     ref="lbliii/pounce#74",
                     hint=(
-                        "Buffer path contains a hidden (dot-prefixed) component that "
-                        "Pounce's static handler rejects; asset requests for this buffer "
-                        "fall back to bengal's _serve_static (#392 mitigation) instead of "
-                        "the fast Pounce static path. Relocating off .bengal/ (#400 Part 2) "
-                        "is gated on upstream pounce#74."
+                        "Buffer path contains a hidden (dot-prefixed) component. "
+                        "Pounce 0.8.0+ serves such buffers correctly (lbliii/pounce#74), "
+                        "but a different static handler or a downgraded Pounce would 404 "
+                        "every asset under it. Surfaced here as a boundary safety net "
+                        "(#400 Part 1) so the constraint fails visibly at setup, not as "
+                        "runtime 404s downstream."
                     ),
                 )
 

--- a/changelog.d/400.changed.md
+++ b/changelog.d/400.changed.md
@@ -1,0 +1,1 @@
+Dev-server assets now serve through the fast static path; the hidden-buffer 404 workaround is removed (requires bengal-pounce 0.8.0+).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "psutil>=5.9.0",                           # For better process management in cleanup
     "questionary>=2.0.0",                      # Interactive CLI prompts with arrow key navigation
     "watchfiles>=0.20",                        # Rust-based file watching for dev server (fast)
-    "bengal-pounce>=0.7.1",                    # ASGI server for dev server (replaces ThreadingTCPServer)
+    "bengal-pounce>=0.8.0",                    # ASGI server for dev server (replaces ThreadingTCPServer)
     "httpx>=0.27.0",                           # Async HTTP client for link checking
     "uvloop>=0.21.0; sys_platform != 'win32'", # Rust-based event loop (Linux/macOS)
     "packaging>=23.0",                         # Version parsing for upgrade checks

--- a/tests/unit/server/test_asgi_app.py
+++ b/tests/unit/server/test_asgi_app.py
@@ -153,12 +153,12 @@ async def test_static_asset_served_from_hidden_buffer_dir(tmp_path: Path) -> Non
     """Assets under a hidden (dot-prefixed) serving dir must serve, not 404 (regression).
 
     The dev double-buffer stages builds in ``<root>/.bengal/staging`` and serves from
-    whichever buffer is active. Pounce's static handler rejects any path whose resolved
-    absolute path contains a hidden component (``.bengal``), so when that buffer was
-    active *every* asset 404'd while HTML still loaded — the "theme drops to unstyled
-    for long periods while editing" bug. The app must route around Pounce to
-    ``_serve_static`` for hidden serving dirs so assets keep serving regardless of which
-    buffer is active. Before the fix this returned 404.
+    whichever buffer is active. Historically Pounce's static handler rejected any path
+    whose resolved absolute path contained a hidden component (``.bengal``), so when that
+    buffer was active *every* asset 404'd while HTML still loaded — the "theme drops to
+    unstyled for long periods while editing" bug. Pounce 0.8.0 (lbliii/pounce#74) only
+    treats components *below* the mount root as hidden, so the hidden staging buffer now
+    serves through the fast Pounce static path. This must keep returning 200.
     """
     staging = tmp_path / ".bengal" / "staging"
     (staging / "assets" / "css").mkdir(parents=True)
@@ -181,28 +181,19 @@ async def test_static_asset_served_from_hidden_buffer_dir(tmp_path: Path) -> Non
     assert _body(sent) == b"body { color: red; }"
 
 
-def test_has_hidden_path_component(tmp_path: Path) -> None:
-    """Detects dot-prefixed components anywhere in the resolved path (except .well-known)."""
-    from bengal.server.asgi_app import _has_hidden_path_component
-
-    assert _has_hidden_path_component(tmp_path / ".bengal" / "staging") is True
-    assert _has_hidden_path_component(tmp_path / "public") is False
-    assert _has_hidden_path_component(tmp_path / "public-bengal-staging") is False
-    assert _has_hidden_path_component(tmp_path / ".well-known") is False
-
-
 @pytest.mark.asyncio
 async def test_asset_404_with_present_file_emits_diagnostic(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """A 404 for an asset that exists on disk emits a loud diagnostic (serve-path-bug canary).
 
     A genuinely-missing file 404 and an existing-file-404 (a serving bug) look identical to a
     client. This diagnostic distinguishes them — it is what would have made the hidden-buffer
-    bug a one-line signal instead of a multi-theory investigation. Driven directly through the
-    Pounce path with a hidden serving dir (which Pounce rejects) so the file is present yet 404s.
+    bug a one-line signal instead of a multi-theory investigation. Pounce 0.8.0 serves a buffer
+    rooted under a dotfile, but still rejects a hidden component *below* the mount root, so we
+    drive a ``.secret/`` subdir asset (present on disk, yet 404'd) to exercise the diagnostic.
     """
     from bengal.server import asgi_app
 
-    hidden = tmp_path / ".bengal" / "staging" / "assets" / "css"
+    hidden = tmp_path / ".secret" / "css"
     hidden.mkdir(parents=True)
     (hidden / "style.css").write_text("body {}")
 
@@ -219,15 +210,16 @@ async def test_asset_404_with_present_file_emits_diagnostic(tmp_path: Path, monk
 
     sent, send = _make_send_capture()
     served = await asgi_app._serve_pounce_static_asset(
-        {"type": "http", "method": "GET", "path": "/assets/css/style.css", "headers": []},
+        {"type": "http", "method": "GET", "path": "/.secret/css/style.css", "headers": []},
         _noop_receive,
         send,
-        output_dir=tmp_path / ".bengal" / "staging",
+        output_dir=tmp_path,
         static_asset_handlers={},
     )
 
     assert served is True
-    assert sent[0]["status"] == 404  # Pounce rejects the hidden path even though the file exists
+    # Pounce rejects the hidden component below the mount root even though the file exists.
+    assert sent[0]["status"] == 404
     assert any("404_but_file_present" in msg for msg, _ in warnings), (
         "an asset that exists on disk but 404s must emit a diagnostic warning"
     )
@@ -534,9 +526,15 @@ async def test_preview_app_serves_generated_artifact_as_static_file(tmp_path: Pa
 
 @pytest.mark.asyncio
 async def test_preview_app_uses_protocol_owned_pounce_sendfile(tmp_path: Path) -> None:
-    """Preview static files use Pounce's h11-accounted sendfile message."""
+    """Preview static files use Pounce's h11-accounted sendfile message.
+
+    Pounce 0.8.0 only emits ``pounce.response.sendfile`` for bodies at/above its
+    zero-copy threshold (``_SENDFILE_MIN_SIZE``, 16 KiB); tiny files stream via
+    chunked ``http.response.body``. Use a body past that threshold so the
+    protocol-owned sendfile path is the one exercised here.
+    """
     asset_path = tmp_path / "app.js"
-    asset_path.write_text("console.log('preview')")
+    asset_path.write_text("console.log('preview');" + "x" * (32 * 1024))
 
     app = create_bengal_preview_app(output_dir=tmp_path)
     sent, send = _make_send_capture()

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'github'", specifier = ">=3.9.0" },
     { name = "aiohttp", marker = "extra == 'notion'", specifier = ">=3.9.0" },
     { name = "aiohttp", marker = "extra == 'rest'", specifier = ">=3.9.0" },
-    { name = "bengal-pounce", specifier = ">=0.7.1" },
+    { name = "bengal-pounce", specifier = ">=0.8.0" },
     { name = "cachetools", marker = "extra == 'all-sources'", specifier = ">=5.0.0" },
     { name = "cachetools", marker = "extra == 'notion'", specifier = ">=5.0.0" },
     { name = "chirp-ui", marker = "extra == 'chirp'", specifier = ">=0.9.0" },
@@ -274,15 +274,15 @@ dev = [
 
 [[package]]
 name = "bengal-pounce"
-version = "0.7.1"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "milo-cli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/89/987fe874d2aa008b8a777676f34a524aea04d8f5c0066854aae6fc940a9d/bengal_pounce-0.7.1.tar.gz", hash = "sha256:326452f317351488319292ee5b1032e98054993a146f63ba3550275eab853331", size = 201077, upload-time = "2026-05-23T16:49:26.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/77/a61cd170de9e6ab0681520d4de36bc43658518857fb5326609e5e0bf558f/bengal_pounce-0.8.1.tar.gz", hash = "sha256:ada2cf7603e7fc1dcd4993856bbb856cc7487ad8dcec43d199bb561f2b80a8cd", size = 238476, upload-time = "2026-06-15T21:09:01.709Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/0b/868403f83e95b3048a244014eff1f932a522372eccb699fca5f5040c01fd/bengal_pounce-0.7.1-py3-none-any.whl", hash = "sha256:63a04aab2596be51dbccba4146a8ab44223f9451f59fe16206ce05ffbed8b2ca", size = 232327, upload-time = "2026-05-23T16:49:24.372Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/81/61324b3d1864c6fc426ff1b3db533a93b8d80275f14869aabf55285e9169/bengal_pounce-0.8.1-py3-none-any.whl", hash = "sha256:5eb229297cbeab24878c02ccddf46bf752925af19431fdbfbe96b9557496fbe8", size = 272453, upload-time = "2026-06-15T21:09:00.059Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `bengal-pounce` pin to `>=0.8.0` (relocked to 0.8.1). 0.8.0 ships the lbliii/pounce#74 fix: the static handler's hidden-file check now only inspects path components *below* the mount root, so a buffer rooted under a dotfile (`<root>/.bengal/staging`) serves correctly.
- Drop the #392 `_has_hidden_path_component` guard in `bengal/server/asgi_app.py` that routed hidden-buffer asset requests around Pounce into `_serve_static`. Both dev double-buffers now use Pounce's fast static path; the slow detour for the staging buffer is gone.
- Remove the now-dead `_has_hidden_path_component` helper.
- Keep `BufferManager.setup()`'s construction-time hidden-path warning (#400 Part 1) as a forward-looking boundary safety net; reword its docstring/hint to reflect that Pounce 0.8.0+ serves such buffers.
- The pounce#72 sendfile-EAGAIN workaround (`_scope_without_sendfile`) is untouched — separate concern, out of scope.

Closes #400.

## Proof

- [x] Focused tests: `uv run pytest tests -k "server or dev_server or buffer or staging or serve or asgi" -q` → 704 passed. Full server suite + live HTTP integration: `uv run pytest tests/unit/server tests/integration/test_live_dev_server_http.py tests/integration/test_dev_server_buffer_manifest.py -q -o addopts=""` → 478 passed.
- [x] `poe`/scoped equivalent: pre-commit hooks (ruff, ruff format, ty, import-cycle/dep-layer guards) pass on commit.
- [x] Docs/examples/changelog updated: `changelog.d/400.changed.md` added; `uv run poe changelog-lint` clean.

Asset-serving verification: drove a CSS asset under `.bengal/staging` directly through `_serve_pounce_static_asset` (the now-unguarded fast path) → HTTP 200, `content-type: text/css`, correct body. The live HTTP integration test boots a real dev server, edits content concurrently to force buffer swaps, and asserts every referenced CSS/JS asset stays 200.

Two pre-existing tests were updated for post-0.8.0 Pounce behavior: the diagnostic-canary test now uses a hidden subdir *below* the mount (still rejected) since a hidden mount root no longer 404s; the sendfile-message test uses a body above Pounce's 16 KiB zero-copy threshold so it still exercises the `pounce.response.sendfile` path. The `_has_hidden_path_component` unit test was removed with the helper.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable — dependency pin bump + dev-server static-path simplification; no performance claim; dev-server tests green.

## Steward Notes

- `bengal/server/` is perf-sensitive; this removes a per-request branch and a slow `_serve_static` detour for the staging buffer, but makes no measured performance claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
