### PR TITLE
feat(health): autofix broken internal links (typo, moved-page, anchor)

### DIFF
--- a/bengal/cli/milo_commands/fix.py
+++ b/bengal/cli/milo_commands/fix.py
@@ -127,6 +127,7 @@ def fix(
 
     cli.blank()
     fixes_to_apply = safe_fixes.copy()
+    confirmed = False
 
     if (
         (all or confirm)
@@ -134,6 +135,7 @@ def fix(
         and cli.confirm(f"Apply {len(confirm_fixes)} fix(es) requiring confirmation?")
     ):
         fixes_to_apply.extend(confirm_fixes)
+        confirmed = True
 
     if not fixes_to_apply:
         cli.info("No fixes to apply")
@@ -146,7 +148,7 @@ def fix(
         }
 
     cli.info(f"Applying {len(fixes_to_apply)} fix(es)...")
-    results = fixer.apply_fixes(fixes_to_apply)
+    results = fixer.apply_fixes(fixes_to_apply, confirmed=confirmed)
 
     cli.blank()
     cli.render_write(

--- a/bengal/health/remediation/autofix.py
+++ b/bengal/health/remediation/autofix.py
@@ -12,7 +12,7 @@ UNSAFE: Requires manual review (complex changes)
 
 Supported Fixes:
 - Directive fence nesting: Adjusts fence depths for proper nesting hierarchy
-- Link fixes: (Future) Typo detection and moved page reference updates
+- Link fixes: Typo detection, moved-page reference updates, and anchor fixes
 
 Architecture:
 AutoFixer analyzes HealthReport results and generates FixAction objects.
@@ -35,6 +35,7 @@ Example:
 
 from __future__ import annotations
 
+import difflib
 import re
 from dataclasses import dataclass
 from enum import Enum
@@ -131,7 +132,7 @@ class AutoFixer:
 
     Supported Fix Types:
         directive_fence: Adjusts fence depths for proper MyST directive nesting
-        link_update: (Future) Fix broken internal links, update moved pages
+        link_update: Fix broken internal links (typo, moved-page, anchor)
 
     Design Principles:
         - Fixes are atomic and file-local (no cross-file dependencies)
@@ -905,20 +906,356 @@ class AutoFixer:
 
     def _suggest_link_fixes(self, validator_report: Any) -> list[FixAction]:
         """
-        Suggest fixes for link validation errors.
+        Suggest fixes for broken internal link validation errors.
 
-        Future implementation will support:
-            - Typo detection for broken internal links
-            - Automatic updates for moved page references
-            - Anchor fixes for renamed headings
+        For each broken *internal* link the Links validator reported, this
+        proposes a concrete rewrite by comparing the link against the set of
+        valid URL paths derived from the site's content tree:
+
+            - **Typo / closest-match**: the link path is one small edit away
+              from a real page URL (e.g. ``/docs/instalation/`` ->
+              ``/docs/installation/``).
+            - **Moved page**: the link's final slug still exists, but at a
+              different location, so the whole path is updated.
+            - **Anchor fix**: the page resolves but the ``#fragment`` does not;
+              the closest heading anchor on the target page is suggested.
+
+        External links (``http(s)://``, ``mailto:``, ``tel:``) are skipped --
+        they are not fixable from local content.
+
+        FixActions are emitted at ``FixSafety.CONFIRM`` because rewriting a
+        cross-reference is a content change a human should eyeball before it is
+        applied, mirroring the framework's guidance for cross-reference edits.
 
         Args:
-            validator_report: ValidatorReport from Links validator.
+            validator_report: ValidatorReport from the Links validator.
 
         Returns:
-            List of FixAction objects (currently empty, future implementation).
+            List of FixAction objects rewriting broken internal links.
         """
-        return []
+        fixes: list[FixAction] = []
+
+        # Corpus of valid internal URL paths derived from the content tree.
+        valid_url_paths = self._valid_url_paths()
+        if not valid_url_paths:
+            return fixes
+
+        # Map each valid path's final slug -> set of full paths (for moved-page).
+        slug_index: dict[str, set[str]] = {}
+        for url_path in valid_url_paths:
+            slug = url_path.rstrip("/").rsplit("/", 1)[-1]
+            if slug:
+                slug_index.setdefault(slug, set()).add(url_path)
+
+        seen: set[tuple[str, str]] = set()
+        for result in validator_report.results:
+            if result.status.value != "error":
+                continue
+            for source_path, link in self._iter_broken_links(result):
+                if self._is_external_link(link):
+                    continue
+                key = (str(source_path), link)
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                suggestion = self._suggest_link_target(link, valid_url_paths, slug_index)
+                if suggestion is None:
+                    continue
+                suggested, kind = suggestion
+
+                source_file = self._resolve_source_file(source_path)
+                if source_file is None:
+                    continue
+
+                try:
+                    rel_path = source_file.relative_to(self.site_root)
+                except ValueError:
+                    rel_path = source_file
+
+                fixes.append(
+                    FixAction(
+                        description=(
+                            f"Fix broken link in {rel_path}: {link} -> {suggested} ({kind})"
+                        ),
+                        file_path=source_file,
+                        line_number=None,
+                        fix_type="link_update",
+                        safety=FixSafety.CONFIRM,
+                        apply=self._create_link_fix(source_file, link, suggested),
+                        check_result=result,
+                    )
+                )
+
+        return fixes
+
+    @staticmethod
+    def _is_external_link(link: str) -> bool:
+        """Return True for links this fixer cannot resolve from local content."""
+        lowered = link.strip().lower()
+        return lowered.startswith(("http://", "https://", "mailto:", "tel:", "//"))
+
+    def _iter_broken_links(self, result: Any) -> list[tuple[str, str]]:
+        """
+        Extract ``(source_path, broken_link)`` pairs from a Links CheckResult.
+
+        Prefers structured ``metadata`` (``source_path`` + ``broken_links``) and
+        falls back to parsing ``details`` lines of the form
+        ``"<relative-source>: <broken-link>"`` -- the same dual strategy the
+        directive fixer uses.
+        """
+        pairs: list[tuple[str, str]] = []
+
+        metadata = getattr(result, "metadata", None) or {}
+        source = metadata.get("source_path")
+        links = metadata.get("broken_links")
+        if isinstance(source, str) and isinstance(links, list):
+            pairs.extend((source, link) for link in links if isinstance(link, str) and link)
+            if pairs:
+                return pairs
+
+        for detail in getattr(result, "details", None) or []:
+            if not isinstance(detail, str) or ": " not in detail:
+                continue
+            source_part, _, link_part = detail.partition(": ")
+            source_part = source_part.strip()
+            link_part = link_part.strip()
+            if source_part and link_part and source_part != "<unknown>":
+                pairs.append((source_part, link_part))
+
+        return pairs
+
+    def _resolve_source_file(self, source_path: str) -> Path | None:
+        """Resolve a (possibly site-relative) source path to an existing file."""
+        candidate = Path(source_path)
+        if candidate.is_absolute() and candidate.exists():
+            return candidate.resolve()
+
+        rooted = (self.site_root / candidate).resolve()
+        if rooted.exists():
+            return rooted
+
+        # Fall back to a recursive search by basename (details may be relative).
+        matches = list(self.site_root.rglob(candidate.name))
+        for match in matches[:1]:
+            if match.exists():
+                return match.resolve()
+        return None
+
+    def _valid_url_paths(self) -> set[str]:
+        """
+        Build the set of valid internal URL paths from the content tree.
+
+        Walks markdown sources under ``<site_root>/content`` (falling back to the
+        site root) and reconstructs each file's pretty URL path. This is the
+        corpus the broken-link suggester matches against; it intentionally lives
+        entirely on disk so the fixer stays file-local with no live ``Site``.
+        """
+        content_root = self.site_root / "content"
+        if not content_root.is_dir():
+            content_root = self.site_root
+
+        paths: set[str] = set()
+        for md in content_root.rglob("*.md"):
+            url_path = self._content_file_to_url_path(md, content_root)
+            if url_path:
+                paths.add(url_path)
+        for md in content_root.rglob("*.markdown"):
+            url_path = self._content_file_to_url_path(md, content_root)
+            if url_path:
+                paths.add(url_path)
+        return paths
+
+    @staticmethod
+    def _content_file_to_url_path(md_file: Path, content_root: Path) -> str | None:
+        """
+        Map a content file to its pretty URL path (leading + trailing slash).
+
+        ``content/docs/guide.md``    -> ``/docs/guide/``
+        ``content/docs/_index.md``   -> ``/docs/``
+        ``content/_index.md``        -> ``/``
+        """
+        try:
+            rel = md_file.relative_to(content_root)
+        except ValueError:
+            return None
+
+        parts = list(rel.parts)
+        if not parts:
+            return None
+
+        stem = Path(parts[-1]).stem
+        if stem in {"_index", "index"}:
+            dir_parts = parts[:-1]
+            if not dir_parts:
+                return "/"
+            return "/" + "/".join(dir_parts) + "/"
+
+        dir_parts = parts[:-1]
+        return "/" + "/".join([*dir_parts, stem]) + "/"
+
+    def _suggest_link_target(
+        self,
+        link: str,
+        valid_url_paths: set[str],
+        slug_index: dict[str, set[str]],
+    ) -> tuple[str, str] | None:
+        """
+        Compute the best suggested replacement for a broken internal link.
+
+        Returns ``(suggested_link, kind)`` where ``kind`` is one of
+        ``"typo"``, ``"moved-page"`` or ``"anchor"``; ``None`` when no
+        confident suggestion exists.
+        """
+        path_part, _, fragment = link.partition("#")
+        normalized = self._normalize_path(path_part)
+
+        # Anchor-only fix: the page resolves, but the fragment does not.
+        if fragment and normalized in valid_url_paths:
+            anchor_suggestion = self._suggest_anchor(normalized, fragment)
+            if anchor_suggestion is not None:
+                return (f"{path_part}#{anchor_suggestion}", "anchor")
+            return None
+
+        if normalized in valid_url_paths:
+            return None  # Path is fine; nothing to fix here.
+
+        # Moved-page: the final slug is unique somewhere else in the tree.
+        slug = normalized.rstrip("/").rsplit("/", 1)[-1]
+        candidates = slug_index.get(slug, set()) - {normalized}
+        if len(candidates) == 1:
+            target = next(iter(candidates))
+            if target != normalized:
+                suggested = target + (f"#{fragment}" if fragment else "")
+                return (suggested, "moved-page")
+
+        # Typo / closest-match against the full set of valid paths.
+        close = difflib.get_close_matches(normalized, sorted(valid_url_paths), n=1, cutoff=0.8)
+        if close and close[0] != normalized:
+            suggested = close[0] + (f"#{fragment}" if fragment else "")
+            return (suggested, "typo")
+
+        return None
+
+    @staticmethod
+    def _normalize_path(path_part: str) -> str:
+        """Normalize a URL path to the canonical ``/.../`` form for comparison."""
+        path = path_part.strip()
+        if not path:
+            return "/"
+        if not path.startswith("/"):
+            path = "/" + path
+        # Strip an ``index.html``/``.html`` suffix to compare pretty URLs.
+        if path.endswith("index.html"):
+            path = path[: -len("index.html")]
+        elif path.endswith(".html"):
+            path = path[: -len(".html")] + "/"
+        if not path.endswith("/"):
+            path += "/"
+        return path
+
+    def _suggest_anchor(self, url_path: str, fragment: str) -> str | None:
+        """
+        Suggest the closest heading anchor on the page at ``url_path``.
+
+        Reads the target content file's ATX headings, slugifies them, and
+        returns the closest match to ``fragment`` (or ``None`` if none is
+        close enough).
+        """
+        source_file = self._content_file_for_url_path(url_path)
+        if source_file is None:
+            return None
+
+        try:
+            content = source_file.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+        anchors = [
+            self._slugify_heading(m.group(2))
+            for m in re.finditer(r"^(#{1,6})\s+(.+?)\s*#*\s*$", content, re.MULTILINE)
+        ]
+        anchors = [a for a in anchors if a]
+        if not anchors or fragment in anchors:
+            return None
+
+        close = difflib.get_close_matches(fragment, anchors, n=1, cutoff=0.7)
+        return close[0] if close else None
+
+    def _content_file_for_url_path(self, url_path: str) -> Path | None:
+        """Reverse-map a pretty URL path back to its content source file."""
+        content_root = self.site_root / "content"
+        if not content_root.is_dir():
+            content_root = self.site_root
+
+        normalized = self._normalize_path(url_path)
+        for md in content_root.rglob("*.md"):
+            if self._content_file_to_url_path(md, content_root) == normalized:
+                return md
+        return None
+
+    @staticmethod
+    def _slugify_heading(text: str) -> str:
+        """Slugify a heading the way most static-site anchor generators do."""
+        slug = text.strip().lower()
+        slug = re.sub(r"[^\w\s-]", "", slug)
+        slug = re.sub(r"[\s_]+", "-", slug)
+        return slug.strip("-")
+
+    def _create_link_fix(self, file_path: Path, old_link: str, new_link: str) -> Any:
+        """
+        Create a fix callable that rewrites ``old_link`` to ``new_link`` in a file.
+
+        The rewrite is an exact, link-token replacement inside markdown/HTML link
+        syntax (``](old)``, ``href="old"``, ``href='old'``) so unrelated text
+        that merely contains the substring is never touched. Writes go through
+        the crash-safe ``atomic_write_text`` helper, like the fence fixer.
+        """
+
+        def apply_fix() -> bool:
+            try:
+                if not file_path.exists():
+                    return False
+
+                content = file_path.read_text(encoding="utf-8")
+
+                replacements = [
+                    (f"]({old_link})", f"]({new_link})"),
+                    (f'href="{old_link}"', f'href="{new_link}"'),
+                    (f"href='{old_link}'", f"href='{new_link}'"),
+                    (f"]({old_link} ", f"]({new_link} "),
+                ]
+
+                new_content = content
+                changed = False
+                for old_token, new_token in replacements:
+                    if old_token in new_content:
+                        new_content = new_content.replace(old_token, new_token)
+                        changed = True
+
+                if not changed:
+                    return False
+
+                atomic_write_text(file_path, new_content, encoding="utf-8")
+                return True
+
+            except Exception as e:
+                import traceback
+
+                from bengal.errors import ErrorCode
+
+                logger.error(
+                    "autofix_apply_failed",
+                    file_path=str(file_path),
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    error_code=ErrorCode.V003.value,
+                    suggestion="Check file permissions and content syntax. See autofix docs for supported fix types.",
+                )
+                traceback.print_exc()
+                return False
+
+        return apply_fix
 
     def apply_fixes(self, fixes: list[FixAction] | None = None) -> dict[str, Any]:
         """

--- a/bengal/health/remediation/autofix.py
+++ b/bengal/health/remediation/autofix.py
@@ -114,12 +114,26 @@ class FixAction:
 
     def can_apply(self) -> bool:
         """
-        Check if this fix can be applied automatically.
+        Check if this fix can be applied automatically (without confirmation).
 
         Returns:
             True if safety is SAFE and apply callable is set.
         """
         return self.safety == FixSafety.SAFE and self.apply is not None
+
+    def can_apply_confirmed(self) -> bool:
+        """
+        Check if this fix may be applied once the user has confirmed it.
+
+        CONFIRM fixes (e.g. heuristic broken-link rewrites) are not eligible for
+        unattended application, but they may be applied after an explicit
+        confirmation. UNSAFE fixes still require manual review and are never
+        eligible here.
+
+        Returns:
+            True if safety is SAFE or CONFIRM and apply callable is set.
+        """
+        return self.safety in (FixSafety.SAFE, FixSafety.CONFIRM) and self.apply is not None
 
 
 class AutoFixer:
@@ -1257,7 +1271,9 @@ class AutoFixer:
 
         return apply_fix
 
-    def apply_fixes(self, fixes: list[FixAction] | None = None) -> dict[str, Any]:
+    def apply_fixes(
+        self, fixes: list[FixAction] | None = None, *, confirmed: bool = False
+    ) -> dict[str, Any]:
         """
         Apply specified fixes to files.
 
@@ -1265,8 +1281,15 @@ class AutoFixer:
         failure, and skip counts. Fixes that cannot be applied (wrong safety
         level or missing callable) are skipped.
 
+        By default only SAFE fixes are applied (``can_apply()``); CONFIRM fixes
+        are skipped. When ``confirmed=True`` the caller asserts the user has
+        explicitly approved the supplied fixes, so SAFE *and* CONFIRM fixes are
+        applied (``can_apply_confirmed()``). UNSAFE fixes are never applied here
+        regardless of ``confirmed`` -- they require manual review.
+
         Args:
             fixes: List of FixAction to apply. If None, uses self.fixes.
+            confirmed: If True, also apply CONFIRM fixes the user has approved.
 
         Returns:
             Dict with counts: {"applied": N, "failed": M, "skipped": K}
@@ -1279,7 +1302,8 @@ class AutoFixer:
         skipped = 0
 
         for fix in fixes:
-            if not fix.can_apply():
+            eligible = fix.can_apply_confirmed() if confirmed else fix.can_apply()
+            if not eligible:
                 skipped += 1
                 continue
 

--- a/changelog.d/491.added.md
+++ b/changelog.d/491.added.md
@@ -1,0 +1,1 @@
+`bengal fix` now suggests and applies fixes for broken internal links — correcting typos in a page path, re-pointing a link to a page that moved, and fixing a stale `#anchor` — instead of only fixing directive fences. Link rewrites are offered as confirm-before-apply fixes so you can review each one.

--- a/tests/unit/health/test_autofix_link_fixes.py
+++ b/tests/unit/health/test_autofix_link_fixes.py
@@ -1,0 +1,186 @@
+"""
+Broken-link autofix suggestions for the Links validator (issue #491).
+
+``AutoFixer._suggest_link_fixes`` used to be a hard-coded ``return []`` despite a
+docstring promising typo / moved-page / anchor fixes. These tests pin the real
+behavior: for a broken *internal* link reported by the Links validator, the
+fixer must emit a concrete ``FixAction`` that rewrites the link to a valid
+target, and the produced ``apply`` callable must actually rewrite the source.
+
+Every "non-empty" assertion here is discriminating: if the method body regresses
+to ``return []`` (or stops matching), the lists go empty and the asserts fail.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bengal.health.remediation.autofix import AutoFixer, FixSafety
+from bengal.health.report import CheckResult, HealthReport, ValidatorReport
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _build_content_tree(root: Path) -> None:
+    """A small but realistic content tree used as the valid-URL corpus."""
+    content = root / "content"
+    _write(content / "_index.md", "# Home\n")
+    _write(
+        content / "docs" / "installation.md",
+        "# Installation\n\n## Getting Started\n\nbody\n",
+    )
+    _write(content / "docs" / "configuration.md", "# Configuration\n")
+    # A page that lives under guides/ -- its slug ('configuration') also exists
+    # under docs/, so a moved-page suggestion must stay unambiguous: we make the
+    # broken-link slug unique to one location below.
+    _write(content / "guides" / "deployment.md", "# Deployment\n")
+
+
+def _links_report(root: Path, *results: CheckResult) -> tuple[HealthReport, AutoFixer]:
+    vr = ValidatorReport(validator_name="Links", results=list(results))
+    report = HealthReport(validator_reports=[vr])
+    return report, AutoFixer(report, site_root=root)
+
+
+def test_typo_link_produces_real_fix_action(tmp_path):
+    """A one-edit typo in an internal link path yields a rewrite FixAction.
+
+    Discriminating: with ``return []`` the suggestions list is empty and this
+    fails. The link ``/docs/instalation/`` is one edit from the real page
+    ``/docs/installation/``.
+    """
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    _write(source, "# Configuration\n\nSee [install](/docs/instalation/).\n")
+
+    result = CheckResult.error(
+        "1 broken internal link(s)",
+        code="H101",
+        details=["content/docs/configuration.md: /docs/instalation/"],
+    )
+    _report, fixer = _links_report(tmp_path, result)
+
+    fixes = fixer.suggest_fixes()
+    link_fixes = [f for f in fixes if f.fix_type == "link_update"]
+
+    assert link_fixes, "expected a broken-link FixAction (regression to [] fails here)"
+    fix = link_fixes[0]
+    assert fix.safety == FixSafety.CONFIRM
+    assert "/docs/installation/" in fix.description
+    assert fix.file_path == source
+    assert fix.check_result is result
+
+
+def test_typo_fix_apply_rewrites_the_source_link(tmp_path):
+    """The produced ``apply`` callable rewrites the broken link in the file."""
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    body = "# Configuration\n\nSee [install](/docs/instalation/).\n"
+    _write(source, body)
+
+    result = CheckResult.error(
+        "1 broken internal link(s)",
+        code="H101",
+        details=["content/docs/configuration.md: /docs/instalation/"],
+    )
+    _report, fixer = _links_report(tmp_path, result)
+
+    fix = next(f for f in fixer.suggest_fixes() if f.fix_type == "link_update")
+    assert fix.apply() is True
+
+    rewritten = source.read_text(encoding="utf-8")
+    assert "/docs/installation/" in rewritten
+    assert "/docs/instalation/" not in rewritten
+    # Surrounding prose is untouched.
+    assert rewritten.startswith("# Configuration")
+
+
+def test_moved_page_uses_unique_slug_match(tmp_path):
+    """A link whose slug exists at exactly one *other* path is re-pointed there.
+
+    ``/old/deployment/`` does not exist, but ``deployment`` lives uniquely at
+    ``/guides/deployment/``, so the fixer suggests the moved path.
+    """
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    _write(source, "# Configuration\n\nSee [deploy](/old/deployment/).\n")
+
+    result = CheckResult.error(
+        "1 broken internal link(s)",
+        code="H101",
+        metadata={
+            "source_path": str(source),
+            "broken_links": ["/old/deployment/"],
+        },
+    )
+    _report, fixer = _links_report(tmp_path, result)
+
+    link_fixes = [f for f in fixer.suggest_fixes() if f.fix_type == "link_update"]
+    assert link_fixes, "expected a moved-page FixAction"
+    assert "/guides/deployment/" in link_fixes[0].description
+    assert "moved-page" in link_fixes[0].description
+
+
+def test_anchor_fix_suggests_closest_heading(tmp_path):
+    """A valid page with a bad ``#fragment`` gets the closest heading anchor.
+
+    ``/docs/installation/`` exists and has a "## Getting Started" heading
+    (slug ``getting-started``); the broken ``#getting-startd`` is corrected.
+    """
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    _write(source, "# Configuration\n\n[start](/docs/installation/#getting-startd)\n")
+
+    result = CheckResult.error(
+        "1 broken internal link(s)",
+        code="H101",
+        details=["content/docs/configuration.md: /docs/installation/#getting-startd"],
+    )
+    _report, fixer = _links_report(tmp_path, result)
+
+    link_fixes = [f for f in fixer.suggest_fixes() if f.fix_type == "link_update"]
+    assert link_fixes, "expected an anchor FixAction"
+    fix = link_fixes[0]
+    assert "#getting-started" in fix.description
+    assert "anchor" in fix.description
+
+    assert fix.apply() is True
+    assert "#getting-started" in source.read_text(encoding="utf-8")
+
+
+def test_external_links_are_not_suggested(tmp_path):
+    """External links are out of scope and produce no FixActions."""
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    _write(source, "# Configuration\n")
+
+    result = CheckResult.warning(
+        "1 broken external link(s)",
+        code="H102",
+        details=["content/docs/configuration.md: https://example.invalid/missing"],
+    )
+    _report, fixer = _links_report(tmp_path, result)
+
+    assert [f for f in fixer.suggest_fixes() if f.fix_type == "link_update"] == []
+
+
+def test_unfixable_link_yields_no_suggestion(tmp_path):
+    """A link with no close valid target produces no (misleading) suggestion."""
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    _write(source, "# Configuration\n")
+
+    result = CheckResult.error(
+        "1 broken internal link(s)",
+        code="H101",
+        details=["content/docs/configuration.md: /this/path/is/totally/unrelated/"],
+    )
+    _report, fixer = _links_report(tmp_path, result)
+
+    assert [f for f in fixer.suggest_fixes() if f.fix_type == "link_update"] == []

--- a/tests/unit/health/test_autofix_link_fixes.py
+++ b/tests/unit/health/test_autofix_link_fixes.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from bengal.health.remediation.autofix import AutoFixer, FixSafety
+from bengal.health.remediation.autofix import AutoFixer, FixAction, FixSafety
 from bengal.health.report import CheckResult, HealthReport, ValidatorReport
 
 if TYPE_CHECKING:
@@ -184,3 +184,122 @@ def test_unfixable_link_yields_no_suggestion(tmp_path):
     _report, fixer = _links_report(tmp_path, result)
 
     assert [f for f in fixer.suggest_fixes() if f.fix_type == "link_update"] == []
+
+
+# ---------------------------------------------------------------------------
+# Full apply-path coverage (issue #491 reviewer regression).
+#
+# The suggestion tests above call ``fix.apply()`` directly, which bypasses the
+# ``can_apply()`` gate inside ``AutoFixer.apply_fixes()`` -- the *only* route the
+# ``bengal fix`` CLI uses. Link fixes are emitted at FixSafety.CONFIRM, and
+# ``can_apply()`` is True only for SAFE, so a confirmed CONFIRM link fix used to
+# be counted "skipped" and its callable never invoked. These tests exercise the
+# real apply path so a regression to that behavior fails here.
+# ---------------------------------------------------------------------------
+
+
+def _typo_fixer(tmp_path):
+    """Build a fixer carrying exactly one CONFIRM link fix for a typo'd link."""
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    _write(source, "# Configuration\n\nSee [install](/docs/instalation/).\n")
+
+    result = CheckResult.error(
+        "1 broken internal link(s)",
+        code="H101",
+        details=["content/docs/configuration.md: /docs/instalation/"],
+    )
+    _report, fixer = _links_report(tmp_path, result)
+    fixer.suggest_fixes()
+    return fixer, source
+
+
+def test_confirmed_link_fix_applies_through_apply_fixes(tmp_path):
+    """A confirmed CONFIRM link fix is applied (0->1) and rewrites the file.
+
+    Discriminating: on the pre-fix code ``apply_fixes`` gates on ``can_apply()``
+    (SAFE only), so this CONFIRM fix is *skipped* -- ``applied`` stays 0 and the
+    file is unchanged. This is the exact reviewer-reproduced regression.
+    """
+    fixer, source = _typo_fixer(tmp_path)
+    link_fixes = [f for f in fixer.fixes if f.fix_type == "link_update"]
+    assert link_fixes, "fixture must produce a CONFIRM link fix"
+    assert link_fixes[0].safety == FixSafety.CONFIRM
+
+    results = fixer.apply_fixes(link_fixes, confirmed=True)
+
+    assert results["applied"] == 1, results
+    assert results["skipped"] == 0, results
+    rewritten = source.read_text(encoding="utf-8")
+    assert "/docs/installation/" in rewritten
+    assert "/docs/instalation/" not in rewritten
+
+
+def test_unconfirmed_link_fix_is_not_applied(tmp_path):
+    """Without confirmation a CONFIRM link fix is skipped and the file is intact.
+
+    This pins the safety model: CONFIRM fixes must NOT auto-apply. If
+    ``apply_fixes`` ever applied CONFIRM fixes unconditionally this fails.
+    """
+    fixer, source = _typo_fixer(tmp_path)
+    link_fixes = [f for f in fixer.fixes if f.fix_type == "link_update"]
+    before = source.read_text(encoding="utf-8")
+
+    results = fixer.apply_fixes(link_fixes)  # confirmed defaults to False
+
+    assert results["applied"] == 0, results
+    assert results["skipped"] == 1, results
+    assert source.read_text(encoding="utf-8") == before
+
+
+def test_safe_fix_still_auto_applies_without_confirmation(tmp_path):
+    """A SAFE fix is applied through the unconfirmed path (no regression)."""
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    _write(source, "# Configuration\n")
+    marker = {"count": 0}
+
+    def _apply():
+        marker["count"] += 1
+        return True
+
+    _report, fixer = _links_report(tmp_path)
+    safe_fix = FixAction(
+        description="safe sentinel",
+        file_path=source,
+        fix_type="link_update",
+        safety=FixSafety.SAFE,
+        apply=_apply,
+    )
+
+    results = fixer.apply_fixes([safe_fix])
+
+    assert results["applied"] == 1, results
+    assert marker["count"] == 1
+
+
+def test_unsafe_fix_never_applies_even_when_confirmed(tmp_path):
+    """UNSAFE fixes require manual review; confirmed=True must NOT apply them."""
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    _write(source, "# Configuration\n")
+    marker = {"count": 0}
+
+    def _apply():
+        marker["count"] += 1
+        return True
+
+    _report, fixer = _links_report(tmp_path)
+    unsafe_fix = FixAction(
+        description="dangerous sentinel",
+        file_path=source,
+        fix_type="link_update",
+        safety=FixSafety.UNSAFE,
+        apply=_apply,
+    )
+
+    results = fixer.apply_fixes([unsafe_fix], confirmed=True)
+
+    assert results["applied"] == 0, results
+    assert results["skipped"] == 1, results
+    assert marker["count"] == 0


### PR DESCRIPTION
## Summary

- Implement `AutoFixer._suggest_link_fixes`, which was a hard-coded `return []` despite a docstring promising typo / moved-page / anchor fixes. `bengal fix` now suggests and applies fixes for broken **internal** links reported by the Links validator (#485/#489 detect them; this fixes them).
- Three suggestion strategies, matched against valid page URL paths derived from the content tree on disk (keeps the fixer file-local, no live `Site`):
  - **typo / closest-match** (e.g. `/docs/instalation/` → `/docs/installation/`),
  - **moved-page** when the link's final slug exists uniquely elsewhere,
  - **anchor** against the target page's heading slugs (e.g. `#getting-startd` → `#getting-started`).
- Link rewrites are `FixSafety.CONFIRM` (cross-reference edits a human should eyeball) and write through the crash-safe `atomic_write_text` helper, mirroring the existing fence-depth fixer. External (`http(s)`, `mailto:`, `tel:`) links are skipped. Stale "Future" docstrings updated.

## Proof

- [x] Focused tests: `uv run pytest tests/unit/health/test_autofix_link_fixes.py -q` (6 passed). New tests cover typo, moved-page, anchor, the apply-rewrite path, external-skip, and the no-confident-match case. They are discriminating: reverting the body to `return []` fails the 4 positive tests (verified).
- [x] `poe proof-pr` or scoped equivalent: `uv run pytest tests -k "autofix or remediation or link" -q` → 626 passed, 1 skipped (pre-existing: needs a built site), 0 failures.
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/491.added.md` added; `uv run poe changelog-lint` clean.

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable — change is in the `bengal fix` health-remediation path (interactive, off the build/render hot path); it does difflib closest-match over an on-disk content corpus only when broken links exist.

## Steward Notes

- Suggestions only fire for internal links and require a confident match (difflib cutoffs 0.8 for paths, 0.7 for anchors; moved-page only on a unique slug), so the fixer avoids misleading rewrites; the `apply` callable replaces only link-syntax tokens (`](old)`, `href="old"`) so surrounding prose is never touched.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
