### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [0.5.0] - 2026-06-15
+
+### Added
+
+- `bengal serve --drafts` and `bengal build --drafts` (or `drafts = true` under `[build]`) render pages marked `draft: true` so you can preview unpublished content locally; drafts stay hidden by default. (`#488`)
+- `bengal fix` now suggests and applies fixes for broken internal links — correcting typos in a page path, re-pointing a link to a page that moved, and fixing a stale `#anchor` — instead of only fixing directive fences. Link rewrites are offered as confirm-before-apply fixes so you can review each one. (`#491`)
+- `define_collection(..., transform=callable)` runs your callable on each record's frontmatter before schema validation, so you can normalize legacy field names during a migration without rewriting source files. (`#492`)
+- Autodoc CLI extraction now supports argparse: point it at an `argparse.ArgumentParser` with `framework="argparse"` and it documents subcommands, positional arguments, and options just like the Click and Typer paths. (`#493`)
+
+### Changed
+
+- Dev-server assets now serve through the fast static path; the hidden-buffer 404 workaround is removed (requires bengal-pounce 0.8.0+). (`#400`)
+- `bengal build --memory-optimized` is now labeled experimental, and its help text and docs no longer promise a fixed memory saving — measure peak memory with and without the flag on your own site before relying on it. (`#487`)
+
+### Fixed
+
+- Autodoc no longer turns illustrative cross-reference and directive examples in docstrings into live (often broken) links, so generated API pages and the broken-link health check stay clean. (`#485`)
+- The internal link checker now resolves relative links (such as `../other/`) against the page that references them and reports broken ones, instead of silently passing them. (`#489`)
+
+
 ## [0.4.3] - 2026-06-15
 
 ### Fixed

--- a/changelog.d/400.changed.md
+++ b/changelog.d/400.changed.md
@@ -1,1 +1,0 @@
-Dev-server assets now serve through the fast static path; the hidden-buffer 404 workaround is removed (requires bengal-pounce 0.8.0+).

--- a/changelog.d/485.fixed.md
+++ b/changelog.d/485.fixed.md
@@ -1,1 +1,0 @@
-Autodoc no longer turns illustrative cross-reference and directive examples in docstrings into live (often broken) links, so generated API pages and the broken-link health check stay clean.

--- a/changelog.d/487.changed.md
+++ b/changelog.d/487.changed.md
@@ -1,1 +1,0 @@
-`bengal build --memory-optimized` is now labeled experimental, and its help text and docs no longer promise a fixed memory saving — measure peak memory with and without the flag on your own site before relying on it.

--- a/changelog.d/488.added.md
+++ b/changelog.d/488.added.md
@@ -1,1 +1,0 @@
-`bengal serve --drafts` and `bengal build --drafts` (or `drafts = true` under `[build]`) render pages marked `draft: true` so you can preview unpublished content locally; drafts stay hidden by default.

--- a/changelog.d/489.fixed.md
+++ b/changelog.d/489.fixed.md
@@ -1,1 +1,0 @@
-The internal link checker now resolves relative links (such as `../other/`) against the page that references them and reports broken ones, instead of silently passing them.

--- a/changelog.d/491.added.md
+++ b/changelog.d/491.added.md
@@ -1,1 +1,0 @@
-`bengal fix` now suggests and applies fixes for broken internal links — correcting typos in a page path, re-pointing a link to a page that moved, and fixing a stale `#anchor` — instead of only fixing directive fences. Link rewrites are offered as confirm-before-apply fixes so you can review each one.

--- a/changelog.d/492.added.md
+++ b/changelog.d/492.added.md
@@ -1,1 +1,0 @@
-`define_collection(..., transform=callable)` runs your callable on each record's frontmatter before schema validation, so you can normalize legacy field names during a migration without rewriting source files.

--- a/changelog.d/493.added.md
+++ b/changelog.d/493.added.md
@@ -1,1 +1,0 @@
-Autodoc CLI extraction now supports argparse: point it at an `argparse.ArgumentParser` with `framework="argparse"` and it documents subcommands, positional arguments, and options just like the Click and Typer paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bengal"
-version = "0.4.3"
+version = "0.5.0"
 description = "Python static site generator built on free-threading — every layer pure Python, scales with your cores, zero npm"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/site/content/releases/0.5.0.md
+++ b/site/content/releases/0.5.0.md
@@ -1,0 +1,82 @@
+---
+title: Bengal 0.5.0
+description: Link integrity end to end plus a tighter authoring loop — preview drafts locally, detect broken internal links reliably, and apply fixes for typo, moved-page, and stale-anchor links, with broader autodoc and typed-collection migrations.
+date: 2026-06-15
+draft: false
+lang: en
+tags: [release, changelog, links, drafts, autodoc, dev-server]
+keywords: [release, 0.5.0, drafts, broken-links, link-checker, bengal-fix, autodoc, argparse, define-collection]
+category: changelog
+---
+
+# Bengal 0.5.0
+
+**Key theme:** Link integrity end to end, plus a tighter authoring loop. Bengal 0.5.0 closes the loop on broken internal links — it now *detects* them reliably and *fixes* them for you — and adds a local draft-preview workflow so you can iterate on unpublished pages before they ship. Autodoc reaches one more CLI framework, typed collections gain a migration hook, and the dev server gets a faster static path. This is a quality and capability release, not a performance release — proportional warm rebuilds land in 0.6.
+
+---
+
+## Highlights
+
+### Preview drafts locally
+
+Mark a page `draft: true` and it stays out of your published site by default. Now you can see it while you work: run `bengal serve --drafts` or `bengal build --drafts`, or set `drafts = true` under `[build]`, and Bengal renders draft pages so you can preview unpublished content locally. Without the flag, drafts stay hidden — production output is unchanged (#488).
+
+### Broken links, detected and fixed
+
+Bengal now handles broken internal links end to end:
+
+- **Detected reliably.** The internal link checker resolves relative links such as `../other/` against the page that references them and reports the broken ones, instead of silently passing them (#489). And autodoc no longer turns illustrative cross-reference and directive examples in docstrings into live (and often broken) links, so generated API pages — and the broken-link health check — stay clean (#485).
+- **Fixed for you.** `bengal fix` now suggests and applies fixes for broken internal links: correcting a typo in a page path, re-pointing a link to a page that moved, and repairing a stale `#anchor`. Link rewrites are offered as confirm-before-apply fixes, so you review each one before it touches your source (#491).
+
+### Broader autodoc: argparse CLIs
+
+Autodoc CLI extraction now supports argparse alongside Click and Typer. Point it at an `argparse.ArgumentParser` with `framework="argparse"` and it documents subcommands, positional arguments, and options the same way (#493).
+
+### Typed-collection migrations
+
+`define_collection(..., transform=callable)` runs your callable on each record's frontmatter before schema validation. You can normalize legacy field names during a migration without rewriting source files first (#492).
+
+### Dev server: faster static path
+
+Dev-server assets now serve through the fast static path, and the hidden-buffer 404 workaround is removed. This requires bengal-pounce 0.8.0 or newer (#400).
+
+### Honest claims
+
+- `bengal build --memory-optimized` is now labeled experimental, and its help text and docs no longer promise a fixed memory saving — measure peak memory with and without the flag on your own site before relying on it (#487).
+- The plugin documentation now lists the extension points that are actually wired, instead of over-claiming (#503).
+
+---
+
+## Added
+
+- Local draft preview: `bengal serve --drafts` / `bengal build --drafts` (or `drafts = true` under `[build]`); drafts stay hidden by default (#488).
+- `bengal fix` suggests and applies fixes for broken internal links — typo, moved-page, and stale-anchor corrections, confirm-before-apply (#491).
+- `define_collection(..., transform=callable)` normalizes records before schema validation (#492).
+- Autodoc CLI extraction supports argparse alongside Click and Typer (#493).
+
+## Changed
+
+- Dev-server assets serve through the fast static path; the hidden-buffer 404 workaround is removed (requires bengal-pounce 0.8.0+) (#400).
+- `bengal build --memory-optimized` is labeled experimental, with no promised memory saving (#487).
+
+## Fixed
+
+- The internal link checker resolves relative links against the referencing page and reports broken ones, instead of silently passing them (#489).
+- Autodoc no longer turns docstring cross-reference and directive examples into live (often broken) links, so generated API pages and the broken-link health check stay clean (#485).
+
+---
+
+## Upgrading
+
+```bash
+uv pip install --upgrade bengal
+# or
+pip install --upgrade bengal
+```
+
+A few things to know:
+
+- **Drafts are opt-in to preview.** Pages marked `draft: true` are still hidden from a normal build; pass `--drafts` (or set `drafts = true` under `[build]`) to render them.
+- **The dev-server fast static path needs bengal-pounce 0.8.0 or newer.** Upgrade bengal-pounce alongside Bengal.
+- **`--memory-optimized` is experimental.** It no longer promises a fixed memory saving; measure peak memory on your own site before relying on it.
+- **Not a performance release.** Proportional warm rebuilds are planned for 0.6; 0.5.0 focuses on link integrity and the authoring loop.

--- a/uv.lock
+++ b/uv.lock
@@ -110,7 +110,7 @@ wheels = [
 
 [[package]]
 name = "bengal"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "bengal-pounce" },


### PR DESCRIPTION
## Summary

Cut release **v0.5.0** from current `main`. Quality + capability release (not a performance release — proportional warm rebuilds are planned for 0.6). The through-line is link integrity end to end plus a tighter authoring loop.

User-facing highlights:

- **Preview drafts locally:** `bengal serve --drafts` / `bengal build --drafts` (or `drafts = true` under `[build]`); drafts stay hidden by default (#488).
- **Broken links, end to end:** the link checker now resolves and validates relative links instead of silently passing them (#489), autodoc no longer turns docstring example references into live/broken links (#485), and `bengal fix` now suggests and applies typo / moved-page / stale-anchor corrections for broken internal links (#491).
- **Broader autodoc:** argparse CLI apps are supported alongside Click/Typer (#493).
- **Typed-collection migrations:** `define_collection(transform=...)` normalizes records before validation (#492).
- **Dev server:** hidden-buffer assets now serve through the fast static path (requires bengal-pounce 0.8.0+) (#400).
- **Honest claims:** `--memory-optimized` is labeled experimental with no promised saving (#487); plugin docs state the accurately-wired extension points (#503).

Changelog (the [0.5.0] section compiled from 8 fragments):

Added
- Local draft preview: `bengal serve --drafts` / `bengal build --drafts` / `drafts = true` (#488).
- `bengal fix` suggests/applies broken-internal-link fixes — typo, moved-page, stale-anchor — confirm-before-apply (#491).
- `define_collection(..., transform=callable)` normalizes records before schema validation (#492).
- Autodoc CLI extraction supports argparse alongside Click and Typer (#493).

Changed
- Dev-server assets serve through the fast static path; hidden-buffer 404 workaround removed (requires bengal-pounce 0.8.0+) (#400).
- `bengal build --memory-optimized` labeled experimental, no promised memory saving (#487).

Fixed
- Internal link checker resolves relative links against the referencing page and reports broken ones (#489).
- Autodoc no longer turns docstring cross-reference/directive examples into live (often broken) links (#485).

Release mechanics in this PR:

- `pyproject.toml` version `0.4.3` → `0.5.0` (single source of truth; `bengal/__init__.py` derives `__version__` from importlib metadata; `uv.lock` editable-package version updated to match).
- `uv run towncrier build --version 0.5.0` compiled all 8 `changelog.d/` fragments into the `[0.5.0]` CHANGELOG section and removed the fragments.
- Added user-facing release page `site/content/releases/0.5.0.md`.

Tag/GitHub release/PyPI publish are intentionally **not** included — those are the maintainer's manual step (tagging auto-publishes to PyPI).

## Proof

- [x] Focused tests: `uv run poe changelog-lint` clean (CI fragment gate, 0 files scanned post-build); `--releases` reports only pre-existing leaks in historical 0.1.x/0.2.6/0.4.x pages, none in the new `0.5.0.md`.
- [x] `poe proof-pr` or scoped equivalent: `uv run bengal build --source site` → 708 pages, 0 errors / 0 warnings, Quality 100% (Excellent); release page renders at `releases/0.5.0/`.
- [x] Version check: `uv run python -c "import bengal; print(bengal.__version__)"` → `0.5.0`.
- [x] Docs/examples/changelog updated or no-impact noted: CHANGELOG `[0.5.0]` section + `site/content/releases/0.5.0.md`; all 8 fragments consumed.

## Performance Evidence

- Benchmark matrix row: not applicable — release chore
- Command: not applicable — release chore
- Python build: not applicable — release chore
- Machine/OS: not applicable — release chore
- Baseline commit or saved result: not applicable — release chore
- Current commit or saved result: not applicable — release chore
- Artifact path: not applicable — release chore
- Interpretation: not applicable — release chore (no hot path or concurrent behavior changed; v0.5.0 is explicitly not a performance release)

## Steward Notes

- Release page follows the `site/AGENTS.md` Release Pages steward: distilled (not transcribed), progressive disclosure, content-based theme (link integrity + authoring loop, not an editorial verdict), numeric issue refs only, `bengal` install command (not `bengal-ssg`).
- No tag, no GitHub release, no merge — maintainer performs those (PyPI auto-publishes on the GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
