### PR TITLE
Re-gate shard byte-parity tests (#431)

### DIFF
--- a/changelog.d/431.changed.md
+++ b/changelog.d/431.changed.md
@@ -1,0 +1,1 @@
+Re-gate shard render byte-parity tests now that aggregate output ordering is deterministic (#431, #529).

--- a/tests/integration/test_shard_render_parity.py
+++ b/tests/integration/test_shard_render_parity.py
@@ -80,7 +80,6 @@ _PARITY_FIXTURES = [
 ]
 
 
-@pytest.mark.known_gap  # experimental shard backend byte-parity → nightly signal, not a PR gate (see #376)
 @pytest.mark.serial
 @pytest.mark.parametrize(("root_name", "exclude"), _PARITY_FIXTURES)
 def test_shard_build_byte_identical_to_thread(tmp_path, root_name, exclude):
@@ -160,7 +159,6 @@ _FULL_OUTPUT_FIXTURES = [
 ]
 
 
-@pytest.mark.known_gap  # experimental shard backend byte-parity → nightly signal, not a PR gate (see #376)
 @pytest.mark.serial
 @pytest.mark.parametrize(("root_name", "sentinels"), _FULL_OUTPUT_FIXTURES)
 def test_shard_full_output_byte_identical_excluding_nondeterminism(tmp_path, root_name, sentinels):

--- a/tests/unit/orchestration/render/test_shard_worker.py
+++ b/tests/unit/orchestration/render/test_shard_worker.py
@@ -49,11 +49,9 @@ def _built(site_factory, root: str) -> Site:
     return site
 
 
-# known_gap: the experimental shard backend ships off by default (render_isolation="off").
-# Its byte-parity vs the in-process path is order-dependent-flaky under pytest-randomly, so it
-# runs as nightly signal, not a PR merge gate. Output-determinism work is tracked in #376 and the
-# shard-determinism follow-up, which must close before the backend goes default-on.
-@pytest.mark.known_gap
+# Byte-parity vs the in-process path is gated in CI after #431 (deterministic aggregate
+# outputs) and #529 (stable sitemap/agent.json ordering). render_isolation stays OFF by
+# default until the backend is promoted default-on.
 @pytest.mark.parametrize("root", ROOTS)
 def test_parse_shard_matches_in_process_parse(site_factory, root):
     """A worker re-parsing a file shard in isolation produces pages whose PageView is
@@ -255,7 +253,6 @@ print("RESULTJSON " + json.dumps({
 """
 
 
-@pytest.mark.known_gap  # experimental shard backend byte-parity → nightly signal, not a PR gate (see #376)
 @pytest.mark.serial
 def test_worker_site_renders_page_byte_identical(tmp_path):
     """A page rendered through a WorkerSite reconstructed (and pickle-transported) from a
@@ -443,7 +440,6 @@ print("MSREPORT " + json.dumps({
 """
 
 
-@pytest.mark.known_gap  # experimental shard backend byte-parity → nightly signal, not a PR gate (see #376)
 @pytest.mark.serial
 @pytest.mark.parametrize("fixture", ["test-product", "test-navigation"])
 @pytest.mark.parametrize("num_shards", [2, 3])


### PR DESCRIPTION
## Summary
- Remove `known_gap` markers from shard render byte-parity tests now that aggregate output ordering is deterministic (#529).
- Update comments to reflect that parity is a CI gate again while `render_isolation` stays off by default.

## Test plan
- [x] `uv run pytest tests/integration/test_shard_render_parity.py tests/unit/orchestration/render/test_shard_worker.py -v`
- [ ] CI integration job picks up re-gated tests (no longer excluded by `known_gap`)

Closes #431.


Made with [Cursor](https://cursor.com)