### PR TITLE
fix(build): harden ProvenanceCache for free-threading (#438)

### DIFF
--- a/bengal/build/provenance/filter.py
+++ b/bengal/build/provenance/filter.py
@@ -234,11 +234,13 @@ class ProvenanceFilter:
                     lambda item: self._verify_page_provenance(item[0], item[1]),
                     pages_to_verify,
                 )
-                for r in results:
+                for r, (page, _) in zip(results, pages_to_verify, strict=True):
                     if r.error:
                         raise r.error
                     assert r.value is not None  # guarded by r.error check above
-                    build, skip, tags, sections, paths = r.value
+                    build, skip, tags, sections, paths, cascade_invalidated = r.value
+                    if cascade_invalidated:
+                        page._cascade_invalidated = True
                     if build is not None:
                         pages_to_build.append(build)
                         affected_tags.update(tags)
@@ -248,7 +250,11 @@ class ProvenanceFilter:
                         pages_skipped.append(skip)
         else:
             for page, stored_hash in pages_to_verify:
-                build, skip, tags, sections, paths = self._verify_page_provenance(page, stored_hash)
+                build, skip, tags, sections, paths, cascade_invalidated = (
+                    self._verify_page_provenance(page, stored_hash)
+                )
+                if cascade_invalidated:
+                    page._cascade_invalidated = True
                 if build is not None:
                     pages_to_build.append(build)
                     affected_tags.update(tags)
@@ -321,17 +327,19 @@ class ProvenanceFilter:
         self,
         page: PageLike,
         stored_hash: ContentHash,
-    ) -> tuple[PageLike | None, PageLike | None, set[str], set[str], set[Path]]:
+    ) -> tuple[PageLike | None, PageLike | None, set[str], set[str], set[Path], bool]:
         """
         Verify if cached provenance still matches. Thread-safe.
 
         Returns:
-            (page_to_build, page_to_skip, affected_tags, affected_sections, changed_paths)
+            (page_to_build, page_to_skip, affected_tags, affected_sections,
+             changed_paths, cascade_invalidated)
             Exactly one of page_to_build or page_to_skip is non-None.
         """
         tags: set[str] = set()
         sections: set[str] = set()
         paths: set[Path] = set()
+        cascade_invalidated = False
         page_path = self._get_page_key(page)
         is_virtual = getattr(page, "virtual", False)
 
@@ -339,14 +347,14 @@ class ProvenanceFilter:
         if self._mtime_short_circuit(page, stored_hash):
             with self._session_lock:
                 self._mtime_short_circuit_hits += 1
-            return (None, page, tags, sections, paths)
+            return (None, page, tags, sections, paths, cascade_invalidated)
 
         if not is_virtual and page.source_path.exists():
             provenance_fast = self._compute_provenance_fast(page)
             if provenance_fast is not None and provenance_fast.combined_hash == stored_hash:
-                return (None, page, tags, sections, paths)
+                return (None, page, tags, sections, paths, cascade_invalidated)
             if provenance_fast is not None:
-                page._cascade_invalidated = True
+                cascade_invalidated = True
 
         try:
             provenance = self._compute_provenance(page)
@@ -359,7 +367,7 @@ class ProvenanceFilter:
             )
             self._collect_affected(page, tags, sections)
             paths.add(page.source_path)
-            return (page, None, tags, sections, paths)
+            return (page, None, tags, sections, paths, cascade_invalidated)
 
         if provenance.input_count == 0:
             logger.warning(
@@ -370,13 +378,13 @@ class ProvenanceFilter:
             )
             self._collect_affected(page, tags, sections)
             paths.add(page.source_path)
-            return (page, None, tags, sections, paths)
+            return (page, None, tags, sections, paths, cascade_invalidated)
 
         if provenance.combined_hash == stored_hash:
-            return (None, page, tags, sections, paths)
+            return (None, page, tags, sections, paths, cascade_invalidated)
         self._collect_affected(page, tags, sections)
         paths.add(page.source_path)
-        return (page, None, tags, sections, paths)
+        return (page, None, tags, sections, paths, cascade_invalidated)
 
     def record_build(self, page: PageLike, output_hash: ContentHash | None = None) -> None:
         """

--- a/bengal/build/provenance/store.py
+++ b/bengal/build/provenance/store.py
@@ -205,17 +205,16 @@ class ProvenanceCache:
 
     def _get_record(self, combined_hash: ContentHash) -> ProvenanceRecord | None:
         """Load a provenance record by hash."""
-        # Check memory cache first
-        if combined_hash in self._records:
-            return self._records[combined_hash]
+        with self._lock:
+            cached = self._records.get(combined_hash)
+            if cached is not None:
+                return cached
 
-        # Load from disk
+        # Load from disk (I/O outside lock)
         record_path = self._records_dir / f"{combined_hash}.json"
         try:
             data = json_load(record_path)
             record = ProvenanceRecord.from_dict(data)
-            self._records[combined_hash] = record
-            return record
         except FileNotFoundError:
             return None
         except (JSONDecodeError, KeyError, TypeError, ValueError) as e:
@@ -225,6 +224,13 @@ class ProvenanceCache:
                 action="treating_record_as_missing",
             )
             return None
+
+        with self._lock:
+            existing = self._records.get(combined_hash)
+            if existing is not None:
+                return existing
+            self._records[combined_hash] = record
+            return record
 
     def get(self, page_path: CacheKey) -> ProvenanceRecord | None:
         """Get provenance record for a page (thread-safe)."""

--- a/changelog.d/438.fixed.md
+++ b/changelog.d/438.fixed.md
@@ -1,0 +1,2 @@
+Fixed provenance cache races that could return stale warm-build output under
+free-threaded Python when provenance records were loaded or verified concurrently.

--- a/tests/unit/build/provenance/test_store.py
+++ b/tests/unit/build/provenance/test_store.py
@@ -660,3 +660,45 @@ class TestProvenanceCacheThreadSafety:
             for i in range(5):
                 result = store.get(CacheKey(f"batch{batch_idx}/page{i}.md"))
                 assert result is not None
+
+    def test_concurrent_get_record_disk_load(self, cache_dir: Path) -> None:
+        """Concurrent _get_record disk loads do not corrupt the memory cache (#438)."""
+        import threading
+
+        record = ProvenanceRecord(
+            page_path=CacheKey("content/about.md"),
+            provenance=Provenance().with_input(
+                "content", CacheKey("content/about.md"), ContentHash("abc123")
+            ),
+            output_hash=ContentHash("output123"),
+        )
+        store = ProvenanceCache(cache_dir=cache_dir)
+        store.store(record)
+        store.save()
+
+        combined_hash = record.provenance.combined_hash
+
+        # Fresh store: memory cache empty, records on disk only.
+        fresh = ProvenanceCache(cache_dir=cache_dir)
+        errors: list[Exception] = []
+        results: list[ProvenanceRecord | None] = []
+        lock = threading.Lock()
+
+        def load_record() -> None:
+            try:
+                loaded = fresh._get_record(combined_hash)
+                with lock:
+                    results.append(loaded)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=load_record) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Thread errors: {errors}"
+        assert len(results) == 20
+        assert all(r is not None for r in results)
+        assert all(r.page_path == record.page_path for r in results if r is not None)


### PR DESCRIPTION
## Summary
- Lock `_get_record` memory-cache reads/writes so concurrent disk loads cannot tear the `_records` dict under Python 3.14t.
- Return `cascade_invalidated` from `_verify_page_provenance` and set `_cascade_invalidated` on the main thread after parallel verification (no worker-thread mutation of shared `Page` objects).

## Test plan
- [x] `uv run pytest tests/unit/build/provenance/ -q`
- [x] New concurrent `_get_record` disk-load regression test

## Performance Evidence
- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

Closes #438