### PR TITLE
fix(theme): keep header nav submenus open across hover gap

### DIFF
--- a/bengal/themes/default/assets/css/layouts/header.css
+++ b/bengal/themes/default/assets/css/layouts/header.css
@@ -263,6 +263,16 @@ header[role="banner"][data-sticky="false"] {
   position: relative;
 }
 
+/* Invisible hover bridge — keeps submenu open while moving through the gap */
+.nav-main>li.has-submenu::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  height: var(--space-2);
+}
+
 /* Nav links with submenus - positioning context for dropdown */
 .nav-main>li.has-submenu>a,
 .nav-main>li.has-submenu>.nav-dropdown-trigger {

--- a/changelog.d/568.fixed.md
+++ b/changelog.d/568.fixed.md
@@ -1,0 +1,3 @@
+Header navigation dropdowns stay open while you move the pointer into their menu items.
+
+The default theme adds an invisible hover bridge between each submenu trigger and its panel so the gap no longer closes the menu before you can click an option.


### PR DESCRIPTION
## Summary

- Header nav dropdowns (e.g. Dev) closed before users could reach menu items because the submenu is offset below the trigger, leaving a hover dead zone.
- Adds an invisible `::after` hover bridge on `li.has-submenu` to span that gap so the submenu stays open while moving the pointer into the panel.

## Proof

- [ ] Focused tests: not applicable (CSS-only hover fix)
- [ ] `poe proof-pr` or scoped equivalent: not run (CSS-only change)
- [ ] Docs/examples/changelog updated or no-impact noted: no-impact — internal theme CSS fix with no user-facing API or docs change

## Performance Evidence

not applicable

## Steward Notes

- Manual check: hover a header item with a submenu (e.g. Dev), move the pointer down into the menu, and confirm options remain clickable.

Made with [Cursor](https://cursor.com)