### PR TITLE
feat(core): Pridelands sibling core issues (#546–#549)

### DIFF
--- a/bengal/config/defaults.py
+++ b/bengal/config/defaults.py
@@ -227,6 +227,10 @@ DEFAULTS: dict[str, Any] = {
         "toc_style": "nested",  # nested | flat
         "sort_pages_by": "weight",  # weight | date | title | modified
         "sort_order": "asc",  # asc | desc
+        "git_info": {
+            "enabled": False,
+            "lastmod": True,
+        },
     },
     # -------------------------------------------------------------------------
     # Search
@@ -362,6 +366,7 @@ DEFAULTS: dict[str, Any] = {
             "json_indent": None,
             "llm_separator_width": 80,
             "include_full_content_in_index": False,
+            "include_heading_index": False,
             "include_chunks": True,
             "exclude_sections": [],
             "exclude_patterns": ["404.html", "search.html"],

--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -533,6 +533,8 @@ class ContentDiscovery:
         self.sections = self._section_builder.sections
         self.pages = self._section_builder.pages
 
+        self._enrich_git_lastmod()
+
         # Log metrics
         top_sections, top_pages = self._section_builder.get_top_level_counts()
         logger.info(
@@ -785,6 +787,27 @@ class ContentDiscovery:
             )
 
         return enriched
+
+    def _enrich_git_lastmod(self) -> None:
+        """Populate optional git-derived lastmod dates on the site instance."""
+        if self.site is None or not self.pages:
+            return
+
+        content_config = (
+            self.site.config.get("content", {}) if isinstance(self.site.config, dict) else {}
+        )
+        git_info = content_config.get("git_info", {}) if isinstance(content_config, dict) else {}
+        if not git_info.get("enabled") or not git_info.get("lastmod", True):
+            return
+
+        from bengal.utils.scm.git_dates import batch_git_last_modified
+
+        source_paths = [
+            page.source_path for page in self.pages if getattr(page, "source_path", None)
+        ]
+        git_dates = batch_git_last_modified(source_paths)
+        if git_dates:
+            self.site.git_lastmod_by_source = git_dates
 
     def _build_source_page(
         self,

--- a/bengal/core/page/lastmod.py
+++ b/bengal/core/page/lastmod.py
@@ -1,0 +1,71 @@
+"""Last-modified resolution for pages (frontmatter, git, file mtime)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bengal.protocols import PageLike
+
+
+def resolve_page_lastmod(
+    page: PageLike, git_dates: dict[Path, datetime] | None = None
+) -> datetime | None:
+    """
+    Resolve a page's last-modified timestamp.
+
+    Precedence:
+    1. Frontmatter ``lastmod`` / ``last_modified`` / ``updated``
+    2. Git commit date (when ``git_dates`` supplies the source path)
+    3. Source file mtime
+    """
+    metadata = getattr(page, "metadata", {}) or {}
+    for key in ("lastmod", "last_modified", "updated"):
+        if value := metadata.get(key):
+            parsed = _coerce_datetime(value)
+            if parsed is not None:
+                return parsed
+
+    source_path = getattr(page, "source_path", None)
+    if source_path and git_dates:
+        git_date = git_dates.get(source_path.resolve())
+        if git_date is not None:
+            return git_date
+
+    if source_path:
+        try:
+            return datetime.fromtimestamp(source_path.stat().st_mtime)
+        except OSError:
+            pass
+
+    return None
+
+
+def resolve_page_lastmod_iso(
+    page: PageLike,
+    git_dates: dict[Path, datetime] | None = None,
+) -> str | None:
+    """Return ISO 8601 last-modified string for a page, if available."""
+    lastmod = resolve_page_lastmod(page, git_dates=git_dates)
+    if lastmod is None:
+        return None
+    return lastmod.isoformat()
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if hasattr(value, "isoformat") and not isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.isoformat())
+        except TypeError, ValueError:
+            return None
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None

--- a/bengal/core/page/lastmod.py
+++ b/bengal/core/page/lastmod.py
@@ -11,6 +11,23 @@ if TYPE_CHECKING:
     from bengal.protocols import PageLike
 
 
+def _frontmatter_lastmod_iso(metadata: dict[str, Any]) -> str | None:
+    """Return a frontmatter lastmod string without normalizing author-provided text."""
+    for key in ("lastmod", "last_modified", "updated"):
+        if (value := metadata.get(key)) is None:
+            continue
+        if isinstance(value, str):
+            return value
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if hasattr(value, "isoformat"):
+            try:
+                return value.isoformat()
+            except TypeError, ValueError:
+                continue
+    return None
+
+
 def resolve_page_lastmod(
     page: PageLike, git_dates: dict[Path, datetime] | None = None
 ) -> datetime | None:
@@ -29,10 +46,32 @@ def resolve_page_lastmod(
             if parsed is not None:
                 return parsed
 
+    return _resolve_git_or_mtime(page, git_dates)
+
+
+def resolve_page_lastmod_iso(
+    page: PageLike,
+    git_dates: dict[Path, datetime] | None = None,
+) -> str | None:
+    """Return last-modified for JSON output, preserving frontmatter string values."""
+    metadata = getattr(page, "metadata", {}) or {}
+    if frontmatter := _frontmatter_lastmod_iso(metadata):
+        return frontmatter
+
+    lastmod = _resolve_git_or_mtime(page, git_dates)
+    if lastmod is None:
+        return None
+    return lastmod.isoformat()
+
+
+def _resolve_git_or_mtime(
+    page: PageLike,
+    git_dates: dict[Path, datetime] | None,
+) -> datetime | None:
     source_path = getattr(page, "source_path", None)
-    if source_path and git_dates:
+    if source_path and isinstance(git_dates, dict):
         git_date = git_dates.get(source_path.resolve())
-        if git_date is not None:
+        if isinstance(git_date, datetime):
             return git_date
 
     if source_path:
@@ -42,17 +81,6 @@ def resolve_page_lastmod(
             pass
 
     return None
-
-
-def resolve_page_lastmod_iso(
-    page: PageLike,
-    git_dates: dict[Path, datetime] | None = None,
-) -> str | None:
-    """Return ISO 8601 last-modified string for a page, if available."""
-    lastmod = resolve_page_lastmod(page, git_dates=git_dates)
-    if lastmod is None:
-        return None
-    return lastmod.isoformat()
 
 
 def _coerce_datetime(value: Any) -> datetime | None:

--- a/bengal/core/page/runtime.py
+++ b/bengal/core/page/runtime.py
@@ -226,6 +226,16 @@ class RuntimePage:
         return parse_date(self.metadata.get("date"))
 
     @property
+    def lastmod(self) -> datetime | None:
+        """Last modified timestamp (frontmatter, optional git, or file mtime)."""
+        from bengal.core.page.lastmod import resolve_page_lastmod
+
+        git_dates = None
+        if self._site is not None:
+            git_dates = getattr(self._site, "git_lastmod_by_source", None)
+        return resolve_page_lastmod(self, git_dates=git_dates)
+
+    @property
     def slug(self) -> str:
         return infer_slug(self.metadata, self.source_path)
 

--- a/bengal/core/page/runtime.py
+++ b/bengal/core/page/runtime.py
@@ -232,7 +232,9 @@ class RuntimePage:
 
         git_dates = None
         if self._site is not None:
-            git_dates = getattr(self._site, "git_lastmod_by_source", None)
+            raw_git_dates = getattr(self._site, "git_lastmod_by_source", None)
+            if isinstance(raw_git_dates, dict):
+                git_dates = raw_git_dates
         return resolve_page_lastmod(self, git_dates=git_dates)
 
     @property

--- a/bengal/parsing/backends/patitas/renderers/blocks.py
+++ b/bengal/parsing/backends/patitas/renderers/blocks.py
@@ -33,39 +33,13 @@ from bengal.parsing.backends.patitas.renderers.utils import (
     escape_attr,
     escape_html,
 )
-from bengal.utils.primitives.code import HL_LINES_PATTERN, parse_hl_lines
+from bengal.rendering.highlighting.deferred import wrap_code_block_title
+from bengal.utils.primitives.code import CodeFenceAttrs, parse_fence_attrs
 
 if TYPE_CHECKING:
     from patitas.stringbuilder import StringBuilder
 
     from bengal.parsing.backends.patitas.renderers.protocols import HtmlRendererProtocol
-
-# Alias for internal use (maintains backward compatibility)
-_HL_LINES_PATTERN = HL_LINES_PATTERN
-_parse_hl_lines = parse_hl_lines
-
-
-def _parse_code_info(info: str) -> tuple[str, list[int]]:
-    """Parse code fence info string for language and line highlights.
-
-    Args:
-        info: Code fence info string (e.g., "python {1,3-5}")
-
-    Returns:
-        Tuple of (language, hl_lines list)
-    """
-    if not info:
-        return "", []
-
-    match = _HL_LINES_PATTERN.match(info.strip())
-    if match:
-        lang = match.group(1)
-        hl_spec = match.group(2)
-        hl_lines = _parse_hl_lines(hl_spec) if hl_spec else []
-        return lang, hl_lines
-
-    # Fallback: just take first word as language
-    return info.split()[0], []
 
 
 class BlockRendererMixin:
@@ -336,12 +310,13 @@ class BlockRendererMixin:
             end = node.source_end
             if end > node.source_start and self._source[end - 1] == "\n":
                 end -= 1
-            highlighted = self._try_highlight_range(node.source_start, end, info)
+            fence_attrs = parse_fence_attrs(info)
+            highlighted = self._try_highlight_range(node.source_start, end, fence_attrs)
             if highlighted:
                 # Rosettes parity: ensure trailing newline before closing tags
                 if highlighted.endswith("</code></pre></div>"):
                     highlighted = highlighted[:-19] + "\n</code></pre></div>"
-                sb.append(highlighted)
+                sb.append(wrap_code_block_title(highlighted, fence_attrs.title))
                 return
 
         # Plain code block extraction
@@ -389,7 +364,10 @@ class BlockRendererMixin:
         sb.append("\n</code></pre></div>\n")
 
     def _try_highlight_range(
-        self: HtmlRendererProtocol, start: int, end: int, info: str
+        self: HtmlRendererProtocol,
+        start: int,
+        end: int,
+        fence_attrs: CodeFenceAttrs,
     ) -> str | None:
         """Try to highlight a source range using internal rosettes.
 
@@ -400,7 +378,7 @@ class BlockRendererMixin:
         if not self._rosettes_available:
             return None
 
-        lang, hl_lines = _parse_code_info(info)
+        lang = fence_attrs.highlight_language
         if not lang:
             return None
 
@@ -413,7 +391,8 @@ class BlockRendererMixin:
                 css_class_style=self._highlight_style,
                 start=start,
                 end=end,
-                hl_lines=frozenset(hl_lines) if hl_lines else None,
+                hl_lines=frozenset(fence_attrs.hl_lines) if fence_attrs.hl_lines else None,
+                show_linenos=fence_attrs.show_linenos,
             )
         except LookupError, ValueError:
             return None

--- a/bengal/postprocess/output_formats/__init__.py
+++ b/bengal/postprocess/output_formats/__init__.py
@@ -373,11 +373,13 @@ class OutputFormatsGenerator:
             excerpt_length = options.get("excerpt_length", 200)
             json_indent = options.get("json_indent")
             include_full_content = options.get("include_full_content_in_index", False)
+            include_heading_index = options.get("include_heading_index", False)
             index_gen = SiteIndexGenerator(
                 self.site,
                 excerpt_length=excerpt_length,
                 json_indent=json_indent,
                 include_full_content=include_full_content,
+                include_heading_index=include_heading_index,
             )
             # OPTIMIZATION: Pass accumulated page data for hybrid mode
             # See: plan/drafted/rfc-unified-page-data-accumulation.md
@@ -390,6 +392,7 @@ class OutputFormatsGenerator:
                     "excerpt_length": excerpt_length,
                     "json_indent": json_indent,
                     "include_full_content": include_full_content,
+                    "include_heading_index": include_heading_index,
                 },
                 self._expected_site_wide_outputs("site_index_json"),
                 lambda: index_gen.generate(

--- a/bengal/postprocess/output_formats/index_generator.py
+++ b/bengal/postprocess/output_formats/index_generator.py
@@ -77,6 +77,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from bengal.postprocess.output_formats.utils import (
+    build_heading_index_records,
     generate_excerpt,
     get_i18n_output_path,
     get_page_relative_url,
@@ -141,6 +142,7 @@ class SiteIndexGenerator:
         excerpt_length: int = 200,
         json_indent: int | None = None,
         include_full_content: bool = False,
+        include_heading_index: bool = False,
     ) -> None:
         """
         Initialize the index generator.
@@ -150,11 +152,13 @@ class SiteIndexGenerator:
             excerpt_length: Length of excerpts in characters
             json_indent: JSON indentation (None for compact)
             include_full_content: Include full content in index (increases size)
+            include_heading_index: Emit per-heading search records (default: False)
         """
         self.site = site
         self.excerpt_length = excerpt_length
         self.json_indent = json_indent
         self.include_full_content = include_full_content
+        self.include_heading_index = include_heading_index
 
     def generate(
         self,
@@ -299,6 +303,9 @@ class SiteIndexGenerator:
         ]
         # Sort pages by URL for deterministic output (important for idempotent builds)
         site_data["pages"] = sorted(site_data["pages"], key=lambda p: p.get("url", ""))
+
+        if self.include_heading_index:
+            site_data["headings"] = self._build_heading_records(pages)
 
         logger.debug(
             "site_index_data_aggregated",
@@ -460,6 +467,9 @@ class SiteIndexGenerator:
         # Sort pages by URL for deterministic output (important for idempotent builds)
         site_data["pages"] = sorted(site_data["pages"], key=lambda p: p.get("url", ""))
 
+        if self.include_heading_index:
+            site_data["headings"] = self._build_heading_records(pages)
+
         # Determine output path
         if version_id is None or self._is_latest_version(version_id):
             # Latest version: output_dir/index.json
@@ -521,6 +531,47 @@ class SiteIndexGenerator:
         - Hash stored in .hash sidecar file
         """
         write_if_content_changed(path, content, hash_suffix=".hash")
+
+    def _build_heading_records(self, pages: Sequence[PageLike]) -> list[dict[str, Any]]:
+        """Build deterministic per-heading search records across pages."""
+        records: list[dict[str, Any]] = []
+        baseurl = (self.site.baseurl or "").rstrip("/")
+
+        for page in pages:
+            if getattr(page, "draft", False):
+                continue
+
+            metadata = getattr(page, "metadata", {}) or {}
+            visibility = metadata.get("visibility")
+            search_exclude = bool(
+                metadata.get("search_exclude")
+                or metadata.get("hidden", False)
+                or (isinstance(visibility, dict) and not visibility.get("search", True))
+            )
+
+            page_uri = get_page_relative_url(page, self.site)
+            page_url = f"{baseurl}{page_uri}" if baseurl else page_uri
+            html_content = (
+                getattr(page, "html_content", None)
+                or getattr(page, "rendered_html", None)
+                or getattr(page, "_html_cache", None)
+                or ""
+            )
+            toc_items = getattr(page, "toc_items", None) or []
+
+            records.extend(
+                build_heading_index_records(
+                    page_uri=page_uri,
+                    page_url=page_url,
+                    page_title=page.title,
+                    html_content=html_content,
+                    toc_items=list(toc_items),
+                    excerpt_length=self.excerpt_length,
+                    search_exclude=search_exclude,
+                )
+            )
+
+        return sorted(records, key=lambda record: record.get("objectID", ""))
 
     def page_to_summary(self, page: PageLike) -> dict[str, Any]:
         """

--- a/bengal/postprocess/output_formats/json_generator.py
+++ b/bengal/postprocess/output_formats/json_generator.py
@@ -383,7 +383,9 @@ class PageJSONGenerator:
         git_dates = None
         site = getattr(self, "site", None)
         if site is not None:
-            git_dates = getattr(site, "git_lastmod_by_source", None)
+            raw_git_dates = getattr(site, "git_lastmod_by_source", None)
+            if isinstance(raw_git_dates, dict):
+                git_dates = raw_git_dates
         return resolve_page_lastmod_iso(page, git_dates=git_dates)
 
     def _build_graph_indexes(self, graph_data: dict[str, Any]) -> None:

--- a/bengal/postprocess/output_formats/json_generator.py
+++ b/bengal/postprocess/output_formats/json_generator.py
@@ -75,7 +75,6 @@ from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from pathlib import Path
 
     from bengal.protocols import PageLike, SiteLike
 
@@ -378,28 +377,14 @@ class PageJSONGenerator:
         return nav if nav else None
 
     def _get_last_modified(self, page: PageLike) -> str | None:
-        """Resolve last-modified timestamp from frontmatter or file mtime."""
-        # Frontmatter takes priority
-        for key in ("lastmod", "last_modified", "updated"):
-            val = page.metadata.get(key)
-            if val:
-                if isinstance(val, datetime):
-                    return val.isoformat()
-                if hasattr(val, "isoformat"):
-                    return val.isoformat()
-                if isinstance(val, str):
-                    return val
+        """Resolve last-modified timestamp from frontmatter, git, or file mtime."""
+        from bengal.core.page.lastmod import resolve_page_lastmod_iso
 
-        # Fall back to source file mtime
-        source: Path | None = getattr(page, "source_path", None)
-        if source:
-            try:
-                mtime = source.stat().st_mtime
-                return datetime.fromtimestamp(mtime).isoformat()
-            except OSError, ValueError:
-                pass
-
-        return None
+        git_dates = None
+        site = getattr(self, "site", None)
+        if site is not None:
+            git_dates = getattr(site, "git_lastmod_by_source", None)
+        return resolve_page_lastmod_iso(page, git_dates=git_dates)
 
     def _build_graph_indexes(self, graph_data: dict[str, Any]) -> None:
         """

--- a/bengal/postprocess/output_formats/lunr_index_generator.py
+++ b/bengal/postprocess/output_formats/lunr_index_generator.py
@@ -88,6 +88,7 @@ class LunrIndexGenerator:
         "author": 2,
         "search_keywords": 8,
         "kind": 1,
+        "parent_title": 3,
     }
 
     def __init__(self, site: SiteLike) -> None:
@@ -152,6 +153,9 @@ class LunrIndexGenerator:
 
             # Build documents for Lunr
             documents = self._build_documents(pages)
+            headings = data.get("headings", [])
+            if headings:
+                documents.extend(self._build_heading_documents(headings))
 
             if not documents:
                 logger.warning(
@@ -235,6 +239,31 @@ class LunrIndexGenerator:
             }
 
             documents.append(doc)
+
+        return documents
+
+    def _build_heading_documents(self, headings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Build Lunr documents from per-heading index records."""
+        documents: list[dict[str, Any]] = []
+
+        for heading in headings:
+            if not heading.get("title"):
+                continue
+
+            documents.append(
+                {
+                    "objectID": heading.get("objectID") or heading.get("url", ""),
+                    "title": heading.get("title", ""),
+                    "description": heading.get("breadcrumb", ""),
+                    "content": heading.get("content", ""),
+                    "section": heading.get("section", ""),
+                    "parent_title": heading.get("parent_title", ""),
+                    "kind": "heading",
+                    "anchor": heading.get("anchor", ""),
+                    "parent_objectID": heading.get("parent_objectID", ""),
+                    "url": heading.get("url", ""),
+                }
+            )
 
         return documents
 

--- a/bengal/postprocess/output_formats/utils.py
+++ b/bengal/postprocess/output_formats/utils.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 
 import hashlib
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bengal.utils.io.atomic_write import AtomicFile
 from bengal.utils.observability.logger import get_logger
@@ -470,6 +470,89 @@ def extract_heading_chunks(
         )
 
     return chunks
+
+
+def normalize_toc_items(toc_items: list[dict[str, str | int]]) -> list[dict[str, str | int]]:
+    """Normalize Patitas/HTML TOC item shapes to ``{id, title, level}``."""
+    normalized: list[dict[str, str | int]] = []
+    for item in toc_items:
+        anchor = item.get("id") or item.get("slug") or ""
+        title = item.get("title") or item.get("text") or ""
+        level = item.get("level", 2)
+        if anchor or title:
+            normalized.append(
+                {
+                    "id": str(anchor),
+                    "title": str(title),
+                    "level": int(level),
+                }
+            )
+    return normalized
+
+
+def build_heading_index_records(
+    *,
+    page_uri: str,
+    page_url: str,
+    page_title: str,
+    html_content: str,
+    toc_items: list[dict[str, str | int]],
+    excerpt_length: int,
+    search_exclude: bool = False,
+) -> list[dict[str, Any]]:
+    """
+    Build per-heading search index records for a page.
+
+    Uses rendered HTML + TOC anchors when available; falls back to TOC-only
+    records (title/anchor without section body) when HTML is absent.
+    """
+    if search_exclude:
+        return []
+
+    normalized_toc = normalize_toc_items(toc_items)
+    chunks = extract_heading_chunks(html_content, normalized_toc, page_uri) if html_content else []
+
+    chunk_by_anchor = {
+        str(chunk.get("anchor", "")): chunk for chunk in chunks if chunk.get("anchor")
+    }
+
+    records: list[dict[str, Any]] = []
+    seen_anchors: set[str] = set()
+
+    for item in normalized_toc:
+        anchor = str(item.get("id", ""))
+        if not anchor or anchor in seen_anchors:
+            continue
+        seen_anchors.add(anchor)
+
+        chunk = chunk_by_anchor.get(anchor, {})
+        heading_title = str(chunk.get("title") or item.get("title") or anchor)
+        content = str(chunk.get("content") or "")
+        if content:
+            content = generate_excerpt(content, excerpt_length * 3)
+
+        anchor_url = str(chunk.get("anchor_url") or f"{page_url.rstrip('/')}#{anchor}")
+        object_id = f"{page_uri.rstrip('/')}#{anchor}"
+
+        records.append(
+            {
+                "objectID": object_id,
+                "kind": "heading",
+                "title": heading_title,
+                "anchor": anchor,
+                "url": anchor_url,
+                "href": anchor_url,
+                "parent_objectID": page_uri,
+                "parent_url": page_url,
+                "parent_title": page_title,
+                "breadcrumb": f"{page_title} › {heading_title}",
+                "level": int(chunk.get("level") or item.get("level") or 2),
+                "content": content,
+                "section": "",
+            }
+        )
+
+    return records
 
 
 def write_if_content_changed(

--- a/bengal/postprocess/sitemap.py
+++ b/bengal/postprocess/sitemap.py
@@ -202,8 +202,15 @@ class SitemapGenerator:
             included_count += 1
 
             # Add lastmod if available
-            if page.date:
+            lastmod_dt = getattr(page, "lastmod", None)
+            if lastmod_dt is not None:
+                lastmod = lastmod_dt.strftime("%Y-%m-%d")
+            elif page.date:
                 lastmod = page.date.strftime("%Y-%m-%d")
+            else:
+                lastmod = None
+
+            if lastmod:
                 ET.SubElement(url_elem, "lastmod").text = lastmod
 
             # Add default priority and changefreq

--- a/bengal/postprocess/sitemap.py
+++ b/bengal/postprocess/sitemap.py
@@ -202,7 +202,12 @@ class SitemapGenerator:
             included_count += 1
 
             # Add lastmod if available
-            lastmod_dt = getattr(page, "lastmod", None)
+            from bengal.core.page.lastmod import resolve_page_lastmod
+
+            git_dates = getattr(self.site, "git_lastmod_by_source", None)
+            if not isinstance(git_dates, dict):
+                git_dates = None
+            lastmod_dt = resolve_page_lastmod(page, git_dates=git_dates)
             if lastmod_dt is not None:
                 lastmod = lastmod_dt.strftime("%Y-%m-%d")
             elif page.date:

--- a/bengal/rendering/highlighting/deferred.py
+++ b/bengal/rendering/highlighting/deferred.py
@@ -34,22 +34,13 @@ from typing import TYPE_CHECKING
 
 from bengal.rendering.highlighting.rosettes import RosettesBackend
 from bengal.utils.observability.logger import get_logger
-from bengal.utils.primitives.code import parse_hl_lines
+from bengal.utils.primitives.code import parse_fence_attrs
 
 if TYPE_CHECKING:
     from bengal.rendering.highlighting.cache import HighlightCache
 
-# Pattern to extract line highlight syntax from code fence info string
-# Matches: python {5} or yaml {1,3,5} or js {1-3,5,7-9}
+# Pattern kept for backward compatibility with external imports/tests.
 HL_LINES_PATTERN = re.compile(r"^(\S+)\s*\{([^}]+)\}$")
-
-# Pattern to parse code fence info with optional title and line highlights
-# Matches: python, python title="file.py", python {1,3}, python title="file.py" {1,3}
-CODE_INFO_PATTERN = re.compile(
-    r"^(?P<lang>\S+)"  # Language (required, no spaces)
-    r'(?:\s+title="(?P<title>[^"]*)")?'  # title="..." (optional)
-    r"(?:\s*\{(?P<hl>[^}]+)\})?$"  # {1,3-5} line highlights (optional)
-)
 
 logger = get_logger(__name__)
 
@@ -169,7 +160,7 @@ class CodeBlockCollector:
                 key = _cache_key(block)
                 cached = cache.get(key)
                 if cached is not None:
-                    results[block.placeholder_id] = _wrap_with_title(cached, block.title)
+                    results[block.placeholder_id] = wrap_code_block_title(cached, block.title)
                     continue
                 uncached.append((block, key))
             else:
@@ -213,7 +204,7 @@ class CodeBlockCollector:
             for (block, key), html in zip(uncached, highlighted, strict=True):
                 if cache and key:
                     cache.set(key, html)
-                results[block.placeholder_id] = _wrap_with_title(html, block.title)
+                results[block.placeholder_id] = wrap_code_block_title(html, block.title)
         else:
             # Fallback for rosettes < 0.2.0: simple blocks parallel, complex sequential
             simple_blocks: list[tuple[str, str, PendingCodeBlock, str]] = []
@@ -230,7 +221,7 @@ class CodeBlockCollector:
                 for (_, _, block, key), html in zip(simple_blocks, highlighted, strict=True):
                     if cache and key:
                         cache.set(key, html)
-                    results[block.placeholder_id] = _wrap_with_title(html, block.title)
+                    results[block.placeholder_id] = wrap_code_block_title(html, block.title)
 
             backend = RosettesBackend()
             for block, key in complex_blocks:
@@ -243,7 +234,7 @@ class CodeBlockCollector:
                     )
                     if cache and key:
                         cache.set(key, html)
-                    results[block.placeholder_id] = _wrap_with_title(html, block.title)
+                    results[block.placeholder_id] = wrap_code_block_title(html, block.title)
                 except Exception as e:
                     logger.warning("highlight_failed", language=block.language, error=str(e))
                     results[block.placeholder_id] = _fallback_code_block(
@@ -280,6 +271,23 @@ def _fallback_code_block(code: str, language: str, title: str | None) -> str:
     plain_block = f'<pre><code class="language-{language}">{escaped_code}</code></pre>\n'
 
     return _wrap_with_title(plain_block, title)
+
+
+def wrap_code_block_title(html: str, title: str | None) -> str:
+    """Wrap highlighted code with an optional filename/title label."""
+    return _wrap_with_title(html, title)
+
+
+def parse_fence_info(info: str) -> tuple[str, list[int], str | None, bool, bool]:
+    """Parse a fence info string into highlight kwargs for deferred mode."""
+    attrs = parse_fence_attrs(info)
+    return (
+        attrs.highlight_language,
+        list(attrs.hl_lines),
+        attrs.title,
+        attrs.diff,
+        attrs.show_linenos,
+    )
 
 
 # =============================================================================
@@ -352,5 +360,6 @@ __all__ = [
     "enable_deferred_highlighting",
     "flush_deferred_highlighting",
     "is_deferred_highlighting_enabled",
-    "parse_hl_lines",
+    "parse_fence_info",
+    "wrap_code_block_title",
 ]

--- a/bengal/rendering/template_functions/tables.py
+++ b/bengal/rendering/template_functions/tables.py
@@ -2,12 +2,15 @@
 Table functions for templates.
 
 Provides functions for rendering interactive data tables from YAML/CSV files.
+Core emits a renderer-agnostic table contract; the default theme adapts it to
+Tabulator when the vendored runtime is present.
 """
 
 from __future__ import annotations
 
 import csv
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from kida import Markup
@@ -24,7 +27,47 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-__all__ = ["data_table", "register"]
+__all__ = [
+    "DataTableColumn",
+    "DataTableOptions",
+    "DataTableSpec",
+    "build_data_table_spec",
+    "data_table",
+    "load_data_table",
+    "register",
+    "render_data_table_html",
+    "spec_to_contract",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class DataTableColumn:
+    """Renderer-agnostic column descriptor."""
+
+    field: str
+    title: str
+
+
+@dataclass(frozen=True, slots=True)
+class DataTableOptions:
+    """Renderer-agnostic table behavior flags."""
+
+    search: bool = True
+    filterable: bool = True
+    sortable: bool = True
+    paginated: int | bool = 50
+    height: str = "auto"
+    visible_columns: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DataTableSpec:
+    """Canonical data-table payload consumed by theme renderers."""
+
+    table_id: str
+    columns: tuple[DataTableColumn, ...]
+    rows: tuple[dict[str, Any], ...]
+    options: DataTableOptions
 
 
 def register(env: TemplateEnvironment, site: SiteConfig) -> None:
@@ -70,6 +113,11 @@ def _load_data(path: str, root_path: Path) -> dict[str, Any]:
     if suffix == ".csv":
         return _load_csv_data(file_path)
     return {"error": f"Unsupported file format: {suffix} (use .yaml, .yml, or .csv)"}
+
+
+def load_data_table(path: str, root_path: Path) -> dict[str, Any]:
+    """Load table columns and rows from a data file."""
+    return _load_data(path, root_path)
 
 
 def _load_yaml_data(file_path: Path) -> dict[str, Any]:
@@ -160,52 +208,78 @@ def _parse_pagination(value: str | bool | int) -> int | bool:
         return 50
 
 
-def _parse_columns(value: str) -> list[str] | None:
+def _parse_columns(value: str) -> tuple[str, ...] | None:
     """Parse visible columns option."""
     if not value or not value.strip():
         return None
-    return [col.strip() for col in value.split(",") if col.strip()]
+    return tuple(col.strip() for col in value.split(",") if col.strip())
 
 
-def render_data_table_html(
-    columns: list[dict[str, Any]],
-    data: list[dict[str, Any]],
-    table_id: str,
-    search: bool = True,
-    filter_enabled: bool = True,
-    pagination: int | bool = 50,
-    height: str = "auto",
-    visible_columns: list[str] | None = None,
-) -> str:
-    """Render data table to HTML."""
-    if visible_columns:
-        columns = [col for col in columns if col["field"] in visible_columns]
+def build_data_table_spec(
+    path: str, root_path: Path, **options: Any
+) -> DataTableSpec | dict[str, Any]:
+    """Load data and build a renderer-agnostic table spec."""
+    data_result = _load_data(path, root_path)
+    if "error" in data_result:
+        return data_result
 
-    config: dict[str, Any] = {
+    table_options = DataTableOptions(
+        search=_parse_bool(options.get("search", True)),
+        filterable=_parse_bool(options.get("filter", True)),
+        sortable=_parse_bool(options.get("sort", True)),
+        paginated=_parse_pagination(options.get("pagination", 50)),
+        height=str(options.get("height", "auto")),
+        visible_columns=_parse_columns(str(options.get("columns", ""))),
+    )
+
+    columns = tuple(
+        DataTableColumn(field=str(col["field"]), title=str(col.get("title", col["field"])))
+        for col in data_result["columns"]
+    )
+    rows = tuple(dict(row) for row in data_result["data"])
+
+    return DataTableSpec(
+        table_id=_generate_table_id(path),
+        columns=columns,
+        rows=rows,
+        options=table_options,
+    )
+
+
+def spec_to_contract(spec: DataTableSpec) -> dict[str, Any]:
+    """Serialize a table spec to the generic JSON contract."""
+    columns = [{"field": col.field, "title": col.title} for col in spec.columns]
+    if spec.options.visible_columns:
+        visible = set(spec.options.visible_columns)
+        columns = [col for col in columns if col["field"] in visible]
+
+    paginated = spec.options.paginated
+    return {
+        "table_id": spec.table_id,
         "columns": columns,
-        "data": data,
-        "layout": "fitColumns",
-        "responsiveLayout": "collapse",
-        "pagination": pagination if pagination else False,
-        "paginationSize": pagination if isinstance(pagination, int) else 50,
-        "movableColumns": True,
-        "resizableColumnFit": True,
+        "rows": list(spec.rows),
+        "options": {
+            "search": spec.options.search,
+            "filterable": spec.options.filterable,
+            "sortable": spec.options.sortable,
+            "paginated": paginated if paginated else False,
+            "page_size": paginated if isinstance(paginated, int) else 50,
+            "height": spec.options.height,
+        },
     }
 
-    if height and height != "auto":
-        config["height"] = height
 
-    if filter_enabled:
-        for col in config["columns"]:
-            col["headerFilter"] = "input"
-
-    config_json = json.dumps(config, indent=None)
+def render_data_table_html(spec: DataTableSpec) -> str:
+    """Render a data table wrapper with the generic JSON contract embedded."""
+    contract = spec_to_contract(spec)
+    contract_json = json.dumps(contract, indent=None, sort_keys=True)
+    table_id = spec.table_id
 
     html_parts = [
         f'<div class="bengal-data-table-wrapper" data-table-id="{table_id}">',
     ]
 
-    if search:
+    if spec.options.search:
         html_parts.append(
             f'  <div class="bengal-data-table-toolbar">'
             f'    <input type="text" id="{table_id}-search" '
@@ -216,11 +290,9 @@ def render_data_table_html(
         )
 
     html_parts.append(f'  <div id="{table_id}" class="bengal-data-table"></div>')
-
     html_parts.append(
-        f'  <script type="application/json" data-table-config="{table_id}">{config_json}</script>'
+        f'  <script type="application/json" data-table-spec="{table_id}">{contract_json}</script>'
     )
-
     html_parts.append("</div>")
 
     return "\n".join(html_parts)
@@ -282,43 +354,21 @@ def data_table(path: str, site: Any, **options: Any) -> Markup:
     if not hasattr(site, "root_path"):
         raise TypeError("Site object missing required 'root_path' attribute")
 
-    # Load data
-    data_result = _load_data(path, site.root_path)
-
-    if "error" in data_result:
+    spec_result = build_data_table_spec(path, site.root_path, **options)
+    if isinstance(spec_result, dict) and "error" in spec_result:
         logger.error(
             "data_table_load_error",
             path=path,
-            error=data_result["error"],
+            error=spec_result["error"],
             caller="template",
             error_code=ErrorCode.R003.value,
             suggestion="Check that data file exists and is valid JSON/YAML/CSV",
         )
         return Markup(
             f'<div class="bengal-data-table-error" role="alert">'
-            f"<strong>Data Table Error:</strong> {data_result['error']}"
+            f"<strong>Data Table Error:</strong> {spec_result['error']}"
             f"<br><small>File: {path}</small>"
             f"</div>"
         )
 
-    # Parse options
-    table_id = _generate_table_id(path)
-    search = _parse_bool(options.get("search", True))
-    filter_enabled = _parse_bool(options.get("filter", True))
-    _parse_bool(options.get("sort", True))
-    pagination = _parse_pagination(options.get("pagination", 50))
-    height = options.get("height", "auto")
-    visible_columns = _parse_columns(options.get("columns", ""))
-
-    html = render_data_table_html(
-        columns=data_result["columns"],
-        data=data_result["data"],
-        table_id=table_id,
-        search=search,
-        filter_enabled=filter_enabled,
-        pagination=pagination,
-        height=height,
-        visible_columns=visible_columns,
-    )
-
-    return Markup(html)
+    return Markup(render_data_table_html(spec_result))

--- a/bengal/themes/default/assets/js/enhancements/data-table.js
+++ b/bengal/themes/default/assets/js/enhancements/data-table.js
@@ -41,6 +41,39 @@
   }
 
   /**
+   * Convert the core renderer-agnostic contract to Tabulator config.
+   * @param {Object} spec - Generic data-table spec from core
+   * @returns {Object} Tabulator configuration
+   */
+  function specToTabulatorConfig(spec) {
+    const options = spec.options || {};
+    const paginated = options.paginated;
+    const pageSize = typeof paginated === 'number' ? paginated : (options.page_size || 50);
+
+    const config = {
+      columns: (spec.columns || []).map(col => ({
+        title: col.title,
+        field: col.field,
+        headerFilter: options.filterable ? 'input' : false,
+      })),
+      data: spec.rows || [],
+      layout: 'fitColumns',
+      responsiveLayout: 'collapse',
+      pagination: Boolean(paginated),
+      paginationSize: pageSize,
+      movableColumns: true,
+      resizableColumnFit: true,
+      sort: options.sortable !== false,
+    };
+
+    if (options.height && options.height !== 'auto') {
+      config.height = options.height;
+    }
+
+    return config;
+  }
+
+  /**
    * Initialize a single data table
    * @param {HTMLElement} wrapper - Table wrapper element
    */
@@ -48,7 +81,9 @@
     const tableId = wrapper.getAttribute('data-table-id');
     const tableElement = wrapper.querySelector(`#${tableId}`);
     const searchInput = wrapper.querySelector(`#${tableId}-search`);
-    const configScript = wrapper.querySelector(`script[data-table-config="${tableId}"]`);
+    const specScript = wrapper.querySelector(`script[data-table-spec="${tableId}"]`);
+    const legacyConfigScript = wrapper.querySelector(`script[data-table-config="${tableId}"]`);
+    const configScript = specScript || legacyConfigScript;
 
     if (!tableElement || !configScript) {
       console.error(`Data table ${tableId} missing required elements`);
@@ -58,7 +93,8 @@
     // Parse configuration
     let config;
     try {
-      config = JSON.parse(configScript.textContent);
+      const payload = JSON.parse(configScript.textContent);
+      config = specScript ? specToTabulatorConfig(payload) : payload;
     } catch (e) {
       console.error(`Failed to parse config for table ${tableId}:`, e);
       return;

--- a/bengal/utils/primitives/code.py
+++ b/bengal/utils/primitives/code.py
@@ -8,20 +8,49 @@ duplicate implementations found in rendering and parsing modules.
 Example:
 
 ```python
-from bengal.utils.primitives.code import parse_hl_lines, parse_code_info
+from bengal.utils.primitives.code import parse_fence_attrs, parse_hl_lines
 
 lines = parse_hl_lines("1,3-5,7")  # [1, 3, 4, 5, 7]
-lang, highlights = parse_code_info("python {1,3-5}")  # ("python", [1, 3, 4, 5])
+attrs = parse_fence_attrs('python title="app.py" {1,3-5}')
 ```
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 
 # Pattern to parse code fence info with optional line highlights
 # Matches: python, python {1,3}, python {1-3,5}, python {}
 HL_LINES_PATTERN = re.compile(r"^(\S+)\s*(?:\{([^}]*)\})?$")
+
+# Canonical fence info: language, optional diff flag, title, brace attrs, linenos
+FENCE_INFO_PATTERN = re.compile(
+    r"^(?P<lang>\S+)"
+    r"(?:\s+(?P<diff>diff))?"
+    r'(?:\s+title="(?P<title>[^"]*)")?'
+    r"(?:\s*\{(?P<brace>[^}]*)\})?"
+    r'(?:\s+title="(?P<title2>[^"]*)")?'
+    r"(?:\s+(?P<linenos>linenos))?$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CodeFenceAttrs:
+    """Parsed attributes from a markdown code fence info string."""
+
+    language: str = ""
+    hl_lines: tuple[int, ...] = ()
+    title: str | None = None
+    diff: bool = False
+    show_linenos: bool = False
+
+    @property
+    def highlight_language(self) -> str:
+        """Language passed to the highlighter (diff fences use the diff lexer)."""
+        if self.diff or self.language.lower() == "diff":
+            return "diff"
+        return self.language
 
 
 def parse_hl_lines(hl_spec: str) -> list[int]:
@@ -66,6 +95,10 @@ def parse_hl_lines(hl_spec: str) -> list[int]:
     lines: set[int] = set()
     for part in hl_spec.split(","):
         part = part.strip()
+        if not part:
+            continue
+        if part.lower() == "diff":
+            continue
         if "-" in part:
             # Range: "3-5" -> 3, 4, 5
             try:
@@ -80,6 +113,69 @@ def parse_hl_lines(hl_spec: str) -> list[int]:
             except ValueError:
                 continue
     return sorted(lines)
+
+
+def _parse_brace_content(brace: str | None) -> tuple[tuple[int, ...], bool]:
+    """Parse brace content into highlight lines and optional diff flag."""
+    if not brace:
+        return (), False
+
+    brace = brace.strip()
+    if not brace:
+        return (), False
+
+    if brace.lower() == "diff":
+        return (), True
+
+    hl_lines = tuple(parse_hl_lines(brace))
+    parts = {segment.strip().lower() for segment in brace.split(",") if segment.strip()}
+    diff = "diff" in parts
+    if diff:
+        filtered = [
+            segment.strip() for segment in brace.split(",") if segment.strip().lower() != "diff"
+        ]
+        hl_lines = tuple(line for segment in filtered for line in parse_hl_lines(segment))
+    return hl_lines, diff
+
+
+def parse_fence_attrs(info: str) -> CodeFenceAttrs:
+    """
+    Parse a code fence info string into structured highlight attributes.
+
+    Handles:
+    - ``python`` -> language only
+    - ``python {1,3-5}`` -> line highlights
+    - ``python title="app.py" {2}`` -> title + highlights
+    - ``python diff`` / ``diff`` -> unified diff rendering
+    - ``python linenos`` -> line-number gutter (via rosettes)
+
+    Args:
+        info: Code fence info string after the opening backticks.
+
+    Returns:
+        Parsed :class:`CodeFenceAttrs`.
+    """
+    if not info:
+        return CodeFenceAttrs()
+
+    info = info.strip()
+    match = FENCE_INFO_PATTERN.match(info)
+    if match:
+        lang = match.group("lang")
+        diff = match.group("diff") is not None or lang.lower() == "diff"
+        title = match.group("title") or match.group("title2")
+        show_linenos = match.group("linenos") is not None
+        hl_lines, brace_diff = _parse_brace_content(match.group("brace"))
+        return CodeFenceAttrs(
+            language=lang,
+            hl_lines=hl_lines,
+            title=title or None,
+            diff=diff or brace_diff,
+            show_linenos=show_linenos,
+        )
+
+    # Fallback: first token is language, remainder ignored
+    return CodeFenceAttrs(language=info.split()[0])
 
 
 def parse_code_info(info: str) -> tuple[str, list[int]]:
@@ -106,15 +202,5 @@ def parse_code_info(info: str) -> tuple[str, list[int]]:
         ('', [])
 
     """
-    if not info:
-        return "", []
-
-    info = info.strip()
-    match = HL_LINES_PATTERN.match(info)
-    if match:
-        lang = match.group(1)
-        hl_spec = match.group(2)
-        return lang, parse_hl_lines(hl_spec) if hl_spec else []
-
-    # Fallback: treat entire string as language
-    return info, []
+    attrs = parse_fence_attrs(info)
+    return attrs.language, list(attrs.hl_lines)

--- a/bengal/utils/scm/git_dates.py
+++ b/bengal/utils/scm/git_dates.py
@@ -1,0 +1,132 @@
+"""Git-derived metadata helpers for content files."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from bengal.utils.observability.logger import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+logger = get_logger(__name__)
+
+
+def find_git_root(start: Path) -> Path | None:
+    """Return the git repository root containing ``start``, or None."""
+    path = start.resolve()
+    if not path.is_dir():
+        path = path.parent
+
+    for candidate in [path, *path.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def batch_git_last_modified(
+    paths: Sequence[Path],
+    *,
+    repo_root: Path | None = None,
+) -> dict[Path, datetime]:
+    """
+    Batch-resolve last commit dates for content files via ``git log``.
+
+    Uses a single ``git log --name-only`` pass and keeps the first (most
+    recent) commit date encountered for each tracked file.
+
+    Returns an empty dict when git is unavailable, the tree is not a repo,
+    or the subprocess fails (shallow CI clones, sandbox builds, etc.).
+
+    Args:
+        paths: Absolute or repo-relative source file paths.
+        repo_root: Optional git root. When omitted, inferred from the first path.
+
+    Returns:
+        Mapping of resolved absolute paths to UTC commit datetimes.
+    """
+    if not paths:
+        return {}
+
+    resolved_paths = [path.resolve() for path in paths]
+    root = repo_root or find_git_root(resolved_paths[0])
+    if root is None:
+        return {}
+
+    rel_paths: list[str] = []
+    rel_to_abs: dict[str, Path] = {}
+    for path in resolved_paths:
+        try:
+            rel = path.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        rel_paths.append(rel)
+        rel_to_abs[rel] = path
+
+    if not rel_paths:
+        return {}
+
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "log",
+                "--format=%cI",
+                "--name-only",
+                "--",
+                *rel_paths,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("git_lastmod_lookup_failed", error=str(exc))
+        return {}
+
+    if completed.returncode != 0:
+        logger.debug(
+            "git_lastmod_lookup_nonzero",
+            returncode=completed.returncode,
+            stderr=completed.stderr.strip(),
+        )
+        return {}
+
+    wanted = set(rel_paths)
+    results: dict[Path, datetime] = {}
+    current_date: datetime | None = None
+
+    for raw_line in completed.stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        parsed = _parse_git_timestamp(line)
+        if parsed is not None:
+            current_date = parsed
+            continue
+
+        if current_date is None or line not in wanted or line in results:
+            continue
+
+        abs_path = rel_to_abs.get(line)
+        if abs_path is not None:
+            results[abs_path] = current_date
+
+    return results
+
+
+def _parse_git_timestamp(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).replace(tzinfo=None)

--- a/bengal/utils/scm/lastmod.py
+++ b/bengal/utils/scm/lastmod.py
@@ -1,0 +1,5 @@
+"""Re-export last-modified helpers from core (postprocess convenience)."""
+
+from bengal.core.page.lastmod import resolve_page_lastmod, resolve_page_lastmod_iso
+
+__all__ = ["resolve_page_lastmod", "resolve_page_lastmod_iso"]

--- a/changelog.d/546.changed.md
+++ b/changelog.d/546.changed.md
@@ -1,0 +1,1 @@
+Core: emit per-heading search index records for deep-link search results.

--- a/changelog.d/547.changed.md
+++ b/changelog.d/547.changed.md
@@ -1,0 +1,1 @@
+Core: renderer-agnostic data-table contract decoupled from Tabulator config.

--- a/changelog.d/548.changed.md
+++ b/changelog.d/548.changed.md
@@ -1,0 +1,1 @@
+Core: optional git-derived last-modified field for pages.

--- a/changelog.d/549.changed.md
+++ b/changelog.d/549.changed.md
@@ -1,0 +1,1 @@
+Core: parse code-fence attributes (title, diff, line ranges) through to the highlighter.

--- a/site/config/_default/content.yaml
+++ b/site/config/_default/content.yaml
@@ -35,3 +35,9 @@ content:
   # Content Organization
   sort_pages_by: "weight"    # Options: "weight", "date", "title", "modified"
   sort_order: "asc"          # Options: "asc", "desc"
+
+  # Git-derived metadata (Pridelands #548)
+  # Derives "last updated" from git commit dates when frontmatter is absent.
+  git_info:
+    enabled: true
+    lastmod: true

--- a/site/config/_default/outputs.yaml
+++ b/site/config/_default/outputs.yaml
@@ -14,6 +14,11 @@ features:
   llm_txt: true    # Generate LLM-friendly text files (index.txt, llm-full.txt)
   markdown: true   # Generate per-page .md files for agent markdown URL support
 
+# Output format options (search index, per-page JSON, etc.)
+output_formats:
+  options:
+    include_heading_index: true   # Per-heading search records for deep-link results (#546)
+
 # Social Cards Configuration
 # ==========================
 # Auto-generates Open Graph images for social media sharing.

--- a/tests/unit/postprocess/test_heading_index_records.py
+++ b/tests/unit/postprocess/test_heading_index_records.py
@@ -1,0 +1,49 @@
+"""Tests for per-heading search index record generation."""
+
+from __future__ import annotations
+
+from bengal.postprocess.output_formats.utils import build_heading_index_records
+
+
+def test_build_heading_index_records_from_toc_and_html() -> None:
+    html = """
+    <p>Intro paragraph.</p>
+    <h2 id="install">Install</h2>
+    <p>Install instructions here.</p>
+    <h3 id="verify">Verify</h3>
+    <p>Verification steps.</p>
+    """
+
+    records = build_heading_index_records(
+        page_uri="/docs/start/",
+        page_url="/docs/start/",
+        page_title="Getting Started",
+        html_content=html,
+        toc_items=[
+            {"id": "install", "title": "Install", "level": 2},
+            {"id": "verify", "title": "Verify", "level": 3},
+        ],
+        excerpt_length=50,
+    )
+
+    assert len(records) == 2
+    assert records[0]["objectID"] == "/docs/start#install"
+    assert records[0]["kind"] == "heading"
+    assert records[0]["parent_objectID"] == "/docs/start/"
+    assert records[0]["breadcrumb"] == "Getting Started › Install"
+    assert "Install instructions" in records[0]["content"]
+    assert records[1]["anchor"] == "verify"
+
+
+def test_build_heading_index_records_skips_search_excluded_pages() -> None:
+    records = build_heading_index_records(
+        page_uri="/docs/hidden/",
+        page_url="/docs/hidden/",
+        page_title="Hidden",
+        html_content="<h2 id='x'>X</h2>",
+        toc_items=[{"id": "x", "title": "X", "level": 2}],
+        excerpt_length=50,
+        search_exclude=True,
+    )
+
+    assert records == []

--- a/tests/unit/postprocess/test_output_formats_config.py
+++ b/tests/unit/postprocess/test_output_formats_config.py
@@ -554,6 +554,7 @@ class TestConfigNormalizationEdgeCases:
                 "excerpt_length": 200,
                 "json_indent": None,
                 "include_full_content": False,
+                "include_heading_index": False,
             },
         )
         assert fingerprint is not None
@@ -607,6 +608,7 @@ class TestConfigNormalizationEdgeCases:
                 "excerpt_length": 200,
                 "json_indent": None,
                 "include_full_content": False,
+                "include_heading_index": False,
             },
         )
         assert index_fingerprint is not None

--- a/tests/unit/rendering/test_fence_attrs.py
+++ b/tests/unit/rendering/test_fence_attrs.py
@@ -1,0 +1,31 @@
+"""Tests for fence title and diff rendering."""
+
+from __future__ import annotations
+
+from bengal.parsing import PatitasParser
+
+
+class TestFenceTitleAndDiff:
+    @staticmethod
+    def _parser() -> PatitasParser:
+        return PatitasParser(enable_highlighting=True)
+
+    def test_fence_title_renders_label(self) -> None:
+        content = """
+```python title="app.py"
+print("hello")
+```
+"""
+        html = self._parser().parse(content, {})
+        assert 'class="code-block-title">app.py</div>' in html
+
+    def test_diff_fence_renders_added_removed_classes(self) -> None:
+        content = """
+```diff
+-old
++new
+ context
+```
+"""
+        html = self._parser().parse(content, {})
+        assert "syntax-added" in html or "syntax-removed" in html

--- a/tests/unit/template_functions/test_tables.py
+++ b/tests/unit/template_functions/test_tables.py
@@ -211,8 +211,7 @@ class TestDataTableFunction:
         )
 
         html = str(result)
-        # Filter adds headerFilter to columns in config
-        assert "headerFilter" in html
+        assert '"filterable": true' in html
 
     def test_with_pagination(self, mock_env, yaml_data_file):
         """Test data table with pagination."""
@@ -221,7 +220,7 @@ class TestDataTableFunction:
         )
 
         html = str(result)
-        assert '"paginationSize": 100' in html
+        assert '"page_size": 100' in html
 
     def test_without_pagination(self, mock_env, yaml_data_file):
         """Test data table without pagination."""
@@ -230,7 +229,7 @@ class TestDataTableFunction:
         )
 
         html = str(result)
-        assert '"pagination": false' in html
+        assert '"paginated": false' in html
 
     def test_with_custom_height(self, mock_env, yaml_data_file):
         """Test data table with custom height."""
@@ -286,7 +285,7 @@ class TestDataTableInTemplate:
         result = template.render(path=f"data/{yaml_data_file.name}")
 
         assert "bengal-data-table-search" in result
-        assert '"paginationSize": 50' in result
+        assert '"page_size": 50' in result
         assert '"height": "400px"' in result
 
     def test_conditional_rendering_in_template(self, mock_env, yaml_data_file):

--- a/tests/unit/utils/scm/test_lastmod.py
+++ b/tests/unit/utils/scm/test_lastmod.py
@@ -31,9 +31,18 @@ def test_resolve_page_lastmod_uses_git_dates_when_frontmatter_missing() -> None:
     assert result == git_dates[source_path]
 
 
-def test_resolve_page_lastmod_iso_returns_string() -> None:
+def test_resolve_page_lastmod_iso_preserves_frontmatter_string() -> None:
     page = Mock()
-    page.metadata = {"updated": "2024-01-15"}
+    page.metadata = {"lastmod": "2025-06-15"}
     page.source_path = Path("/tmp/content/page.md")
 
-    assert resolve_page_lastmod_iso(page) == "2024-01-15T00:00:00"
+    assert resolve_page_lastmod_iso(page) == "2025-06-15"
+
+
+def test_resolve_page_lastmod_ignores_magicmock_git_dates() -> None:
+    page = Mock()
+    page.metadata = {}
+    page.source_path = Path("/nonexistent/path/page.md")
+
+    assert resolve_page_lastmod(page, git_dates=Mock()) is None
+    assert resolve_page_lastmod_iso(page, git_dates=Mock()) is None

--- a/tests/unit/utils/scm/test_lastmod.py
+++ b/tests/unit/utils/scm/test_lastmod.py
@@ -1,0 +1,39 @@
+"""Tests for git-derived last-modified helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+from bengal.core.page.lastmod import resolve_page_lastmod, resolve_page_lastmod_iso
+
+
+def test_resolve_page_lastmod_prefers_frontmatter() -> None:
+    page = Mock()
+    page.metadata = {"lastmod": "2024-05-01T12:00:00"}
+    page.source_path = Path("/tmp/content/page.md")
+
+    result = resolve_page_lastmod(page)
+
+    assert result == datetime.fromisoformat("2024-05-01T12:00:00")
+
+
+def test_resolve_page_lastmod_uses_git_dates_when_frontmatter_missing() -> None:
+    page = Mock()
+    page.metadata = {}
+    source_path = Path("/repo/content/page.md").resolve()
+    page.source_path = source_path
+
+    git_dates = {source_path: datetime(2024, 6, 2, 9, 30, 0)}
+    result = resolve_page_lastmod(page, git_dates=git_dates)
+
+    assert result == git_dates[source_path]
+
+
+def test_resolve_page_lastmod_iso_returns_string() -> None:
+    page = Mock()
+    page.metadata = {"updated": "2024-01-15"}
+    page.source_path = Path("/tmp/content/page.md")
+
+    assert resolve_page_lastmod_iso(page) == "2024-01-15T00:00:00"

--- a/tests/unit/utils/test_code.py
+++ b/tests/unit/utils/test_code.py
@@ -4,7 +4,9 @@ Tests for code processing utilities.
 
 from bengal.utils.primitives.code import (
     HL_LINES_PATTERN,
+    CodeFenceAttrs,
     parse_code_info,
+    parse_fence_attrs,
     parse_hl_lines,
 )
 
@@ -98,6 +100,40 @@ class TestParseCodeInfo:
         """Test language names with special characters."""
         assert parse_code_info("c++") == ("c++", [])
         assert parse_code_info("c#") == ("c#", [])
+
+
+class TestParseFenceAttrs:
+    """Tests for parse_fence_attrs."""
+
+    def test_title_and_highlights(self):
+        attrs = parse_fence_attrs('python title="app.py" {1,3}')
+        assert attrs == CodeFenceAttrs(
+            language="python",
+            hl_lines=(1, 3),
+            title="app.py",
+            diff=False,
+            show_linenos=False,
+        )
+        assert attrs.highlight_language == "python"
+
+    def test_diff_flag(self):
+        attrs = parse_fence_attrs("python diff")
+        assert attrs.diff is True
+        assert attrs.highlight_language == "diff"
+
+    def test_diff_language(self):
+        attrs = parse_fence_attrs("diff")
+        assert attrs.language == "diff"
+        assert attrs.highlight_language == "diff"
+
+    def test_linenos(self):
+        attrs = parse_fence_attrs("python linenos")
+        assert attrs.show_linenos is True
+
+    def test_title_after_braces(self):
+        attrs = parse_fence_attrs('python {2} title="late-title.py"')
+        assert attrs.title == "late-title.py"
+        assert attrs.hl_lines == (2,)
 
 
 class TestHlLinesPattern:


### PR DESCRIPTION
## Summary
- **#546** — Opt-in per-heading search index records (`output_formats.options.include_heading_index`) emitted into `index.json` and the pre-built Lunr index for deep-link search hits
- **#548** — Opt-in git-derived `page.lastmod` (`content.git_info.enabled`) with frontmatter → git → mtime precedence; wired into sitemap and per-page JSON
- **#547** — Renderer-agnostic `data-table-spec` JSON contract from core; default theme adapts it to Tabulator (legacy `data-table-config` still supported)
- **#549** — Canonical fence attribute parsing (`title`, `diff`, `{hl_lines}`, `linenos`) wired through Patitas blocks and deferred highlighting
- Enables both new features on the Bengal docs site config (`site/config/_default/content.yaml`, `outputs.yaml`)

## Test plan
- [x] `pytest tests/unit/utils/test_code.py tests/unit/utils/scm/test_lastmod.py tests/unit/postprocess/test_heading_index_records.py tests/unit/template_functions/test_tables.py tests/unit/rendering/test_fence_attrs.py tests/unit/rendering/test_code_block_highlighting.py`
- [ ] Build Bengal docs site and confirm `index.json` contains `headings[]` when `include_heading_index: true`
- [ ] Verify docs pages show git-derived last-updated dates where frontmatter is absent
- [ ] Smoke-test data tables and titled/diff code fences on a docs page


Made with [Cursor](https://cursor.com)