### PR TITLE
feat(theme): compact sidebar version switcher + base-path link fixes

### DIFF
--- a/bengal/themes/default/assets/css/components/versioning.css
+++ b/bengal/themes/default/assets/css/components/versioning.css
@@ -127,6 +127,170 @@
 }
 
 /* =============================================================================
+   Version Switcher (Merged sidebar header — "Documentation · Latest ▾")
+   The docs-nav root header IS the version dropdown. Built on a native
+   <details>/<summary> so versions stay switchable with zero JS; each option is
+   a real <a> with a build-time, baseurl-correct target.
+   ============================================================================= */
+
+.docs-nav-vswitch {
+  position: relative; /* anchor for the absolutely-positioned menu */
+}
+
+/* The <summary> reuses .docs-nav-group-header layout; strip the native marker */
+.docs-nav-vswitch__summary {
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  border-radius: var(--radius-md);
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+.docs-nav-vswitch__summary::-webkit-details-marker { display: none; }
+.docs-nav-vswitch__summary::marker { content: ""; }
+.docs-nav-vswitch__summary:hover { color: var(--color-primary); }
+.docs-nav-vswitch__summary:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* Title block: bold doc name + middot + version pill, takes the free space */
+.docs-nav-vswitch__title {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.docs-nav-vswitch__doc {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.docs-nav-vswitch__sep {
+  flex: 0 0 auto;
+  color: var(--color-text-tertiary);
+}
+
+/* Version pill — muted by default, status-tinted via the badge tokens */
+.docs-nav-vswitch__pill {
+  flex: 0 0 auto;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  line-height: 1.4;
+  color: var(--color-text-secondary);
+  padding: 0.0625rem 0.4375rem;
+  border-radius: var(--radius-full);
+  background-color: var(--color-bg-secondary);
+}
+.docs-nav-vswitch__pill[data-status="legacy"] {
+  color: var(--color-warning-text);
+  background-color: var(--color-warning-bg);
+}
+.docs-nav-vswitch__pill[data-status="deprecated"],
+.docs-nav-vswitch__pill[data-status="eol"] {
+  color: var(--color-error-text);
+  background-color: var(--color-error-bg);
+}
+.docs-nav-vswitch__pill[data-status="preview"] {
+  color: var(--color-primary);
+  background-color: color-mix(in srgb, var(--color-primary) 14%, transparent);
+}
+
+/* Caret rotates open via the native [open] attribute — no JS needed */
+.docs-nav-vswitch__caret {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-text-tertiary);
+  transition: transform var(--transition-fast), color var(--transition-fast);
+}
+.docs-nav-vswitch[open] .docs-nav-vswitch__caret { transform: rotate(180deg); }
+.docs-nav-vswitch__summary:hover .docs-nav-vswitch__caret { color: var(--color-primary); }
+
+/* Popover menu — explicit display control so it never depends on UA quirks */
+.docs-nav-vswitch__menu {
+  display: none;
+  position: absolute;
+  inset-block-start: calc(100% - 0.25rem);
+  inset-inline: 0;
+  z-index: 30;
+  margin: 0;
+  padding: var(--space-1);
+  list-style: none;
+  max-width: min(20rem, 92vw);
+  max-height: 18rem;
+  overflow-y: auto;
+  background-color: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elevation-card);
+}
+.docs-nav-vswitch[open] .docs-nav-vswitch__menu { display: block; }
+
+.docs-nav-vswitch__item { border-radius: var(--radius-md); }
+.docs-nav-vswitch__link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.375rem 0.5rem;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  text-decoration: none;
+  border-radius: var(--radius-md);
+}
+.docs-nav-vswitch__link:hover,
+.docs-nav-vswitch__link:focus-visible {
+  background-color: var(--color-bg-hover);
+}
+.docs-nav-vswitch__link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
+}
+.docs-nav-vswitch__check {
+  flex: 0 0 auto;
+  display: inline-flex;
+  width: 14px;
+  color: var(--color-primary);
+}
+.docs-nav-vswitch__item-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.docs-nav-vswitch__item.is-current .docs-nav-vswitch__item-label {
+  font-weight: var(--weight-semibold);
+  color: var(--color-primary);
+}
+.docs-nav-vswitch__item.is-deprecated .docs-nav-vswitch__item-label {
+  font-style: italic;
+  color: var(--color-text-secondary);
+}
+.docs-nav-vswitch__item-hint {
+  flex: 0 0 auto;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+.docs-nav-vswitch__item-hint[data-status="deprecated"],
+.docs-nav-vswitch__item-hint[data-status="eol"] { color: var(--color-warning-text); }
+
+/* Dark mode — match the dual token + explicit-override pattern used elsewhere */
+[data-theme="dark"] .docs-nav-vswitch__menu {
+  background-color: var(--color-bg-elevated);
+  border-color: var(--color-border);
+}
+[data-theme="dark"] .docs-nav-vswitch__pill { background-color: var(--color-bg-secondary); }
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-nav-vswitch__caret,
+  .docs-nav-vswitch__summary { transition: none; }
+}
+
+@media print { .docs-nav-vswitch { display: none; } }
+
+/* =============================================================================
    Version Banner (Full-Width Alert for Older Versions)
    ============================================================================= */
 

--- a/bengal/themes/default/assets/js/core/version-selector.js
+++ b/bengal/themes/default/assets/js/core/version-selector.js
@@ -1,12 +1,23 @@
 /**
- * Version Selector
+ * Version Selector / Switcher
  *
- * Handles version switching for versioned documentation.
- * Uses pre-computed target URLs for instant navigation without 404 errors.
+ * Two shapes share this file:
+ *
+ *   1. <select id="version-select">          — the boxed dropdown still used on
+ *      non-docs pages (page.html / index.html). Navigates on `change` via each
+ *      option's pre-computed, baseurl-correct data-target.
+ *
+ *   2. <details data-version-switcher>        — the compact sidebar switcher that
+ *      merges into the docs-nav "Documentation · Latest ▾" header. The native
+ *      <details>/<summary> disclosure and the real <a> options mean version
+ *      switching works with zero JS; this script only adds the niceties:
+ *      close-on-outside-click, Escape-to-close, and arrow-key navigation.
  */
 
 (function () {
   'use strict';
+
+  /* ----- 1. Native <select> version selector ----- */
 
   function handleVersionChange(event) {
     const selectedOption = event.target.selectedOptions[0];
@@ -15,11 +26,97 @@
     }
   }
 
-  function init() {
+  function initSelect() {
     const versionSelect = document.getElementById('version-select');
     if (versionSelect) {
       versionSelect.addEventListener('change', handleVersionChange);
     }
+  }
+
+  /* ----- 2. <details>-based sidebar version switcher ----- */
+
+  function enhanceSwitcher(details) {
+    const summary = details.querySelector('summary');
+    const links = Array.prototype.slice.call(
+      details.querySelectorAll('.docs-nav-vswitch__link')
+    );
+    if (!summary) {
+      return;
+    }
+
+    function close(focusSummary) {
+      if (!details.open) {
+        return;
+      }
+      details.open = false;
+      if (focusSummary) {
+        summary.focus();
+      }
+    }
+
+    function focusLink(index) {
+      if (!links.length) {
+        return;
+      }
+      const i = (index + links.length) % links.length;
+      links[i].focus();
+    }
+
+    // Open + focus the first option when arrowing down from the summary.
+    summary.addEventListener('keydown', function (e) {
+      if (e.key === 'ArrowDown' || e.key === 'Down') {
+        e.preventDefault();
+        details.open = true;
+        focusLink(0);
+      }
+    });
+
+    // Arrow / Home / End / Escape while focus is inside the open menu.
+    details.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' || e.key === 'Esc') {
+        close(true);
+        return;
+      }
+      const current = links.indexOf(document.activeElement);
+      if (current === -1) {
+        return;
+      }
+      if (e.key === 'ArrowDown' || e.key === 'Down') {
+        e.preventDefault();
+        focusLink(current + 1);
+      } else if (e.key === 'ArrowUp' || e.key === 'Up') {
+        e.preventDefault();
+        focusLink(current - 1);
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        focusLink(0);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        focusLink(links.length - 1);
+      }
+    });
+
+    // Close when a click or focus leaves the widget.
+    document.addEventListener('click', function (e) {
+      if (details.open && !details.contains(e.target)) {
+        close(false);
+      }
+    });
+    details.addEventListener('focusout', function (e) {
+      if (!details.contains(e.relatedTarget)) {
+        close(false);
+      }
+    });
+  }
+
+  function initSwitchers() {
+    const switchers = document.querySelectorAll('details[data-version-switcher]');
+    Array.prototype.forEach.call(switchers, enhanceSwitcher);
+  }
+
+  function init() {
+    initSelect();
+    initSwitchers();
   }
 
   if (document.readyState === 'loading') {

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -203,12 +203,12 @@ HELPER: Render a menu item (desktop/mobile)
     {% let rss_href = '/' ~ _current_lang ~ '/rss.xml' %}
     {% end %}
     {% end %}
-    <link rel="alternate" type="application/rss+xml" title="{{ _site_title }} RSS Feed" href="{{ rss_href }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ _site_title }} RSS Feed" href="{{ rss_href | absolute_url }}">
     {% end %}
 
     {# hreflang alternates #}
     {% for alt in alternate_links(page) %}
-    <link rel="alternate" hreflang="{{ alt.hreflang }}" href="{{ alt.href }}">
+    <link rel="alternate" hreflang="{{ alt.hreflang }}" href="{{ alt.href | absolute_url }}">
     {% end %}
 
     {# Favicon, preconnect, fonts, stylesheets — site-stable, same for every page in a build #}

--- a/bengal/themes/default/templates/partials/docs-nav.html
+++ b/bengal/themes/default/templates/partials/docs-nav.html
@@ -38,7 +38,7 @@ Macros are compiled once and called as functions, eliminating the
 per-call overhead of {% include %} (context copy, template lookup).
 ============================================================================= #}
 
-{% def nav_node(item, depth=0) %}
+{% def nav_node(item, depth=0, version_trigger=false) %}
 {# Extract values once with null-safe access #}
 {% let item_title = item?.title ?? 'Untitled' %}
 {% let item_icon = item?.icon ?? '' %}
@@ -52,7 +52,63 @@ per-call overhead of {% include %} (context copy, template lookup).
 {% match has_children, depth %}
 {# ===== ROOT NODE (depth 0) - Static header, no toggle ===== #}
 {% case true, 0 %}
+{# Show the merged version switcher only on versioned, non-autodoc docs pages
+   with more than one version — same guard the old version-selector used. When
+   it does not hold, the root header renders exactly as before (byte-identical). #}
+{% let vs_show =
+     version_trigger
+     and versioning_enabled
+     and versions | length > 1
+     and page?.version is not none
+     and not (is_autodoc_page(page) if is_autodoc_page else false) %}
 <div class="docs-nav-group docs-nav-group--root{{ ' is-in-trail' if is_in_trail else '' }}" data-depth="{{ depth }}">
+  {% if vs_show %}
+  {# ===== MERGED VERSION SWITCHER: the "Documentation" title IS the dropdown =====
+     Native <details>/<summary> = the disclosure, so versions stay switchable
+     with zero JS (each option is a real <a>); CSS rotates the caret via [open];
+     version-selector.js only adds close-on-outside-click + Esc + arrow keys. #}
+  {% let vcur = current_version ?? site.latest_version %}
+  {% let vlabel = vcur?.label ?? 'Latest' %}
+  {% let vstatus = vcur?.status ?? 'current' %}
+  <details class="docs-nav-vswitch" data-version-switcher>
+    <summary class="docs-nav-group-header docs-nav-vswitch__summary" title="Switch documentation version">
+      {% if show_nav_icons %}
+      {% spaceless %}
+      <span class="docs-nav-icon" {{ ' data-default="true"' | safe if not item_icon else '' }}>
+        {{ icon(item_icon ?? 'book', size=16) }}
+      </span>
+      {% end %}
+      {% end %}
+      <span class="docs-nav-group-title docs-nav-vswitch__title">
+        <bdi class="docs-nav-vswitch__doc">{{ item_title }}</bdi>
+        {% if vlabel %}
+        <span class="docs-nav-vswitch__sep" aria-hidden="true">·</span>
+        <span class="docs-nav-vswitch__pill" data-status="{{ vstatus }}">{{ vlabel }}</span>
+        {% end %}
+      </span>
+      <span class="docs-nav-vswitch__caret" aria-hidden="true">{{ icon('caret-down', size=14) }}</span>
+    </summary>
+
+    <ul class="docs-nav-vswitch__menu" aria-label="Documentation versions">
+      {% for v in versions %}
+      {% let v_is_current = current_version and current_version.id == v.id %}
+      {% let v_status = v.status or (v.deprecated and 'deprecated' or 'legacy') %}
+      <li class="docs-nav-vswitch__item{{ ' is-current' if v_is_current else '' }}{{ ' is-deprecated' if v.deprecated else '' }}">
+        <a class="docs-nav-vswitch__link"
+           href="{{ site.get_version_target_url(page, v) }}"
+           {{ 'aria-current="true"' | safe if v_is_current else '' }}>
+          <span class="docs-nav-vswitch__check" aria-hidden="true">{{ icon('check', size=14) if v_is_current else '' }}</span>
+          <span class="docs-nav-vswitch__item-label"><bdi>{{ v.label }}</bdi></span>
+          <span class="docs-nav-vswitch__item-hint" data-status="{{ v_status }}">
+            {% if v.latest %}Latest{% elif v.status == 'preview' %}Preview{% elif v.deprecated %}deprecated{% else %}older{% end %}
+          </span>
+        </a>
+      </li>
+      {% end %}
+    </ul>
+  </details>
+  {% else %}
+  {# ===== Unchanged plain root header (non-versioned / autodoc / single version) ===== #}
   <div class="docs-nav-group-header">
     {% if show_nav_icons %}
     {% spaceless %}
@@ -71,6 +127,7 @@ per-call overhead of {% include %} (context copy, template lookup).
     <span class="docs-nav-group-title"><bdi>{{ item_title }}</bdi></span>
     {% end %}
   </div>
+  {% end %}
 
   <div class="docs-nav-group-items is-expanded expanded">
     {% for child in item_children %}
@@ -170,20 +227,21 @@ per-call overhead of {% include %} (context copy, template lookup).
 
     <bengal-docs-nav>
     <nav class="docs-nav" aria-label="Documentation pages">
-      {# Version Selector - only show if page is versioned (not autodoc) #}
-      {% unless is_autodoc %}
-      {% include 'partials/version-selector.html' %}
-      {% end %}
-
       {# Navigation Tree - uses cached NavTree infrastructure #}
       <div class="docs-nav-tree">
         {% if root_section %}
-        {# Scoped navigation: include root section as header #}
+        {# Scoped navigation: the root section header doubles as the version
+           switcher (version_trigger=true), so the standalone selector is gone. #}
         {% let nav_context = get_nav_context(page, root_section=root_section) %}
         {% with nav_context?.root as root_item %}
-        {{ nav_node(root_item, 0) }}
+        {{ nav_node(root_item, 0, version_trigger=true) }}
         {% end %}
         {% else %}
+        {# Fallback (no section root): keep the standalone version selector,
+           since there is no single root header to merge it into here. #}
+        {% unless is_autodoc %}
+        {% include 'partials/version-selector.html' %}
+        {% end %}
         {# Regular navigation: render all top-level items #}
         {% let nav_items = get_nav_tree(page) ?? [] %}
         {% for item in nav_items %}

--- a/bengal/themes/default/templates/partials/language-switcher.html
+++ b/bengal/themes/default/templates/partials/language-switcher.html
@@ -48,7 +48,7 @@ Example usage in base.html:
       role="option"
       {%- if alt.hreflang == current %} aria-selected="true" class="language-switcher__item language-switcher__item--active"{% else %} class="language-switcher__item"{% end %}
     >
-      <a href="{{ alt.href }}" hreflang="{{ alt.hreflang }}" lang="{{ alt.hreflang }}">
+      <a href="{{ alt.href | absolute_url }}" hreflang="{{ alt.hreflang }}" lang="{{ alt.hreflang }}">
         {{ lang_info?.name ?? lang_fallback }}
       </a>
     </li>
@@ -61,7 +61,7 @@ Example usage in base.html:
       role="option"
       {%- if lang.code == current %} aria-selected="true" class="language-switcher__item language-switcher__item--active"{% else %} class="language-switcher__item"{% end %}
     >
-      <a href="/{{ lang.code }}/" hreflang="{{ lang.code }}" lang="{{ lang.code }}">
+      <a href="{{ ('/' ~ lang.code ~ '/') | absolute_url }}" hreflang="{{ lang.code }}" lang="{{ lang.code }}">
         {{ lang.name }}
       </a>
     </li>

--- a/bengal/themes/default/templates/partials/version-banner.html
+++ b/bengal/themes/default/templates/partials/version-banner.html
@@ -40,7 +40,7 @@
       {% if site.latest_version %}
       <span class="version-banner__link-text">
         {{ t('version.see_latest', default='For the latest documentation, see') }}
-        <a href="{{ site.latest_version.url_prefix or '/' }}" class="version-banner__link">
+        <a href="{{ (site.latest_version.url_prefix or '/') | absolute_url }}" class="version-banner__link">
           {{ t('version.version_label', {'label': site.latest_version.label}, default='version {label}') }}
         </a>.
       </span>

--- a/changelog.d/+theme-baseurl-links.fixed.md
+++ b/changelog.d/+theme-baseurl-links.fixed.md
@@ -1,0 +1,1 @@
+Theme links that emitted site-relative paths now include the site's base path, so they resolve correctly on sites served from a subpath (for example a GitHub Pages project site) instead of returning 404. This covers the old-version banner's "latest documentation" link, RSS feed autodiscovery, and the `hreflang` and language-switcher alternate-language links.

--- a/changelog.d/+version-switcher.changed.md
+++ b/changelog.d/+version-switcher.changed.md
@@ -1,0 +1,3 @@
+The documentation version switcher now lives in the sidebar's section header: the title reads "Documentation · <version>" and opens a compact dropdown to switch versions, replacing the separate boxed selector that sat above it and reclaiming a row of vertical space.
+
+Each version in the menu still links to the closest matching page in that version, the current version is marked, and the control works without JavaScript via a native disclosure (the script only adds Escape/outside-click close and arrow-key navigation).


### PR DESCRIPTION
## Summary

- Merges the documentation version selector into the docs sidebar's section header: the title now reads "Documentation · <version>" and opens a compact, native `<details>` dropdown to switch versions, replacing the separate boxed `<select>` and reclaiming a row of vertical space. Each option links to the closest matching page in that version, the current version is marked, and it works with no JavaScript (the script only adds Escape/outside-click close + arrow-key nav).
- Fixes theme links that emitted site-relative paths so they include the site base path and resolve on subpath deploys (e.g. GitHub Pages project sites) instead of 404ing — the old-version banner's "latest documentation" link (the reported bug), plus RSS autodiscovery and the `hreflang`/language-switcher alternates, all now run through `| absolute_url`.

## Proof

- [x] Focused tests: `test_version_selector_template`, `test_navigation_templates_baseurl`, `test_template_links_baseurl`, `test_i18n_template_functions`, `test_one_enhancement_model`, `test_wave_scheduler` — all green.
- [x] `poe proof-pr` or scoped equivalent: scoped unit suites above + a production-baseurl `--all-versions` build of the doc site. Verified on a versioned page: switcher renders "Documentation · 0.5.0", the boxed `<select>` is gone, the banner "latest" link emits `/bengal/`, and RSS emits `/bengal/rss.xml`. (pre-commit "template CSS classes have definitions" passes for the new `docs-nav-vswitch__*` classes.)
- [x] Docs/examples/changelog updated or no-impact noted: <!-- changelog.d/ fragment: lead with one user-facing sentence, then engineering detail (see docs/b-stack-changelog-strategy.md) --> two fragments added (`+version-switcher.changed.md`, `+theme-baseurl-links.fixed.md`); `poe changelog-lint` clean.

## Performance Evidence

Theme template/CSS/JS only; no hot path, free-threaded, or concurrent behavior changed.

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

## Steward Notes

- Not fixed here (separate follow-up): the reported `/docs/<version>/about/` 404. Root-caused to a multi-version-build bug — `bengal build --all-versions` drops some section-index pages because consecutive in-process version builds reuse a stale thread-local render pipeline (the `about` page's `layout: list` scheduling lands it on the retaining thread). A one-line `clear_thread_local_pipelines()` in `WaveScheduler.render_all` did not reliably fix it in real builds and risked dropping other section indexes, so it is deferred for a proper fix at the per-version-build boundary. This PR is theme-only and does not touch that path.