### PR TITLE
fix(theme): restore Mermaid recolorization and dropdown active state

### DIFF
--- a/bengal/themes/default/assets/js/core/theme.js
+++ b/bengal/themes/default/assets/js/core/theme.js
@@ -71,6 +71,24 @@
     return localStorage.getItem(PALETTE_KEY) || '';
   }
 
+  /**
+   * Resolve the palette currently applied to the page.
+   * Inline theme init may set data-palette from site defaults before localStorage
+   * is populated, so fall back to the DOM attribute and BENGAL_THEME_DEFAULTS.
+   */
+  function getEffectivePalette() {
+    return (
+      getPalette() ||
+      document.documentElement.getAttribute('data-palette') ||
+      (window.BENGAL_THEME_DEFAULTS && window.BENGAL_THEME_DEFAULTS.palette) ||
+      ''
+    );
+  }
+
+  function getStoredAppearance() {
+    return localStorage.getItem(THEME_KEY) || THEMES.SYSTEM;
+  }
+
   function setPalette(palette) {
     if (palette !== null) {
       if (palette) {
@@ -178,8 +196,8 @@
    * Update active states for popover-based menus
    */
   function updatePopoverActiveStates(menu) {
-    const currentAppearance = localStorage.getItem(THEME_KEY) || THEMES.SYSTEM;
-    const currentPalette = getPalette();
+    const currentAppearance = getStoredAppearance();
+    const currentPalette = getEffectivePalette();
 
     // Update appearance buttons
     menu.querySelectorAll('[data-appearance]').forEach(function (btn) {
@@ -191,6 +209,12 @@
     menu.querySelectorAll('[data-palette]').forEach(function (btn) {
       const palette = btn.getAttribute('data-palette');
       btn.classList.toggle('active', palette === currentPalette);
+    });
+  }
+
+  function refreshAllPopoverActiveStates() {
+    document.querySelectorAll('.theme-dropdown__menu--popover[popover]').forEach(function (menu) {
+      updatePopoverActiveStates(menu);
     });
   }
 
@@ -218,19 +242,20 @@
     setPalette: setPalette
   };
 
-  // Auto-initialize after DOM is ready
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', function () {
-      initTheme();
-      setupToggleButton();
-      setupPopoverMenus();
-      watchSystemTheme();
-    });
-  } else {
+  function init() {
     initTheme();
     setupToggleButton();
     setupPopoverMenus();
     watchSystemTheme();
+    window.addEventListener('themechange', refreshAllPopoverActiveStates);
+    window.addEventListener('palettechange', refreshAllPopoverActiveStates);
+  }
+
+  // Auto-initialize after DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
   }
 
   log('[BengalTheme] Initialized');

--- a/bengal/themes/default/assets/js/mermaid-theme.js
+++ b/bengal/themes/default/assets/js/mermaid-theme.js
@@ -24,18 +24,15 @@
      * @param {CSSStyleDeclaration} [cachedStyles] - Optional cached getComputedStyle result
      */
     function getCSSVariable(variable, fallback = '#000000', cachedStyles = null) {
+        // Palette tokens use oklch(), light-dark(), relative-color, and color-mix.
+        // getPropertyValue returns the authored expression unevaluated; Mermaid only
+        // accepts concrete sRGB. Always resolve via the browser's color engine.
+        const resolved = resolveColor('var(' + variable + ')');
+        if (resolved) return resolved;
+
         const styles = cachedStyles || getComputedStyle(document.documentElement);
         const value = styles.getPropertyValue(variable).trim();
-        if (!value) return fallback;
-        // Derived palette tokens are authored as relative-color / color-mix
-        // expressions (e.g. "oklch(from var(--color-primary) calc(l - 0.07) c h)").
-        // getPropertyValue returns these unevaluated for unregistered custom
-        // properties, which Mermaid's color parser cannot consume. Resolve them to
-        // a concrete sRGB value before handing them to Mermaid.
-        if (value.includes('from ') || value.includes('color-mix')) {
-            return resolveColor('var(' + variable + ')') || fallback;
-        }
-        return value;
+        return value || fallback;
     }
 
     /**
@@ -68,6 +65,7 @@
         const htmlEl = document.documentElement;
         const themeAttr = htmlEl.getAttribute('data-theme');
         if (themeAttr === 'dark') return true;
+        if (themeAttr === 'light') return false;
         if (htmlEl.classList.contains('dark')) return true;
         if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
             return true;

--- a/changelog.d/567.fixed.md
+++ b/changelog.d/567.fixed.md
@@ -1,0 +1,3 @@
+Mermaid diagrams and the theme preset dropdown now follow the active palette and light/dark mode again.
+
+Diagram colors resolve OKLCH and `light-dark()` tokens to sRGB before Mermaid renders, and the dropdown marks the effective palette on first load instead of waiting for a manual selection.


### PR DESCRIPTION
## Summary

- Restore Mermaid diagram recolorization after the OKLCH palette migration by resolving all CSS color tokens (including `light-dark()` and `oklch()`) to concrete sRGB before passing them to Mermaid.
- Fix `isDarkMode()` so an explicit `data-theme="light"` is not overridden by the OS dark preference.
- Fix the theme dropdown so the active palette/appearance is selected on first load by reading the effective palette from `data-palette` and `BENGAL_THEME_DEFAULTS`, not just `localStorage`.
- Keep dropdown checkmarks in sync when appearance or palette changes via `themechange` / `palettechange` events.

## Proof

- [x] Focused tests: `pytest tests/unit/themes/test_theme_controls.py tests/unit/capabilities/test_runtime.py` (9 passed)
- [ ] `poe proof-pr` or scoped equivalent: not run (JS-only theme fix)
- [x] Docs/examples/changelog updated or no-impact noted: no-impact — bug fix restoring pre-OKLCH behavior; no user-facing API or config changes

## Performance Evidence

not applicable — restores client-side theme resolution; no hot-path or concurrency changes

## Steward Notes

The OKLCH re-author (#534) left Mermaid theming intact structurally but broke color handoff: `getPropertyValue()` returns authored expressions Mermaid cannot parse. Always resolving via the browser color engine (`resolveColor`) is the durable fix across token types.


Made with [Cursor](https://cursor.com)