### PR TITLE
feat(autodoc): implement argparse CLI extraction

### DIFF
--- a/bengal/autodoc/extractors/cli.py
+++ b/bengal/autodoc/extractors/cli.py
@@ -81,8 +81,8 @@ class CLIExtractor(Extractor):
     Supported frameworks:
     - Click (full support)
     - milo (full support)
-    - argparse (planned)
-    - Typer (planned)
+    - argparse (full support)
+    - Typer (full support)
 
     Example:
             >>> from bengal.cli import cli
@@ -896,18 +896,310 @@ class CLIExtractor(Extractor):
 
     def _extract_from_argparse(self, parser: Any) -> list[DocElement]:
         """
-        Extract documentation from argparse ArgumentParser.
+        Extract documentation from an argparse ArgumentParser.
+
+        Mirrors the Click path: the root parser becomes a command-group and
+        each subparser (registered via ``add_subparsers().add_parser(...)``)
+        becomes a command. Parsers without subparsers are emitted as a single
+        command. Positional arguments map to ``argument`` elements and
+        optionals to ``option`` elements; the implicit ``-h/--help`` action is
+        skipped.
 
         Args:
-            parser: ArgumentParser instance
+            parser: argparse.ArgumentParser instance
 
         Returns:
-            List of DocElements
-
-        Note:
-            This is a placeholder for future implementation
+            Flat list of DocElements (root + all commands/groups)
         """
-        raise NotImplementedError("argparse support is planned but not yet implemented")
+        import argparse
+
+        if not isinstance(parser, argparse.ArgumentParser):
+            from bengal.errors import BengalDiscoveryError, ErrorCode
+
+            raise BengalDiscoveryError(
+                f"Expected an argparse.ArgumentParser, got {type(parser).__name__}.",
+                suggestion="Pass an argparse.ArgumentParser instance",
+                code=ErrorCode.O004,
+            )
+
+        name = parser.prog or "cli"
+
+        if self._argparse_subparsers(parser):
+            # Parser with subcommands -> command-group root.
+            root = self._extract_argparse_group(parser, name, parent_name=None)
+        else:
+            # Flat parser (no subcommands) -> single command.
+            root = self._extract_argparse_command(parser, name, parent_name=None)
+
+        elements: list[DocElement] = [root]
+
+        def flatten(children: list[DocElement]) -> None:
+            for child in children:
+                elements.append(child)
+                if child.element_type == "command-group" and child.children:
+                    flatten(child.children)
+
+        # A flat command's children are its parameters, not subcommands, so
+        # only flatten the command-tree under a command-group root.
+        if root.element_type == "command-group":
+            flatten(root.children)
+        return elements
+
+    @staticmethod
+    def _argparse_subparsers(parser: Any) -> Any:
+        """
+        Return the _SubParsersAction for a parser, or None if it has none.
+
+        Args:
+            parser: argparse.ArgumentParser instance
+
+        Returns:
+            The _SubParsersAction instance or None
+        """
+        import argparse
+
+        for action in parser._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                return action
+        return None
+
+    def _extract_argparse_group(
+        self, parser: Any, name: str, parent_name: str | None
+    ) -> DocElement:
+        """
+        Extract an argparse parser that has subparsers as a command-group.
+
+        Args:
+            parser: argparse.ArgumentParser instance with subparsers
+            name: Display name for this group
+            parent_name: Parent qualified name (None for the root)
+
+        Returns:
+            DocElement of type 'command-group' with one child per subparser
+        """
+        qualified_name = f"{parent_name}.{name}" if parent_name else name
+
+        subparsers = self._argparse_subparsers(parser)
+
+        # Map subcommand name -> help string from the _choices_actions table.
+        help_by_name: dict[str, str] = {}
+        for choice_action in getattr(subparsers, "_choices_actions", []):
+            help_by_name[choice_action.dest] = choice_action.help or ""
+
+        children: list[DocElement] = []
+        seen_ids: set[int] = set()
+        for sub_name, sub_parser in subparsers.choices.items():
+            # argparse stores aliases as extra dict keys pointing at the same
+            # parser object; emit each parser once under its canonical name.
+            if id(sub_parser) in seen_ids:
+                continue
+            seen_ids.add(id(sub_parser))
+
+            help_text = help_by_name.get(sub_name)
+            if self._argparse_subparsers(sub_parser):
+                children.append(self._extract_argparse_group(sub_parser, sub_name, qualified_name))
+            else:
+                children.append(
+                    self._extract_argparse_command(
+                        sub_parser, sub_name, qualified_name, help_text=help_text
+                    )
+                )
+
+        description = sanitize_text(parser.description)
+
+        typed_meta = CLIGroupMetadata(
+            callback=None,
+            command_count=len(children),
+        )
+
+        return DocElement(
+            name=name,
+            qualified_name=qualified_name,
+            description=description,
+            element_type="command-group",
+            source_file=None,
+            line_number=None,
+            metadata={
+                "callback": None,
+                "command_count": len(children),
+            },
+            typed_metadata=typed_meta,
+            children=children,
+            examples=[],
+            see_also=[],
+            deprecated=None,
+        )
+
+    def _extract_argparse_command(
+        self,
+        parser: Any,
+        name: str,
+        parent_name: str | None,
+        help_text: str | None = None,
+    ) -> DocElement:
+        """
+        Extract an argparse parser (without subparsers) as a command.
+
+        Args:
+            parser: argparse.ArgumentParser instance
+            name: Display name for this command
+            parent_name: Parent qualified name (None for the root)
+            help_text: Short help from the parent subparsers table, if any
+
+        Returns:
+            DocElement of type 'command' with one child per argument/option
+        """
+        import argparse
+
+        qualified_name = f"{parent_name}.{name}" if parent_name else name
+
+        arguments: list[DocElement] = []
+        options: list[DocElement] = []
+
+        for action in parser._actions:
+            # Skip the implicit help action and any nested subparsers action.
+            if isinstance(action, argparse._HelpAction | argparse._SubParsersAction):
+                continue
+
+            param_doc = self._extract_argparse_parameter(action, qualified_name)
+            if action.option_strings:
+                options.append(param_doc)
+            else:
+                arguments.append(param_doc)
+
+        children = arguments + options
+
+        # Prefer the parser's own description; fall back to the subparsers
+        # help string (argparse's `help=` on add_parser).
+        description = sanitize_text(parser.description or help_text)
+
+        typed_meta = CLICommandMetadata(
+            callback=None,
+            option_count=len(options),
+            argument_count=len(arguments),
+            is_group=False,
+            is_hidden=False,
+        )
+
+        return DocElement(
+            name=name,
+            qualified_name=qualified_name,
+            description=description,
+            element_type="command",
+            source_file=None,
+            line_number=None,
+            metadata={
+                "callback": None,
+                "option_count": len(options),
+                "argument_count": len(arguments),
+            },
+            typed_metadata=typed_meta,
+            children=children,
+            examples=[],
+            see_also=[],
+            deprecated=None,
+        )
+
+    def _extract_argparse_parameter(self, action: Any, parent_name: str) -> DocElement:
+        """
+        Extract an argparse Action as an option or argument DocElement.
+
+        Args:
+            action: argparse.Action instance (not a help/subparsers action)
+            parent_name: Parent command qualified name
+
+        Returns:
+            DocElement of type 'option' (has option_strings) or 'argument'
+        """
+        is_option = bool(action.option_strings)
+        element_type = "option" if is_option else "argument"
+
+        # argparse uses `dest` as the canonical parameter name.
+        param_name = action.dest
+
+        # Flags/opt strings, e.g. ("-v", "--verbose"). Positionals expose none,
+        # so fall back to the metavar/dest for display.
+        if is_option:
+            opts: tuple[str, ...] = tuple(action.option_strings)
+        else:
+            opts = (action.metavar or param_name,)
+
+        type_name = self._argparse_type_name(action)
+        description = sanitize_text(action.help)
+
+        # A store_true/store_false/store_const optional with nargs==0 is a flag.
+        is_flag = is_option and action.nargs == 0
+        # `count` actions (-vvv) expose nargs==0 and integer accumulation.
+        is_count = is_option and action.__class__.__name__ == "_CountAction"
+        # Positionals are required unless they accept zero values.
+        required = bool(action.required) if is_option else action.nargs not in ("?", "*")
+        multiple = action.nargs in ("*", "+") or action.__class__.__name__ == "_AppendAction"
+
+        default = _format_default_value(action.default)
+
+        metadata: dict[str, Any] = {
+            "param_type": element_type,
+            "type": type_name,
+            "required": required,
+            "default": default,
+            "multiple": multiple,
+            "is_flag": is_flag,
+            "count": is_count,
+            "opts": list(opts),
+        }
+
+        if action.choices is not None:
+            # _SubParsersAction is filtered upstream, so choices here are values.
+            metadata["choices"] = [str(c) for c in action.choices]
+
+        typed_meta = CLIOptionMetadata(
+            name=param_name or "",
+            param_type="argument" if element_type == "argument" else "option",
+            type_name=type_name.upper() if type_name else "STRING",
+            required=required,
+            default=default,
+            multiple=multiple,
+            is_flag=is_flag,
+            count=is_count,
+            opts=opts,
+            envvar=None,
+            help_text=action.help or "",
+        )
+
+        return DocElement(
+            name=param_name or "",
+            qualified_name=f"{parent_name}.{param_name or ''}",
+            description=description,
+            element_type=element_type,
+            source_file=None,
+            line_number=None,
+            metadata=metadata,
+            typed_metadata=typed_meta,
+            children=[],
+            examples=[],
+            see_also=[],
+            deprecated=None,
+        )
+
+    @staticmethod
+    def _argparse_type_name(action: Any) -> str:
+        """
+        Derive a display type name for an argparse Action.
+
+        Args:
+            action: argparse.Action instance
+
+        Returns:
+            Lowercase type name (e.g. 'int', 'str', 'bool', 'any')
+        """
+        # store_true/store_false present as booleans regardless of `type`.
+        if action.__class__.__name__ in ("_StoreTrueAction", "_StoreFalseAction"):
+            return "bool"
+
+        action_type = action.type
+        if action_type is None:
+            return "str" if action.option_strings or action.dest else "any"
+        return getattr(action_type, "__name__", str(action_type)).lower()
 
     def _extract_from_typer(self, app: Any) -> list[DocElement]:
         """

--- a/changelog.d/493.added.md
+++ b/changelog.d/493.added.md
@@ -1,0 +1,1 @@
+Autodoc CLI extraction now supports argparse: point it at an `argparse.ArgumentParser` with `framework="argparse"` and it documents subcommands, positional arguments, and options just like the Click and Typer paths.

--- a/tests/unit/autodoc/test_cli_extractor.py
+++ b/tests/unit/autodoc/test_cli_extractor.py
@@ -2,6 +2,7 @@
 Tests for CLI documentation extractor.
 """
 
+import argparse
 from pathlib import Path
 
 import click
@@ -996,3 +997,218 @@ class TestMiloExtractor:
         greet = next(e for e in elements if e.name == "greet")
         loud_param = next(p for p in greet.children if p.name == "loud")
         assert "--loud" in loud_param.metadata["opts"]
+
+
+# ============================================================================
+# argparse Tests
+# ============================================================================
+
+
+def _build_sample_argparse_cli():
+    """Build a sample argparse parser with subcommands for testing."""
+    parser = argparse.ArgumentParser(prog="argtool", description="A sample argparse application")
+    subparsers = parser.add_subparsers(dest="command")
+
+    process = subparsers.add_parser("process", help="Process a file")
+    process.add_argument("filename", help="File to process")
+    process.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+    process.add_argument("-c", "--count", type=int, default=1, help="Number of times to process")
+
+    clean = subparsers.add_parser("clean", help="Clean up resources")
+    clean.add_argument("-f", "--force", action="store_true", help="Force the operation")
+
+    return parser
+
+
+class TestArgparseExtractor:
+    """Tests for argparse CLI extraction."""
+
+    def test_extract_root(self):
+        """Test extracting the root argparse parser as a command-group."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        assert len(elements) >= 1
+        root = elements[0]
+        assert root.name == "argtool"
+        assert root.element_type == "command-group"
+        assert "sample argparse application" in root.description
+
+    def test_extract_commands(self):
+        """Test that subcommands are extracted."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        command_names = [e.name for e in elements if e.element_type == "command"]
+        assert "process" in command_names
+        assert "clean" in command_names
+
+    def test_command_help_from_subparsers_table(self):
+        """Test that the subparsers help= becomes the command description."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        clean_cmd = next(e for e in elements if e.name == "clean")
+        assert "Clean up resources" in clean_cmd.description
+
+    def test_positional_is_argument(self):
+        """Test that positional arguments are extracted as arguments."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        process_cmd = next(e for e in elements if e.name == "process")
+        arguments = [p for p in process_cmd.children if p.element_type == "argument"]
+        arg_names = [a.name for a in arguments]
+        assert "filename" in arg_names
+
+        filename = next(a for a in arguments if a.name == "filename")
+        assert filename.metadata["required"] is True
+
+    def test_optionals_are_options(self):
+        """Test that optionals are extracted as options."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        process_cmd = next(e for e in elements if e.name == "process")
+        option_names = [p.name for p in process_cmd.children if p.element_type == "option"]
+        assert "verbose" in option_names
+        assert "count" in option_names
+
+    def test_help_action_skipped(self):
+        """Test that the implicit -h/--help action is not emitted."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        process_cmd = next(e for e in elements if e.name == "process")
+        names = [p.name for p in process_cmd.children]
+        assert "help" not in names
+
+    def test_store_true_is_flag(self):
+        """Test that store_true optionals are detected as flags of type bool."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        process_cmd = next(e for e in elements if e.name == "process")
+        verbose = next(p for p in process_cmd.children if p.name == "verbose")
+        assert verbose.metadata["is_flag"] is True
+        assert verbose.metadata["type"] == "bool"
+        assert "-v" in verbose.metadata["opts"]
+        assert "--verbose" in verbose.metadata["opts"]
+
+    def test_typed_option_metadata(self):
+        """Test that typed options expose type and default."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        process_cmd = next(e for e in elements if e.name == "process")
+        count = next(p for p in process_cmd.children if p.name == "count")
+        assert count.metadata["type"] == "int"
+        assert count.metadata["default"] == "1"
+        assert count.metadata["is_flag"] is False
+
+    def test_qualified_names(self):
+        """Test that qualified names are hierarchical."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        process_cmd = next(e for e in elements if e.name == "process")
+        assert process_cmd.qualified_name == "argtool.process"
+
+    def test_output_paths(self):
+        """Test that output paths are generated correctly."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        root = elements[0]
+        assert extractor.get_output_path(root) == Path("_index.md")
+
+        process_cmd = next(e for e in elements if e.name == "process")
+        assert extractor.get_output_path(process_cmd) == Path("process.md")
+
+    def test_command_count_metadata(self):
+        """Test that the root group reports its command count."""
+        parser = _build_sample_argparse_cli()
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        root = elements[0]
+        assert root.metadata["command_count"] == 2
+
+    def test_nested_subparsers(self):
+        """Test that nested subparsers are extracted as nested command-groups."""
+        parser = argparse.ArgumentParser(prog="argtool", description="root")
+        sub = parser.add_subparsers(dest="command")
+        manage = sub.add_parser("manage", help="Manage resources")
+        manage_sub = manage.add_subparsers(dest="manage_command")
+        create = manage_sub.add_parser("create", help="Create a resource")
+        create.add_argument("name", help="Resource name")
+
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        group_names = [e.name for e in elements if e.element_type == "command-group"]
+        assert "manage" in group_names
+
+        create_cmd = next(e for e in elements if e.name == "create")
+        assert create_cmd.qualified_name == "argtool.manage.create"
+        assert extractor.get_output_path(create_cmd) == Path("manage/create.md")
+
+    def test_flat_parser_without_subcommands(self):
+        """Test that a parser without subparsers becomes a single command."""
+        parser = argparse.ArgumentParser(prog="flat", description="A flat tool")
+        parser.add_argument("path", help="Input path")
+        parser.add_argument("--dry-run", action="store_true", help="Dry run")
+
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        assert len(elements) == 1
+        root = elements[0]
+        assert root.element_type == "command"
+        assert root.name == "flat"
+        child_names = [c.name for c in root.children]
+        assert "path" in child_names
+        assert "dry_run" in child_names
+
+    def test_optional_positional_not_required(self):
+        """Test that a positional with nargs='?' is not required."""
+        parser = argparse.ArgumentParser(prog="flat")
+        parser.add_argument("maybe", nargs="?", help="Optional positional")
+
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        root = elements[0]
+        maybe = next(c for c in root.children if c.name == "maybe")
+        assert maybe.element_type == "argument"
+        assert maybe.metadata["required"] is False
+
+    def test_choices_captured(self):
+        """Test that argparse choices are captured in metadata."""
+        parser = argparse.ArgumentParser(prog="flat")
+        parser.add_argument("--mode", choices=["fast", "slow"], help="Mode")
+
+        extractor = CLIExtractor(framework="argparse")
+        elements = extractor.extract(parser)
+
+        root = elements[0]
+        mode = next(c for c in root.children if c.name == "mode")
+        assert mode.metadata["choices"] == ["fast", "slow"]
+
+    def test_wrong_source_type_raises(self):
+        """Test that passing a non-parser raises a clear error."""
+        from bengal.errors import BengalDiscoveryError
+
+        extractor = CLIExtractor(framework="argparse")
+        with pytest.raises(BengalDiscoveryError, match="argparse"):
+            extractor.extract("not a parser")


### PR DESCRIPTION
## Summary

- Implements argparse extraction in the autodoc CLI extractor, parallel to the existing Click/Typer/milo paths. Previously `CLIExtractor(framework="argparse")` constructed fine but raised `NotImplementedError` only at extract time (a late-failure sharp edge).
- The root `ArgumentParser` becomes a `command-group`; each subparser (from `add_subparsers().add_parser(...)`) becomes a `command`, recursively for nested subparsers. Positionals map to `argument` elements, optionals to `option` elements.
- The implicit `-h/--help` action is skipped; `store_true`/`store_false` optionals are reported as boolean flags; `choices`, defaults, required-ness, and multiplicity (`nargs`) are captured in metadata. A flat parser (no subparsers) is emitted as a single `command`.
- Corrects the stale `argparse (planned)` / `Typer (planned)` support docstring at the top of `CLIExtractor` (both are now implemented).

## Proof

- [x] Focused tests: `uv run pytest tests -k "autodoc and (cli or argparse or extractor)" -q` → 156 passed, 20 skipped (skips are Typer-not-installed and site-not-built integration cases, pre-existing).
- [x] New `TestArgparseExtractor` (16 tests) extracts real `argparse.ArgumentParser` instances: subcommands, nested subparsers, positionals-as-arguments, optionals-as-options, store_true flags, typed defaults, choices, qualified names, output paths, flat parser, and the construction-vs-extract error path.
- [x] Docs/examples/changelog updated: `changelog.d/493.added.md` (added; leads with the user-facing sentence). `uv run poe changelog-lint` clean.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable — autodoc CLI extraction is build-time documentation introspection, not a hot path or concurrent/free-threaded code; no performance claim made.

## Steward Notes

- argparse exposes its structure via private members (`_actions`, `_SubParsersAction`, `_choices_actions`); these are stable across supported CPython versions and are the same surface the stdlib's own help formatter reads. No public alternative exists.
- `argparse` is imported inside the methods (deferred) consistent with the file's other framework branches.

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)
