### PR TITLE
fix(postprocess): deterministic sitemap and agent.json ordering (#431)

### DIFF
--- a/bengal/postprocess/output_formats/agent_manifest_generator.py
+++ b/bengal/postprocess/output_formats/agent_manifest_generator.py
@@ -143,6 +143,7 @@ class AgentManifestGenerator:
                     "last_modified": last_mod,
                 }
             )
+        result.sort(key=lambda entry: entry["url"])
         return result
 
     def _build_sections(
@@ -175,6 +176,7 @@ class AgentManifestGenerator:
                         "last_modified": last_mod,
                     }
                 )
+            section_pages.sort(key=lambda entry: entry["url"])
 
             children = self._build_sections(
                 getattr(section, "sorted_subsections", section.subsections),
@@ -189,6 +191,7 @@ class AgentManifestGenerator:
                     "pages": section_pages,
                 }
             )
+        result.sort(key=lambda section: section["path"])
         return result
 
     def _get_last_modified(self, page: PageLike) -> str | None:

--- a/bengal/postprocess/sitemap.py
+++ b/bengal/postprocess/sitemap.py
@@ -119,11 +119,18 @@ class SitemapGenerator:
 
         baseurl = self.site.baseurl or ""
 
+        # Stable page order so aggregate outputs (sitemap.xml) are byte-identical
+        # regardless of site.pages insertion order (shard vs thread backends).
+        pages_for_sitemap = sorted(
+            self.site.pages,
+            key=self._sitemap_page_sort_key,
+        )
+
         # Add each page to sitemap
         included_count = 0
         skipped_count = 0
 
-        for page in self.site.pages:
+        for page in pages_for_sitemap:
             # Skip pages that shouldn't be in sitemap (hidden, visibility.sitemap=false, drafts)
             if not page.in_sitemap:
                 skipped_count += 1
@@ -255,6 +262,17 @@ class SitemapGenerator:
                 suggestion="Check output directory permissions and available disk space.",
             )
             raise error from e
+
+    def _sitemap_page_sort_key(self, page: Any) -> str:
+        """Stable sort key for deterministic sitemap entry ordering."""
+        output_path = getattr(page, "output_path", None)
+        if output_path:
+            try:
+                return to_posix(output_path.relative_to(self.site.output_dir))
+            except ValueError:
+                pass
+        slug = getattr(page, "slug", None)
+        return slug if isinstance(slug, str) else ""
 
     def _get_version_priority(self, page: Any) -> str:
         """

--- a/changelog.d/431.fixed.md
+++ b/changelog.d/431.fixed.md
@@ -1,0 +1,2 @@
+Sitemap and agent.json aggregate outputs now use stable URL/path ordering so
+byte-identical results do not depend on page discovery order.

--- a/tests/unit/postprocess/test_aggregate_output_ordering.py
+++ b/tests/unit/postprocess/test_aggregate_output_ordering.py
@@ -1,0 +1,92 @@
+"""Deterministic ordering for aggregate postprocess outputs (#431)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class TestSitemapDeterministicOrdering:
+    def test_pages_sorted_by_output_path_before_emit(self, tmp_path: Path) -> None:
+        from bengal.postprocess.sitemap import SitemapGenerator
+
+        page_z = MagicMock()
+        page_z.in_sitemap = True
+        page_z.output_path = tmp_path / "z-page" / "index.html"
+        page_z.slug = "z-page"
+        page_z.date = datetime(2024, 1, 1)
+        page_z.translation_key = None
+
+        page_a = MagicMock()
+        page_a.in_sitemap = True
+        page_a.output_path = tmp_path / "a-page" / "index.html"
+        page_a.slug = "a-page"
+        page_a.date = datetime(2024, 1, 2)
+        page_a.translation_key = None
+
+        site = MagicMock()
+        site.pages = [page_z, page_a]
+        site.baseurl = "https://example.com"
+        site.output_dir = tmp_path
+        site.config = {}
+        site.versioning_enabled = False
+
+        generator = SitemapGenerator(site)
+
+        with patch("bengal.utils.io.atomic_write.AtomicFile") as mock_atomic:
+            mock_file = MagicMock()
+            mock_atomic.return_value.__enter__ = MagicMock(return_value=mock_file)
+            mock_atomic.return_value.__exit__ = MagicMock(return_value=False)
+            generator.generate()
+
+        written = mock_file.write.call_args[0][0].decode("utf-8")
+        assert written.index("a-page") < written.index("z-page")
+
+
+class TestAgentManifestDeterministicOrdering:
+    def test_section_pages_sorted_by_url(self) -> None:
+        from bengal.postprocess.output_formats.agent_manifest_generator import (
+            AgentManifestGenerator,
+        )
+
+        site = MagicMock()
+        site.baseurl = ""
+        site.config = {"output_formats": {}}
+        generator = AgentManifestGenerator(site)
+
+        page_by_href = {
+            "/b": MagicMock(
+                title="B",
+                plain_text="b",
+                metadata={},
+                type="doc",
+                description="",
+            ),
+            "/a": MagicMock(
+                title="A",
+                plain_text="a",
+                metadata={},
+                type="doc",
+                description="",
+            ),
+        }
+        for href, page in page_by_href.items():
+            page.output_path = Path("out") / href.strip("/")
+            type(page).kind = "doc"
+
+        section = MagicMock()
+        section.title = "Docs"
+        section.href = "/docs/"
+        section.sorted_pages = [MagicMock(), MagicMock()]
+        section.sorted_pages[0].output_path = Path("out/b")
+        section.sorted_pages[1].output_path = Path("out/a")
+
+        with patch(
+            "bengal.postprocess.output_formats.agent_manifest_generator.get_page_url",
+            side_effect=["/b", "/a"],
+        ):
+            sections = generator._build_sections([section], page_by_href)
+
+        urls = [entry["url"] for entry in sections[0]["pages"]]
+        assert urls == sorted(urls)


### PR DESCRIPTION
## Summary
- Sort `sitemap.xml` entries by stable output-path key before emit
- Sort `agent.json` sections by path and page lists by URL

Partial fix for shard/thread aggregate-output byte-parity (#431); does not yet re-gate the `known_gap` parity tests.

## Test plan
- [x] `uv run pytest tests/unit/postprocess/test_aggregate_output_ordering.py -q`

Part of #431


Made with [Cursor](https://cursor.com)