### PR TITLE
tests: fix content-type registry xdist flake (#518)

### DIFF
--- a/bengal-syntax-highlighter/CHANGELOG.md
+++ b/bengal-syntax-highlighter/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the "Bengal SSG Syntax Highlighter" extension will be documented in this file.
 
+## [1.2.0] - 2026-06-16
+
+### Fixed
+- Restored missing `language-configuration.json` referenced by `package.json`
+- Stopped Kida primary grammar from hijacking all `.html` files; Kida tags in HTML
+  templates now use a dedicated `text.html` injection grammar instead
+
 ## [1.1.0] - 2025-12-30
 
 ### Added

--- a/bengal-syntax-highlighter/language-configuration.json
+++ b/bengal-syntax-highlighter/language-configuration.json
@@ -1,0 +1,34 @@
+{
+  "comments": {
+    "blockComment": ["{#", "#}"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["<", ">"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string"] },
+    { "open": "{%", "close": "%}", "notIn": ["string", "comment"] },
+    { "open": "{{", "close": "}}", "notIn": ["string", "comment"] },
+    { "open": "{#", "close": "#}", "notIn": ["string", "comment"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*{%\\s*(block|if|for|match|while|cache|spaceless|autoescape|raw|capture|macro)\\b",
+      "end": "^\\s*{%\\s*end\\b"
+    }
+  }
+}

--- a/bengal-syntax-highlighter/package.json
+++ b/bengal-syntax-highlighter/package.json
@@ -30,6 +30,11 @@
         "injectTo": ["text.html.markdown"]
       },
       {
+        "scopeName": "text.html.kida.injection",
+        "path": "./syntaxes/kida-html.injection.tmLanguage.json",
+        "injectTo": ["text.html"]
+      },
+      {
         "language": "kida",
         "scopeName": "source.kida",
         "path": "./syntaxes/kida.tmLanguage.json"

--- a/bengal-syntax-highlighter/syntaxes/kida-html.injection.tmLanguage.json
+++ b/bengal-syntax-highlighter/syntaxes/kida-html.injection.tmLanguage.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "scopeName": "text.html.kida.injection",
+  "injectionSelector": "L:text.html",
+  "patterns": [
+    {
+      "include": "source.kida#kida-template-tag"
+    },
+    {
+      "include": "source.kida#kida-variable-output"
+    },
+    {
+      "include": "source.kida#kida-comment"
+    }
+  ]
+}

--- a/bengal-syntax-highlighter/syntaxes/kida.tmLanguage.json
+++ b/bengal-syntax-highlighter/syntaxes/kida.tmLanguage.json
@@ -3,8 +3,7 @@
     "scopeName": "source.kida",
     "name": "Kida",
     "fileTypes": [
-        "kida",
-        "html"
+        "kida"
     ],
     "patterns": [
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -460,6 +460,15 @@ def reset_bengal_state(request):
     except ImportError:
         logger.debug("Active plugin registry reset skipped: set_active_registry not available")
 
+    # Scaffold tests import generated modules that call register_strategy() at
+    # import time; restore the registry after each test so xdist workers stay clean.
+    try:
+        from bengal.content_types.registry import CONTENT_TYPE_REGISTRY
+
+        content_type_registry_snapshot = dict(CONTENT_TYPE_REGISTRY)
+    except ImportError:
+        content_type_registry_snapshot = None
+
     yield
 
     # Teardown: Reset all stateful components after each test
@@ -534,6 +543,12 @@ def reset_bengal_state(request):
         set_active_registry(None)
     except ImportError:
         logger.debug("Active plugin registry reset skipped: set_active_registry not available")
+
+    if content_type_registry_snapshot is not None:
+        from bengal.content_types.registry import CONTENT_TYPE_REGISTRY
+
+        CONTENT_TYPE_REGISTRY.clear()
+        CONTENT_TYPE_REGISTRY.update(content_type_registry_snapshot)
 
 
 @pytest.fixture(scope="class")

--- a/tests/unit/cli/test_new_content_type.py
+++ b/tests/unit/cli/test_new_content_type.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from bengal.cli.milo_commands.new import new_content_type
-from bengal.content_types import get_strategy
+from bengal.content_types import CONTENT_TYPE_REGISTRY, get_strategy
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -62,6 +62,8 @@ class TestNewContentTypeScaffold:
             assert type(strategy).__name__ == "CaseStudyStrategy"
         finally:
             sys.modules.pop("case_study_strategy", None)
+            # register_strategy() runs at import time — drop the leaked key (#518).
+            CONTENT_TYPE_REGISTRY.pop("case-study", None)
 
     def test_class_name_pascal_cased_from_hyphens(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_syntax_highlighter_package.py
+++ b/tests/unit/test_syntax_highlighter_package.py
@@ -1,0 +1,41 @@
+"""Packaging integrity checks for the VS Code syntax-highlighter extension."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HIGHLIGHTER_ROOT = REPO_ROOT / "bengal-syntax-highlighter"
+PACKAGE_JSON = HIGHLIGHTER_ROOT / "package.json"
+KIDA_GRAMMAR = HIGHLIGHTER_ROOT / "syntaxes" / "kida.tmLanguage.json"
+
+
+def _package_json_paths() -> list[Path]:
+    data = json.loads(PACKAGE_JSON.read_text())
+    paths: list[Path] = []
+
+    for language in data.get("contributes", {}).get("languages", []):
+        config = language.get("configuration")
+        if config:
+            paths.append(HIGHLIGHTER_ROOT / config.lstrip("./"))
+
+    for grammar in data.get("contributes", {}).get("grammars", []):
+        grammar_path = grammar.get("path")
+        if grammar_path:
+            paths.append(HIGHLIGHTER_ROOT / grammar_path.lstrip("./"))
+
+    return paths
+
+
+class TestSyntaxHighlighterPackage:
+    def test_package_json_declared_files_exist(self) -> None:
+        missing = [path for path in _package_json_paths() if not path.is_file()]
+        assert not missing, f"Missing syntax-highlighter files: {missing}"
+
+    def test_kida_grammar_does_not_hijack_html_file_type(self) -> None:
+        data = json.loads(KIDA_GRAMMAR.read_text())
+        file_types = data.get("fileTypes", [])
+        assert "html" not in file_types, (
+            "Kida primary grammar must not register .html — use text.html injection instead"
+        )


### PR DESCRIPTION
Restore syntax-highlighter language config and HTML injection grammar (#448).

## Summary

-

## Proof

- [ ] Focused tests:
- [ ] `poe proof-pr` or scoped equivalent:
- [ ] Docs/examples/changelog updated or no-impact noted: <!-- changelog.d/ fragment: lead with one user-facing sentence, then engineering detail (see docs/b-stack-changelog-strategy.md) -->

## Performance Evidence

Required when this PR makes a performance claim, changes a hot path, or changes
free-threaded/concurrent behavior.

- Benchmark matrix row:
- Command:
- Python build:
- Machine/OS:
- Baseline commit or saved result:
- Current commit or saved result:
- Artifact path:
- Interpretation:

CI only enforces this section for performance-sensitive behavior paths. Use
`not applicable` when those paths changed but the PR makes no performance
claim.

## Steward Notes

-
