### PR TITLE
fix(rendering): wikilink aliases, tab sync, directive AST bugs

### DIFF
--- a/bengal/parsing/backends/patitas/directives/builtins/code_tabs.py
+++ b/bengal/parsing/backends/patitas/directives/builtins/code_tabs.py
@@ -204,6 +204,18 @@ class CodeTabItem:
     code_lang: str  # Actual language for highlighting
 
 
+def _unique_sync_values(tabs: tuple[CodeTabItem, ...]) -> tuple[str, ...]:
+    """Derive per-tab sync keys, suffixing duplicates within a group."""
+    counts: dict[str, int] = {}
+    values: list[str] = []
+    for tab in tabs:
+        base = tab.lang.lower().replace(" ", "-")
+        seen = counts.get(base, 0)
+        counts[base] = seen + 1
+        values.append(base if seen == 0 else f"{base}-{seen + 1}")
+    return tuple(values)
+
+
 # =============================================================================
 # Code Tabs Directive
 # =============================================================================
@@ -410,16 +422,15 @@ class CodeTabsDirective:
         sb.append(f'<div class="code-tabs" id="{tab_id}" data-bengal="tabs"{sync_attr}>\n')
         sb.append('  <ul class="tab-nav" role="tablist">\n')
 
+        sync_values = _unique_sync_values(tabs)
         for i, tab in enumerate(tabs):
             active_class = ' class="active"' if i == 0 else ""
             aria_selected = "true" if i == 0 else "false"
 
-            sync_value = tab.lang.lower().replace(" ", "-")
-            sync_value_attr = (
-                f' data-sync-value="{html_escape(sync_value)}"'
-                if sync_key and sync_key.lower() != "none"
-                else ""
-            )
+            sync_value_attr = ""
+            if sync_key and sync_key.lower() != "none":
+                sync_value = sync_values[i]
+                sync_value_attr = f' data-sync-value="{html_escape(sync_value)}"'
 
             # Build tab label with optional icon
             icon_html = self._get_language_icon(tab.code_lang)

--- a/bengal/parsing/backends/patitas/directives/builtins/include.py
+++ b/bengal/parsing/backends/patitas/directives/builtins/include.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from html import escape as html_escape
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Protocol
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 from patitas.directives.options import DirectiveOptions
 from patitas.nodes import Directive
@@ -46,7 +46,10 @@ __all__ = [
     "FileResolver",
     "IncludeDirective",
     "LiteralIncludeDirective",
+    "SiteFileResolver",
 ]
+
+_MAX_INCLUDE_BYTES = 1_048_576  # 1 MiB
 
 
 # =============================================================================
@@ -95,6 +98,103 @@ class FileResolver(Protocol):
         ...
 
 
+class SiteFileResolver:
+    """Resolve and load include targets relative to a Bengal site."""
+
+    def __init__(self, site_root: Path) -> None:
+        self._site_root = site_root.resolve()
+
+    def resolve_path(self, path: str, source_file: str | None) -> Path | None:
+        return resolve_include_path(path, source_file=source_file, site_root=self._site_root)
+
+    def load_file(
+        self,
+        path: Path,
+        start_line: int | None = None,
+        end_line: int | None = None,
+    ) -> str | None:
+        content, error = load_include_file(path, start_line=start_line, end_line=end_line)
+        return None if error else content
+
+
+def resolve_include_path(
+    path: str,
+    *,
+    source_file: str | Path | None,
+    site_root: Path,
+) -> Path | None:
+    """Resolve an include path relative to the source page or site root."""
+    cleaned = path.strip()
+    if not cleaned:
+        return None
+
+    root = site_root.resolve()
+    raw = Path(cleaned)
+    candidates: list[Path] = []
+    if raw.is_absolute():
+        candidates.append(raw)
+    if source_file:
+        candidates.append(Path(source_file).resolve().parent / raw)
+    candidates.extend((root / "content" / raw, root / raw))
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            resolved = candidate.resolve(strict=False)
+        except OSError:
+            continue
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            continue
+        if resolved.is_file():
+            return resolved
+    return None
+
+
+def load_include_file(
+    path: Path,
+    *,
+    start_line: int | None = None,
+    end_line: int | None = None,
+    max_bytes: int = _MAX_INCLUDE_BYTES,
+) -> tuple[str, str]:
+    """Load include file content with optional 1-indexed line bounds."""
+    try:
+        size = path.stat().st_size
+        if size > max_bytes:
+            return "", f"File too large ({size} bytes, max {max_bytes})"
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return "", str(exc)
+
+    if start_line is None and end_line is None:
+        return text, ""
+
+    lines = text.splitlines(keepends=True)
+    start_idx = max((start_line or 1) - 1, 0)
+    end_idx = end_line if end_line is not None else len(lines)
+    return "".join(lines[start_idx:end_idx]), ""
+
+
+def _site_root_from_context(page_context: Any | None, site: Any | None) -> Path | None:
+    if site is not None and hasattr(site, "root_path"):
+        return Path(site.root_path)
+    if page_context is not None and hasattr(page_context, "site") and page_context.site is not None:
+        return Path(page_context.site.root_path)
+    return None
+
+
+def _source_file_from_context(page_context: Any | None) -> str | None:
+    if page_context is None:
+        return None
+    source_path = getattr(page_context, "source_path", None)
+    return str(source_path) if source_path else None
+
+
 # =============================================================================
 # Include Directive
 # =============================================================================
@@ -104,8 +204,11 @@ class FileResolver(Protocol):
 class IncludeOptions(DirectiveOptions):
     """Options for include directive."""
 
+    file: str = ""
     start_line: int | None = None
     end_line: int | None = None
+    file_path: str = ""
+    error: str = ""
 
 
 class IncludeDirective:
@@ -160,17 +263,13 @@ class IncludeDirective:
         happens in a separate integration step, not during parse.
         The parse method just captures the configuration.
         """
-        file_path = title.strip() if title else ""
+        file_path = (title.strip() if title else "") or options.file.strip()
 
-        # Store configuration in options
         computed_opts = replace(
             options,
-            start_line=options.start_line,
-            end_line=options.end_line,
+            file_path=file_path,
+            error="" if file_path else "No file path specified",
         )
-        # Add file path as attribute
-        object.__setattr__(computed_opts, "file_path", file_path)
-        object.__setattr__(computed_opts, "error", "" if file_path else "No file path specified")
 
         return Directive(
             location=location,
@@ -186,15 +285,42 @@ class IncludeDirective:
         node: Directive[IncludeOptions],
         rendered_children: str,
         sb: StringBuilder,
+        *,
+        page_context: Any | None = None,
+        site: Any | None = None,
     ) -> None:
         """Render include directive."""
         opts = node.options
 
-        error = getattr(opts, "error", "")
+        error = opts.error
+        file_path = opts.file_path
+        if not error and not rendered_children.strip():
+            site_root = _site_root_from_context(page_context, site)
+            if site_root is None:
+                error = "Include requires site context to load files"
+            else:
+                resolved = resolve_include_path(
+                    file_path,
+                    source_file=_source_file_from_context(page_context),
+                    site_root=site_root,
+                )
+                if resolved is None:
+                    error = f"File not found: {file_path}"
+                else:
+                    content, load_error = load_include_file(
+                        resolved,
+                        start_line=opts.start_line,
+                        end_line=opts.end_line,
+                    )
+                    if load_error:
+                        error = load_error
+                    else:
+                        sb.append(content)
+                        return
+
         if error:
             import warnings
 
-            file_path = getattr(opts, "file_path", "unknown")
             loc = node.location
             loc_str = f" (line {loc.line})" if loc and hasattr(loc, "line") else ""
             warnings.warn(
@@ -272,12 +398,16 @@ EXTENSION_LANGUAGE_MAP = {
 class LiteralIncludeOptions(DirectiveOptions):
     """Options for literalinclude directive."""
 
+    file: str = ""
     language: str = ""
     start_line: int | None = None
     end_line: int | None = None
     emphasize_lines: str = ""
     linenos: bool = False
     caption: str = ""
+    file_path: str = ""
+    code: str = ""
+    error: str = ""
 
 
 class LiteralIncludeDirective:
@@ -322,23 +452,20 @@ class LiteralIncludeDirective:
         location: SourceLocation,
     ) -> Directive:
         """Build literalinclude AST node."""
-        file_path = title.strip() if title else ""
+        file_path = (title.strip() if title else "") or options.file.strip()
 
-        # Auto-detect language from extension if not specified
         language = options.language
         if not language and file_path:
             ext = Path(file_path).suffix.lower()
             language = EXTENSION_LANGUAGE_MAP.get(ext, "")
 
-        # Store configuration in options
         computed_opts = replace(
             options,
             language=language,
+            file_path=file_path,
+            code="",
+            error="" if file_path else "No file path specified",
         )
-        # Add computed attributes
-        object.__setattr__(computed_opts, "file_path", file_path)
-        object.__setattr__(computed_opts, "code", "")  # Will be populated by integration
-        object.__setattr__(computed_opts, "error", "" if file_path else "No file path specified")
 
         return Directive(
             location=location,
@@ -353,15 +480,40 @@ class LiteralIncludeDirective:
         node: Directive[LiteralIncludeOptions],
         rendered_children: str,
         sb: StringBuilder,
+        *,
+        page_context: Any | None = None,
+        site: Any | None = None,
     ) -> None:
         """Render literalinclude as code block."""
         opts = node.options
 
-        error = getattr(opts, "error", "")
+        error = opts.error
+        file_path = opts.file_path
+        code = opts.code
+        if not error and not code:
+            site_root = _site_root_from_context(page_context, site)
+            if site_root is None:
+                error = "Literal include requires site context to load files"
+            else:
+                resolved = resolve_include_path(
+                    file_path,
+                    source_file=_source_file_from_context(page_context),
+                    site_root=site_root,
+                )
+                if resolved is None:
+                    error = f"File not found: {file_path}"
+                else:
+                    code, load_error = load_include_file(
+                        resolved,
+                        start_line=opts.start_line,
+                        end_line=opts.end_line,
+                    )
+                    if load_error:
+                        error = load_error
+
         if error:
             import warnings
 
-            file_path = getattr(opts, "file_path", "unknown")
             loc = node.location
             loc_str = f" (line {loc.line})" if loc and hasattr(loc, "line") else ""
             warnings.warn(
@@ -375,7 +527,6 @@ class LiteralIncludeDirective:
             )
             return
 
-        code = getattr(opts, "code", "")
         language = opts.language
         linenos = opts.linenos
         emphasize_lines = opts.emphasize_lines

--- a/bengal/parsing/backends/patitas/directives/options.py
+++ b/bengal/parsing/backends/patitas/directives/options.py
@@ -27,11 +27,13 @@ import logging
 from dataclasses import MISSING, dataclass, fields
 from typing import Any, ClassVar, Self, get_type_hints
 
+from patitas.directives.options import DirectiveOptions as PatitasDirectiveOptions
+
 _logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
-class DirectiveOptions:
+class DirectiveOptions(PatitasDirectiveOptions):
     """Base class for typed directive options.
 
     Subclass this to define options for your directive. Options are

--- a/bengal/parsing/backends/patitas/wrapper.py
+++ b/bengal/parsing/backends/patitas/wrapper.py
@@ -830,7 +830,9 @@ class PatitasParser(BaseMarkdownParser):
         """
         import patitas
 
-        result = patitas.to_dict(node)
+        from bengal.utils.serialization import to_jsonable
+
+        result = to_jsonable(patitas.to_dict(node))
         _capture_zclh_code(node, result, source)
         _annotate_bengal_type(result)
         return result

--- a/bengal/rendering/pipeline/core.py
+++ b/bengal/rendering/pipeline/core.py
@@ -634,7 +634,7 @@ class RenderingPipeline:
 
             meta = page.metadata
             metadata_with_source = dict(meta or {})
-            metadata_with_source["_source_path"] = page.source_path
+            metadata_with_source["_source_path"] = str(page.source_path)
             content_cfg = self.site.config.get("content", {}) or {}
             metadata_with_source["_excerpt_length"] = resolve_excerpt_length(page, content_cfg)
 
@@ -663,7 +663,7 @@ class RenderingPipeline:
             # Build mutable metadata for parser (CascadeView is immutable)
             meta = page.metadata
             metadata_for_parser = dict(meta or {})
-            metadata_for_parser["_source_path"] = page.source_path
+            metadata_for_parser["_source_path"] = str(page.source_path)
             content_cfg = self.site.config.get("content", {}) or {}
             metadata_for_parser["_excerpt_length"] = resolve_excerpt_length(page, content_cfg)
 
@@ -709,6 +709,8 @@ class RenderingPipeline:
                     if hasattr(self.parser, "parse_to_document"):
                         import patitas
 
+                        from bengal.utils.serialization import to_jsonable
+
                         parser_with_document = cast("Any", self.parser)
                         doc = None
                         consume_last_document = getattr(self.parser, "consume_last_document", None)
@@ -718,7 +720,7 @@ class RenderingPipeline:
                             doc = parser_with_document.parse_to_document(
                                 source, metadata_for_parser
                             )
-                        ast_cache = patitas.to_dict(doc)
+                        ast_cache = to_jsonable(patitas.to_dict(doc))
                     elif hasattr(self.parser, "parse_to_ast"):
                         ast_tokens = self.parser.parse_to_ast(source, metadata_for_parser)
                         ast_cache = ast_tokens

--- a/bengal/rendering/plugins/cross_references.py
+++ b/bengal/rendering/plugins/cross_references.py
@@ -123,11 +123,6 @@ class CrossReferencePlugin:
     # Pattern to find [[...]] spans that contain pipes (for table protection)
     _BRACKET_PATTERN = re.compile(r"\[\[[^\]]*\|[^\]]*\]\]")
 
-    # Pattern to split HTML by code blocks (pre/code) for xref substitution
-    _CODE_BLOCK_SPLIT = re.compile(
-        r"(<pre.*?</pre>|<code[^>]*>.*?</code>)", re.DOTALL | re.IGNORECASE
-    )
-
     @staticmethod
     def protect_table_pipes(source: str) -> str:
         """Pre-process markdown source to protect pipes inside [[...]] from table splitting.
@@ -204,16 +199,73 @@ class CrossReferencePlugin:
         if "[[" not in html:
             return html
 
-        # Split by code blocks (both pre/code blocks and inline code)
-        # Use non-greedy matching for content
-        # Pattern captures delimiters so they are included in parts
-        parts = self._CODE_BLOCK_SPLIT.split(html)
-
+        # Fenced blocks are always literal — never substitute inside <pre>.
+        parts = self._PRE_BLOCK_SPLIT.split(html)
         for i in range(0, len(parts), 2):
-            # Even indices are text outside code blocks
-            parts[i] = self._replace_xrefs_in_text(parts[i])
-
+            parts[i] = self._substitute_xrefs_outside_code(parts[i])
         return "".join(parts)
+
+    # Fenced code only. Inline <code> inside [[alias|...]] must not be split out.
+    _PRE_BLOCK_SPLIT = re.compile(r"(<pre\b.*?</pre>)", re.DOTALL | re.IGNORECASE)
+
+    @staticmethod
+    def _find_xref_span(text: str, start: int) -> tuple[str, int] | None:
+        """Return a full ``[[...]]`` span starting at *start*, allowing inline HTML in aliases."""
+        if not text.startswith("[[", start):
+            return None
+        i = start + 2
+        length = len(text)
+        while i < length:
+            if text.startswith("]]", i):
+                return text[start : i + 2], i + 2
+            if text[i] == "<":
+                tag_end = text.find(">", i)
+                if tag_end == -1:
+                    return None
+                i = tag_end + 1
+                continue
+            i += 1
+        return None
+
+    def _substitute_xrefs_outside_code(self, segment: str) -> str:
+        """Substitute xrefs in *segment*, skipping standalone ``<code>`` blocks."""
+        if "[[" not in segment:
+            return segment
+
+        result: list[str] = []
+        i = 0
+        length = len(segment)
+
+        while i < length:
+            next_code = segment.find("<code", i)
+            next_xref = segment.find("[[", i)
+
+            if next_xref == -1 and next_code == -1:
+                result.append(segment[i:])
+                break
+
+            # Standalone inline code (including ``<code>[[...]]</code>``) stays literal.
+            if next_code != -1 and (next_xref == -1 or next_code < next_xref):
+                code_end = segment.find("</code>", next_code)
+                if code_end == -1:
+                    result.append(segment[i:])
+                    break
+                result.append(segment[i : code_end + 7])
+                i = code_end + 7
+                continue
+
+            result.append(segment[i:next_xref])
+            found = self._find_xref_span(segment, next_xref)
+            if found is None:
+                result.append("[[")
+                i = next_xref + 2
+                continue
+
+            xref_span, end = found
+            result.append(self._replace_xrefs_in_text(xref_span))
+            i = end
+
+        return "".join(result)
 
     def _replace_xrefs_in_text(self, text: str) -> str:
         """

--- a/bengal/themes/default/assets/js/enhancements/tabs.js
+++ b/bengal/themes/default/assets/js/enhancements/tabs.js
@@ -98,13 +98,15 @@
    * @param {string} syncKey - The sync group key (e.g., "language")
    * @param {string} syncValue - The value to sync to (e.g., "python")
    */
-  function syncTabs(syncKey, syncValue) {
+  function syncTabs(syncKey, syncValue, skipContainer = null) {
     if (!syncKey || syncKey === 'none') return;
 
     // Find all containers with this sync key
     const containers = document.querySelectorAll(`[data-sync="${syncKey}"]`);
 
     containers.forEach(container => {
+      if (container === skipContainer) return;
+
       // Find link with matching sync value
       const matchingLink = container.querySelector(
         `[data-sync-value="${syncValue}"]`
@@ -353,12 +355,12 @@
     const syncKey = container.dataset.sync;
     const syncValue = link.dataset.syncValue;
 
+    // Always switch the clicked tab first — sync must not override local selection.
+    switchTab(container, link, targetId);
+
     if (syncKey && syncValue && syncKey !== 'none') {
-      // Sync all containers with same key
-      syncTabs(syncKey, syncValue);
-    } else {
-      // Just switch this tab
-      switchTab(container, link, targetId);
+      // Sync peer containers only (skip the one the user clicked).
+      syncTabs(syncKey, syncValue, container);
     }
   });
 

--- a/bengal/utils/serialization.py
+++ b/bengal/utils/serialization.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,8 @@ def to_jsonable(value: Any) -> Any:
         return value
     if isinstance(value, Path):
         return str(value)
+    if isinstance(value, MappingProxyType):
+        return {str(k): to_jsonable(v) for k, v in value.items()}
 
     # Handle dataclasses (including those from reloaded modules where is_dataclass might fail)
     if is_dataclass(value) or hasattr(value, "__dataclass_fields__"):

--- a/changelog.d/558.fixed.md
+++ b/changelog.d/558.fixed.md
@@ -1,0 +1,3 @@
+Admonition and `literalinclude` directives no longer fail with JSON serialization errors, so affected pages render instead of being dropped from the build.
+
+Directive options now serialize through Patitas, `_source_path` is stored as a string, and include targets load at render time when site context is available.

--- a/changelog.d/560.fixed.md
+++ b/changelog.d/560.fixed.md
@@ -1,0 +1,1 @@
+Wikilinks whose alias uses inline code (for example ``[[page|`Title`]]``) now resolve to the linked page instead of leaving raw `[[…]]` syntax in the output.

--- a/changelog.d/561.fixed.md
+++ b/changelog.d/561.fixed.md
@@ -1,0 +1,1 @@
+Code tabs with duplicate labels (for example two "Python" tabs in one group) now stay selectable when sync groups link multiple tab sets on a page.

--- a/tests/unit/rendering/test_code_tabs.py
+++ b/tests/unit/rendering/test_code_tabs.py
@@ -1,0 +1,140 @@
+"""Tests for code-tabs directive rendering and sync-key uniqueness."""
+
+from __future__ import annotations
+
+from bengal.parsing.backends.patitas.directives.builtins.code_tabs import (
+    CodeTabItem,
+    _unique_sync_values,
+)
+
+
+class TestUniqueSyncValues:
+    """Regression: duplicate tab labels must not share the same sync key."""
+
+    def test_distinct_labels_unchanged(self) -> None:
+        tabs = (
+            CodeTabItem(lang="Python", code="a", filename="", hl_lines=(), code_lang="python"),
+            CodeTabItem(
+                lang="JavaScript", code="b", filename="", hl_lines=(), code_lang="javascript"
+            ),
+        )
+        assert _unique_sync_values(tabs) == ("python", "javascript")
+
+    def test_duplicate_labels_get_suffix(self) -> None:
+        tabs = (
+            CodeTabItem(lang="Python", code="a", filename="", hl_lines=(), code_lang="python"),
+            CodeTabItem(lang="Python", code="b", filename="", hl_lines=(), code_lang="python"),
+            CodeTabItem(lang="Python", code="c", filename="", hl_lines=(), code_lang="python"),
+        )
+        assert _unique_sync_values(tabs) == ("python", "python-2", "python-3")
+
+    def test_duplicate_after_distinct(self) -> None:
+        tabs = (
+            CodeTabItem(lang="Python", code="a", filename="", hl_lines=(), code_lang="python"),
+            CodeTabItem(lang="Bash", code="b", filename="", hl_lines=(), code_lang="bash"),
+            CodeTabItem(lang="Bash", code="c", filename="", hl_lines=(), code_lang="bash"),
+        )
+        assert _unique_sync_values(tabs) == ("python", "bash", "bash-2")
+
+
+class TestCodeTabsDirective:
+    """Integration tests for code-tabs HTML output."""
+
+    def test_duplicate_python_tabs_have_unique_sync_values(self, parser) -> None:
+        content = """
+:::{code-tabs}
+
+```python
+def sync_handler(): ...
+```
+
+```python
+async def async_handler(): ...
+```
+
+:::
+"""
+        result = parser.parse(content, {})
+
+        assert result.count('data-sync-value="python"') == 1
+        assert 'data-sync-value="python-2"' in result
+        assert result.count('class="tab-pane active"') == 1
+        assert 'data-tab-target="' in result
+
+    def test_distinct_languages_keep_canonical_sync_keys(self, parser) -> None:
+        content = """
+:::{code-tabs}
+
+```python
+print("py")
+```
+
+```javascript
+console.log("js");
+```
+
+:::
+"""
+        result = parser.parse(content, {})
+
+        assert 'data-sync-value="python"' in result
+        assert 'data-sync-value="javascript"' in result
+
+    def test_sync_none_omits_sync_values(self, parser) -> None:
+        content = """
+:::{code-tabs}
+:sync: none
+
+```python
+a = 1
+```
+
+```python
+b = 2
+```
+
+:::
+"""
+        result = parser.parse(content, {})
+
+        assert "data-sync-value" not in result
+
+    def test_titles_preserve_distinct_sync_keys(self, parser) -> None:
+        content = """
+:::{code-tabs}
+
+```python title="Sync handler"
+def sync_handler(): ...
+```
+
+```python title="Async handler"
+async def async_handler(): ...
+```
+
+:::
+"""
+        result = parser.parse(content, {})
+
+        assert 'data-sync-value="sync-handler"' in result
+        assert 'data-sync-value="async-handler"' in result
+
+    def test_v2_fence_syntax_without_markers(self, parser) -> None:
+        content = """
+:::{code-tabs}
+
+```python
+first
+```
+
+```rust
+second
+```
+
+:::
+"""
+        result = parser.parse(content, {})
+
+        assert "Python" in result or "python" in result.lower()
+        assert "Rust" in result or "rust" in result.lower()
+        assert 'data-sync-value="python"' in result
+        assert 'data-sync-value="rust"' in result

--- a/tests/unit/rendering/test_directive_ast_serialization.py
+++ b/tests/unit/rendering/test_directive_ast_serialization.py
@@ -1,0 +1,134 @@
+"""Regression tests for directive AST JSON serialization (#558).
+
+Bengal directive options must inherit from Patitas DirectiveOptions so
+``patitas.to_dict`` emits JSON-safe option dicts. Parser metadata must store
+``_source_path`` as a string, not ``Path``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import patitas
+import pytest
+from patitas.directives.options import DirectiveOptions as PatitasDirectiveOptions
+
+from bengal.core.records import parsed_page_from_page_state
+from bengal.core.site import Site
+from bengal.orchestration.content import ContentOrchestrator
+from bengal.parsing.backends.patitas.wrapper import PatitasParser
+from bengal.rendering.pipeline import RenderingPipeline
+from bengal.utils.serialization import to_jsonable
+
+
+class TestDirectiveOptionsInheritance:
+    def test_bengal_admonition_options_are_patitas_options(self) -> None:
+        from bengal.parsing.backends.patitas.directives.options import AdmonitionOptions
+
+        opts = AdmonitionOptions()
+        assert isinstance(opts, PatitasDirectiveOptions)
+
+
+class TestDirectiveAstJsonSerialization:
+    @pytest.fixture
+    def parser(self) -> PatitasParser:
+        return PatitasParser()
+
+    def test_seealso_ast_is_json_serializable_after_toc_parse(self, parser: PatitasParser) -> None:
+        content = """:::{seealso}
+See also content.
+:::
+"""
+        metadata = {"_source_path": str(Path("content/page.md"))}
+        context: dict = {"config": {}}
+
+        parser.parse_with_toc_and_context(content, metadata, context)
+        doc = parser.consume_last_document()
+        assert doc is not None
+
+        ast_dict = patitas.to_dict(doc)
+        options = ast_dict["children"][0]["options"]
+        assert isinstance(options, dict)
+        assert options.get("_type") == "DirectiveOptions"
+
+        json.dumps(ast_dict)
+
+    def test_admonition_directives_serialize_options_as_dicts(self, parser: PatitasParser) -> None:
+        metadata = {"_source_path": str(Path("content/page.md"))}
+        context: dict = {"config": {}}
+
+        for directive in ("note", "seealso"):
+            parser.parse_with_toc_and_context(
+                f":::{{{directive}}}\nbody\n:::\n",
+                metadata,
+                context,
+            )
+            doc = parser.consume_last_document()
+            assert doc is not None
+            ast_dict = patitas.to_dict(doc)
+            directive_nodes = [
+                node for node in ast_dict.get("children", []) if node.get("_type") == "Directive"
+            ]
+            assert directive_nodes, directive
+            options = directive_nodes[0]["options"]
+            assert isinstance(options, dict), directive
+            json.dumps(ast_dict)
+
+    def test_literalinclude_ast_is_json_serializable_after_toc_parse(
+        self, parser: PatitasParser
+    ) -> None:
+        content = """:::{literalinclude} examples/snippet.py
+:::
+"""
+        metadata = {"_source_path": str(Path("content/page.md"))}
+        context: dict = {"config": {}}
+
+        parser.parse_with_toc_and_context(content, metadata, context)
+        doc = parser.consume_last_document()
+        assert doc is not None
+
+        ast_dict = patitas.to_dict(doc)
+        options = ast_dict["children"][0]["options"]
+        assert isinstance(options, dict)
+        assert options.get("_type") == "DirectiveOptions"
+        assert options.get("file_path") == "examples/snippet.py"
+
+        json.dumps(ast_dict)
+
+
+class TestParserMetadataSourcePath:
+    def test_parse_content_produces_seealso_html_with_string_metadata(self, tmp_path: Path) -> None:
+        content_dir = tmp_path / "content"
+        content_dir.mkdir()
+        (content_dir / "page.md").write_text(
+            """---
+title: Test
+---
+
+:::{seealso}
+Links here.
+:::
+"""
+        )
+
+        site = Site(
+            root_path=tmp_path,
+            config={
+                "title": "Test",
+                "markdown_engine": "patitas",
+                "markdown": {"ast_cache": {"persist_tokens": True}},
+            },
+            theme="default",
+        )
+        ContentOrchestrator(site).discover_content()
+        page = site.pages[0]
+
+        RenderingPipeline(site, quiet=True)._parse_content(page)
+
+        parsed = parsed_page_from_page_state(page)
+        assert parsed is not None
+        assert "seealso" in (parsed.html_content or "")
+        assert "markdown-error" not in (parsed.html_content or "")
+        if parsed.ast_cache is not None:
+            json.dumps(to_jsonable(parsed.ast_cache))

--- a/tests/unit/rendering/test_xref_bug.py
+++ b/tests/unit/rendering/test_xref_bug.py
@@ -262,3 +262,73 @@ class TestLinksCollector:
         source = "Just a paragraph."
         result = parser._md(source)
         assert "<p>" in result
+
+
+class TestWikilinkInlineCodeAlias:
+    """Regression: [[target|`Code`]] must resolve after inline-code HTML is emitted."""
+
+    @pytest.fixture
+    def xref_index(self):
+        mock_page = MockPage(
+            title="Return Values",
+            href="/docs/about/core-concepts/return-values/",
+            slug="return-values",
+        )
+        return {
+            "by_path": {"docs/about/core-concepts/return-values": mock_page},
+            "by_slug": {},
+            "by_id": {},
+            "by_heading": {},
+            "by_anchor": {},
+        }
+
+    def test_inline_code_alias_resolves(self, parser, xref_index):
+        parser.enable_cross_references(xref_index)
+
+        source = "Return [[docs/about/core-concepts/return-values|`Page`]] from a handler."
+        result = parser.parse(source, {})
+
+        assert "[[docs/about/core-concepts/return-values" not in result
+        assert '<a href="/docs/about/core-concepts/return-values/">' in result
+        assert "<code>Page</code></a>" in result
+
+    def test_inline_code_alias_with_call_syntax(self, parser, xref_index):
+        parser.enable_cross_references(xref_index)
+
+        source = "Use [[docs/about/core-concepts/return-values|`app.check()`]] here."
+        result = parser.parse(source, {})
+
+        assert '<a href="/docs/about/core-concepts/return-values/">' in result
+        assert "<code>app.check()</code></a>" in result
+
+    def test_xref_inside_standalone_code_stays_literal(self, parser, xref_index):
+        """Inline code wrapping a wikilink must remain literal."""
+        parser.enable_cross_references(xref_index)
+
+        source = "Literal `[[docs/about/core-concepts/return-values|Page]]` in code."
+        result = parser.parse(source, {})
+
+        assert "<code>[[docs/about/core-concepts/return-values|Page]]</code>" in result
+        assert result.count('<a href="/docs/about/core-concepts/return-values/">') == 0
+
+    def test_emphasis_in_alias_resolves(self, parser, xref_index):
+        """Other inline HTML in aliases should resolve (same split bug class)."""
+        parser.enable_cross_references(xref_index)
+
+        source = "See [[docs/about/core-concepts/return-values|*Page*]] for details."
+        result = parser.parse(source, {})
+
+        assert '<a href="/docs/about/core-concepts/return-values/">' in result
+        assert "<em>Page</em></a>" in result
+
+    def test_substitute_xrefs_unit(self, xref_index):
+        plugin = CrossReferencePlugin(xref_index)
+        html = (
+            "<p>Return [[docs/about/core-concepts/return-values|"
+            "<code>Page</code>]] from handler.</p>"
+        )
+        result = plugin._substitute_xrefs(html)
+
+        assert "[[docs/about/core-concepts/return-values" not in result
+        assert '<a href="/docs/about/core-concepts/return-values/">' in result
+        assert "<code>Page</code></a>" in result


### PR DESCRIPTION
## Summary

- Fix wikilink resolution when aliases contain inline HTML such as `` `Page` `` (#560) by substituting only outside fenced `<pre>` blocks and standalone `<code>` spans.
- Fix duplicate code-tab labels sharing the same sync key and tabs.js re-selecting the first match instead of the clicked tab (#561).
- Fix directive AST JSON serialization that dropped pages on `seealso`/`literalinclude` (#558) by aligning Bengal options with Patitas, stringifying `_source_path`, and loading include files at render time.

## Proof

- [x] Focused tests: `pytest tests/unit/rendering/test_xref_bug.py tests/unit/rendering/test_code_tabs.py tests/unit/rendering/test_directive_ast_serialization.py` (33 passed)
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/558.fixed.md`, `560.fixed.md`, `561.fixed.md`

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

## Steward Notes

- Single commit on top of `main`; no performance-sensitive paths changed.