### PR TITLE
test(concurrency): guard canonical GIL detection (#381 finding 7)

### DIFF
--- a/changelog.d/381.changed.md
+++ b/changelog.d/381.changed.md
@@ -1,0 +1,2 @@
+Consolidated free-threading detection to the canonical ``bengal.utils.concurrency``
+helper so executor selection and render paths no longer drift on GIL fallback logic.

--- a/tests/unit/utils/test_gil_consolidation.py
+++ b/tests/unit/utils/test_gil_consolidation.py
@@ -1,0 +1,32 @@
+"""Guard tests for canonical GIL detection (#381 finding 7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BENGAL_ROOT = _REPO_ROOT / "bengal"
+_GIL_MODULE = _BENGAL_ROOT / "utils" / "concurrency" / "gil.py"
+
+_FORBIDDEN_MARKERS = ("_is_gil_enabled", "Py_GIL_DISABLED")
+
+
+def _is_allowed(path: Path) -> bool:
+    try:
+        path.relative_to(_GIL_MODULE.parent)
+    except ValueError:
+        return False
+    return path == _GIL_MODULE
+
+
+@pytest.mark.parametrize("marker", _FORBIDDEN_MARKERS)
+def test_gil_detection_implementation_is_canonical(marker: str) -> None:
+    offenders: list[str] = []
+    for path in _BENGAL_ROOT.rglob("*.py"):
+        if _is_allowed(path):
+            continue
+        if marker in path.read_text(encoding="utf-8"):
+            offenders.append(str(path.relative_to(_REPO_ROOT)))
+    assert offenders == [], f"{marker} found outside canonical gil.py: {offenders}"


### PR DESCRIPTION
## Summary
- Add regression guard that `_is_gil_enabled` / `Py_GIL_DISABLED` references exist only in `bengal/utils/concurrency/gil.py`
- Completes Finding 7 acceptance criteria (consolidation was already landed via thin aliases to `is_gil_disabled`)

## Test plan
- [x] `uv run pytest tests/unit/utils/test_gil_consolidation.py -q`

Part of #381 (Finding 7 only; Finding 5 remains gated on benchmark sweep)


Made with [Cursor](https://cursor.com)