### PR TITLE
Persistent-site warm-rebuild foundation (#522) + reproducible build output

### DIFF
--- a/bengal/analysis/graph/visualizer.py
+++ b/bengal/analysis/graph/visualizer.py
@@ -146,16 +146,50 @@ class GraphVisualizer:
 
     def _get_page_id(self, page: Any) -> str:
         """
-        Get a stable ID for a page (using source_path hash).
+        Get a stable, build-reproducible ID for a page.
+
+        Hashes the *site-relative* source path with a fixed algorithm. Python's
+        built-in ``hash()`` is per-process randomized (PYTHONHASHSEED), and an
+        absolute path varies by checkout location — both make ``graph.json`` /
+        ``index.json`` node ids differ between otherwise-identical builds, which
+        breaks byte-reproducible output and the warm==cold parity contract. A
+        deterministic hash of the site-relative path is stable across builds and
+        machines while staying unique per page.
 
         Args:
             page: Page object
 
         Returns:
-            String ID for the page
+            Stable string ID for the page
         """
-        # Use hash of source_path for stable IDs (pages are hashable by source_path)
-        return str(hash(page.source_path))
+        from bengal.utils.primitives.hashing import hash_str
+
+        source_path = getattr(page, "source_path", None)
+        if source_path is None:
+            # Generated/virtual pages without a source file: derive a stable id
+            # from a location-independent identifier.
+            try:
+                seed = str(page.href)
+            except Exception:
+                seed = str(getattr(page, "title", "") or id(page))
+            return hash_str(seed, truncate=16)
+
+        rel: Any = source_path
+        root = getattr(self.site, "root_path", None)
+        if root is not None:
+            # Canonicalize both sides before taking the relative path: the page
+            # source and the site root can carry different symlink forms (e.g.
+            # macOS ``/var`` vs ``/private/var``), which would make a naive
+            # ``relative_to`` fall back to the absolute (location-dependent) path
+            # and reintroduce nondeterminism across build locations.
+            try:
+                rel = Path(source_path).resolve().relative_to(Path(root).resolve())
+            except ValueError, OSError:
+                try:
+                    rel = Path(source_path).relative_to(root)
+                except ValueError:
+                    rel = source_path
+        return hash_str(Path(rel).as_posix(), truncate=16)
 
     def generate_graph_data(self) -> dict[str, Any]:
         """
@@ -309,11 +343,15 @@ class GraphVisualizer:
         for page in content_pages:
             source_id = page_id_map[page]
             targets = self.graph.outgoing_refs.get(page, set())
-            for target in targets:
-                if target in page_id_map:
-                    target_id = page_id_map[target]
-                    raw_edges.append((source_id, target_id))
-                    edge_set.add((source_id, target_id))
+            # Iterate targets in a stable order: ``outgoing_refs`` is a set of
+            # Page objects whose iteration order varies per process/instance,
+            # which would make the emitted edge order (and thus graph.json)
+            # nondeterministic. Sort by the target's stable node id.
+            for target_id in sorted(
+                page_id_map[target] for target in targets if target in page_id_map
+            ):
+                raw_edges.append((source_id, target_id))
+                edge_set.add((source_id, target_id))
 
         # Second pass: create edges with weight based on bidirectionality
         seen_pairs = set()  # Avoid duplicate edges for bidirectional links

--- a/bengal/orchestration/incremental/state_mutator.py
+++ b/bengal/orchestration/incremental/state_mutator.py
@@ -1,0 +1,128 @@
+"""
+Surgical warm-rebuild state mutation (persistent resident Site).
+
+Design: ``plan/rfc-persistent-resident-site.md`` · Epic: #522.
+
+The warm dev-loop today tears the Site down (`SiteRunner.prepare_for_rebuild`)
+and rebuilds it from disk on every edit, so cost scales with total site size
+rather than change size. The persistent-resident-Site model instead keeps the
+built Site in memory and *surgically mutates only what changed*, with a
+conservative fallback to the full teardown rebuild.
+
+This module defines the contract that makes that safe:
+
+* :class:`SurgicalRebuildPlan` — an ``IncrementalPlan``-shaped result describing
+  what a surgical rebuild would touch, or *why it cannot* (``fallback_reasons``).
+* :class:`SiteStateMutator` — given the resident Site + the changed paths, either
+  mutates the resident state in place and returns an empty-fallback plan, or
+  returns a plan with non-empty ``fallback_reasons`` so the caller does a full
+  teardown rebuild instead.
+
+**The contract (steward: "conservative fallback with reasons", "warm equals
+cold"):** a caller MUST treat ``plan.is_fallback`` as "do the full teardown
+rebuild". A surgical result is only valid when the mutator can *prove* it equals
+a full rebuild; otherwise it names a reason and bails. Each change-type is
+enabled only after a committed byte-parity test (see
+``tests/integration/warm_build/surgical_parity.py``).
+
+**Phase 0 (this commit):** the skeleton + contract only. ``apply()`` always
+returns a fallback plan (no change-type is enabled yet), and this module is NOT
+wired into the dev-server build path — so behavior is identical to today. Later
+phases (frontmatter → data → template → … → structural, per the RFC) fill in
+real in-place mutation behind per-change-type parity gates and wire the gate into
+``bengal/server/build_trigger.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bengal.utils.observability.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from bengal.build.contracts.dependency_index import DependencyReadIndex
+    from bengal.protocols.core import SiteLike
+
+logger = get_logger(__name__)
+
+# Phase 0 sentinel: no surgical change-type is enabled yet, so every change
+# falls back to the full teardown rebuild. Replaced per-type in later phases.
+_PHASE0_FALLBACK = "surgical warm rebuild not enabled yet (RFC persistent-resident-site, phase 0)"
+
+
+@dataclass(frozen=True, slots=True)
+class SurgicalRebuildPlan:
+    """Immutable result of attempting a surgical warm rebuild.
+
+    Mirrors the ``IncrementalPlan`` shape from
+    ``rfc-snapshot-build-plan-handoff.md``. When ``fallback_reasons`` is
+    non-empty the surgical path declined to handle the change and the caller
+    must perform a full teardown rebuild; the reasons are observable for
+    diagnostics (steward: "conservative fallback with reasons").
+
+    Attributes:
+        changed_inputs: The source paths that triggered this rebuild.
+        affected_pages: Page keys (content-relative source paths) whose output
+            must be re-rendered. Empty on a pure fallback.
+        affected_outputs: Output keys (site-relative output paths) that must be
+            (re)written, including site-wide artifacts. Empty on a pure fallback.
+        fallback_reasons: Non-empty iff the surgical path declined; each entry
+            names *why* a full rebuild is required.
+    """
+
+    changed_inputs: tuple[Path, ...] = ()
+    affected_pages: tuple[str, ...] = ()
+    affected_outputs: tuple[str, ...] = ()
+    fallback_reasons: tuple[str, ...] = ()
+
+    @property
+    def is_fallback(self) -> bool:
+        """True when the caller must perform a full teardown rebuild."""
+        return bool(self.fallback_reasons)
+
+    @classmethod
+    def fallback(cls, changed_inputs: Iterable[Path], reason: str) -> SurgicalRebuildPlan:
+        """Build a plan that declines surgery for ``reason``."""
+        return cls(changed_inputs=tuple(changed_inputs), fallback_reasons=(reason,))
+
+
+@dataclass(slots=True)
+class SiteStateMutator:
+    """Surgically mutate a resident Site for a warm rebuild (or decline).
+
+    Holds a reference to the resident ``site`` (mutated in place by later phases)
+    and, when available, the ``dependency_index`` used to resolve which pages and
+    outputs a changed input affects without scanning the whole site.
+
+    Phase 0: :meth:`apply` always declines (returns a fallback plan). No resident
+    state is mutated and the dev-server build path does not call this yet, so the
+    warm build behaves exactly as before.
+    """
+
+    site: SiteLike
+    dependency_index: DependencyReadIndex | None = None
+    _enabled_change_types: frozenset[str] = field(default_factory=frozenset)
+
+    def apply(self, changed_paths: Iterable[Path]) -> SurgicalRebuildPlan:
+        """Attempt a surgical warm rebuild for ``changed_paths``.
+
+        Returns a :class:`SurgicalRebuildPlan`. While ``plan.is_fallback`` is
+        True the caller must run the full teardown rebuild
+        (``site.prepare_for_rebuild()`` + ``site.build(incremental=True)``).
+
+        Phase 0 always returns a fallback plan — the eligibility gate and
+        in-place mutation land per change-type in later phases, each behind a
+        byte-parity proof.
+        """
+        changed = tuple(changed_paths)
+        # No change-type is enabled yet: decline conservatively.
+        logger.debug(
+            "surgical_rebuild_declined",
+            reason=_PHASE0_FALLBACK,
+            changed=[str(p) for p in changed],
+        )
+        return SurgicalRebuildPlan.fallback(changed, _PHASE0_FALLBACK)

--- a/bengal/postprocess/output_formats/index_generator.py
+++ b/bengal/postprocess/output_formats/index_generator.py
@@ -295,7 +295,7 @@ class SiteIndexGenerator:
         ]
         site_data["tags"] = [
             {"name": name, "count": count}
-            for name, count in sorted(site_data["tags"].items(), key=lambda x: -x[1])
+            for name, count in sorted(site_data["tags"].items(), key=lambda x: (-x[1], x[0]))
         ]
         # Sort pages by URL for deterministic output (important for idempotent builds)
         site_data["pages"] = sorted(site_data["pages"], key=lambda p: p.get("url", ""))
@@ -455,7 +455,7 @@ class SiteIndexGenerator:
         ]
         site_data["tags"] = [
             {"name": name, "count": count}
-            for name, count in sorted(site_data["tags"].items(), key=lambda x: -x[1])
+            for name, count in sorted(site_data["tags"].items(), key=lambda x: (-x[1], x[0]))
         ]
         # Sort pages by URL for deterministic output (important for idempotent builds)
         site_data["pages"] = sorted(site_data["pages"], key=lambda p: p.get("url", ""))

--- a/changelog.d/+reproducible-graph-index-output.fixed.md
+++ b/changelog.d/+reproducible-graph-index-output.fixed.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **output**: `graph/graph.json` and the search `index.json` are now byte-identical
+  across rebuilds of unchanged content. Knowledge-graph node ids previously used a
+  per-process randomized hash (and an absolute path), graph edges came out in a
+  process-dependent order, and equally-weighted tags were ordered nondeterministically
+  — so two builds of the same site produced diffing output. IDs are now a stable hash
+  of the site-relative path, edges and tags sort deterministically.

--- a/plan/rfc-persistent-resident-site.md
+++ b/plan/rfc-persistent-resident-site.md
@@ -1,0 +1,194 @@
+# RFC: Persistent Resident Site (warm-rebuild architecture)
+
+**Status**: Draft / proposed
+**Created**: 2026-06-16
+**Author**: Claude (Opus 4.8)
+**Related**: `rfc-snapshot-build-plan-handoff.md`, `rfc-incremental-dependency-indexes.md`,
+`rfc-effect-traced-incremental-builds.md`; issues #330, #332, #521, #310 (warm-build arc);
+#350 (orthogonal — cold render-at-scale).
+
+## Why this RFC exists
+
+Per-phase profiling of the warm dev-loop (2026-06-16, free-threaded 3.14t, committed
+`benchmarks/baselines/warm_build.json` harness) established two things:
+
+1. The warm single-page rebuild scales with **total site size**, not change size
+   (1.7s @100p → 6.2s @1000p baseline; ~1.8s @800p on the synthetic harness).
+2. The cost is spread across *every* build phase — Discovery ~16%, plus
+   Config/filter, Initialization, Post-process, Health (~66% combined). **No single
+   phase is a dominant target, and none has a safe quick proportional win** (see #521:
+   each does heavy O(total) per-page work or its incremental machinery conservatively
+   bails). Discovery-pass proportionality (#332) addresses ~6%; the dominant phases are
+   near their per-phase floor for a content edit.
+
+The root cause is structural: **every warm rebuild tears the Site down and rebuilds it
+from disk.** `SiteRunner.prepare_for_rebuild()` (`bengal/orchestration/site_runner.py`)
+clears `site.pages`, `site.sections`, `site.taxonomies`, `site.menu*`, `site.xref_index`,
+`site._cascade_snapshot`, `site.registry`, and `site.url_registry` to empty; the build
+then re-discovers (full content-dir walk), reconstructs/re-parses pages, rebuilds every
+derived index, re-serializes site-wide outputs, and re-validates the whole site. The
+work is O(total pages) *by construction* — the changed file is one row in a full rebuild.
+
+No amount of per-phase tuning escapes this. The lever is architectural: **keep the built
+Site resident in memory across warm rebuilds and surgically mutate only what changed.**
+
+## Goals
+
+- Warm edit-to-reload latency **proportional to the change**, not total site size, for
+  the common dev-loop edits (content body, frontmatter, single data file, template).
+- **Byte-identical** output vs a full cold rebuild on the same final state — proven per
+  change-type before that type is enabled.
+- A **conservative fallback to the current full teardown** on any change the surgical
+  path cannot prove it handles. Never trade correctness for latency.
+- Build on the existing incremental contracts (`DependencyReadIndex`, the effect tracer,
+  the snapshot `IncrementalPlan` shape) rather than inventing parallel machinery.
+
+## Non-Goals
+
+- Cold-build / render-at-scale parallelism — that is #350 (shard / heap isolation),
+  which is **orthogonal**: #350 forks workers to escape free-threading's coherency tax
+  on large *cold* builds; this RFC keeps a Site resident for *warm* in-process edits.
+  A dev server can use the resident model for warm edits and (eventually) shard for the
+  initial cold build.
+- Changing the cold-build path. The first build of a session is unchanged; the resident
+  model only governs subsequent warm rebuilds.
+- Removing `prepare_for_rebuild()`. It remains the safety-net fallback.
+
+## What already exists (build on these)
+
+- **Reactive single-page handler** (`bengal/server/reactive/handler.py`,
+  `ReactiveContentHandler.handle_content_change`) is the existing proof that surgical
+  in-place mutation works: it re-reads one file's body, `clear_parsed_page_state(page)`,
+  re-renders only that page against the resident Site, writes, and returns — no rebuild.
+  Its hard limit: **body-only, single page, no rendered dependents** (it `return None`s
+  to a full warm build on `_has_rendered_dependents`, frontmatter changes, etc.).
+- **Dependency read-index** (`bengal/build/contracts/dependency_index.py`, persisted at
+  `.bengal/provenance/dependency-index.json`) already answers "which pages/outputs depend
+  on dependency X?" — the query that drives *which* resident state to touch.
+- **Effect tracer** (`bengal/effects/`) captures *what* changed (files/computations).
+- **Snapshot handoff** (`rfc-snapshot-build-plan-handoff.md`) already specifies an
+  `IncrementalPlan(changed_inputs, affected_pages, affected_outputs, fallback_reasons)`
+  record — the natural shape for a surgical rebuild plan.
+- **The dev-server decision gate** (`bengal/server/build_trigger.py`) already classifies
+  changes three ways: structural → subprocess full; content-only-no-dependents → reactive;
+  else → `_run_warm_build()` which calls `prepare_for_rebuild()` (L629). The new path slots
+  in as a fourth, between reactive and full teardown.
+
+**Correction to note:** `ContentDiscovery._discover_surgical()` is *not* affected-only — it
+still walks the whole content dir and reconstructs every unchanged page from cache (returns
+the full page set). The resident model's win is avoiding that walk entirely by keeping
+`site.pages` resident; surgical discovery is a fallback, not the mechanism.
+
+## Proposed model
+
+Keep the Site object resident across warm rebuilds (the dev server already holds it). On a
+change, instead of `prepare_for_rebuild()` + full build, run a **surgical mutation**:
+
+```
+BuildTrigger._run_warm_build(changed_paths, event_types):
+  if not _surgical_eligible(changed_paths, event_types):   # NEW gate
+      site.prepare_for_rebuild(); full warm build           # unchanged fallback
+  else:
+      plan = SiteStateMutator(site, dep_index).apply(changed_paths)   # NEW
+      if plan.fallback_reasons:                              # mutator couldn't prove it
+          site.prepare_for_rebuild(); full warm build        # fallback
+      else:
+          render(plan.affected_pages); postprocess(plan.affected_outputs)
+```
+
+The net-new component is **`SiteStateMutator`** (`bengal/orchestration/incremental/`):
+given the resident `site` + the changed paths + the dependency index, it mutates *in place*
+only the affected slices of each derived structure, and returns an `IncrementalPlan`-shaped
+result (or non-empty `fallback_reasons` to bail):
+
+| Resident structure | Today (teardown) | Surgical mutation |
+| --- | --- | --- |
+| `site.pages` | cleared + full re-walk/reparse | re-parse only changed pages; replace those entries |
+| `site.taxonomies` | cleared + recomputed | add/remove only the changed pages' tags |
+| `site.menu*` | cleared + rebuilt | rebuild only menus whose member pages changed |
+| `site.xref_index` | cleared + rebuilt | re-index only changed pages (ordering caveat below) |
+| `site._cascade_snapshot` | nulled + rebuilt | recompute only affected section subtrees |
+| `site.registry` / `url_registry` | cleared + rebuilt | update only affected sections/URLs |
+| post-process (sitemap/RSS/index.json/llm) | regenerated wholesale | regenerate only if the affected output's input set changed |
+| health validators | re-run over all pages | re-validate changed pages + genuinely-global checks |
+
+## The hard part (be honest)
+
+Byte-parity of *incremental global-state mutation* is the entire difficulty, and it is the
+same landmine class that sank earlier spikes (the xref `by_anchor` collision-order
+dependence; the parsed-content reconstruction that broke the provenance filter, #332). Each
+derived structure has cross-page, order-sensitive semantics that a naive "patch the changed
+rows" will get subtly wrong:
+
+- **xref `by_anchor`** resolves collisions by page-processing order and heading-vs-target
+  precedence *across pages* — a removed/re-added page can change which entry wins.
+- **taxonomies / menu** have weight/title/date ordering that a changed page can reorder.
+- **cascade** is inherited down section subtrees — a changed `_index.md` affects descendants.
+- **deletes and moves** must remove resident state (and the orphaned output file) correctly.
+
+Therefore the model is only safe with two invariants:
+
+1. **Fallback is part of the contract.** The mutator emits a `fallback_reason` and the
+   caller does a full teardown rebuild whenever it cannot *prove* the surgical result equals
+   a full rebuild (unknown change type, ambiguous dependency, structural move, config/theme
+   change). A fast miss is only valid when proven; otherwise rebuild.
+2. **Per-change-type byte-parity gate.** A change type is enabled only after a committed
+   test proves `surgical_output == full_rebuild_output` (HTML + sitemap/RSS/index.json +
+   the changed-output set) across the warm fixtures — the discriminating-assertion standard,
+   not page-count checks.
+
+## Phased rollout (safest change-types first)
+
+1. **Foundation** — `SiteStateMutator` skeleton + the `_surgical_eligible` gate + the
+   byte-parity harness (full vs surgical on the same final state). Everything still falls
+   back to teardown; zero behavior change until a type is enabled.
+2. **Frontmatter-only edit** (no nav/cascade keys) — re-parse one page, patch its pages
+   entry + taxonomy membership + xref entry; render it + its dependents. Extends the
+   reactive handler past body-only.
+3. **Single data-file edit** — use the dependency index to find affected pages; re-render
+   them; mutate nothing global. (Index already supports `data` kind.)
+4. **Template edit** — re-render the index-resolved affected pages; no content re-parse.
+5. **Multi-page content edits** — generalize 2–3 to a set.
+6. **Structural (add / delete / move)** — the hardest; resident add/remove + menu/xref/
+   taxonomy/cascade repair + orphan output cleanup. May stay on full-teardown fallback
+   indefinitely if parity can't be cheaply proven.
+
+Post-process and health proportionalization (#521) ride along: once the affected-page set
+is authoritative, site-wide outputs regenerate via per-page chunk reuse and health
+validates only changed pages + global checks.
+
+## Proof matrix
+
+| Surface | Required proof |
+| --- | --- |
+| Unit | mutator updates each derived index correctly for a single changed page |
+| Parity | per change-type: surgical output byte-identical to full rebuild on same final state (HTML + sitemap + RSS + index.json + changed-output set) |
+| Fallback | every non-enabled / ambiguous change type falls back to full teardown with a named reason; no silent surgical attempt |
+| Scaling | warm edit latency flat vs site size for enabled types, measured against `warm_build.json` |
+| Free-threading | resident mutation runs on the dev-server control thread; render still parallel — assert no shared-state races introduced |
+| Memory | resident Site does not grow unbounded across a long session (adds/deletes pruned) |
+
+## Risks
+
+- **Byte-parity** (primary) — gated per change-type; fallback on any doubt.
+- **Resident-state drift** — the in-memory Site silently diverging from disk (the failure
+  mode behind the dead reconstruction path, #332). Mitigation: the mutator derives strictly
+  from re-read changed inputs + the dependency index; never trusts stale resident derived
+  state for the changed slice.
+- **Free-threading** — resident mutable state mutated between parallel renders; keep mutation
+  single-threaded (control thread) and treat the resident Site as frozen during render.
+- **Scope creep into #350** — keep cold-render parallelism out; this is warm in-process only.
+- **Memory** — a long dev session accumulates resident state; prune on delete/move.
+
+## Relationship to the existing warm-build arc
+
+This RFC reframes the warm-build epic. #332 (proportional discovery) and #521 (dominant-phase
+proportionality) are *components* of the surgical path, not standalone goals — they only reach
+the sub-second dev loop inside a resident-Site model that stops tearing the Site down. #330
+becomes the umbrella; this RFC is its architecture. #350 is unaffected (cold render-at-scale).
+
+## Not now
+
+- Persisting the resident Site across *process* restarts (in-process / dev-server session only).
+- Merging with #350 shard workers.
+- Incremental search-backend (lunr) index updates beyond regenerate-if-affected.

--- a/tests/integration/warm_build/surgical_parity.py
+++ b/tests/integration/warm_build/surgical_parity.py
@@ -1,0 +1,186 @@
+"""
+Byte-parity harness for the persistent-resident-Site warm-rebuild work (#522).
+
+The persistent-site model (``plan/rfc-persistent-resident-site.md``) only ships a
+change-type once a surgical warm rebuild is *proven byte-identical* to a full
+cold rebuild of the same final state. This module is that proof harness — a
+reusable, discriminating output-tree comparison plus the determinism floor it
+rests on.
+
+Steward contract (``bengal/orchestration/incremental/AGENTS.md``): "warm equals
+cold". A green parity test only means something if its comparison would FAIL when
+the surgical path under-rebuilds — hence the discriminating-power guard test
+(#130 vacuous-test lesson).
+
+Phase 0 uses this to lock in the determinism floor (two full builds of the same
+source are byte-identical after normalizing known nondeterminism) and the
+discriminating power of the comparison. Later phases call
+:func:`assert_surgical_matches_full` to gate each enabled change-type.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from bengal.orchestration.incremental.state_mutator import SiteStateMutator
+
+# Known build-output nondeterminism: ISO-8601 timestamps embedded in JSON
+# sidecars / text artifacts (index.json, agent.json, llm-full.txt headers). These
+# are the documented exception to byte-determinism, so the parity comparison
+# normalizes them rather than flagging them as real divergence.
+_ISO_TS = re.compile(rb"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?")
+_TS_PLACEHOLDER = b"<TS>"
+
+# Text-ish output extensions we normalize timestamps in. Binary outputs (images,
+# fonts) are compared byte-for-byte with no normalization.
+_TEXT_SUFFIXES = {".html", ".json", ".xml", ".txt", ".md", ".css", ".js", ".rss", ".atom"}
+
+# Derived integrity-hash sidecars (e.g. ``index.json.hash``) are sha256 of the
+# *raw* artifact, which legitimately includes the build timestamp we normalize
+# away — so the hash varies even when the content is byte-identical. They are a
+# separate stale-output integrity net (#130/#314), not page content, so the
+# parity comparison (which already diffs the content directly, normalized)
+# excludes them rather than flagging the propagated timestamp noise.
+_SKIP_SUFFIXES = {".hash"}
+
+
+def normalize_bytes(rel_path: str, content: bytes) -> bytes:
+    """Normalize documented nondeterminism (timestamps) for text-ish outputs."""
+    suffix = Path(rel_path).suffix.lower()
+    if suffix in _TEXT_SUFFIXES:
+        return _ISO_TS.sub(_TS_PLACEHOLDER, content)
+    return content
+
+
+def snapshot_output_tree(output_dir: Path, *, normalize: bool = True) -> dict[str, bytes]:
+    """Map every output file (relative posix path) to its (normalized) bytes."""
+    snapshot: dict[str, bytes] = {}
+    if not output_dir.exists():
+        return snapshot
+    for path in sorted(output_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() in _SKIP_SUFFIXES:
+            continue
+        rel = path.relative_to(output_dir).as_posix()
+        data = path.read_bytes()
+        snapshot[rel] = normalize_bytes(rel, data) if normalize else data
+    return snapshot
+
+
+def diff_trees(a: dict[str, bytes], b: dict[str, bytes]) -> list[str]:
+    """Return human-readable diffs between two output snapshots (empty == equal)."""
+    diffs: list[str] = []
+    only_a = sorted(set(a) - set(b))
+    only_b = sorted(set(b) - set(a))
+    diffs.extend(f"only in A: {p}" for p in only_a)
+    diffs.extend(f"only in B: {p}" for p in only_b)
+    diffs.extend(
+        f"differs: {p} ({len(a[p])}B vs {len(b[p])}B)"
+        for p in sorted(set(a) & set(b))
+        if a[p] != b[p]
+    )
+    return diffs
+
+
+def assert_trees_equal(a: dict[str, bytes], b: dict[str, bytes], *, context: str) -> None:
+    """Assert two output snapshots are byte-identical (after normalization)."""
+    diffs = diff_trees(a, b)
+    assert not diffs, f"output-tree parity FAILED ({context}):\n  " + "\n  ".join(diffs[:40])
+
+
+def _reset_process_build_globals() -> None:
+    """Reset module/thread-global build state so each build is hermetic.
+
+    The dev server resets these between warm builds (``reset_ephemeral_state``);
+    two raw full builds in one test process would otherwise share accumulating
+    process globals (the asset manifest, created-dirs set), making two builds of
+    identical source differ — a comparison artifact, not real nondeterminism.
+    Mirroring the reset keeps the parity comparison apples-to-apples.
+    """
+    from bengal.rendering.assets import reset_asset_manifest
+    from bengal.rendering.pipeline.thread_local import get_created_dirs
+
+    get_created_dirs().clear()
+    reset_asset_manifest()
+
+
+def _cold_build(site_dir: Path) -> Path:
+    """Run a full (cold) build of ``site_dir`` and return its output dir."""
+    _reset_process_build_globals()
+    site = Site.from_config(site_dir)
+    site.discover_content()
+    site.discover_assets()
+    site.build(BuildOptions(incremental=False, force_sequential=True))
+    return site_dir / "public"
+
+
+def _copy_site(src: Path, dst: Path) -> Path:
+    """Copy a site tree to ``dst`` excluding build/cache artifacts."""
+    shutil.copytree(
+        src,
+        dst,
+        ignore=shutil.ignore_patterns("public", ".bengal", "__pycache__"),
+    )
+    return dst
+
+
+def assert_full_build_deterministic(site_dir: Path, work_dir: Path) -> None:
+    """Two independent full builds of the same source are byte-identical.
+
+    This is the floor the surgical parity gate rests on: if a clean rebuild is
+    not reproducible, no incremental==full claim can be trusted. Builds happen in
+    two fresh copies (independent ``.bengal`` caches) under ``work_dir``.
+    """
+    a = _cold_build(_copy_site(site_dir, work_dir / "det_a"))
+    b = _cold_build(_copy_site(site_dir, work_dir / "det_b"))
+    assert_trees_equal(
+        snapshot_output_tree(a),
+        snapshot_output_tree(b),
+        context="two full builds of identical source",
+    )
+
+
+def assert_surgical_matches_full(
+    site_dir: Path,
+    work_dir: Path,
+    apply_change: Callable[[Path], None],
+    surgical_rebuild: Callable[[Path], SiteStateMutator | None],
+) -> None:
+    """Gate a change-type: surgical warm rebuild must equal a full rebuild.
+
+    Both legs start from a cold build of ``site_dir`` in a fresh copy, then apply
+    the SAME ``apply_change`` to reach the same final state:
+
+    * leg A runs ``surgical_rebuild`` (the resident-Site mutation path);
+    * leg B runs a full cold rebuild.
+
+    Their output trees must be byte-identical (after normalization). Until a
+    change-type is enabled, ``surgical_rebuild`` falls back to a full rebuild, so
+    this asserts the harness + fallback wiring, not yet a real surgical win.
+    """
+    a_dir = _copy_site(site_dir, work_dir / "surgical")
+    _cold_build(a_dir)
+    apply_change(a_dir)
+    # The dev server resets process-global build state before every rebuild;
+    # mirror that so the surgical leg starts as hermetically as the full leg.
+    _reset_process_build_globals()
+    surgical_rebuild(a_dir)  # leg A: surgical (or fallback to full)
+    a = snapshot_output_tree(a_dir / "public")
+
+    b_dir = _copy_site(site_dir, work_dir / "full")
+    _cold_build(b_dir)
+    apply_change(b_dir)
+    _cold_build(b_dir)  # leg B: full rebuild of the final state
+    b = snapshot_output_tree(b_dir / "public")
+
+    assert_trees_equal(a, b, context="surgical warm rebuild vs full rebuild")

--- a/tests/integration/warm_build/test_surgical_parity_phase0.py
+++ b/tests/integration/warm_build/test_surgical_parity_phase0.py
@@ -1,0 +1,195 @@
+"""
+Phase 0 guard tests for the persistent-resident-Site warm-rebuild work (#522).
+
+Phase 0 lands the skeleton + the byte-parity safety net only; no surgical
+change-type is enabled, so behavior is unchanged. These tests lock in the
+foundation every later phase relies on:
+
+1. Determinism floor — two full builds of the same source are byte-identical
+   (after normalizing documented timestamp nondeterminism). The surgical
+   parity gate is meaningless without this.
+2. Discriminating power — the comparison FAILS on a real content difference, so
+   a future surgical==full assertion cannot pass vacuously (#130 lesson).
+3. Mutator contract — ``SiteStateMutator.apply`` declines conservatively with an
+   observable reason (steward: "conservative fallback with reasons").
+4. Harness + fallback wiring — the surgical-vs-full gate runs end-to-end; with
+   the Phase 0 stub (fallback → full rebuild) the two legs match.
+
+See ``surgical_parity.py`` and ``plan/rfc-persistent-resident-site.md``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+from bengal.orchestration.incremental.state_mutator import SiteStateMutator, SurgicalRebuildPlan
+
+from .conftest import create_output_formats_site_structure, create_taxonomy_site_structure
+from .surgical_parity import (
+    assert_full_build_deterministic,
+    assert_surgical_matches_full,
+    diff_trees,
+    snapshot_output_tree,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.integration
+
+
+def _build_cold(site_dir: Path) -> None:
+    site = Site.from_config(site_dir)
+    site.discover_content()
+    site.discover_assets()
+    site.build(BuildOptions(incremental=False, force_sequential=True))
+
+
+# ---------------------------------------------------------------------------
+# 1. Determinism floor
+# ---------------------------------------------------------------------------
+
+
+def test_full_build_is_byte_deterministic_output_formats(tmp_path: Path) -> None:
+    """Two full builds of a site with sitemap/RSS/output-formats match byte-for-byte.
+
+    Output formats carry the most nondeterminism surface (timestamps in
+    index.json / agent.json / llm-full.txt) — exactly what the harness must
+    normalize. If this fails on something other than a timestamp, there is real
+    build nondeterminism to fix before any surgical parity claim.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    create_output_formats_site_structure(src)
+    assert_full_build_deterministic(src, tmp_path / "work")
+
+
+def test_full_build_is_byte_deterministic_taxonomy(tmp_path: Path) -> None:
+    """Determinism also holds for taxonomy (generated tag/category pages)."""
+    src = tmp_path / "src"
+    src.mkdir()
+    create_taxonomy_site_structure(src)
+    assert_full_build_deterministic(src, tmp_path / "work")
+
+
+# ---------------------------------------------------------------------------
+# 2. Discriminating power (the comparison is NOT vacuous)
+# ---------------------------------------------------------------------------
+
+
+def test_parity_comparison_detects_a_real_content_difference(tmp_path: Path) -> None:
+    """A one-page content change MUST surface as an output-tree diff.
+
+    Guards the #130 vacuous-test failure mode: if this comparison could not
+    detect a real divergence, a surgical==full assertion built on it would be
+    worthless.
+    """
+    base = tmp_path / "base"
+    base.mkdir()
+    create_taxonomy_site_structure(base)
+
+    import shutil
+
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    shutil.copytree(base, a_dir)
+    shutil.copytree(base, b_dir)
+
+    # Diverge one page's body in b only.
+    (b_dir / "content" / "blog" / "post1.md").write_text(
+        """---
+title: Python Tutorial
+date: 2026-01-01
+tags: [python, tutorial]
+categories: [tutorials]
+---
+
+A DIFFERENT python tutorial body that changes the rendered HTML.
+"""
+    )
+
+    _build_cold(a_dir)
+    _build_cold(b_dir)
+
+    diffs = diff_trees(
+        snapshot_output_tree(a_dir / "public"),
+        snapshot_output_tree(b_dir / "public"),
+    )
+    assert diffs, "comparison is vacuous: it failed to detect a real content change"
+    assert any("post1" in d for d in diffs), f"expected the changed page in diffs, got: {diffs}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Mutator contract (conservative fallback with reasons)
+# ---------------------------------------------------------------------------
+
+
+def test_mutator_declines_conservatively_in_phase0(tmp_path: Path) -> None:
+    """Phase 0 SiteStateMutator.apply always returns an observable fallback."""
+    src = tmp_path / "src"
+    src.mkdir()
+    create_taxonomy_site_structure(src)
+    site = Site.from_config(src)
+    site.discover_content()
+
+    mutator = SiteStateMutator(site=site)
+    plan = mutator.apply([src / "content" / "blog" / "post1.md"])
+
+    assert plan.is_fallback, "phase 0 must decline every change"
+    assert plan.fallback_reasons, "fallback must name an observable reason"
+    assert plan.changed_inputs == (src / "content" / "blog" / "post1.md",)
+    assert plan.affected_pages == ()
+    assert plan.affected_outputs == ()
+
+
+def test_empty_plan_is_not_a_fallback() -> None:
+    """A plan with no fallback_reasons signals a usable surgical result."""
+    assert SurgicalRebuildPlan().is_fallback is False
+    assert SurgicalRebuildPlan(fallback_reasons=("x",)).is_fallback is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Harness + fallback wiring (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def test_surgical_gate_falls_back_to_full_and_matches(tmp_path: Path) -> None:
+    """End-to-end: the surgical gate (Phase 0 stub) falls back to full and matches.
+
+    Exercises the full surgical-vs-full harness path. Because the Phase 0 mutator
+    declines, the 'surgical' leg performs a full rebuild — so the two legs are
+    byte-identical. This proves the harness + fallback contract before any real
+    surgical mutation exists.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    create_taxonomy_site_structure(src)
+
+    def apply_change(site_dir: Path) -> None:
+        (site_dir / "content" / "blog" / "post1.md").write_text(
+            """---
+title: Python Tutorial
+date: 2026-01-01
+tags: [python, tutorial]
+categories: [tutorials]
+---
+
+Edited body for the surgical-vs-full parity harness.
+"""
+        )
+
+    def surgical_rebuild(site_dir: Path) -> SiteStateMutator | None:
+        # Mirror the caller contract: attempt surgery; on fallback, full rebuild.
+        site = Site.from_config(site_dir)
+        site.discover_content()
+        site.discover_assets()
+        plan = SiteStateMutator(site=site).apply([site_dir / "content" / "blog" / "post1.md"])
+        if plan.is_fallback:
+            site.build(BuildOptions(incremental=False, force_sequential=True))
+        return None
+
+    assert_surgical_matches_full(src, tmp_path / "work", apply_change, surgical_rebuild)


### PR DESCRIPTION
## Summary

- Phase 0 of the persistent-resident-Site warm-rebuild architecture (#522): a `SiteStateMutator` skeleton + `SurgicalRebuildPlan` contract that is inert by design — it always returns a conservative fallback and is not wired into the build path, so behavior is unchanged — plus a reusable byte-parity harness and determinism-floor guard tests under `tests/integration/warm_build/`, and the design RFC `plan/rfc-persistent-resident-site.md`.
- The determinism floor surfaced (and this PR fixes) three real build-reproducibility bugs where two builds of identical content produced diffing `graph.json` / `index.json`: graph node ids used a per-process randomized `hash()` of an absolute path (now a stable hash of the site-relative path), graph edges iterated an unordered set (now sorted by stable id), and equal-weight tags in `index.json` lacked a tie-break (now count desc, name asc).

## Proof

- [x] Focused tests: `tests/integration/warm_build/test_surgical_parity_phase0.py` — 6 tests (determinism floor x2, discriminating-power, mutator contract x2, fallback wiring); pass and stable across runs.
- [x] `poe proof-pr` or scoped equivalent: graph + postprocess unit tests (468 passed); full `warm_build` integration suite (67 passed, 4 skipped).
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/+reproducible-graph-index-output.fixed.md` (user-facing: byte-reproducible build output).

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: No performance claim. The touched paths change output determinism only (graph id/edge ordering, index.json tag tie-break), and the new `bengal/orchestration/incremental/` module is inert — not wired into any build path — so behavior and timing are unchanged.

## Steward Notes

- Incremental (`bengal/orchestration/incremental/`): honors "warm equals cold" and "conservative fallback with reasons" — the mutator declines every change in Phase 0 with an observable reason; later change-types are gated on `assert_surgical_matches_full` against the determinism floor. No build-path wiring in this PR.
