### PR TITLE
health: expose per-source link metadata for autofix (#508)

### DIFF
--- a/bengal/health/validators/links.py
+++ b/bengal/health/validators/links.py
@@ -102,7 +102,7 @@ def _file_results_by_source(
                     recommendation="Fix broken internal links. They point to pages that don't exist.",
                     details=[
                         f"{_format_link_location(source_path, site.root_path)}: {link}"
-                        for link in internal_links[:5]
+                        for link in internal_links
                     ],
                     metadata={
                         "source_path": str(source_path),
@@ -118,7 +118,7 @@ def _file_results_by_source(
                     recommendation="External links may be temporarily unavailable or incorrect.",
                     details=[
                         f"{_format_link_location(source_path, site.root_path)}: {link}"
-                        for link in external_links[:5]
+                        for link in external_links
                     ],
                     metadata={
                         "source_path": str(source_path),
@@ -129,6 +129,15 @@ def _file_results_by_source(
         file_results[source_path] = results
 
     return file_results
+
+
+def _flatten_file_results(file_results: dict[Path, list[CheckResult]]) -> list[CheckResult]:
+    """Return per-source CheckResults in stable source-path order."""
+    return [
+        result
+        for source_path in sorted(file_results, key=str)
+        for result in file_results[source_path]
+    ]
 
 
 class LinkValidator:
@@ -726,47 +735,7 @@ class LinkValidatorWrapper(BaseValidator):
         self.last_file_results = _file_results_by_source(broken_links, site)
 
         if all_broken_links:
-            # broken_links is list of (page_path, link_url) tuples
-            # Group by type based on the link URL (second element)
-            internal_broken = [
-                (page, link)
-                for page, link in all_broken_links
-                if not link.startswith(("http://", "https://"))
-            ]
-            external_broken = [
-                (page, link)
-                for page, link in all_broken_links
-                if link.startswith(("http://", "https://"))
-            ]
-
-            if internal_broken:
-                # Format as "page: link" for display (using relative paths)
-                details = [
-                    f"{_format_link_location(page, site.root_path)}: {link}"
-                    for page, link in internal_broken[:5]
-                ]
-                results.append(
-                    CheckResult.error(
-                        f"{len(internal_broken)} broken internal link(s)",
-                        code="H101",
-                        recommendation="Fix broken internal links. They point to pages that don't exist.",
-                        details=details,
-                    )
-                )
-
-            if external_broken:
-                details = [
-                    f"{_format_link_location(page, site.root_path)}: {link}"
-                    for page, link in external_broken[:5]
-                ]
-                results.append(
-                    CheckResult.warning(
-                        f"{len(external_broken)} broken external link(s)",
-                        code="H102",
-                        recommendation="External links may be temporarily unavailable or incorrect.",
-                        details=details,
-                    )
-                )
+            results.extend(_flatten_file_results(_file_results_by_source(all_broken_links, site)))
         # No success message - if all links are valid, silence is golden
 
         # Store stats

--- a/changelog.d/508.fixed.md
+++ b/changelog.d/508.fixed.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **health**: Link autofix now receives per-source `CheckResult` metadata from the
+  Links validator, so `bengal fix` can suggest repairs for every broken internal
+  link on a page (not just the first five shown in validator details).

--- a/tests/unit/health/test_autofix_link_fixes.py
+++ b/tests/unit/health/test_autofix_link_fixes.py
@@ -170,6 +170,36 @@ def test_external_links_are_not_suggested(tmp_path):
     assert [f for f in fixer.suggest_fixes() if f.fix_type == "link_update"] == []
 
 
+def test_metadata_path_supports_more_than_five_broken_links(tmp_path):
+    """Production-shaped Links results expose every broken link via metadata (#508)."""
+    _build_content_tree(tmp_path)
+    source = tmp_path / "content" / "docs" / "configuration.md"
+    broken_links = [f"/docs/instalation-{index}/" for index in range(6)]
+    _write(
+        source,
+        "# Configuration\n\n"
+        + "\n".join(f"[link{i}]({link})" for i, link in enumerate(broken_links))
+        + "\n",
+    )
+
+    for index in range(len(broken_links)):
+        typo_page = tmp_path / "content" / "docs" / f"installation-{index}.md"
+        _write(typo_page, f"# Installation {index}\n")
+
+    result = CheckResult.error(
+        "6 broken internal link(s)",
+        code="H101",
+        metadata={
+            "source_path": str(source),
+            "broken_links": broken_links,
+        },
+    )
+    _report, fixer = _links_report(tmp_path, result)
+
+    link_fixes = [fix for fix in fixer.suggest_fixes() if fix.fix_type == "link_update"]
+    assert len(link_fixes) == 6
+
+
 def test_unfixable_link_yields_no_suggestion(tmp_path):
     """A link with no close valid target produces no (misleading) suggestion."""
     _build_content_tree(tmp_path)

--- a/tests/unit/health/validators/test_links.py
+++ b/tests/unit/health/validators/test_links.py
@@ -178,6 +178,27 @@ class TestLinkValidatorWrapperBrokenLinks:
         assert len(error_results) >= 1
         assert error_results[0].details is not None
         assert len(error_results[0].details) >= 1
+        assert error_results[0].metadata["broken_links"] == ["/nonexistent/", "/missing-page/"]
+
+    def test_broken_links_are_not_truncated_to_five(self, validator):
+        """Per-source results expose every broken link for autofix/report consumers."""
+        site = MagicMock()
+        site.config = {"validate_links": True}
+        site.root_path = Path("/project")
+        site.link_registry = None
+
+        broken = [f"/missing-{index}/" for index in range(7)]
+        page = MagicMock()
+        page.url = "/docs/"
+        page.source_path = Path("/project/content/docs/_index.md")
+        _seed_links(page, broken)
+        site.pages = [page]
+
+        results = validator.validate(site)
+
+        assert len(results) == 1
+        assert results[0].metadata["broken_links"] == broken
+        assert len(results[0].details) == 7
 
 
 class TestLinkValidatorWrapperStats:
@@ -265,6 +286,7 @@ class TestLinkValidatorWrapperStats:
 
         assert len(results) == 1
         assert results[0].code == "H101"
+        assert results[0].metadata["broken_links"] == ["/cached-missing/"]
         assert "cached-missing" in results[0].details[0]
         assert validator.last_stats is not None
         assert validator.last_stats.metrics["cached_files"] == 1
@@ -356,12 +378,13 @@ class TestLinkValidatorHealthScopeIntegration:
         report = health_check.run(incremental=True, cache=cache)
 
         link_report = report.validator_reports[0]
-        assert link_report.results[0].code == "H101"
-        assert "2 broken internal link(s)" in link_report.results[0].message
-        details = link_report.results[0].details
-        assert details is not None
-        assert any("cached-missing" in detail for detail in details)
-        assert any("missing-now" in detail for detail in details)
+        error_results = [result for result in link_report.results if result.code == "H101"]
+        assert len(error_results) == 2
+        broken_links = {
+            link for result in error_results for link in result.metadata.get("broken_links", [])
+        }
+        assert "/cached-missing/" in broken_links
+        assert "/missing-now/" in broken_links
         cache.cache_validation_results.assert_called_once()
         cached_path, validator_name, file_results = cache.cache_validation_results.call_args.args
         assert cached_path == changed_page.source_path


### PR DESCRIPTION
Return per-file CheckResults with full broken_links metadata and remove the five-link details truncation cap.

## Summary

-

## Proof

- [ ] Focused tests:
- [ ] `poe proof-pr` or scoped equivalent:
- [ ] Docs/examples/changelog updated or no-impact noted: <!-- changelog.d/ fragment: lead with one user-facing sentence, then engineering detail (see docs/b-stack-changelog-strategy.md) -->

## Performance Evidence

Required when this PR makes a performance claim, changes a hot path, or changes
free-threaded/concurrent behavior.

- Benchmark matrix row:
- Command:
- Python build:
- Machine/OS:
- Baseline commit or saved result:
- Current commit or saved result:
- Artifact path:
- Interpretation:

CI only enforces this section for performance-sensitive behavior paths. Use
`not applicable` when those paths changed but the PR makes no performance
claim.

## Steward Notes

-
