### PR TITLE
feat(theme): SEO structured data + docs sidebar consolidation (#536)

### DIFF
--- a/bengal/rendering/template_functions/navigation/breadcrumbs.py
+++ b/bengal/rendering/template_functions/navigation/breadcrumbs.py
@@ -96,7 +96,8 @@ def get_breadcrumbs(page: PageLike) -> list[dict[str, Any]]:
         return items
 
     # Handle pages without ancestors (fallback)
-    if not hasattr(page, "ancestors") or not page.ancestors:
+    ancestors_list = _page_ancestors(page)
+    if not ancestors_list:
         # If page doesn't have enough info to generate breadcrumbs, return empty
         has_title = hasattr(page, "title") and isinstance(getattr(page, "title", None), str)
         has_url = hasattr(page, "_path") and isinstance(getattr(page, "_path", None), str)
@@ -110,7 +111,6 @@ def get_breadcrumbs(page: PageLike) -> list[dict[str, Any]]:
         return items
 
     # Get ancestors in reverse order (root to current)
-    ancestors_list = list(page.ancestors)
     reversed_ancestors = list(reversed(ancestors_list))
 
     # Limit to last 2 ancestors (skip Home and deep nesting)
@@ -158,6 +158,19 @@ def get_breadcrumbs(page: PageLike) -> list[dict[str, Any]]:
         items.append({"title": page_title, "href": page_url, "is_current": True})
 
     return items
+
+
+def _page_ancestors(page: PageLike) -> list[Any]:
+    """Return page ancestors as a list; treat missing/non-iterable as empty."""
+    ancestors_raw = getattr(page, "ancestors", None)
+    if ancestors_raw is None:
+        return []
+    if isinstance(ancestors_raw, list):
+        return ancestors_raw
+    try:
+        return list(ancestors_raw)
+    except TypeError:
+        return []
 
 
 def _derive_title(obj: Any, url: str) -> str:

--- a/bengal/rendering/template_functions/seo.py
+++ b/bengal/rendering/template_functions/seo.py
@@ -15,10 +15,128 @@ Extended for social cards:
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from bengal.protocols import PageLike, SiteLike, TemplateEnvironment
+
+# Content types that render as articles (og:type=article; JSON-LD via article-jsonld.html)
+_ARTICLE_PAGE_TYPES = frozenset(
+    {
+        "post",
+        "doc",
+        "tutorial",
+        "changelog",
+        "notebook",
+        "blog",
+        "autodoc-python",
+        "autodoc-cli",
+        "autodoc-rest",
+    }
+)
+
+# List/index surfaces that emit CollectionPage JSON-LD (not article-jsonld)
+_COLLECTION_PAGE_TYPES = frozenset(
+    {
+        "tag-index",
+        "tags",
+        "archive",
+        "category-browser",
+    }
+)
+
+
+def _page_metadata(page: PageLike) -> dict[str, Any]:
+    meta = getattr(page, "metadata", None)
+    return meta if isinstance(meta, dict) else {}
+
+
+def _page_path(page: PageLike) -> str:
+    path = getattr(page, "_path", None)
+    if isinstance(path, str):
+        return path
+    href = getattr(page, "href", None)
+    if isinstance(href, str):
+        return href
+    return ""
+
+
+def is_home_page(page: PageLike | None) -> bool:
+    """Return True when ``page`` is the site home/landing surface."""
+    if page is None:
+        return False
+    if getattr(page, "is_home", False):
+        return True
+    kind = getattr(page, "kind", None)
+    if kind == "home":
+        return True
+    path = _page_path(page)
+    normalized = path.rstrip("/")
+    return normalized in ("", "/") or getattr(page, "slug", None) in ("index", "_index", "home")
+
+
+def is_collection_page(page: PageLike | None) -> bool:
+    """Return True for section/list index surfaces (CollectionPage JSON-LD)."""
+    if page is None or is_home_page(page):
+        return False
+    kind = getattr(page, "kind", None)
+    if kind == "section":
+        return True
+    if getattr(page, "is_section", False):
+        return True
+    meta = _page_metadata(page)
+    if meta.get("is_section_index"):
+        return True
+    # Section objects expose subsections but not source-backed page files.
+    if hasattr(page, "subsections") and not hasattr(page, "source_path"):
+        return True
+    page_type = getattr(page, "type", None) or meta.get("type")
+    return page_type in _COLLECTION_PAGE_TYPES
+
+
+def og_type(page: PageLike | None = None) -> str:
+    """
+    Open Graph ``og:type`` value for a page.
+
+    Honors frontmatter ``og_type`` when set. Home and list/index surfaces use
+    ``website``; docs/posts use ``article``.
+    """
+    if page is None:
+        return "website"
+
+    meta = _page_metadata(page)
+    custom = meta.get("og_type")
+    if custom:
+        return str(custom)
+
+    if is_home_page(page) or is_collection_page(page):
+        return "website"
+
+    page_type = getattr(page, "type", None) or meta.get("type")
+    if page_type in _ARTICLE_PAGE_TYPES:
+        return "article"
+    if page_type in ("author", "profile"):
+        return "profile"
+    if page_type == "product":
+        return "product"
+
+    return "website"
+
+
+def structured_data_type(page: PageLike | None = None) -> str | None:
+    """
+    JSON-LD @type for page-level schema emitted in base.html head.
+
+    Returns ``WebSite`` or ``CollectionPage`` for landing/list surfaces.
+    Returns ``None`` when article-jsonld.html owns the page schema.
+    """
+    if page is None:
+        return None
+    if is_home_page(page):
+        return "WebSite"
+    if is_collection_page(page):
+        return "CollectionPage"
+    return None
 
 
 def register(env: TemplateEnvironment, site: SiteLike) -> None:
@@ -58,6 +176,8 @@ def register(env: TemplateEnvironment, site: SiteLike) -> None:
             "canonical_url": canonical_url_with_site,
             "og_image": og_image_with_site,
             "get_social_card_url": get_social_card_url_with_site,
+            "og_type": og_type,
+            "structured_data_type": structured_data_type,
         }
     )
 

--- a/bengal/themes/default/templates/autodoc/cli/command-group.html
+++ b/bengal/themes/default/templates/autodoc/cli/command-group.html
@@ -41,7 +41,7 @@ providing a consistent API via CommandView:
   {# Main Content #}
   <div class="docs-main">
     {# Page Hero: Use direct macro call with explicit context #}
-    {% from 'partials/page-hero.html' import hero_element %}
+    {% from 'partials/page-hero/_macros.html' import hero_element %}
     {{ hero_element(element, page, config) }}
 
     {# Article Content - Unified autodoc skeleton #}

--- a/bengal/themes/default/templates/autodoc/python/module.html
+++ b/bengal/themes/default/templates/autodoc/python/module.html
@@ -45,8 +45,8 @@ KIDA FEATURES USED:
 
   {# Main Content #}
   <div class="docs-main">
-    {# Page Hero: Use direct macro call with explicit context #}
-    {% from 'partials/page-hero.html' import hero_element %}
+    {# Page Hero: Use direct macro from _macros (page-hero.html is the dispatcher include) #}
+    {% from 'partials/page-hero/_macros.html' import hero_element %}
     {{ hero_element(element, page, config) }}
 
     {# Article Content - Unified autodoc skeleton #}

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -153,7 +153,7 @@ HELPER: Render a menu item (desktop/mobile)
     {% end %}
 
     {# Open Graph / Facebook #}
-    <meta property="og:type" content="article">
+    <meta property="og:type" content="{{ og_type(page) }}">
     <meta property="og:title" content="{{ page_title | trim }}">
     {% if meta_desc %}
     <meta property="og:description" content="{{ meta_desc | trim }}">
@@ -300,6 +300,13 @@ HELPER: Render a menu item (desktop/mobile)
     {% end %}{# /cache base-meta-generator #}
     {% include 'partials/article-jsonld.html' %}
     {% include 'partials/product-jsonld.html' %}
+    {% let _sd_type = structured_data_type(page) %}
+    {% if _sd_type == 'WebSite' %}
+    {% include 'partials/website-jsonld.html' %}
+    {% elif _sd_type == 'CollectionPage' %}
+    {% include 'partials/collection-jsonld.html' %}
+    {% end %}
+    {% include 'partials/breadcrumb-jsonld.html' %}
 
 </head>
 

--- a/bengal/themes/default/templates/doc/list.html
+++ b/bengal/themes/default/templates/doc/list.html
@@ -38,7 +38,7 @@ Or set `type: doc` to auto-select this template
 ================================================================================
 #}
 
-{% from 'partials/navigation-components.html' import breadcrumbs, page_navigation, toc %}
+{% from 'partials/navigation-components.html' import page_navigation %}
 {% from 'partials/components/tags.html' import tag_list %}
 {% from 'partials/components/tiles.html' import content_tiles %}
 
@@ -131,20 +131,7 @@ Or set `type: doc` to auto-select this template
   </aside>
 
   {# Right Sidebar: Contextual Graph + TOC + Metadata #}
-  {% if toc_items %}
-  <aside class="docs-toc" role="complementary" aria-label="Table of contents">
-    {# Contextual Graph Minimap - starts hidden, JS expands when data available #}
-    {% set show_graph = theme.features is not defined or 'graph.contextual' in theme.features %}
-    {% if show_graph %}
-    <div class="graph-contextual" data-page-url="{{ page?.href ?? '' }}">
-      <div class="graph-contextual-container graph-loading"></div>
-    </div>
-    {% end %}
-
-    {# Table of Contents #}
-    {{ toc(toc_items=toc_items, toc=toc, page=page) }}
-  </aside>
-  {% end %}
+  {% include 'partials/docs-toc-sidebar.html' %}
 </div>
 
 {# Mobile sidebar toggle #}

--- a/bengal/themes/default/templates/doc/single.html
+++ b/bengal/themes/default/templates/doc/single.html
@@ -34,7 +34,7 @@ Or set `type: doc` to auto-select this template
 ================================================================================
 #}
 
-{% from 'partials/navigation-components.html' import breadcrumbs, page_navigation, toc %}
+{% from 'partials/navigation-components.html' import page_navigation %}
 {% from 'partials/components/tags.html' import tag_list %}
 
 {% block content %}
@@ -88,20 +88,7 @@ Or set `type: doc` to auto-select this template
   </aside>
 
   {# Right Sidebar: Contextual Graph + TOC + Metadata #}
-  {% if toc_items %}
-  <aside class="docs-toc" role="complementary" aria-label="Table of contents">
-    {# Contextual Graph Minimap - starts hidden, JS expands when data available #}
-    {% set show_graph = theme.features is not defined or 'graph.contextual' in theme.features %}
-    {% if show_graph %}
-    <div class="graph-contextual" data-page-url="{{ page_href }}">
-      <div class="graph-contextual-container graph-loading"></div>
-    </div>
-    {% end %}
-
-    {# Table of Contents #}
-    {{ toc(toc_items=toc_items, toc=toc, page=page) }}
-  </aside>
-  {% end %}
+  {% include 'partials/docs-toc-sidebar.html' %}
 </div>
 
 {# Mobile sidebar toggle button #}

--- a/bengal/themes/default/templates/notebook/single.html
+++ b/bengal/themes/default/templates/notebook/single.html
@@ -31,7 +31,7 @@ KIDA FEATURES USED:
 ================================================================================
 #}
 
-{% from 'partials/navigation-components.html' import breadcrumbs, page_navigation, toc %}
+{% from 'partials/navigation-components.html' import page_navigation %}
 {% from 'partials/page-hero/_macros.html' import _breadcrumb_eyebrow, _share_dropdown %}
 {% from 'partials/components/tags.html' import tag_list %}
 
@@ -152,19 +152,8 @@ MAIN TEMPLATE
     {{ page_navigation(page) }}
   </div>
 
-  {# Right Sidebar: Contextual Graph + TOC (empty aside when no toc → CSS collapses) #}
-  <aside class="docs-toc" role="complementary" aria-label="Table of contents">
-    {% if toc_items %}
-    {% set show_graph = theme.features is not defined or 'graph.contextual' in theme.features %}
-    {% if show_graph %}
-    <div class="graph-contextual" data-page-url="{{ page_href }}">
-      <div class="graph-contextual-container graph-loading"></div>
-    </div>
-    {% end %}
-
-    {{ toc(toc_items=toc_items, toc=toc, page=page) }}
-    {% end %}
-  </aside>
+  {# Right Sidebar: Contextual Graph + TOC #}
+  {% include 'partials/docs-toc-sidebar.html' %}
 </div>
 
 {# Mobile sidebar toggle button #}

--- a/bengal/themes/default/templates/page.html
+++ b/bengal/themes/default/templates/page.html
@@ -58,13 +58,7 @@ Auto-selected for pages without a specific type
 
     {% if toc %}
     <aside class="page-sidebar">
-      {# Contextual Graph Minimap - starts hidden, JS expands when data available #}
-      {% set show_graph = theme.features is not defined or 'graph.contextual' in theme.features %}
-      {% if show_graph %}
-      <div class="graph-contextual" data-page-url="{{ page_href }}">
-        <div class="graph-contextual-container graph-loading"></div>
-      </div>
-      {% end %}
+      {% with page_url=page_href %}{% include 'partials/graph-contextual.html' %}{% end %}
 
       <nav class="toc" aria-label="Table of contents">
         <h2 class="toc-title">On This Page</h2>

--- a/bengal/themes/default/templates/partials/breadcrumb-jsonld.html
+++ b/bengal/themes/default/templates/partials/breadcrumb-jsonld.html
@@ -1,0 +1,23 @@
+{# BreadcrumbList JSON-LD — emitted once in <head> from base.html #}
+{% if page %}
+{% with get_breadcrumbs(page) as breadcrumb_items %}
+{% if breadcrumb_items | length > 0 %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {% for item in breadcrumb_items %}
+    {
+      "@type": "ListItem",
+      "position": {{ loop.index }},
+      "name": {{ item.title | tojson }},
+      "item": {{ (item.href | absolute_url) | tojson }}
+    }{{ "," if not loop.last else "" }}
+    {% endfor %}
+  ]
+}
+</script>
+{% end %}
+{% end %}
+{% end %}

--- a/bengal/themes/default/templates/partials/collection-jsonld.html
+++ b/bengal/themes/default/templates/partials/collection-jsonld.html
@@ -1,0 +1,17 @@
+{# CollectionPage JSON-LD for section/list index surfaces #}
+{% let _collection_title = page?.title ?? section?.title ?? site.title %}
+{% let _collection_desc = meta_desc | trim if meta_desc else (page?.description ?? section?.description ?? '') %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": {{ _collection_title | tojson }}{% if _collection_desc %},
+  "description": {{ _collection_desc | tojson }}{% end %}{% if site.baseurl and _page_url %},
+  "url": {{ canonical_url(_page_url) | tojson }}{% end %}{% if site.title %},
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": {{ site.title | tojson }}{% if site.baseurl %},
+    "url": {{ site.baseurl | tojson }}{% end %}
+  }{% end %}
+}
+</script>

--- a/bengal/themes/default/templates/partials/docs-toc-sidebar.html
+++ b/bengal/themes/default/templates/partials/docs-toc-sidebar.html
@@ -1,13 +1,8 @@
 {#
 Docs TOC Sidebar Component
 
-Right sidebarual graph minimap and table of contents.
-Used by docs-family templates: doc, autodoc-python, autodoc-cli.
-
-Features:
-- Contextual graph minimap (shows connections to current page)
-- Table of contents (via toc macro)
-- Conditionally rendered based on toc_items availability
+Right sidebar: contextual graph minimap and table of contents.
+Used by docs-family templates: doc, autodoc-python, autodoc-cli, notebook.
 
 Usage:
 {% include 'partials/docs-toc-sidebar.html' %}
@@ -16,26 +11,13 @@ Context required:
 - page: Current page object
 - toc_items: List of TOC items (from markdown headings)
 - toc: TOC HTML string (optional, for raw HTML fallback)
-
-Configuration:
-- Graph minimap can be disabled via theme config
 #}
 
 {% from 'partials/navigation-components.html' import toc %}
 
 {% if toc_items %}
 <aside class="docs-toc" role="complementary" aria-label="Table of contents">
-  {# Contextual Graph Minimap - shows connections to current page #}
-  {# Feature: graph.contextual (enabled by default for docs) #}
-  {% set show_graph = theme.features is not defined or 'graph.contextual' in theme.features %}
-  {% if show_graph %}
-  <div class="graph-contextual" data-page-url="{{ page.href }}">
-    {# Starts hidden - JS expands when data available #}
-    <div class="graph-contextual-container graph-loading"></div>
-  </div>
-  {% end %}
-
-  {# Table of Contents #}
+  {% include 'partials/graph-contextual.html' %}
   {{ toc(toc_items=toc_items, toc=toc, page=page) }}
 </aside>
 {% end %}

--- a/bengal/themes/default/templates/partials/graph-contextual.html
+++ b/bengal/themes/default/templates/partials/graph-contextual.html
@@ -1,0 +1,13 @@
+{#
+Contextual graph minimap (feature-gated).
+
+Usage:
+  {% with page_url=page_href %}{% include 'partials/graph-contextual.html' %}{% end %}
+#}
+{% let _page_url = page_url ?? page?.href ?? '' %}
+{% let show_graph = theme?.features is not defined or 'graph.contextual' in (theme?.features ?? []) %}
+{% if show_graph %}
+<div class="graph-contextual" data-page-url="{{ _page_url }}">
+  <div class="graph-contextual-container graph-loading"></div>
+</div>
+{% end %}

--- a/bengal/themes/default/templates/partials/website-jsonld.html
+++ b/bengal/themes/default/templates/partials/website-jsonld.html
@@ -1,0 +1,15 @@
+{# WebSite JSON-LD for the home/landing surface #}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": {{ site.title | tojson }}{% if site.baseurl %},
+  "url": {{ site.baseurl | tojson }}{% end %}{% if site.description %},
+  "description": {{ site.description | tojson }}{% end %}{% if config?.search %},
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {{ ((site.baseurl ?? '') ~ '/search/?q={search_term_string}') | tojson }},
+    "query-input": "required name=search_term_string"
+  }{% end %}
+}
+</script>

--- a/changelog.d/536.changed.md
+++ b/changelog.d/536.changed.md
@@ -1,0 +1,1 @@
+The default theme now emits correct ``og:type`` per page kind, ``WebSite``/``CollectionPage`` JSON-LD on landing and list surfaces, ``BreadcrumbList`` structured data, and consolidates the docs right-sidebar graph minimap into shared partials.

--- a/tests/unit/rendering/test_breadcrumb_function.py
+++ b/tests/unit/rendering/test_breadcrumb_function.py
@@ -29,6 +29,19 @@ class TestGetBreadcrumbs:
 
         assert result == []
 
+    def test_non_iterable_ancestors_falls_back(self):
+        """Mock/non-iterable ancestors (e.g. unittest.Mock auto-attrs) are ignored."""
+        page = Mock()
+        page._path = "/docs/guide/"
+        page.title = "Guide"
+
+        result = get_breadcrumbs(page)
+
+        assert len(result) == 2
+        assert result[0]["title"] == "Home"
+        assert result[1]["title"] == "Guide"
+        assert result[1]["is_current"] is True
+
     def test_basic_breadcrumbs(self):
         """Basic breadcrumb generation with ancestors."""
         # Create mock ancestors

--- a/tests/unit/template_functions/test_seo.py
+++ b/tests/unit/template_functions/test_seo.py
@@ -2,9 +2,12 @@
 
 from bengal.rendering.template_functions.seo import (
     canonical_url,
+    is_collection_page,
     meta_description,
     meta_keywords,
     og_image,
+    og_type,
+    structured_data_type,
 )
 
 
@@ -94,3 +97,63 @@ class TestOgImage:
     def test_empty_path(self):
         result = og_image("", "https://example.com")
         assert result == ""
+
+
+class TestOgType:
+    """Tests for og_type and structured_data_type helpers."""
+
+    def test_home_page(self):
+        page = type("Page", (), {"is_home": True, "_path": "/", "metadata": {}})()
+        assert og_type(page) == "website"
+        assert structured_data_type(page) == "WebSite"
+
+    def test_doc_page(self):
+        page = type(
+            "Page",
+            (),
+            {"is_home": False, "type": "doc", "_path": "/docs/guide/", "metadata": {"type": "doc"}},
+        )()
+        assert og_type(page) == "article"
+        assert structured_data_type(page) is None
+
+    def test_section_page(self):
+        page = type(
+            "Page",
+            (),
+            {
+                "kind": "section",
+                "is_home": False,
+                "_path": "/blog/",
+                "metadata": {},
+                "title": "Blog",
+            },
+        )()
+        assert og_type(page) == "website"
+        assert structured_data_type(page) == "CollectionPage"
+
+    def test_frontmatter_override(self):
+        page = type(
+            "Page",
+            (),
+            {"is_home": False, "metadata": {"og_type": "profile"}, "_path": "/about/"},
+        )()
+        assert og_type(page) == "profile"
+
+    def test_none_page(self):
+        assert og_type(None) == "website"
+        assert structured_data_type(None) is None
+
+    def test_tag_index_collection(self):
+        page = type(
+            "Page",
+            (),
+            {
+                "is_home": False,
+                "_path": "/tags/",
+                "metadata": {"type": "tag-index"},
+                "title": "Tags",
+            },
+        )()
+        assert is_collection_page(page)
+        assert og_type(page) == "website"
+        assert structured_data_type(page) == "CollectionPage"


### PR DESCRIPTION
## Summary

- Add `og_type()` / `structured_data_type()` helpers and emit correct `og:type` per page kind (home/list → `website`, docs/posts → `article`).
- Ship `WebSite`, `CollectionPage`, and `BreadcrumbList` JSON-LD partials in `base.html` head.
- Consolidate the docs right-sidebar graph minimap into `graph-contextual.html` and route doc/notebook templates through `docs-toc-sidebar.html`.
- Fix autodoc module/command-group templates to import page-hero macros from `_macros.html`.
- Pridelands slice for #536 (SEO + chrome consolidation).

## Proof

- [x] Focused tests: `pytest tests/unit/template_functions/test_seo.py` (22 passed), `pytest tests/unit/themes/` (76 passed)
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/536.changed.md` — default theme now emits correct og:type and BreadcrumbList/WebSite/CollectionPage JSON-LD; shared graph-contextual partial for docs sidebars.

## Performance Evidence

not applicable

## Steward Notes

- Commit is unsigned (GPG pinentry unavailable in the agent environment).
- Remaining #536 scope: legacy Jinja→Kida template migration and full breadcrumb unification across action-bar/page-hero.


Made with [Cursor](https://cursor.com)