### PR TITLE
perf(benchmarks): commit warm/incremental scaling baseline (record-only) (#331)

### DIFF
--- a/benchmarks/baselines/warm_build.json
+++ b/benchmarks/baselines/warm_build.json
@@ -1,0 +1,46 @@
+{
+  "metadata": {
+    "python_version": "3.14.2 free-threading build (main, Dec 17 2025, 21:08:58) [Clang 21.1.4 ]",
+    "free_threaded": true,
+    "warm_builds_per_size": 5,
+    "platform": "darwin",
+    "record_only": true
+  },
+  "data": {
+    "methodology": "WARM (incremental) single-page rebuild, NOT a cold build. For each site size: generate a synthetic multi-section markdown site, run one cold build(incremental=False) to warm caches, then time N warm rebuilds, each = edit one leaf page + Site.prepare_for_rebuild() + build(incremental=True, changed_sources={that page}) + restore the file (matches the dev-server BuildTrigger path). In-process Site.build, BuildProfile.WRITER, quiet. We report warm single-page rebuild cost (first / mean / median / min) per size. RECORD-ONLY: this baseline is a directional record captured on the maintainer's dev machine, not a CI gate.",
+    "cells": [
+      {
+        "pages": 100,
+        "warm_builds": 5,
+        "cold_s": 9.947183500000392,
+        "warm_first_s": 2.163170416999492,
+        "warm_mean_s": 1.7311290834011743,
+        "warm_median_s": 1.596079875002033,
+        "warm_min_s": 1.3823331669991603,
+        "warm_times_s": [
+          2.16317,
+          1.565454,
+          1.948608,
+          1.382333,
+          1.59608
+        ]
+      },
+      {
+        "pages": 1000,
+        "warm_builds": 5,
+        "cold_s": 51.461490292000235,
+        "warm_first_s": 7.751472791998822,
+        "warm_mean_s": 6.211761525199108,
+        "warm_median_s": 6.095735957998841,
+        "warm_min_s": 5.180662958999164,
+        "warm_times_s": [
+          7.751473,
+          6.353334,
+          5.180663,
+          5.677602,
+          6.095736
+        ]
+      }
+    ]
+  }
+}

--- a/benchmarks/benchmark_warm_build_scaling.py
+++ b/benchmarks/benchmark_warm_build_scaling.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Warm / incremental build scaling baseline (record-only).
+========================================================
+
+Captures the cost of a single-page *warm* rebuild (the dev-server / HMR loop:
+``prepare_for_rebuild()`` + ``build(incremental=True, changed_sources={file})``)
+across two or more site sizes, and commits it as a stable JSON baseline under
+``benchmarks/baselines/warm_build.json``.
+
+Why this exists (issue #331, epic #330)
+---------------------------------------
+``benchmark_gil_speedup.py`` only ever runs ``incremental=False`` (cold builds).
+There was no committed number for the warm single-page rebuild path, so the
+v0.6.0 proportional-rebuild work (#332/#333) had nothing to prove its speedup
+against. This baseline is that number: a deterministic record of how the warm
+single-page rebuild scales with total page count *today*. The current build
+re-renders proportionally to total pages on many edits, so this baseline is
+expected to show warm cost rising with site size — exactly the curve the
+proportional-discovery saga must flatten.
+
+RECORD-ONLY (not a gate)
+------------------------
+This is a maintainer decision: the committed baseline and the comparison
+consumer MEASURE and REPORT a delta, but they never fail CI on regression.
+There is no hard threshold here. The point is to hand #332/#333 a number
+without introducing a flaky-red check on shared CI runners. ``--compare``
+ALWAYS exits 0. A real gate, if ever wanted, must be re-captured on stable,
+idle, many-core hardware first (see ``benchmark_gil_speedup.py`` --gate*).
+
+The committed numbers in ``warm_build.json`` were captured on the maintainer's
+dev machine; treat them as a directional record, not an absolute spec.
+
+Usage
+-----
+    # Capture + print (does NOT write the committed baseline)
+    python benchmarks/benchmark_warm_build_scaling.py
+
+    # Capture and (re)write the committed baseline JSON
+    python benchmarks/benchmark_warm_build_scaling.py --publish
+
+    # Re-run and compare against the committed baseline, printing the delta.
+    # Record-only: exits 0 even on regression.
+    python benchmarks/benchmark_warm_build_scaling.py --compare
+
+    # Custom site sizes / warm-rebuild repeats
+    python benchmarks/benchmark_warm_build_scaling.py --sizes 100,1000 --warm-builds 5
+
+Methodology
+-----------
+For each site size we generate a synthetic multi-section markdown site, do one
+cold build to warm caches, then time ``--warm-builds`` single-leaf-page warm
+rebuilds (edit a leaf page, ``prepare_for_rebuild``, incremental build with that
+file as the only changed source, restore the file). We report the cold time and
+the warm single-page rebuild cost (first warm, mean, median, min). Median/min
+are the most stable summary on a noisy dev machine; mean is kept for continuity
+with the harness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import statistics
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Reuse the warm-build harness (cold build + repeated single-page warm rebuilds)
+# and the committed results manager (timestamped history + latest.json), exactly
+# like benchmark_gil_speedup.py does.
+sys.path.insert(0, str(REPO_ROOT / "tests" / "performance"))
+from benchmark_warm_build_consistency import (  # noqa: E402
+    create_test_site,
+    run_warm_build_consistency_benchmark,
+)
+from results_manager import BenchmarkResults  # noqa: E402
+
+BASELINE_DIR = REPO_ROOT / "benchmarks" / "baselines"
+BASELINE_FILE = BASELINE_DIR / "warm_build.json"
+
+DEFAULT_SIZES = (100, 1000)
+DEFAULT_WARM_BUILDS = 5
+
+METHODOLOGY = (
+    "WARM (incremental) single-page rebuild, NOT a cold build. For each site "
+    "size: generate a synthetic multi-section markdown site, run one cold "
+    "build(incremental=False) to warm caches, then time N warm rebuilds, each = "
+    "edit one leaf page + Site.prepare_for_rebuild() + "
+    "build(incremental=True, changed_sources={that page}) + restore the file "
+    "(matches the dev-server BuildTrigger path). In-process Site.build, "
+    "BuildProfile.WRITER, quiet. We report warm single-page rebuild cost "
+    "(first / mean / median / min) per size. RECORD-ONLY: this baseline is a "
+    "directional record captured on the maintainer's dev machine, not a CI gate."
+)
+
+
+def measure_size(num_pages: int, warm_builds: int) -> dict[str, float | int]:
+    """Capture warm single-page rebuild stats for one site size."""
+    site_root = create_test_site(num_pages=num_pages)
+    try:
+        result = run_warm_build_consistency_benchmark(
+            site_root,
+            num_warm_builds=warm_builds,
+            quiet=True,
+        )
+        warm_times = list(result["warm_times"])
+        return {
+            "pages": num_pages,
+            "warm_builds": warm_builds,
+            "cold_s": result["cold_s"],
+            "warm_first_s": result["warm_1_s"],
+            "warm_mean_s": statistics.mean(warm_times) if warm_times else 0.0,
+            "warm_median_s": statistics.median(warm_times) if warm_times else 0.0,
+            "warm_min_s": min(warm_times) if warm_times else 0.0,
+            "warm_times_s": [round(t, 6) for t in warm_times],
+        }
+    finally:
+        shutil.rmtree(site_root, ignore_errors=True)
+
+
+def run_capture(sizes: list[int], warm_builds: int) -> dict:
+    """Capture a fresh warm-build scaling result payload (data block)."""
+    cells: list[dict] = []
+    print("Warm-build scaling capture")
+    print(f"  sizes:       {', '.join(f'{s:,}' for s in sizes)}")
+    print(f"  warm builds: {warm_builds} single-page rebuilds per size")
+    print()
+    for size in sizes:
+        print(f"  [{size:,} pages] cold build + {warm_builds} warm rebuilds...")
+        cell = measure_size(size, warm_builds)
+        cells.append(cell)
+        print(
+            f"    cold={cell['cold_s']:.3f}s  "
+            f"warm_first={cell['warm_first_s']:.3f}s  "
+            f"warm_median={cell['warm_median_s']:.3f}s  "
+            f"warm_min={cell['warm_min_s']:.3f}s"
+        )
+    return {"methodology": METHODOLOGY, "cells": cells}
+
+
+def metadata(warm_builds: int) -> dict:
+    return {
+        "python_version": sys.version,
+        "free_threaded": not sys._is_gil_enabled(),
+        "warm_builds_per_size": warm_builds,
+        "platform": sys.platform,
+        "record_only": True,
+    }
+
+
+def publish(data: dict, meta: dict) -> Path:
+    """Write the stable committed baseline + a timestamped history entry."""
+    BASELINE_DIR.mkdir(parents=True, exist_ok=True)
+    mgr = BenchmarkResults(results_dir=BASELINE_DIR)
+    mgr.save_result("warm_build", data, metadata=meta)
+    BASELINE_FILE.write_text(json.dumps({"metadata": meta, "data": data}, indent=2) + "\n")
+    return BASELINE_FILE
+
+
+# ---------------------------------------------------------------------------
+# Reusable comparison logic (so #332/#333 can assert a speedup against the
+# committed baseline). compare_to_baseline() is pure: it takes a baseline
+# payload + freshly-measured cells and returns per-size deltas. It NEVER decides
+# pass/fail; callers (a future gate) impose their own threshold.
+# ---------------------------------------------------------------------------
+
+WARM_METRIC = "warm_median_s"
+
+
+def load_baseline(path: Path = BASELINE_FILE) -> dict:
+    """Load the committed baseline JSON ({'metadata':..., 'data':...})."""
+    return json.loads(path.read_text())
+
+
+def _cells_by_size(cells: list[dict]) -> dict[int, dict]:
+    return {int(c["pages"]): c for c in cells}
+
+
+def compare_to_baseline(
+    baseline: dict,
+    measured_cells: list[dict],
+    metric: str = WARM_METRIC,
+) -> list[dict]:
+    """
+    Compare freshly-measured cells against a committed baseline payload.
+
+    Pure + reusable: returns one row per size that exists in BOTH, with the
+    baseline value, the measured value, and the signed fractional delta
+    (``(measured - baseline) / baseline``; negative = faster = improvement).
+    Does NOT raise or decide pass/fail. #332/#333 can call this and assert
+    ``row["delta"] <= -target_speedup`` to prove their improvement.
+    """
+    base_cells = _cells_by_size(baseline.get("data", {}).get("cells", []))
+    meas_cells = _cells_by_size(measured_cells)
+    rows: list[dict] = []
+    for size in sorted(set(base_cells) & set(meas_cells)):
+        b = base_cells[size].get(metric)
+        m = meas_cells[size].get(metric)
+        delta = ((m - b) / b) if (b and m is not None) else None
+        rows.append(
+            {
+                "pages": size,
+                "metric": metric,
+                "baseline_s": b,
+                "measured_s": m,
+                "delta": delta,
+                "speedup": (b / m) if (b and m) else None,
+            }
+        )
+    return rows
+
+
+def print_comparison(rows: list[dict]) -> None:
+    print()
+    print("=" * 78)
+    print("WARM SINGLE-PAGE REBUILD: measured vs committed baseline (RECORD-ONLY)")
+    print("=" * 78)
+    print(
+        f"  {'pages':>8} {'metric':>16} {'baseline':>10} {'measured':>10} {'delta':>8} {'speedup':>8}"
+    )
+    print("-" * 78)
+    for r in rows:
+        b = f"{r['baseline_s']:.3f}" if r["baseline_s"] is not None else "—"
+        m = f"{r['measured_s']:.3f}" if r["measured_s"] is not None else "—"
+        d = f"{r['delta']:+.1%}" if r["delta"] is not None else "—"
+        sp = f"{r['speedup']:.2f}x" if r["speedup"] is not None else "—"
+        print(f"  {r['pages']:>8,} {r['metric']:>16} {b:>10} {m:>10} {d:>8} {sp:>8}")
+    print()
+    print("RECORD-ONLY: this comparison reports the delta and ALWAYS exits 0.")
+    print("It is not a gate. Negative delta = warm rebuild got faster.")
+    print()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sizes",
+        default=",".join(str(s) for s in DEFAULT_SIZES),
+        help="Comma-separated site sizes in pages (default: 100,1000)",
+    )
+    parser.add_argument(
+        "--warm-builds",
+        type=int,
+        default=DEFAULT_WARM_BUILDS,
+        help="Single-page warm rebuilds to time per size (default: 5)",
+    )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help="Write the committed baseline (benchmarks/baselines/warm_build.json)",
+    )
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Re-measure and print the delta vs the committed baseline. "
+        "RECORD-ONLY: always exits 0, even on regression.",
+    )
+    parser.add_argument(
+        "--output", "-o", default=None, help="Also write raw data JSON to this path"
+    )
+    args = parser.parse_args()
+
+    sizes = [int(s) for s in args.sizes.split(",") if s.strip()]
+
+    if args.compare:
+        if not BASELINE_FILE.exists():
+            print(
+                f"ERROR: no committed baseline at {BASELINE_FILE}. "
+                "Capture it first with --publish.",
+                file=sys.stderr,
+            )
+            return 1
+        baseline = load_baseline()
+        data = run_capture(sizes, args.warm_builds)
+        rows = compare_to_baseline(baseline, data["cells"])
+        print_comparison(rows)
+        # RECORD-ONLY: never fail on regression.
+        return 0
+
+    data = run_capture(sizes, args.warm_builds)
+    meta = metadata(args.warm_builds)
+
+    if args.output:
+        Path(args.output).write_text(json.dumps({"metadata": meta, "data": data}, indent=2) + "\n")
+        print(f"Raw JSON: {args.output}")
+
+    if args.publish:
+        path = publish(data, meta)
+        print(f"Baseline committed: {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -432,7 +432,7 @@ benchmark = { cmd = "pytest benchmarks/ tests/performance/ -v --benchmark-only",
 benchmark-compare = { cmd = "pytest benchmarks/ tests/performance/ --benchmark-compare=baseline -v", help = "Compare to baseline" }
 benchmark-save = { cmd = "pytest benchmarks/ tests/performance/ --benchmark-save=baseline -v", help = "Save baseline" }
 benchmark-scenarios = { cmd = "python scripts/generate_benchmark_scenarios.py", help = "Generate cached benchmark scenarios" }
-benchmark-smoke = { cmd = "pytest -o addopts= -n 0 -q tests/unit/benchmarks/test_benchmark_matrix.py tests/performance/test_autodoc_render_regression.py tests/performance/test_asset_fallback_cost.py tests/performance/test_post_render_pipeline_budget.py", help = "Run canonical smoke performance guards without full benchmark timings" }
+benchmark-smoke = { cmd = "pytest -o addopts= -n 0 -q tests/unit/benchmarks/test_benchmark_matrix.py tests/performance/test_autodoc_render_regression.py tests/performance/test_asset_fallback_cost.py tests/performance/test_post_render_pipeline_budget.py tests/performance/test_warm_build_baseline.py", help = "Run canonical smoke performance guards without full benchmark timings" }
 benchmark-matrix = { cmd = "python benchmarks/run_matrix.py", help = "Run benchmark rows from benchmarks/benchmark_matrix.toml" }
 
 # Type Checking

--- a/tests/performance/benchmark_warm_build_consistency.py
+++ b/tests/performance/benchmark_warm_build_consistency.py
@@ -97,11 +97,16 @@ def run_warm_build_consistency_benchmark(
     site_root: Path,
     num_warm_builds: int = 5,
     file_to_modify: Path | None = None,
+    quiet: bool = False,
 ) -> dict[str, float]:
     """
     Run cold + repeated warm builds, return timing stats.
 
     Returns dict with: cold_s, warm_1_s, warm_2_s, warm_1_vs_2_ratio, etc.
+
+    ``quiet`` suppresses the per-build progress output (used by the baseline
+    emitter so the captured timing is not interleaved with console noise); it
+    does not change the measured build path.
     """
     site = Site.from_config(site_root)
     content_dir = site_root / "content"
@@ -110,7 +115,7 @@ def run_warm_build_consistency_benchmark(
 
     # Cold build
     cold_start = time.perf_counter()
-    site.build(BuildOptions(incremental=False, profile=BuildProfile.WRITER))
+    site.build(BuildOptions(incremental=False, profile=BuildProfile.WRITER, quiet=quiet))
     cold_s = time.perf_counter() - cold_start
 
     warm_times: list[float] = []
@@ -127,6 +132,7 @@ def run_warm_build_consistency_benchmark(
                 incremental=True,
                 profile=BuildProfile.WRITER,
                 changed_sources={target_file},
+                quiet=quiet,
             )
         )
         warm_s = time.perf_counter() - warm_start

--- a/tests/performance/test_warm_build_baseline.py
+++ b/tests/performance/test_warm_build_baseline.py
@@ -1,0 +1,115 @@
+"""
+Record-only consumer of the committed warm-build scaling baseline (#331).
+
+This test CONSUMES ``benchmarks/baselines/warm_build.json`` (the warm/incremental
+single-page rebuild baseline) so the baseline is exercised by the suite, and it
+exercises the reusable comparison logic that the v0.6.0 proportional-rebuild
+sagas (#332/#333) will call to prove their speedup.
+
+RECORD-ONLY by design (maintainer decision): this test does NOT run the (slow)
+benchmark and does NOT assert any wall-clock threshold, so it can never go
+flaky-red on a noisy runner. It is fast (pure JSON + arithmetic), which is why
+it lives in the canonical ``poe benchmark-smoke`` set rather than the opt-in
+timed-benchmark tests. It asserts only structural / contract invariants:
+
+  * the committed baseline exists, is shaped like its neighbours
+    (metadata + data.cells), and is flagged record_only;
+  * it captures the warm single-page rebuild metric at >= 2 site sizes;
+  * the warm cost grows with total page count today (the scaling curve the
+    proportional-rebuild saga must flatten — this is the number to beat);
+  * ``compare_to_baseline`` reports a speedup when a downstream saga feeds in a
+    faster measurement (the assertion #332/#333 will rely on).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+BENCHMARKS = REPO_ROOT / "benchmarks"
+BASELINE = BENCHMARKS / "baselines" / "warm_build.json"
+
+# The emitter/comparison module lives under benchmarks/; import its reusable
+# comparison helpers without running any build.
+sys.path.insert(0, str(BENCHMARKS))
+from benchmark_warm_build_scaling import (  # noqa: E402
+    WARM_METRIC,
+    compare_to_baseline,
+    load_baseline,
+)
+
+
+def test_warm_build_baseline_is_committed_and_well_formed() -> None:
+    """The committed baseline exists and mirrors the neighbouring baseline shape."""
+    assert BASELINE.exists(), (
+        f"missing committed warm-build baseline at {BASELINE}; "
+        "regenerate with: python benchmarks/benchmark_warm_build_scaling.py --publish"
+    )
+    payload = json.loads(BASELINE.read_text())
+    assert set(payload) >= {"metadata", "data"}, (
+        "baseline must have metadata + data (gil_speedup shape)"
+    )
+    meta = payload["metadata"]
+    assert meta.get("record_only") is True, "warm baseline must be flagged record_only"
+    assert "warm" in payload["data"]["methodology"].lower(), (
+        "methodology must distinguish warm vs cold"
+    )
+
+
+def test_warm_build_baseline_covers_multiple_sizes_with_metric() -> None:
+    """>= 2 site sizes, each carrying the warm single-page rebuild metric."""
+    cells = load_baseline(BASELINE)["data"]["cells"]
+    sizes = sorted(int(c["pages"]) for c in cells)
+    assert len(sizes) >= 2, f"baseline must cover >=2 site sizes, got {sizes}"
+    for cell in cells:
+        assert WARM_METRIC in cell, f"cell {cell.get('pages')} missing {WARM_METRIC}"
+        assert cell[WARM_METRIC] > 0, f"cell {cell.get('pages')} has non-positive warm time"
+        # Warm time must be cheaper than the cold build it followed (sanity: an
+        # incremental single-page rebuild is not a full cold rebuild).
+        assert cell[WARM_METRIC] < cell["cold_s"], (
+            f"cell {cell.get('pages')}: warm rebuild ({cell[WARM_METRIC]:.3f}s) "
+            f"should be cheaper than cold ({cell['cold_s']:.3f}s)"
+        )
+
+
+def test_warm_build_baseline_shows_total_pages_scaling() -> None:
+    """
+    The current warm rebuild cost rises with total page count.
+
+    This is the property the proportional-discovery saga (#332/#333) must flatten:
+    today a single-page edit re-does work proportional to the whole site, so the
+    larger site's warm rebuild is strictly slower. If this assertion ever flips
+    (warm cost no longer grows with size), proportional rebuild has landed and
+    this baseline should be re-captured / promoted.
+    """
+    cells = sorted(load_baseline(BASELINE)["data"]["cells"], key=lambda c: int(c["pages"]))
+    smallest, largest = cells[0], cells[-1]
+    assert int(largest["pages"]) > int(smallest["pages"])
+    assert largest[WARM_METRIC] > smallest[WARM_METRIC], (
+        "expected warm single-page rebuild to scale UP with total pages "
+        f"({smallest['pages']}p={smallest[WARM_METRIC]:.3f}s vs "
+        f"{largest['pages']}p={largest[WARM_METRIC]:.3f}s); if this no longer "
+        "holds, proportional rebuild may have landed — re-capture the baseline"
+    )
+
+
+def test_compare_to_baseline_reports_downstream_speedup() -> None:
+    """
+    The reusable comparison logic reports a speedup for a faster measurement.
+
+    This is the exact call #332/#333 will make: feed in measured cells and read
+    back per-size delta/speedup vs the committed baseline. A halved warm time
+    must surface as ~2x speedup and a negative delta.
+    """
+    baseline = load_baseline(BASELINE)
+    cells = baseline["data"]["cells"]
+    faster = [{"pages": int(c["pages"]), WARM_METRIC: c[WARM_METRIC] / 2.0} for c in cells]
+    rows = compare_to_baseline(baseline, faster)
+    assert rows, "comparison should produce a row per shared size"
+    for row in rows:
+        assert row["speedup"] == pytest.approx(2.0, rel=1e-6)
+        assert row["delta"] == pytest.approx(-0.5, rel=1e-6)


### PR DESCRIPTION
## Summary

- Commits a **record-only** warm/incremental scaling baseline so the v0.6.0 proportional-rebuild work (#332/#333) has a number to prove its speedup against, without introducing a flaky-red CI gate.
- `benchmarks/benchmark_warm_build_scaling.py` — emitter that reuses the existing `tests/performance/benchmark_warm_build_consistency.py` harness (cold build + repeated single-page `prepare_for_rebuild()` / `build(incremental=True, changed_sources=...)`) and the committed `results_manager`, capturing warm **single-page** rebuild cost at >=2 site sizes (100, 1000). Mirrors the `benchmark_gil_speedup.py` emitter pattern (stable top-level JSON + timestamped history).
- `benchmarks/baselines/warm_build.json` — committed baseline matching the neighbouring `gil_speedup.json` shape (`metadata` + `data.cells`), flagged `record_only: true`. The methodology string distinguishes **warm vs cold**.
- Reusable `compare_to_baseline()` / `load_baseline()` so #332/#333 can assert their speedup against this baseline. `--compare` re-measures, prints the per-size delta, and **always exits 0** (record, not gate).
- `tests/performance/test_warm_build_baseline.py` — record-only consumer that loads the committed baseline, asserts shape + >=2 sizes + today's total-pages scaling curve, and exercises the comparison logic with a synthetic 2x measurement. No wall-clock threshold, so it cannot go flaky-red. Wired into the `benchmark-smoke` poe task, which is consumed by `poe proof-pr` — **no `.github/workflows` edit** (avoids the workflow-token push rejection).
- `benchmark_warm_build_consistency.py` — adds a `quiet` flag (default `False`, preserves existing test/CLI behavior) so the emitter captures clean timings.

Closes #331

## Proof

- [x] Focused tests: `pytest -o addopts= -n 0 -q tests/performance/test_warm_build_baseline.py` → 4 passed; existing `benchmark_warm_build_consistency.py::test_warm_build_first_vs_second_consistency` → 1 passed
- [x] `poe proof-pr` or scoped equivalent: `poe benchmark-smoke` → 20 passed in 17.46s (includes the 4 new consumer tests); `ruff check` + `ruff format --check` clean; pre-commit (ruff/ty/cycles/deps) all passed at commit time
- [x] Docs/examples/changelog updated or no-impact noted: internal CI/perf infra, no user-facing surface → `skip-changelog` label, no fragment

## Performance Evidence

- Benchmark matrix row: warm single-page incremental rebuild, synthetic multi-section markdown site, sizes 100 and 1000 pages, 5 warm rebuilds/size
- Command: `python benchmarks/benchmark_warm_build_scaling.py --sizes 100,1000 --warm-builds 5 --publish` (compare: `python benchmarks/benchmark_warm_build_scaling.py --compare`)
- Python build: CPython 3.14.2 free-threading build (GIL disabled), `Clang 21.1.4`
- Machine/OS: macOS 26.3.1, arm64 (Apple Silicon), 11 logical CPUs — maintainer's dev machine
- Baseline commit or saved result: `benchmarks/baselines/warm_build.json` (this PR, commit 755309a84)
- Current commit or saved result: same file; `--compare` re-run on this branch reported `100p warm_median 1.596s -> 1.478s (-7.4%, 1.08x)` (within dev-machine noise; exited 0)
- Artifact path: `benchmarks/baselines/warm_build.json`
- Interpretation: Warm single-page rebuild cost = `warm_median` 1.596s @ 100 pages, 6.096s @ 1000 pages (`warm_min` 1.382s / 5.181s). A 10x site → ~3.8x warm-rebuild cost, demonstrating today's total-pages scaling: a single-page edit still does work proportional to the whole site. This is the curve #332/#333 proportional-rebuild must flatten and the number it proves its speedup against. **This baseline was captured on the maintainer's dev machine and is a RECORD, not a gate** — the committed JSON and the `--compare` consumer measure and report a delta but never fail CI on regression. If this is ever promoted to a hard gate, it must be re-captured on a stable, idle, many-core host (the same caveat `benchmark_gil_speedup.py`'s `ci_gate` carries).

## Steward Notes

- CI wiring: delivered the record-only consumer as a fast (JSON + arithmetic, no build) test wired into the existing `benchmark-smoke` poe task (run by `poe proof-pr`), deliberately **not** as a new/edited workflow — this keeps the HTTPS push clear of the missing `workflow` OAuth scope. A follow-up could add a dedicated record-only emit+compare step to `perf-gate.yml` (run `benchmark_warm_build_scaling.py --compare`, upload `warm_build.json` as an artifact) if a visible CI report is wanted; it must stay exit-0 / non-gating.
- `tests/performance/results_manager.py` line 219 uses PEP 758 unparenthesized `except KeyError, TypeError:` — intentional Bengal style, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
