### PR TITLE
feat(css): add opt-in AST nesting flatten for legacy targets (#516)

### DIFF
--- a/bengal/css/minify.py
+++ b/bengal/css/minify.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from bengal.css.cascade import resolve, tree_sig
 from bengal.css.config import MinifyLevel
 from bengal.css.errors import warn
+from bengal.css.nesting import flatten_nesting_tree, has_nested_rules
 from bengal.css.optimize import optimize_tree
 from bengal.css.parser import parse_stylesheet
 from bengal.css.serializer import serialize
@@ -29,7 +30,12 @@ def _parse(css: str) -> tuple[Node, ...]:
     return parse_stylesheet(tokenize(css))
 
 
-def minify_css(css: str, *, level: MinifyLevel | str = MinifyLevel.SAFE) -> str:
+def minify_css(
+    css: str,
+    *,
+    level: MinifyLevel | str = MinifyLevel.SAFE,
+    flatten_nesting: bool = False,
+) -> str:
     """Minify CSS text.
 
     Args:
@@ -37,6 +43,9 @@ def minify_css(css: str, *, level: MinifyLevel | str = MinifyLevel.SAFE) -> str:
         level: ``"safe"`` (default, lossless), ``"optimize"`` (value
             normalization), or ``"aggressive"`` (cascade-invariant structural
             rewrites). Accepts a :class:`MinifyLevel` or its string value.
+        flatten_nesting: When ``True``, de-sugar nested qualified rules into
+            flat selectors for legacy browser targets (opt-in; default preserves
+            native nesting).
 
     Returns:
         Minified CSS, guaranteed to be meaning-preserving. Returns the input
@@ -58,9 +67,22 @@ def minify_css(css: str, *, level: MinifyLevel | str = MinifyLevel.SAFE) -> str:
             warn("css_minifier_safe_guard_failed", input_length=len(css))
             return css
         best = safe_out
+        pipeline_tree = in_tree
+
+        if flatten_nesting and has_nested_rules(in_tree):
+            flat_tree = flatten_nesting_tree(in_tree)
+            flat_out = serialize(flat_tree)
+            reparsed = _parse(flat_out)
+            if not has_nested_rules(reparsed) and resolve(flat_tree, normalize=True) == resolve(
+                reparsed, normalize=True
+            ):
+                best = flat_out
+                pipeline_tree = flat_tree
+            else:
+                warn("css_minifier_nesting_guard_failed", input_length=len(css))
 
         if lvl in (MinifyLevel.OPTIMIZE, MinifyLevel.AGGRESSIVE):
-            opt_tree = optimize_tree(in_tree)
+            opt_tree = optimize_tree(pipeline_tree)
             opt_out = serialize(opt_tree)
             in_norm_sig = tree_sig(in_tree, normalize=True)
             if tree_sig(_parse(opt_out), normalize=True) == in_norm_sig:
@@ -70,7 +92,7 @@ def minify_css(css: str, *, level: MinifyLevel | str = MinifyLevel.SAFE) -> str:
                 return best
 
         if lvl is MinifyLevel.AGGRESSIVE:
-            agg_tree = structural_optimize(optimize_tree(in_tree))
+            agg_tree = structural_optimize(optimize_tree(pipeline_tree))
             agg_out = serialize(agg_tree)
             in_resolve = resolve(in_tree, normalize=True)
             if resolve(_parse(agg_out), normalize=True) == in_resolve:

--- a/bengal/css/nesting.py
+++ b/bengal/css/nesting.py
@@ -1,0 +1,159 @@
+"""Optional CSS nesting flatten (de-sugar nested rules for legacy targets).
+
+Transforms nested qualified rules into flat selectors (``.parent .child``,
+``.parent:hover``) while preserving the resolved cascade. Opt-in via
+:func:`bengal.css.minify.minify_css` ``flatten_nesting=True``.
+"""
+
+from bengal.css.nodes import AtRule, Declaration, Node, QualifiedRule
+from bengal.css.tokens import Token, TokenType
+
+_SKIP = (TokenType.WHITESPACE, TokenType.COMMENT)
+_WS = Token(TokenType.WHITESPACE, " ")
+_COMBINATORS = frozenset({">", "+", "~"})
+
+
+def _strip(tokens: tuple[Token, ...]) -> tuple[Token, ...]:
+    start = 0
+    end = len(tokens)
+    while start < end and tokens[start].type in _SKIP:
+        start += 1
+    while end > start and tokens[end - 1].type in _SKIP:
+        end -= 1
+    return tokens[start:end]
+
+
+def _split_selectors(prelude: tuple[Token, ...]) -> list[tuple[Token, ...]]:
+    parts: list[tuple[Token, ...]] = []
+    current: list[Token] = []
+    depth = 0
+    for tok in prelude:
+        if tok.type in (TokenType.LPAREN, TokenType.LBRACKET):
+            depth += 1
+        elif tok.type in (TokenType.RPAREN, TokenType.RBRACKET) and depth > 0:
+            depth -= 1
+        if depth == 0 and tok.type is TokenType.COMMA:
+            part = _strip(tuple(current))
+            if part:
+                parts.append(part)
+            current = []
+            continue
+        current.append(tok)
+    part = _strip(tuple(current))
+    if part:
+        parts.append(part)
+    return parts
+
+
+def _first_significant(tokens: tuple[Token, ...]) -> Token | None:
+    for tok in tokens:
+        if tok.type not in _SKIP:
+            return tok
+    return None
+
+
+def _has_nesting_selector(tokens: tuple[Token, ...]) -> bool:
+    return any(tok.type is TokenType.DELIM and tok.value == "&" for tok in tokens)
+
+
+def _starts_with_combinator(tokens: tuple[Token, ...]) -> bool:
+    first = _first_significant(tokens)
+    return first is not None and first.type is TokenType.DELIM and first.value in _COMBINATORS
+
+
+def _substitute_nesting_selector(
+    parent: tuple[Token, ...], child: tuple[Token, ...]
+) -> tuple[Token, ...]:
+    out: list[Token] = []
+    for tok in child:
+        if tok.type is TokenType.DELIM and tok.value == "&":
+            if out and out[-1].type not in _SKIP:
+                out.append(_WS)
+            out.extend(parent)
+            continue
+        out.append(tok)
+    return _strip(tuple(out))
+
+
+def _combine_selectors(parent: tuple[Token, ...], child: tuple[Token, ...]) -> tuple[Token, ...]:
+    child = _strip(child)
+    if not child:
+        return parent
+    if _has_nesting_selector(child) or _starts_with_combinator(child):
+        return _substitute_nesting_selector(parent, child)
+    return (*parent, _WS, *child)
+
+
+def _combine_preludes(parent: tuple[Token, ...], child: tuple[Token, ...]) -> tuple[Token, ...]:
+    parent_sels = _split_selectors(parent)
+    child_sels = _split_selectors(child)
+    combined: list[tuple[Token, ...]] = [
+        _combine_selectors(p, c) for p in parent_sels for c in child_sels
+    ]
+    if len(combined) == 1:
+        return combined[0]
+    out: list[Token] = []
+    for idx, sel in enumerate(combined):
+        if idx:
+            out.append(Token(TokenType.COMMA, ","))
+        out.extend(sel)
+    return tuple(out)
+
+
+def _flatten_qualified(rule: QualifiedRule) -> tuple[Node, ...]:
+    decls: list[Declaration] = []
+    nested_rules: list[QualifiedRule] = []
+    passthrough: list[Node] = []
+    for node in rule.block:
+        if isinstance(node, Declaration):
+            decls.append(node)
+        elif isinstance(node, QualifiedRule):
+            nested_rules.append(node)
+        else:
+            passthrough.append(node)
+
+    out: list[Node] = []
+    if decls or passthrough:
+        out.append(QualifiedRule(rule.prelude, (*decls, *passthrough)))
+
+    for nested in nested_rules:
+        combined = _combine_preludes(rule.prelude, nested.prelude)
+        out.extend(_flatten_qualified(QualifiedRule(combined, nested.block)))
+    return tuple(out)
+
+
+def _flatten_node(node: Node) -> tuple[Node, ...]:
+    if isinstance(node, QualifiedRule):
+        return _flatten_qualified(node)
+    if isinstance(node, AtRule) and node.block is not None:
+        flat_block = flatten_nesting_tree(node.block)
+        if flat_block is node.block:
+            return (node,)
+        return (AtRule(node.name, node.prelude, flat_block),)
+    return (node,)
+
+
+def flatten_nesting_tree(nodes: tuple[Node, ...]) -> tuple[Node, ...]:
+    """Return a tree with nested qualified rules hoisted to flat selectors."""
+    if not nodes:
+        return nodes
+    changed = False
+    out: list[Node] = []
+    for node in nodes:
+        flat = _flatten_node(node)
+        if flat != (node,):
+            changed = True
+        out.extend(flat)
+    return tuple(out) if changed else nodes
+
+
+def has_nested_rules(nodes: tuple[Node, ...]) -> bool:
+    """Return True if any qualified rule contains a nested qualified rule."""
+    for node in nodes:
+        if isinstance(node, QualifiedRule):
+            for child in node.block:
+                if isinstance(child, QualifiedRule):
+                    return True
+        elif isinstance(node, AtRule) and node.block is not None and has_nested_rules(node.block):
+            return True
+    return False

--- a/changelog.d/516.added.md
+++ b/changelog.d/516.added.md
@@ -1,0 +1,2 @@
+The CSS minifier accepts ``flatten_nesting=True`` to de-sugar nested rules into flat
+selectors for legacy browser targets while preserving the cascade.

--- a/tests/unit/css/test_nesting_flatten.py
+++ b/tests/unit/css/test_nesting_flatten.py
@@ -1,0 +1,45 @@
+"""Tests for opt-in CSS nesting flatten (#516)."""
+
+import pytest
+
+from bengal.css import minify_css
+from bengal.css.nesting import flatten_nesting_tree, has_nested_rules
+from bengal.css.parser import parse_stylesheet
+from bengal.css.tokenizer import tokenize
+
+
+class TestNestingFlatten:
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            (
+                ".parent{color:blue;.child{color:red}}",
+                ".parent{color:blue}.parent .child{color:red}",
+            ),
+            (
+                ".parent{color:blue;&:hover{color:red}}",
+                ".parent{color:blue}.parent:hover{color:red}",
+            ),
+            (
+                ".a,.b{color:blue;.c{color:red}}",
+                ".a,.b{color:blue}.a .c,.b .c{color:red}",
+            ),
+        ],
+    )
+    def test_flatten_nested_rules(self, source: str, expected: str) -> None:
+        assert minify_css(source, flatten_nesting=True) == expected
+
+    def test_disabled_by_default(self) -> None:
+        source = ".parent{color:blue;.child{color:red}}"
+        assert minify_css(source) == source
+        assert "&" in minify_css(source) or ".child" in minify_css(source)
+
+    def test_has_nested_rules_detects_nesting(self) -> None:
+        tree = parse_stylesheet(tokenize(".a{.b{color:red}}"))
+        assert has_nested_rules(tree)
+        flat = parse_stylesheet(tokenize(".a .b{color:red}"))
+        assert not has_nested_rules(flat)
+
+    def test_flatten_tree_idempotent_on_flat_input(self) -> None:
+        tree = parse_stylesheet(tokenize(".a .b{color:red}"))
+        assert flatten_nesting_tree(tree) is tree


### PR DESCRIPTION
## Summary
- Add `bengal/css/nesting.py` AST transform to de-sugar nested qualified rules into flat selectors
- Expose `minify_css(..., flatten_nesting=True)` (opt-in; default preserves native nesting)
- Serialization guard ensures flattened output round-trips without nested rules

## Test plan
- [x] `uv run pytest tests/unit/css/test_nesting_flatten.py -q`

Closes #516


Made with [Cursor](https://cursor.com)