### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [0.5.0] - 2026-06-15
+
+### Added
+
+- `bengal serve --drafts` and `bengal build --drafts` (or `drafts = true` under `[build]`) render pages marked `draft: true` so you can preview unpublished content locally; drafts stay hidden by default. (`#488`)
+
+### Changed
+
+- Dev-server assets now serve through the fast static path; the hidden-buffer 404 workaround is removed (requires bengal-pounce 0.8.0+). (`#400`)
+- `bengal build --memory-optimized` is now labeled experimental, and its help text and docs no longer promise a fixed memory saving — measure peak memory with and without the flag on your own site before relying on it. (`#487`)
+
+### Fixed
+
+- Autodoc no longer turns illustrative cross-reference and directive examples in docstrings into live (often broken) links, so generated API pages and the broken-link health check stay clean. (`#485`)
+- The internal link checker now resolves relative links (such as `../other/`) against the page that references them and reports broken ones, instead of silently passing them. (`#489`)
+
+
 ## [0.4.3] - 2026-06-15
 
 ### Fixed

--- a/changelog.d/400.changed.md
+++ b/changelog.d/400.changed.md
@@ -1,1 +1,0 @@
-Dev-server assets now serve through the fast static path; the hidden-buffer 404 workaround is removed (requires bengal-pounce 0.8.0+).

--- a/changelog.d/485.fixed.md
+++ b/changelog.d/485.fixed.md
@@ -1,1 +1,0 @@
-Autodoc no longer turns illustrative cross-reference and directive examples in docstrings into live (often broken) links, so generated API pages and the broken-link health check stay clean.

--- a/changelog.d/487.changed.md
+++ b/changelog.d/487.changed.md
@@ -1,1 +1,0 @@
-`bengal build --memory-optimized` is now labeled experimental, and its help text and docs no longer promise a fixed memory saving — measure peak memory with and without the flag on your own site before relying on it.

--- a/changelog.d/488.added.md
+++ b/changelog.d/488.added.md
@@ -1,1 +1,0 @@
-`bengal serve --drafts` and `bengal build --drafts` (or `drafts = true` under `[build]`) render pages marked `draft: true` so you can preview unpublished content locally; drafts stay hidden by default.

--- a/changelog.d/489.fixed.md
+++ b/changelog.d/489.fixed.md
@@ -1,1 +1,0 @@
-The internal link checker now resolves relative links (such as `../other/`) against the page that references them and reports broken ones, instead of silently passing them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bengal"
-version = "0.4.3"
+version = "0.5.0"
 description = "Python static site generator built on free-threading — every layer pure Python, scales with your cores, zero npm"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/site/content/releases/0.5.0.md
+++ b/site/content/releases/0.5.0.md
@@ -1,0 +1,78 @@
+---
+title: Bengal 0.5.0
+description: Preview drafts before you publish, and trust the safety nets — draft pages render locally on demand, the broken-link checker now follows relative links, and autodoc stops inventing broken cross-references.
+date: 2026-06-15
+draft: false
+lang: en
+tags: [release, changelog, drafts, dev-server, autodoc, link-check]
+keywords: [release, 0.5.0, drafts, preview, broken-link-check, autodoc, dev-server, relative-links]
+category: changelog
+---
+
+# Bengal 0.5.0
+
+**Key theme:** Author with confidence. Bengal 0.5.0 lets you preview unpublished work in context before it ships, and makes the tools that are supposed to catch your mistakes actually catch them. You can now render draft pages locally on demand; the broken-link health check follows relative links instead of waving them through; and autodoc stops turning illustrative docstring examples into live (often broken) links. One new feature, and a set of safety nets that finally do what they say.
+
+---
+
+## Highlights
+
+### Preview drafts before you publish
+
+Mark a page `draft: true` and it stays out of your built site — but you can now see it in context while you write. Add `--drafts` to either command:
+
+```bash
+bengal serve --drafts   # preview drafts in the dev server
+bengal build --drafts   # include drafts in a build
+```
+
+You can also set `drafts = true` under `[build]` in your config. Drafts remain hidden by default, so nothing changes for a normal build or deploy — the flag is opt-in, per run.
+
+### A broken-link check you can rely on
+
+The internal link checker now resolves **relative links** — `../guide/`, `./other/`, and friends — against the page that references them, and reports the ones that are broken. Previously these links were silently passed, so a typo in a relative path slipped through the health check and shipped as a dead link. Relative links are now held to the same standard as every other link.
+
+### Autodoc stops inventing broken links
+
+Docstrings are full of illustrative examples — cross-reference syntax and directive samples meant to *show* what a reference looks like, not to *be* one. Autodoc used to turn those examples into live links, many of which pointed nowhere. It no longer does, so generated API pages stay clean and the broken-link health check comes back green instead of flagging links you never wrote.
+
+### Dev-server assets serve through the fast path
+
+When the dev server rendered into its hidden staging buffer, asset requests took a slow workaround path. Those assets now serve through the fast static path directly, removing the hidden-buffer 404 workaround. This requires `bengal-pounce` 0.8.0 or newer.
+
+### Honest claims on `--memory-optimized`
+
+`bengal build --memory-optimized` is now labeled **experimental**, and its help text and docs no longer promise a fixed memory saving. The flag still exists; the guidance is now to measure peak memory with and without it on your own site before relying on it, rather than trusting an unbacked number.
+
+---
+
+## Changes at a glance
+
+**Added**
+
+- Preview drafts locally: `bengal serve --drafts` / `bengal build --drafts`, or `drafts = true` under `[build]`. Draft pages render in context; hidden by default (`#488`).
+
+**Changed**
+
+- Dev-server assets now serve through the fast static path; the hidden-buffer 404 workaround is removed (requires `bengal-pounce` 0.8.0+) (`#400`).
+- `bengal build --memory-optimized` is labeled experimental, with no promised memory saving — measure on your own site before relying on it (`#487`).
+
+**Fixed**
+
+- Autodoc no longer turns illustrative cross-reference and directive examples in docstrings into live links, so generated API pages and the broken-link health check stay clean (`#485`).
+- The internal link checker now resolves relative links (such as `../other/`) against the referencing page and reports broken ones, instead of silently passing them (`#489`).
+
+---
+
+## Upgrading
+
+```bash
+uv pip install --upgrade bengal
+# or
+pip install --upgrade bengal
+```
+
+0.5.0 is a drop-in upgrade: no breaking changes and no config migration. A couple of things to know:
+
+- **The dev server now needs `bengal-pounce` 0.8.0+** for the fast asset path; upgrading Bengal pulls it in.
+- **`--memory-optimized` is now experimental.** It still works, but measure peak memory with and without it before depending on it.

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "bengal"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "bengal-pounce" },


### PR DESCRIPTION
## Summary

**v0.5.0 — Author with confidence.** A quality and credibility release: Bengal's safety nets now do what they claim, and you can preview drafts before publishing. The honest scope is one new feature (drafts preview) plus a set of fixes that make the tools trustworthy. The headline build-speed work (proportional warm rebuilds) is the next release; v0.5.0 quietly commits the baselines that will prove it.

This PR cuts the release: folds the five unreleased `changelog.d/` fragments into `CHANGELOG.md` under `[0.5.0]`, bumps the version `0.4.3 → 0.5.0` (pyproject + uv.lock), and adds the site release page `site/content/releases/0.5.0.md`.

Changelog highlights:

- **Preview drafts locally.** `bengal serve --drafts` / `bengal build --drafts` (or `drafts = true` under `[build]`) render pages marked `draft: true` so you can preview unpublished content in context; drafts stay hidden by default (#488).
- **A broken-link check you can rely on.** The internal link checker now resolves relative links (`../guide/`) against the referencing page and reports broken ones instead of silently passing them (#489); autodoc no longer turns illustrative docstring cross-reference/directive examples into live (often broken) links, so API pages and the health check stay clean (#485).
- **Dev server serves assets correctly.** Hidden-buffer assets now load through the fast Pounce static path; the 404 workaround is removed (requires bengal-pounce 0.8.0+) (#400).
- **Honest claims.** `bengal build --memory-optimized` is labeled experimental with no unbacked memory promise (#487).

Not a performance release — proportional warm rebuilds land in v0.6.0.

## Proof

- [x] Focused tests: n/a — release chore (no code change). Existing suite unaffected; pre-commit hooks (trailing whitespace, toml/json, import-cycle, dependency-layer) passed on commit.
- [x] `poe proof-pr` or scoped equivalent: `uv run poe changelog-lint` clean (fragments consumed, 0 files scanned); `uv run bengal build --source site` succeeded (708 pages, health 100%, 0 errors / 0 warnings, validation passed) and rendered the new release page; `uv run python -c "import bengal; print(bengal.__version__)"` reports `0.5.0`.
- [x] Docs/examples/changelog updated or no-impact noted: CHANGELOG.md gained the `[0.5.0]` section (Added #488; Changed #400/#487; Fixed #485/#489); the five fragments are removed from `changelog.d/`; site release page added.

## Performance Evidence

- Benchmark matrix row: not applicable — release chore, no code/perf change
- Command: not applicable — release chore, no code/perf change
- Python build: not applicable — release chore, no code/perf change
- Machine/OS: not applicable — release chore, no code/perf change
- Baseline commit or saved result: not applicable — release chore, no code/perf change
- Current commit or saved result: not applicable — release chore, no code/perf change
- Artifact path: not applicable — release chore, no code/perf change
- Interpretation: not applicable — release chore, no code/perf change

## Steward Notes

- Release page follows the `site/AGENTS.md` "Release Pages" steward: distilled top-down (theme hook → highlights → changes-at-a-glance → upgrading), user-facing test applied, no internal coinage / phase labels / process narration, theme names what the release enables ("Author with confidence") rather than a maturity verdict.
- `changelog-lint --releases` does not flag `site/content/releases/0.5.0.md`; the only flags it reports are pre-existing in older release pages (0.1.8, 0.2.6, 0.4.0–0.4.2), untouched here.
- Install command uses `bengal` (matches PyPI + pyproject `name`), correcting the `bengal-ssg` typo that appeared in the 0.4.2/0.4.3 pages.
- This PR stops at the cut: no tag, no GitHub release, no merge. Tagging (the maintainer's manual PyPI sign-off) is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
