### PR TITLE
feat(collections): add transform= hook to define_collection for pre-validation normalization

### DIFF
--- a/bengal/collections/__init__.py
+++ b/bengal/collections/__init__.py
@@ -92,6 +92,8 @@ from bengal.collections.schemas import (
 from bengal.collections.validator import SchemaValidator, ValidationResult
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from bengal.content.sources.source import ContentSource
 
 
@@ -121,6 +123,10 @@ class CollectionConfig[T]:
         loader: Optional :class:`ContentSource` for fetching remote content.
             When provided, content is fetched from the remote source instead
             of the local filesystem. Requires extras: ``pip install bengal[github]``
+        transform: Optional callable applied to each record's frontmatter dict
+            *before* schema validation. Useful for normalizing legacy
+            frontmatter during a migration. Receives the raw metadata dict and
+            returns the (possibly mutated) dict to validate.
 
     Example:
             >>> config = CollectionConfig(
@@ -145,6 +151,7 @@ class CollectionConfig[T]:
     strict: bool = True
     allow_extra: bool = False
     loader: ContentSource | None = None
+    transform: Callable[[dict[str, Any]], dict[str, Any]] | None = None
 
     def __post_init__(self) -> None:
         """
@@ -199,6 +206,7 @@ def define_collection[T](
     strict: bool = True,
     allow_extra: bool = False,
     loader: ContentSource | None = None,
+    transform: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
 ) -> CollectionConfig[T]:
     """
     Define a content collection with a typed schema.
@@ -221,6 +229,10 @@ def define_collection[T](
             dict on the validated instance. Only effective when ``strict=False``.
         loader: Optional :class:`ContentSource` for fetching remote content.
             Requires extras: ``pip install bengal[github]`` or ``bengal[notion]``.
+        transform: Optional callable run on each record's frontmatter dict
+            *before* schema validation. Receives the raw metadata dict and
+            returns the dict to validate. Use it to normalize legacy field
+            names or shapes during a migration.
 
     Returns:
         A :class:`CollectionConfig` instance for use in the project's
@@ -269,6 +281,7 @@ def define_collection[T](
         strict=strict,
         allow_extra=allow_extra,
         loader=loader,
+        transform=transform,
     )
 
 

--- a/bengal/content/discovery/content_parser.py
+++ b/bengal/content/discovery/content_parser.py
@@ -180,6 +180,9 @@ class ContentParser:
         """
         Validate frontmatter against collection schema if applicable.
 
+        If the matching collection defines a ``transform`` callable, it is
+        applied to the metadata before validation.
+
         Args:
             file_path: Path to content file
             metadata: Parsed frontmatter metadata
@@ -199,6 +202,11 @@ class ContentParser:
             return metadata
 
         from bengal.collections import ContentValidationError, SchemaValidator
+
+        # Apply the optional transform hook before validation so callers can
+        # normalize legacy frontmatter (e.g. rename fields during a migration).
+        if config.transform is not None:
+            metadata = config.transform(metadata)
 
         # Validate
         validator = SchemaValidator(config.schema, strict=config.strict)

--- a/changelog.d/492.added.md
+++ b/changelog.d/492.added.md
@@ -1,0 +1,1 @@
+`define_collection(..., transform=callable)` runs your callable on each record's frontmatter before schema validation, so you can normalize legacy field names during a migration without rewriting source files.

--- a/tests/unit/collections/test_discovery_integration.py
+++ b/tests/unit/collections/test_discovery_integration.py
@@ -337,7 +337,6 @@ Just title and date.
 class TestCollectionTransform:
     """Test collection transform functions."""
 
-    @pytest.mark.skip(reason="Transform feature not yet implemented in define_collection")
     def test_transform_applied(self, content_dir: Path) -> None:
         """Test transform function is called before validation."""
 


### PR DESCRIPTION
## Summary

- Add a `transform=` hook to `define_collection()` that runs a callable on each record's frontmatter dict *before* schema validation, so legacy frontmatter can be normalized during a migration without rewriting source files.
- The transform is stored on `CollectionConfig.transform` and applied in `ContentParser.validate_against_collection` immediately before `SchemaValidator` runs.
- Un-skips and passes the previously-skipped acceptance test `tests/unit/collections/test_discovery_integration.py::TestCollectionTransform::test_transform_applied` (assertions unchanged).

## Proof

- [x] Focused tests: `uv run pytest tests/unit/collections -q` -> 172 passed, 4 skipped (all 4 are pre-existing pydantic-import skips; 0 skipped for transform). `TestCollectionTransform::test_transform_applied` now runs and passes.
- [x] `poe proof-pr` or scoped equivalent: pre-commit hooks ran on commit (ruff, ruff format, ty type checker all Passed); `uv run poe changelog-lint` clean.
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/492.added.md` added; docstrings on `CollectionConfig` and `define_collection` document the new parameter.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable -- this PR adds an opt-in pre-validation hook on the content-collections config path; it touches no hot/concurrent path and makes no performance claim.

## Steward Notes

- New `transform` field on `CollectionConfig` defaults to `None`, so the change is fully backward compatible. `Callable` import lives in the `TYPE_CHECKING` block (annotations are strings under `from __future__ import annotations`).

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)