### PR TITLE
fix(versioning): inherit build-environment capabilities into version builds (#569)

### DIFF
--- a/bengal/cli/milo_commands/build.py
+++ b/bengal/cli/milo_commands/build.py
@@ -543,6 +543,14 @@ def _build_versions(
 
     _install_discovered_versions(site, discovered_versions, base_config=version_config)
 
+    # Capabilities are a build-environment decision and apply to every version
+    # build, including worktrees of tags cut before the capability existed.
+    inherited_capabilities = (
+        site.config.get("capabilities")
+        if isinstance(site.config.get("capabilities"), dict)
+        else None
+    )
+
     if all_versions:
         cli.info(
             f"Found {len(discovered_versions)} versions: {', '.join(v.id for v in discovered_versions)}"
@@ -584,6 +592,7 @@ def _build_versions(
                 current_version=v,
                 output_dir=root_output_dir if v.latest else staging_root / v.id / "public",
                 base_config=version_config,
+                inherited_capabilities=inherited_capabilities,
             )
 
             worktree_build_opts = BuildOptions(
@@ -654,6 +663,7 @@ def _build_versions(
         current_version=v,
         output_dir=output_dir,
         base_config=version_config,
+        inherited_capabilities=inherited_capabilities,
     )
 
     version_build_opts = BuildOptions(
@@ -709,15 +719,43 @@ def _install_discovered_versions(site, versions, *, base_config=None) -> None:
 
 
 def _prepare_git_version_site(
-    site, *, discovered_versions, current_version, output_dir, base_config=None
+    site,
+    *,
+    discovered_versions,
+    current_version,
+    output_dir,
+    base_config=None,
+    inherited_capabilities=None,
 ) -> None:
     """Prepare a site instance to render one discovered Git version."""
     _install_discovered_versions(site, discovered_versions, base_config=base_config)
+    _apply_inherited_capabilities(site, inherited_capabilities)
     site.current_version = current_version
     site.output_dir = output_dir
     if "build" not in site.config:
         site.config["build"] = {}
     site.config["build"]["output_dir"] = str(output_dir)
+
+
+def _apply_inherited_capabilities(site, inherited_capabilities) -> None:
+    """Seed a version worktree's ``[capabilities]`` from the orchestrating build.
+
+    Self-hosted capabilities (Mermaid/KaTeX/Iconify) are a *build-environment*
+    decision — "how we render the docs site today" — not a property of what a
+    historical release tag happened to ship. Worktree builds of older tags read
+    config from the checked-out tree, so a tag cut before a capability was
+    enabled would silently render its diagrams as raw text. Inheriting the
+    orchestrating build's capability flags (which wins on conflict) lets the
+    current tooling provision and activate the feature for every version build.
+    Vendor provisioning and runtime resolution both key off the worktree's own
+    ``assets/vendor/`` dir, so this is sufficient for the whole chain.
+    """
+    if not isinstance(inherited_capabilities, dict) or not inherited_capabilities:
+        return
+    existing = site.config.get("capabilities")
+    merged = dict(existing) if isinstance(existing, dict) else {}
+    merged.update(inherited_capabilities)
+    site.config["capabilities"] = merged
 
 
 def _merge_staged_version_output(*, source_dir, root_output_dir, sections, version_id: str) -> None:

--- a/changelog.d/569.fixed.md
+++ b/changelog.d/569.fixed.md
@@ -1,0 +1,3 @@
+Mermaid diagrams (and other self-hosted capabilities like KaTeX) now render on older versioned docs, not just the latest version.
+
+Per-version builds inherit the capabilities enabled by the current build instead of reading them from each release's git tag, so a diagram feature turned on after a version was tagged still applies when that version is rebuilt.

--- a/plan/rfc-capability-system.md
+++ b/plan/rfc-capability-system.md
@@ -1,0 +1,183 @@
+# RFC: Capabilities as a First-Class, Extensible System
+
+**Status**: Proposed (Phase 0 landed)
+**Created**: 2026-06-18
+**Tracking**: #570 (epic) — children #571, #572, #573; bug fix #569
+**Source**: Root-cause of #569 (Mermaid missing on `/docs/0.5.0/`), generalized to the third-party case
+**Related**: #533/#550 (self-hosted capabilities), `plan/epic-default-theme-refresh.md`, `plan/rfc-theme-library-assets.md`
+
+---
+
+## Why This Matters
+
+"Capabilities" are opt-in heavy frontend features that need build-time provisioning
+and runtime asset loading: Mermaid diagrams, KaTeX math, Iconify icon sets, and
+(future) D3 / third-party visualizations. Today they are a single per-config
+boolean (`capabilities.mermaid: true`) plus a hardcoded vendor table
+(`bengal/capabilities/vendors.py`) and bespoke template/JS wiring in the default
+theme.
+
+That model has two problems, one already breaking production:
+
+1. **Activation is sourced from the wrong place.** #569: the docs site builds
+   previous versions from their git **tags**. Each version build reads `[capabilities]`
+   from the checked-out tag, so a tag cut before a capability was enabled renders
+   its diagrams as raw text forever. Mermaid was enabled (#563) two days after the
+   `v0.5.0` tag — so `/docs/0.5.0/content/#how-content-flows` shipped broken.
+
+2. **There is no extension point.** A third party cannot add a capability without
+   editing core's vendor table, render path, and theme JS. As the ecosystem grows
+   (more diagram engines, math renderers, embeds), this doesn't scale.
+
+The fix for #569 and the design for third-party capabilities are the same insight:
+**get the ownership model right.**
+
+---
+
+## A Capability Spans Three Concerns
+
+A single capability bundles three things that today are scattered across core and
+the theme:
+
+1. **Provisioning spec** — pinned asset URL(s) and where they land
+   (`VENDOR_SOURCES` / `VENDOR_FILES` in `vendors.py`; network I/O is build-time
+   only, runtime uses same-origin URLs).
+2. **Parse-time transform** — the fence/shortcode → HTML element. Mermaid's
+   ` ```mermaid ` fence becomes `<div class="mermaid">…</div>` in the patitas
+   block renderer.
+3. **Runtime contract** — when/how to load the asset, the init hook, and
+   theme-token bindings. Mermaid lazy-loads via an IntersectionObserver on
+   `.mermaid` (`lazy-loaders.js`) and recolors diagrams by resolving OKLCH /
+   `light-dark()` tokens to sRGB before render (`mermaid-theme.js`, #567).
+
+These three concerns have **different owners and different lifecycles**. Collapsing
+them into one versioned boolean is the root cause.
+
+---
+
+## The Ownership Model: Three Owners, Three Control Surfaces
+
+| Layer | Owner | Controls | Lifecycle |
+|---|---|---|---|
+| **Capability definition** | Third-party author | asset pins + SRI, content *detector*, render transform, JS init contract, theme-token hooks, dependencies | ships with the tooling/plugin — **always current** |
+| **Activation policy** | Site owner | enable/disable allow-list, asset *source* (self-host / CDN / local), version-pin override, CSP/SRI policy | **build environment** — applies to *all* version builds |
+| **Actual use** | Content author | writes a ` ```mermaid ` fence — config-free | **versioned with content** |
+
+The build-time resolver becomes a clean conjunction:
+
+> **enabled** (owner) **AND provisioned-successfully** (author spec) **AND needed**
+> (detector) **→ emit assets + init.**
+
+### The one principle that resolves everything
+
+**Enablement is a build-environment decision. "Is it needed?" is answered by
+content-detection — not by a per-version config flag.**
+
+- The *theme/JS machinery* that consumes a capability already comes from the
+  installed `bengal` package (current), not from the historical tag. Capabilities
+  were the odd one out being sourced from historical content.
+- Enabling a capability is cheap because the runtime lazy-loads assets only on
+  pages that actually contain the triggering content. So a site owner can enable
+  Mermaid globally and pay nothing on the 95% of pages without a diagram.
+- Archived docs versions render diagrams with **today's** tooling, which is what a
+  reader wants — not whatever was (or wasn't) wired up the week that tag was cut.
+
+The one knob that *is* legitimately version-overridable is the **asset version
+pin** (an old version's content might require Mermaid 10 syntax, not 11). That
+belongs to the site **owner** as an explicit override, not buried in tag content.
+
+---
+
+## What a Third-Party Author Declares (#572)
+
+A `bengal.capabilities` entry-point registers a capability that declares:
+
+- **Identity + asset spec** — name, pinned version, source URL(s), **SRI hash**
+  (supply chain: they're pulling from a third-party CDN at build time).
+- **Content detector** — "I'm needed if the page contains `.mermaid`" / "a fence
+  of type X". This is what makes broad enablement safe and cheap.
+- **Render hook** — the fence/shortcode → HTML transform, so it lives with the
+  capability instead of core's `blocks.py`.
+- **Init contract** — JS entry, load position (head/body, defer/module), and
+  optional **theme-token bindings** (generalize the recolorization need:
+  "give me these CSS vars resolved to sRGB").
+- **Dependencies** — "I need capability Y first."
+
+---
+
+## What a Site Owner Controls (#573)
+
+- **Allow-list** — capabilities are opt-in (security: third-party JS + third-party
+  CDN downloads).
+- **Source override** — self-host (default) vs CDN vs local file, per capability,
+  for airgapped / CSP-strict / offline builds. This is the point of the #533
+  self-hosting push.
+- **Pin override** — inherit the author's pin by default; force a version when an
+  archived docs version needs older syntax.
+- **CSP / SRI policy** — emit integrity attributes, restrict allowed origins.
+
+---
+
+## What a Content Author Does
+
+Nothing but write the feature: a ` ```mermaid ` fence. The detector triggers the
+capability; zero config. This is the lifecycle that *should* be versioned —
+content is, and only content is.
+
+---
+
+## Phasing
+
+### Phase 0 — Inherit build-environment capabilities (LANDED, #569)
+
+Version worktree builds now inherit the orchestrating build's `[capabilities]`
+(`_apply_inherited_capabilities` in `bengal/cli/milo_commands/build.py`), which
+wins on conflict. Current tooling provisions and activates the feature for every
+version build; vendor provisioning and runtime resolution both key off the
+worktree's own `assets/vendor/`, so the whole chain works.
+
+Verified: `bengal build --build-version 0.5.0 --environment production` provisions
+the 3.3 MB bundle, emits `mermaid: '/bengal/assets/vendor/mermaid.min.<hash>.js'`,
+and copies the fingerprinted file into output.
+
+This is a correctness fix, not the full design — it makes activation a
+build-environment decision in the one place it was leaking from versioned content.
+
+### Phase 1 — Content-detection as first-class metadata (#571)
+
+Formalize the build-time half of detection (the runtime half exists in
+`lazy-loaders.js`). A declarative predicate over rendered HTML / parsed AST decides
+which pages get asset wiring, so global enablement costs nothing on non-using pages
+and authors never touch config.
+
+### Phase 2 — Third-party registry via entry-points (#572)
+
+Promote the hardcoded vendor table to a registry populated by `bengal.capabilities`
+entry-points, carrying the author-owned declaration above. Enforces the
+author/owner/content split at the contract boundary.
+
+### Phase 3 — Supply-chain controls (#573)
+
+SRI hashes, source override (self-host/CDN/local), pin override, CSP policy — the
+owner-facing controls that make self-hosting third-party assets trustworthy.
+
+---
+
+## Non-Goals
+
+- Re-tagging published releases to backfill config (rejected: rewrites release
+  history; Phase 0 makes it unnecessary).
+- Per-content capability *configuration* beyond "use the feature" — content
+  declares need by using the feature, not by setting flags.
+
+---
+
+## History (do not re-litigate)
+
+- Capabilities introduced as self-hosted opt-in assets in #533 / #550 (default
+  theme refresh, zero-dep promise).
+- Mermaid self-hosting enabled for the docs site in #563; recolorization fixed in
+  #567.
+- #569 found activation was sourced from versioned tag content → previous-version
+  docs rendered diagrams as raw text. Phase 0 fixed it by making activation a
+  build-environment inheritance.

--- a/tests/unit/cli/test_git_versioned_build_helpers.py
+++ b/tests/unit/cli/test_git_versioned_build_helpers.py
@@ -2,7 +2,52 @@
 
 from __future__ import annotations
 
-from bengal.cli.milo_commands.build import _merge_staged_version_output
+import types
+
+from bengal.cli.milo_commands.build import (
+    _apply_inherited_capabilities,
+    _merge_staged_version_output,
+)
+
+
+def _site_with_config(config) -> types.SimpleNamespace:
+    return types.SimpleNamespace(config=config)
+
+
+def test_inherited_capabilities_seed_a_worktree_with_none() -> None:
+    """A tag cut before a capability existed gets it from the build environment."""
+    site = _site_with_config({})
+
+    _apply_inherited_capabilities(site, {"mermaid": True})
+
+    assert site.config["capabilities"] == {"mermaid": True}
+
+
+def test_inherited_capabilities_win_on_conflict_but_preserve_local_keys() -> None:
+    """Build-environment activation overrides the tag; worktree-only keys survive."""
+    site = _site_with_config({"capabilities": {"mermaid": False, "legacy": True}})
+
+    _apply_inherited_capabilities(site, {"mermaid": True, "katex": True})
+
+    assert site.config["capabilities"] == {
+        "mermaid": True,  # parent (build env) wins over the tag's False
+        "katex": True,  # parent adds a new capability
+        "legacy": True,  # worktree-only key preserved
+    }
+
+
+def test_inherited_capabilities_noop_when_empty_or_missing() -> None:
+    """No capabilities in the build environment leaves the worktree untouched."""
+    site = _site_with_config({"capabilities": {"mermaid": True}})
+
+    _apply_inherited_capabilities(site, None)
+    _apply_inherited_capabilities(site, {})
+
+    assert site.config["capabilities"] == {"mermaid": True}
+    # And an absent inherited dict must not create the key on a bare site.
+    bare = _site_with_config({})
+    _apply_inherited_capabilities(bare, None)
+    assert "capabilities" not in bare.config
 
 
 def test_merge_staged_version_output_preserves_latest_assets(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- Mermaid diagrams render as raw text on `/docs/0.5.0/` (and other tagged versions) while `/docs/main/` is fine. Root cause (#569): git-tag version builds read `[capabilities]` from the checked-out historical tag, and self-hosted Mermaid (#563) was enabled *after* the `v0.5.0` tag was cut — so vendors were never provisioned and the lazy-asset URL was never emitted for that version.
- Capabilities are a **build-environment** decision, not a property of what a historical tag shipped. The orchestrating build's `[capabilities]` is now inherited into every version worktree build (`_apply_inherited_capabilities`; parent wins on conflict, worktree-only keys preserved). Provisioning and runtime resolution both key off the worktree's own `assets/vendor/`, so the full chain works.
- Generalized the root cause into a capability-system design: epic #570 with follow-ups #571 (content-detection), #572 (third-party registry), #573 (supply-chain controls). Design doc: `plan/rfc-capability-system.md`.

## Proof

- [x] Focused tests: `pytest tests/unit/cli/test_git_versioned_build_helpers.py tests/unit/capabilities` (10 passed; 3 new for capability inheritance — conflict precedence, key preservation, no-op on empty)
- [x] `poe proof-pr` or scoped equivalent: pre-commit clean (ruff, ruff-format, ty, guard hooks all pass)
- [x] Manual end-to-end: `bengal build --build-version 0.5.0 --environment production` now provisions the 3.3 MB bundle, emits `mermaid: '/bengal/assets/vendor/mermaid.min.<hash>.js'` on the diagram page, and copies the fingerprinted vendor file into output. Before this change that asset line was absent.
- [x] Docs/examples/changelog updated: `changelog.d/569.fixed.md` + `plan/rfc-capability-system.md`

## Performance Evidence

not applicable — versioning/config path; no hot-path or free-threaded behavior change.

## Steward Notes

- Closes #569. Epic #570 + children #571/#572/#573 capture the longer-term capability-system design (content-detection, third-party registry via entry-points, SRI/source/pin supply-chain controls).