### PR TITLE
feat(graph): surface topic communities + importance, with determinism floor

### DIFF
--- a/bengal/analysis/graph/builder.py
+++ b/bengal/analysis/graph/builder.py
@@ -119,19 +119,41 @@ class GraphBuilder:
         # Thread-safe lock for merge phase
         self._lock = threading.Lock()
 
+        # Memoized, build-stable analysis-page ordering (see get_analysis_pages).
+        self._sorted_analysis_pages: list[PageLike] | None = None
+
     def get_analysis_pages(self) -> list[PageLike]:
         """
-        Get list of pages to analyze, excluding autodoc pages if configured.
+        Get pages to analyze, in a **build-stable order**, excluding autodoc
+        pages if configured.
+
+        Order is load-bearing for determinism: this single list seeds the node
+        emission order in ``graph.json`` and the iteration order of every
+        downstream analysis (PageRank power-iteration, Louvain initial
+        community assignment + shuffle, path-analysis pivot sampling). Bare
+        ``list(self.site.pages)`` inherits filesystem-discovery order, which is
+        not guaranteed stable across builds/machines — baking anything derived
+        from it would break the warm==cold byte-parity contract. We sort by the
+        stable per-page id (the same key as the graph node id) so the order is
+        reproducible and nodes come out in id order. Computed once and memoized.
 
         Returns:
-            List of pages to include in graph analysis
+            Build-stably-ordered list of pages to include in graph analysis.
         """
+        if self._sorted_analysis_pages is not None:
+            return list(self._sorted_analysis_pages)
+
+        from bengal.analysis.utils.pages import stable_page_id
         from bengal.utils.autodoc import is_autodoc_page
 
-        if not self.exclude_autodoc:
-            return list(self.site.pages)
+        if self.exclude_autodoc:
+            pages = [p for p in self.site.pages if not is_autodoc_page(p)]
+        else:
+            pages = list(self.site.pages)
 
-        return [p for p in self.site.pages if not is_autodoc_page(p)]
+        pages.sort(key=lambda p: stable_page_id(self.site, p))
+        self._sorted_analysis_pages = pages
+        return list(pages)
 
     def build(self) -> None:
         """

--- a/bengal/analysis/graph/community_detection.py
+++ b/bengal/analysis/graph/community_detection.py
@@ -45,7 +45,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from bengal.analysis.utils.pages import get_content_pages
+from bengal.analysis.utils.pages import get_content_pages, stable_page_id
 from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
@@ -55,6 +55,14 @@ if TYPE_CHECKING:
     from bengal.protocols import PageLike
 
 logger = get_logger(__name__)
+
+# Fixed default seed for the node-shuffle PRNG when no explicit seed is passed.
+# Louvain's per-iteration shuffle MUST use a local seeded PRNG (never the global
+# ``random`` module): community ids are baked into ``graph.json`` and the
+# warm==cold byte-parity contract is CI-guarded, so the result has to be
+# reproducible across builds. No build caller passes a seed, so this constant is
+# what the build path actually uses.
+_LOUVAIN_SEED = 42
 
 
 @dataclass
@@ -163,8 +171,9 @@ class LouvainCommunityDetector:
         self.resolution = resolution
         self.random_seed = random_seed
 
-        if random_seed is not None:
-            random.seed(random_seed)
+        # Local, deterministic PRNG — never the global ``random`` module, whose
+        # state would leak across analyses and break reproducible output.
+        self._rng = random.Random(random_seed if random_seed is not None else _LOUVAIN_SEED)
 
     def detect(self) -> CommunityDetectionResults:
         """
@@ -198,6 +207,24 @@ class LouvainCommunityDetector:
         # Compute node degrees
         node_degrees = self._compute_node_degrees(pages, edge_weights)
 
+        # Adjacency index (page -> [(neighbor, weight), ...]) and per-community
+        # total degree, both maintained so each modularity-gain evaluation is
+        # O(degree) instead of O(N). Without this the inner loop is
+        # O(N^2 * degree * iterations): fine on tiny test graphs but tens of
+        # minutes on a real docs site (1000+ pages) — and community detection is
+        # now wired into every build, so this is load-bearing for build time.
+        adjacency: dict[PageLike, list[tuple[PageLike, float]]] = {p: [] for p in pages}
+        for edge, weight in edge_weights.items():
+            members = list(edge)
+            if len(members) == 2:
+                a, b = members
+                adjacency[a].append((b, weight))
+                adjacency[b].append((a, weight))
+
+        comm_degree: dict[int, float] = defaultdict(float)
+        for p in pages:
+            comm_degree[page_to_community[p]] += node_degrees.get(p, 0.0)
+
         # Louvain algorithm main loop
         iteration = 0
         improvement = True
@@ -207,42 +234,45 @@ class LouvainCommunityDetector:
             improvement = False
             iteration += 1
 
-            # Randomize order to avoid bias
+            # Randomize order to avoid bias (deterministic: local seeded PRNG).
             shuffled_pages = list(pages)
-            random.shuffle(shuffled_pages)
+            self._rng.shuffle(shuffled_pages)
 
             # Phase 1: Move nodes to optimize modularity
             for page in shuffled_pages:
                 current_community = page_to_community[page]
+                k_i = node_degrees.get(page, 0.0)
+
+                # Weight from this page into each neighboring community (O(degree)).
+                weight_to_comm: dict[int, float] = defaultdict(float)
+                for neighbor, w in adjacency.get(page, ()):
+                    weight_to_comm[page_to_community[neighbor]] += w
+
+                # Best move among neighboring communities (sorted candidate order
+                # for a deterministic tie-break). The current community is the
+                # baseline (gain 0); a candidate must beat it by > 1e-10. Since
+                # `page` sits in current_community, comm_degree[cand] for cand !=
+                # current is the correct sigma_tot (degree sum excluding page) —
+                # identical to the previous O(N) recomputation, just incremental.
                 best_community = current_community
                 best_gain = 0.0
-
-                # Find neighboring communities
-                neighboring_communities = self._get_neighboring_communities(
-                    page, page_to_community, edge_weights
-                )
-
-                # Try moving to each neighboring community
-                for neighbor_community in neighboring_communities:
-                    if neighbor_community == current_community:
+                for cand in sorted(weight_to_comm):
+                    if cand == current_community:
                         continue
-
-                    # Calculate modularity gain
-                    gain = self._modularity_gain(
-                        page,
-                        neighbor_community,
-                        page_to_community,
-                        edge_weights,
-                        node_degrees,
-                        total_weight,
-                    )
-
+                    sigma_tot = comm_degree[cand]
+                    gain = (
+                        weight_to_comm[cand]
+                        - self.resolution * sigma_tot * k_i / (2 * total_weight)
+                    ) / total_weight
                     if gain > best_gain:
                         best_gain = gain
-                        best_community = neighbor_community
+                        best_community = cand
 
-                # Move to best community if improvement found
+                # Move to best community if improvement found; keep comm_degree in
+                # sync so later moves this pass see the updated community totals.
                 if best_community != current_community and best_gain > 1e-10:
+                    comm_degree[current_community] -= k_i
+                    comm_degree[best_community] += k_i
                     page_to_community[page] = best_community
                     improvement = True
 
@@ -265,11 +295,22 @@ class LouvainCommunityDetector:
         for page, community_id in page_to_community.items():
             community_map[community_id].add(page)
 
-        # Renumber communities sequentially
-        communities = [
-            Community(id=i, pages=pages_set)
-            for i, (_, pages_set) in enumerate(sorted(community_map.items()))
-        ]
+        # Renumber communities by a build-stable rank: largest first, ties broken
+        # by the smallest member node-id. The internal community labels are
+        # enumerate/shuffle-derived and therefore NOT stable to bake; this rank
+        # is. It also gives downstream a deterministic ordering (community 0 =
+        # biggest topic), which the visualizer uses to assign a stable color
+        # index per community.
+        site = getattr(self.graph, "site", None)
+
+        def _min_member_id(pages_set: set[PageLike]) -> str:
+            return min(stable_page_id(site, p) for p in pages_set)
+
+        ordered = sorted(
+            community_map.values(),
+            key=lambda pages_set: (-len(pages_set), _min_member_id(pages_set)),
+        )
+        communities = [Community(id=i, pages=pages_set) for i, pages_set in enumerate(ordered)]
 
         logger.info(
             "community_detection_complete",
@@ -316,60 +357,6 @@ class LouvainCommunityDetector:
                 node_degrees[edge_list[0]] += 2 * weight
 
         return node_degrees
-
-    def _get_neighboring_communities(
-        self,
-        page: PageLike,
-        page_to_community: dict[PageLike, int],
-        edge_weights: dict[frozenset[PageLike], float],
-    ) -> set[int]:
-        """Get communities that are neighbors of this page."""
-        neighboring_communities = set()
-
-        # Add current community
-        neighboring_communities.add(page_to_community[page])
-
-        # Find all pages connected to this page
-        for edge in edge_weights:
-            if page in edge:
-                for neighbor in edge:
-                    if neighbor != page:
-                        neighboring_communities.add(page_to_community[neighbor])
-
-        return neighboring_communities
-
-    def _modularity_gain(
-        self,
-        page: PageLike,
-        to_community: int,
-        page_to_community: dict[PageLike, int],
-        edge_weights: dict[frozenset[PageLike], float],
-        node_degrees: dict[PageLike, float],
-        total_weight: float,
-    ) -> float:
-        """
-        Calculate modularity gain from moving page to new community.
-
-        This uses the fast incremental formula for modularity change.
-        """
-        # Weight of links from page to nodes in to_community
-        k_i_in = 0.0
-        for edge, weight in edge_weights.items():
-            if page in edge:
-                for neighbor in edge:
-                    if neighbor != page and page_to_community[neighbor] == to_community:
-                        k_i_in += weight
-
-        # Sum of degrees in to_community
-        sigma_tot = sum(node_degrees[p] for p, c in page_to_community.items() if c == to_community)
-
-        # Degree of page
-        k_i = node_degrees.get(page, 0.0)
-
-        # Modularity gain formula
-        gain = k_i_in - self.resolution * sigma_tot * k_i / (2 * total_weight)
-
-        return gain / total_weight
 
     def _compute_modularity(
         self,

--- a/bengal/analysis/graph/knowledge_graph.py
+++ b/bengal/analysis/graph/knowledge_graph.py
@@ -240,12 +240,18 @@ class KnowledgeGraph:
         if self._builder:
             return self._builder.get_analysis_pages()
 
-        # Fallback if build() not called yet
+        # Fallback if build() not called yet. Sort by the stable page id so the
+        # order matches the builder path and stays build-reproducible (see
+        # GraphBuilder.get_analysis_pages for why order is load-bearing).
+        from bengal.analysis.utils.pages import stable_page_id
         from bengal.utils.autodoc import is_autodoc_page
 
-        if not self.exclude_autodoc:
-            return list(self.site.pages)
-        return [p for p in self.site.pages if not is_autodoc_page(p)]
+        if self.exclude_autodoc:
+            pages = [p for p in self.site.pages if not is_autodoc_page(p)]
+        else:
+            pages = list(self.site.pages)
+        pages.sort(key=lambda p: stable_page_id(self.site, p))
+        return pages
 
     @require_built
     def get_connectivity(self, page: PageLike) -> PageConnectivity:

--- a/bengal/analysis/graph/layout.py
+++ b/bengal/analysis/graph/layout.py
@@ -210,6 +210,8 @@ def compute_force_layout(
     *,
     seed: int = 1,
     iterations: int | None = None,
+    communities: Mapping[str, int] | None = None,
+    weights: Mapping[tuple[str, str], float] | None = None,
 ) -> dict[str, tuple[float, float]]:
     """Fruchterman-Reingold layout, normalized to ``[0, 1]``.
 
@@ -219,10 +221,22 @@ def compute_force_layout(
             ``node_ids`` are ignored.
         seed: PRNG seed for the deterministic initial placement.
         iterations: Override the (otherwise N-derived) iteration count.
+        communities: Optional ``node_id -> community_id`` map. When given, the
+            layout becomes community-aware: each community is assigned a ring
+            centroid (deterministically, by sorted community id) and nodes are
+            seeded near + gravitated toward their community's centroid instead of
+            a single global center. This separates clusters into distinct visual
+            lobes (the "topic map" look) rather than one center-piled hairball,
+            and — because nodes start near their final neighborhood — tends to
+            converge in fewer iterations.
+        weights: Optional ``(source, target) -> weight`` map (any key order).
+            Edge attraction is scaled by the weight (capped), so strongly /
+            bidirectionally linked pairs sit closer together.
 
     Returns:
         ``dict[node_id, (x, y)]`` with coordinates in ``[0, 1]``. Empty input
-        yields an empty dict; a single node is centered.
+        yields an empty dict; a single node is centered. Deterministic for a
+        given (node set, edge set, communities, weights, seed).
     """
     ids = sorted(set(node_ids))
     n = len(ids)
@@ -232,11 +246,44 @@ def compute_force_layout(
         return {ids[0]: (0.5, 0.5)}
 
     rng = _Rng(seed)
-    # Deterministic initial scatter in a unit square.
-    pos: dict[str, list[float]] = {nid: [rng.random(), rng.random()] for nid in ids}
+
+    # Community centroids on a ring (deterministic: sorted community ids). Nodes
+    # without a community fall to a synthetic center bucket so the math is total.
+    centroids: dict[int, tuple[float, float]] = {}
+    if communities:
+        comm_ids = sorted({int(communities.get(nid, -1)) for nid in ids})
+        num_comms = len(comm_ids)
+        ring_r = 0.35
+        for rank, cid in enumerate(comm_ids):
+            if num_comms <= 1:
+                centroids[cid] = (0.5, 0.5)
+            else:
+                angle = 2.0 * math.pi * rank / num_comms
+                centroids[cid] = (0.5 + ring_r * math.cos(angle), 0.5 + ring_r * math.sin(angle))
+
+    def _centroid(nid: str) -> tuple[float, float]:
+        return (
+            centroids.get(int(communities.get(nid, -1)), (0.5, 0.5)) if communities else (0.5, 0.5)
+        )
+
+    # Initial placement. With communities, seed each node near its centroid (so
+    # clusters start apart); otherwise a deterministic scatter in the unit box.
+    pos: dict[str, list[float]] = {}
+    for nid in ids:
+        if communities:
+            cx, cy = _centroid(nid)
+            pos[nid] = [cx + (rng.random() - 0.5) * 0.12, cy + (rng.random() - 0.5) * 0.12]
+        else:
+            pos[nid] = [rng.random(), rng.random()]
 
     valid = set(ids)
     clean_edges = sorted((s, t) for s, t in edges if s in valid and t in valid and s != t)
+
+    # Normalize edge weights to sorted-pair keys for direction-independent lookup.
+    weight_by_pair: dict[tuple[str, str], float] = {}
+    if weights:
+        for (s, t), w in weights.items():
+            weight_by_pair[(s, t) if s <= t else (t, s)] = float(w)
 
     # FR ideal edge length for a unit area.
     k = math.sqrt(1.0 / n)
@@ -289,14 +336,15 @@ def compute_force_layout(
                     db[0] -= fx
                     db[1] -= fy
 
-        # --- Attraction along edges (springs) ---
+        # --- Attraction along edges (springs), scaled by edge weight ---
         for s, t in clean_edges:
             sx, sy = pos[s]
             tx, ty = pos[t]
             dx = sx - tx
             dy = sy - ty
             dist = math.sqrt(dx * dx + dy * dy) or 1e-6
-            f = (dist * dist) / k
+            w = weight_by_pair.get((s, t) if s <= t else (t, s), 1.0)
+            f = (dist * dist) / k * min(w, 3.0)
             fx = (dx / dist) * f
             fy = (dy / dist) * f
             disp[s][0] -= fx
@@ -304,11 +352,19 @@ def compute_force_layout(
             disp[t][0] += fx
             disp[t][1] += fy
 
-        # --- Mild gravity toward center (keeps disconnected nodes in frame) ---
+        # --- Gravity. Community-aware: pull toward the community centroid (so
+        # clusters stay as separated lobes) plus a weak global cohesion that
+        # keeps the whole graph framed. Without communities, a single mild pull
+        # toward center (keeps disconnected nodes in frame). ---
         for nid in ids:
             px, py = pos[nid]
-            disp[nid][0] += (0.5 - px) * k * 0.5
-            disp[nid][1] += (0.5 - py) * k * 0.5
+            if communities:
+                cx, cy = _centroid(nid)
+                disp[nid][0] += (cx - px) * k * 0.9 + (0.5 - px) * k * 0.12
+                disp[nid][1] += (cy - py) * k * 0.9 + (0.5 - py) * k * 0.12
+            else:
+                disp[nid][0] += (0.5 - px) * k * 0.5
+                disp[nid][1] += (0.5 - py) * k * 0.5
 
         # --- Integrate, capped by temperature ---
         for nid in ids:

--- a/bengal/analysis/graph/page_rank.py
+++ b/bengal/analysis/graph/page_rank.py
@@ -212,10 +212,20 @@ class PageRankCalculator:
         # RFC: rfc-analysis-algorithm-optimization
         incoming_edges: dict[PageLike, list[PageLike]] = self.graph.incoming_edges
 
-        # Pre-compute outgoing link counts for efficiency
-        outgoing_counts: dict[PageLike, int] = {
-            page: len(self.graph.outgoing_refs.get(page, set())) for page in pages
-        }
+        # Pre-compute out-degree CONSISTENT with the incoming-edges index above.
+        # PageRank conserves probability mass only when each source distributes
+        # its score across exactly the edges that deliver it. ``outgoing_refs``
+        # counts only explicit links, but ``incoming_edges`` also encodes
+        # related-posts, section-hierarchy and next/prev navigation edges — so
+        # ``len(outgoing_refs)`` under-counts the true out-degree, which inflates
+        # each recipient's share, amplifies total mass every iteration, and
+        # DIVERGES on dense graphs (scores ran past 1e10 on the docs site).
+        # Deriving the denominator from the same index keeps the random walk a
+        # proper (sub-)stochastic process that converges to a sane distribution.
+        outgoing_counts: dict[PageLike, int] = {}
+        for sources in incoming_edges.values():
+            for source_page in sources:
+                outgoing_counts[source_page] = outgoing_counts.get(source_page, 0) + 1
 
         for iteration in range(self.max_iterations):
             new_scores = {}

--- a/bengal/analysis/graph/visualizer.py
+++ b/bengal/analysis/graph/visualizer.py
@@ -149,13 +149,10 @@ class GraphVisualizer:
         """
         Get a stable, build-reproducible ID for a page.
 
-        Hashes the *site-relative* source path with a fixed algorithm. Python's
-        built-in ``hash()`` is per-process randomized (PYTHONHASHSEED), and an
-        absolute path varies by checkout location — both make ``graph.json`` /
-        ``index.json`` node ids differ between otherwise-identical builds, which
-        breaks byte-reproducible output and the warm==cold parity contract. A
-        deterministic hash of the site-relative path is stable across builds and
-        machines while staying unique per page.
+        Thin wrapper over :func:`bengal.analysis.utils.pages.stable_page_id` —
+        the single source of truth for the page id, shared with the canonical
+        page-ordering key in ``GraphBuilder.get_analysis_pages`` so nodes are
+        emitted in id order and every analysis iterates a build-stable order.
 
         Args:
             page: Page object
@@ -163,34 +160,9 @@ class GraphVisualizer:
         Returns:
             Stable string ID for the page
         """
-        from bengal.utils.primitives.hashing import hash_str
+        from bengal.analysis.utils.pages import stable_page_id
 
-        source_path = getattr(page, "source_path", None)
-        if source_path is None:
-            # Generated/virtual pages without a source file: derive a stable id
-            # from a location-independent identifier.
-            try:
-                seed = str(page.href)
-            except Exception:
-                seed = str(getattr(page, "title", "") or id(page))
-            return hash_str(seed, truncate=16)
-
-        rel: Any = source_path
-        root = getattr(self.site, "root_path", None)
-        if root is not None:
-            # Canonicalize both sides before taking the relative path: the page
-            # source and the site root can carry different symlink forms (e.g.
-            # macOS ``/var`` vs ``/private/var``), which would make a naive
-            # ``relative_to`` fall back to the absolute (location-dependent) path
-            # and reintroduce nondeterminism across build locations.
-            try:
-                rel = Path(source_path).resolve().relative_to(Path(root).resolve())
-            except ValueError, OSError:
-                try:
-                    rel = Path(source_path).relative_to(root)
-                except ValueError:
-                    rel = source_path
-        return hash_str(Path(rel).as_posix(), truncate=16)
+        return stable_page_id(self.site, page)
 
     def generate_graph_data(self) -> dict[str, Any]:
         """
@@ -210,6 +182,39 @@ class GraphVisualizer:
             total_pages=len(content_pages),
             filtered=len(analysis_pages) - len(content_pages),
         )
+
+        # --- Surface the analysis we already compute: topic communities
+        # (Louvain) + importance (PageRank). Both are cached on the graph and
+        # computed once. Communities color the graph as a topic map; PageRank
+        # drives node size. Determinism is guarded upstream (sorted page order +
+        # Louvain local seeded PRNG); we round the PageRank float before baking.
+        community_by_page: dict[Any, int] = {}
+        communities_summary: list[dict[str, Any]] = []
+        pr_scores: dict[Any, float] = {}
+        pr_max = 0.0
+        try:
+            pr_results = self.graph.compute_pagerank()
+            pr_scores = pr_results.scores or {}
+            pr_max = max(pr_scores.values()) if pr_scores else 0.0
+        except Exception as e:
+            logger.debug("graph_viz_pagerank_failed", error=str(e), error_type=type(e).__name__)
+
+        try:
+            community_results = self.graph.detect_communities()
+            for community in community_results.communities:
+                for p in community.pages:
+                    community_by_page[p] = community.id
+            # Rank-ordered (0 = largest) summary for the cluster legend.
+            communities_summary = [
+                {
+                    "id": community.id,
+                    "label": self._community_label(community, pr_scores),
+                    "size": community.size,
+                }
+                for community in community_results.communities[:12]
+            ]
+        except Exception as e:
+            logger.debug("graph_viz_community_failed", error=str(e), error_type=type(e).__name__)
 
         nodes = []
         edges = []
@@ -231,14 +236,19 @@ class GraphVisualizer:
             except ValueError, TypeError:
                 reading_time = 1
 
-            # Calculate visual size based on BOTH connectivity AND content depth
-            # - Connectivity: how central/important (links)
-            # - Reading time: how substantial (content depth)
-            # Formula: base + connectivity bonus + content depth bonus
+            # Calculate visual size from PageRank importance (dominant) blended
+            # with content depth — so genuinely authoritative pages read as large
+            # and luminous, not merely well-connected ones. Falls back to
+            # connectivity when PageRank is unavailable.
+            pr_score = float(pr_scores.get(page, 0.0))
+            pr_norm = (pr_score / pr_max) if pr_max > 0 else 0.0
             base_size = 8
-            connectivity_bonus = min(connectivity.connectivity_score * 1.5, 20)  # max +20
-            content_bonus = min(reading_time * 0.8, 15)  # max +15 (long articles get bigger)
-            size = int(min(50, base_size + connectivity_bonus + content_bonus))
+            if pr_max > 0:
+                importance_bonus = pr_norm * 28  # PageRank drives prominence
+            else:
+                importance_bonus = min(connectivity.connectivity_score * 1.5, 20)
+            content_bonus = min(reading_time * 0.6, 12)
+            size = int(min(50, base_size + importance_bonus + content_bonus))
 
             # Get tags safely
             tags = []
@@ -334,7 +344,14 @@ class GraphVisualizer:
                 color=color,
             )
 
-            nodes.append(asdict(node))
+            # Bake the surfaced analysis onto the node dict (the dataclass stays
+            # a stable shim; new fields ride alongside x/y). ``community`` is a
+            # stable rank-ordered id (-1 = unclustered) the client maps to a
+            # color token; ``pagerank`` is rounded for byte-parity.
+            node_dict = asdict(node)
+            node_dict["community"] = int(community_by_page.get(page, -1))
+            node_dict["pagerank"] = round(pr_score, 6)
+            nodes.append(node_dict)
 
         # Generate edges with bidirectional weight detection
         # If A→B and B→A both exist, that's a stronger relationship (weight=2)
@@ -377,16 +394,27 @@ class GraphVisualizer:
         # guards warm==cold byte parity.
         from bengal.analysis.graph.layout import compute_force_layout
 
+        # Community-aware layout: cluster nodes into separated topical lobes
+        # (not one center-piled hairball) and pull strongly-linked pairs closer.
+        node_community = {n["id"]: n["community"] for n in nodes}
+        edge_weights = {(e["source"], e["target"]): e["weight"] for e in edges}
         coords = compute_force_layout(
             [n["id"] for n in nodes],
             [(e["source"], e["target"]) for e in edges],
+            communities=node_community,
+            weights=edge_weights,
         )
         for n in nodes:
             x, y = coords.get(n["id"], (0.5, 0.5))
             n["x"] = x
             n["y"] = y
 
-        logger.info("graph_viz_generate_complete", nodes=len(nodes), edges=len(edges))
+        logger.info(
+            "graph_viz_generate_complete",
+            nodes=len(nodes),
+            edges=len(edges),
+            communities=len(communities_summary),
+        )
 
         return {
             "nodes": nodes,
@@ -396,6 +424,7 @@ class GraphVisualizer:
                 "total_links": len(edges),
                 "hubs": self.graph.metrics.hub_count if self.graph.metrics else 0,
                 "orphans": self.graph.metrics.orphan_count if self.graph.metrics else 0,
+                "communities": communities_summary,
             },
         }
 
@@ -421,6 +450,48 @@ class GraphVisualizer:
         if page.metadata.get("_generated"):
             return "var(--graph-node-generated)"
         return "var(--graph-node-regular)"
+
+    def _community_label(self, community: Any, pr_scores: dict[Any, float]) -> str:
+        """
+        Derive a human label for a topic community, deterministically.
+
+        Prefers the most frequent tag shared across the community's pages (ties
+        broken alphabetically); falls back to the title of the highest-PageRank
+        member (ties broken by stable page id) so the choice is reproducible.
+
+        Args:
+            community: A detected Community (has ``.id`` and ``.pages``).
+            pr_scores: PageRank scores by page, for the fallback ranking.
+
+        Returns:
+            A short display label for the community.
+        """
+        from collections import Counter
+
+        from bengal.analysis.utils.pages import stable_page_id
+
+        tag_counts: Counter[str] = Counter()
+        for p in community.pages:
+            tags = getattr(p, "tags", None) or []
+            if isinstance(tags, (list, tuple, set)):
+                for t in tags:
+                    if t:
+                        tag_counts[str(t)] += 1
+        if tag_counts:
+            best = sorted(tag_counts.items(), key=lambda kv: (-kv[1], kv[0]))[0][0]
+            if best:
+                return best.replace("-", " ").replace("_", " ").title()
+
+        # Fallback: highest-PageRank member title (tie-break by stable page id).
+        members = sorted(
+            community.pages,
+            key=lambda p: (-float(pr_scores.get(p, 0.0)), stable_page_id(self.site, p)),
+        )
+        for p in members:
+            title = getattr(p, "title", None)
+            if title:
+                return str(title)
+        return f"Cluster {community.id}"
 
     def generate_html(self, title: str | None = None) -> str:
         """

--- a/bengal/analysis/utils/pages.py
+++ b/bengal/analysis/utils/pages.py
@@ -19,7 +19,8 @@ Example:
 
 """
 
-from typing import TYPE_CHECKING, Protocol
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from bengal.protocols import PageLike
@@ -29,6 +30,68 @@ class _GraphLike(Protocol):
     """Protocol for graph-like objects with get_analysis_pages (breaks kg->pages cycle)."""
 
     def get_analysis_pages(self) -> list[PageLike]: ...
+
+
+def stable_page_id(site: Any, page: Any) -> str:
+    """
+    Return a stable, build-reproducible id for a page.
+
+    Hashes the *site-relative* source path with a fixed algorithm. Python's
+    built-in ``hash()`` is per-process randomized (PYTHONHASHSEED) and an
+    absolute path varies by checkout location — both make derived data
+    (``graph.json`` node ids, analysis ordering) differ between otherwise
+    identical builds, which breaks byte-reproducible output and the warm==cold
+    parity contract. A deterministic hash of the site-relative path is stable
+    across builds and machines while staying unique per page.
+
+    This is the single source of truth for the graph node id (consumed by
+    :meth:`GraphVisualizer._get_page_id`) and the canonical page-ordering key
+    (consumed by ``GraphBuilder.get_analysis_pages``), so that nodes are emitted
+    in id order and every analysis iterates a build-stable order.
+
+    Args:
+        site: Site instance (used for ``root_path`` to relativize source paths).
+        page: Page object.
+
+    Returns:
+        Stable string id for the page.
+    """
+    from bengal.utils.primitives.hashing import hash_str
+
+    source_path = getattr(page, "source_path", None)
+    if source_path is not None:
+        try:
+            rel: Any = source_path
+            root = getattr(site, "root_path", None)
+            if root is not None:
+                # Canonicalize both sides before taking the relative path: the
+                # page source and the site root can carry different symlink forms
+                # (e.g. macOS ``/var`` vs ``/private/var``), which would make a
+                # naive ``relative_to`` fall back to the absolute
+                # (location-dependent) path and reintroduce nondeterminism across
+                # build locations.
+                try:
+                    rel = Path(source_path).resolve().relative_to(Path(root).resolve())
+                except ValueError, OSError, TypeError:
+                    # TypeError: root is not path-like. Fall back to a plain
+                    # relative_to, then to the source path itself.
+                    try:
+                        rel = Path(source_path).relative_to(root)
+                    except ValueError, TypeError:
+                        rel = source_path
+            return hash_str(Path(rel).as_posix(), truncate=16)
+        except TypeError:
+            # source_path is not path-like (e.g. a test Mock). Fall through to the
+            # location-independent seed below rather than crashing.
+            pass
+
+    # Generated/virtual pages without a usable source file: derive a stable id
+    # from a location-independent identifier.
+    try:
+        seed = str(page.href)
+    except Exception:
+        seed = str(getattr(page, "title", "") or id(page))
+    return hash_str(seed, truncate=16)
 
 
 def get_content_pages(

--- a/bengal/themes/default/assets/css/components/graph.css
+++ b/bengal/themes/default/assets/css/components/graph.css
@@ -375,6 +375,46 @@
     transform: scale(1.2);
 }
 
+/* Community (topic-cluster) legend: clickable rows that isolate a cluster. */
+.graph-legend-community {
+    width: 100%;
+    border: none;
+    background: none;
+    font: inherit;
+    text-align: start;
+    cursor: pointer;
+    border-radius: 6px;
+    padding: 4px 6px;
+    margin-inline: -6px;
+}
+
+.graph-legend-community .graph-legend-label {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.graph-legend-community .graph-legend-count {
+    margin-inline-start: 8px;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-muted, #9e9e9e);
+}
+
+.graph-legend-community:hover {
+    background: color-mix(in oklab, var(--color-text-primary) 8%, transparent);
+}
+
+.graph-legend-community.is-active {
+    background: color-mix(in oklab, var(--color-accent) 18%, transparent);
+}
+
+.graph-legend-community.is-active .graph-legend-label {
+    color: var(--color-text-primary);
+    font-weight: 600;
+}
+
 /* Graph Nodes and Links */
 .graph-node {
     cursor: pointer;
@@ -520,6 +560,20 @@
     font-size: 12px;
 }
 
+.graph-tooltip-cluster {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
+}
+
+.graph-tooltip-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
 .graph-tooltip .tags {
     display: flex;
     flex-wrap: wrap;
@@ -549,6 +603,34 @@
  * These use vibrant, saturated colors that stand out against
  * the background while staying harmonious with each palette.
  */
+/* ============================================
+   COMMUNITY (TOPIC-CLUSTER) PALETTE
+   ============================================
+ * Categorical colors for Louvain communities, used to paint the graph as a
+ * topic map (the Obsidian-style "wow"). Coherent with Pridelands by
+ * construction: every color is derived from the live `--color-accent` by
+ * ROTATING its hue in OKLCH space (36° steps span the wheel), so the whole
+ * ramp shifts automatically per palette and adapts per scheme via light-dark()
+ * — no parallel hardcoded-hex palette, no [data-theme=dark] override blocks.
+ * Community ids are rank-ordered (0 = largest) and stable (see
+ * community_detection renumber), so color assignment is deterministic. The
+ * canvas explorer reads these via getComputedStyle and keeps hex fallbacks.
+ */
+:root {
+    --graph-community-0: light-dark(oklch(from var(--color-accent) 0.63 0.15 h),        oklch(from var(--color-accent) 0.74 0.15 h));
+    --graph-community-1: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 36)),  oklch(from var(--color-accent) 0.74 0.15 calc(h + 36)));
+    --graph-community-2: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 72)),  oklch(from var(--color-accent) 0.74 0.15 calc(h + 72)));
+    --graph-community-3: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 108)), oklch(from var(--color-accent) 0.74 0.15 calc(h + 108)));
+    --graph-community-4: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 144)), oklch(from var(--color-accent) 0.74 0.15 calc(h + 144)));
+    --graph-community-5: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 180)), oklch(from var(--color-accent) 0.74 0.15 calc(h + 180)));
+    --graph-community-6: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 216)), oklch(from var(--color-accent) 0.74 0.15 calc(h + 216)));
+    --graph-community-7: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 252)), oklch(from var(--color-accent) 0.74 0.15 calc(h + 252)));
+    --graph-community-8: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 288)), oklch(from var(--color-accent) 0.74 0.15 calc(h + 288)));
+    --graph-community-9: light-dark(oklch(from var(--color-accent) 0.63 0.15 calc(h + 324)), oklch(from var(--color-accent) 0.74 0.15 calc(h + 324)));
+    /* Long-tail communities beyond the ramp fall to a muted, theme-aware tint. */
+    --graph-community-other: color-mix(in oklab, var(--color-text-secondary), var(--color-bg-primary) 30%);
+}
+
 :root {
     /* Default palette (Bengal Orange) - Vibrant and distinct */
     --graph-node-hub: #FF9500;           /* Bold orange - central importance */

--- a/bengal/themes/default/assets/js/bengal-graph-explorer.js
+++ b/bengal/themes/default/assets/js/bengal-graph-explorer.js
@@ -41,6 +41,8 @@
     var grid = {};             // picking grid: "cx,cy" -> [node, ...]
     var camera = { scale: 1, tx: 0, ty: 0 };
     var colors = {};
+    var communityColors = [];   // categorical topic-cluster palette (CSS tokens)
+    var communityLabels = {};   // community id -> display label (from stats)
     var hovered = null;
     var dirty = false;
     var rafPending = false;
@@ -50,6 +52,9 @@
     var query = '';
     var typeFilter = 'all';
     var tagParam = null;
+    var communityFilter = null; // when set, isolate one topic cluster (legend click)
+
+    var COMMUNITY_PALETTE_SIZE = 10;
 
     function on(target, event, handler, opts) {
         target.addEventListener(event, handler, opts);
@@ -87,11 +92,33 @@
             generated: v('--graph-node-generated', '#4ECDC4'),
             link: v('--graph-link-color', 'rgba(100,100,100,0.25)'),
             linkHi: v('--graph-link-highlight', 'rgba(255,200,120,0.95)'),
-            label: v('--color-text', '#222'),
-            labelBg: v('--color-bg', '#fff')
+            // These tokens are `--color-text-primary`/`--color-bg-primary` in the
+            // theme; the old `--color-text`/`--color-bg` names don't exist, so
+            // labels used to always fall back to #222/#fff (wrong in dark mode).
+            label: v('--color-text-primary', '#222'),
+            labelBg: v('--color-bg-primary', '#fff'),
+            communityOther: v('--graph-community-other', '#9aa0a6')
         };
+        // Categorical community palette (topic clusters). Hex fallbacks keep the
+        // canvas painting even if an engine returns an unevaluated
+        // oklch()/color-mix() string from getComputedStyle.
+        var COMMUNITY_FALLBACKS = [
+            '#FF9500', '#4ECDC4', '#A78BFA', '#F472B6', '#34D399',
+            '#60A5FA', '#FBBF24', '#FB7185', '#2DD4BF', '#C084FC'
+        ];
+        communityColors = [];
+        for (var i = 0; i < COMMUNITY_PALETTE_SIZE; i++) {
+            communityColors.push(v('--graph-community-' + i, COMMUNITY_FALLBACKS[i]));
+        }
     }
-    function nodeColor(n) { return colors[n.type] || colors.regular; }
+    function nodeColor(n) {
+        // Colour by topic community (the "map" look); fall back to type colour
+        // for unclustered nodes or pre-community data.
+        if (typeof n.community === 'number' && n.community >= 0 && communityColors.length) {
+            return communityColors[n.community % communityColors.length];
+        }
+        return colors[n.type] || colors.regular;
+    }
 
     // ---- Picking grid --------------------------------------------------------
     function gridKey(wx, wy) {
@@ -133,11 +160,51 @@
     }
     function isVisible(n) {
         if (tagParam && !nodeMatchesTag(n)) return false;
+        if (communityFilter !== null && n.community !== communityFilter) return false;
         var matchesSearch = !query ||
             (n.label || '').toLowerCase().indexOf(query) !== -1 ||
             (n.tags || []).some(function (t) { return t.toLowerCase().indexOf(query) !== -1; });
         var matchesType = typeFilter === 'all' || n.type === typeFilter;
         return matchesSearch && matchesType;
+    }
+
+    // ---- Community (topic-cluster) legend -----------------------------------
+    function communityColorFor(id) {
+        if (!communityColors.length) return colors.communityOther;
+        return communityColors[id % communityColors.length];
+    }
+    function buildCommunityLegend(stats) {
+        var legend = document.querySelector('.graph-legend');
+        if (!legend || !stats || !stats.communities || !stats.communities.length) return;
+        communityLabels = {};
+        stats.communities.forEach(function (c) { communityLabels[c.id] = c.label; });
+        var top = stats.communities.slice(0, 8);
+        var frag = document.createElement('div');
+        var html = '<h3>Topic clusters</h3>';
+        top.forEach(function (c) {
+            html += '<button type="button" class="graph-legend-item graph-legend-community" ' +
+                'data-community="' + c.id + '" aria-pressed="false">' +
+                '<span class="graph-legend-color" style="background:' + communityColorFor(c.id) + '"></span>' +
+                '<span class="graph-legend-label">' + escapeHtml(c.label || ('Cluster ' + c.id)) + '</span>' +
+                '<span class="graph-legend-count">' + (c.size || 0) + '</span>' +
+                '</button>';
+        });
+        frag.innerHTML = html;
+        legend.innerHTML = frag.innerHTML;
+        // Click a cluster to isolate it; click again (or another) to toggle.
+        legend.querySelectorAll('.graph-legend-community').forEach(function (btn) {
+            on(btn, 'click', function () {
+                var id = parseInt(btn.getAttribute('data-community'), 10);
+                communityFilter = (communityFilter === id) ? null : id;
+                legend.querySelectorAll('.graph-legend-community').forEach(function (b) {
+                    var on2 = (communityFilter !== null) &&
+                        (parseInt(b.getAttribute('data-community'), 10) === communityFilter);
+                    b.setAttribute('aria-pressed', on2 ? 'true' : 'false');
+                    b.classList.toggle('is-active', on2);
+                });
+                requestRedraw();
+            });
+        });
     }
 
     // ---- Rendering -----------------------------------------------------------
@@ -261,9 +328,15 @@
                 return '<span class="tag">' + escapeHtml(t) + '</span>';
             }).join('') + '</div>'
             : '';
+        var clusterLine = '';
+        if (typeof n.community === 'number' && n.community >= 0 && communityLabels[n.community]) {
+            clusterLine = '<p class="graph-tooltip-cluster">' +
+                '<span class="graph-tooltip-swatch" style="background:' + communityColorFor(n.community) + '"></span>' +
+                escapeHtml(communityLabels[n.community]) + '</p>';
+        }
         tooltipEl.innerHTML = '<h4>' + escapeHtml(n.label || 'Untitled') + '</h4>' +
             '<p>' + (n.reading_time || 0) + ' min read · ' +
-            (n.incoming_refs || 0) + ' in / ' + (n.outgoing_refs || 0) + ' out</p>' + tags;
+            (n.incoming_refs || 0) + ' in / ' + (n.outgoing_refs || 0) + ' out</p>' + clusterLine + tags;
         tooltipEl.style.display = 'block';
         tooltipEl.style.left = (evt.clientX + 12) + 'px';
         tooltipEl.style.top = (evt.clientY + 12) + 'px';
@@ -349,7 +422,11 @@
             } else if (e.key === 'Escape') {
                 if (searchInput) searchInput.value = '';
                 if (filterSelect) filterSelect.value = 'all';
-                query = ''; typeFilter = 'all';
+                query = ''; typeFilter = 'all'; communityFilter = null;
+                document.querySelectorAll('.graph-legend-community').forEach(function (b) {
+                    b.setAttribute('aria-pressed', 'false');
+                    b.classList.remove('is-active');
+                });
                 requestRedraw();
             }
         });
@@ -461,6 +538,7 @@
                 setupControls();
                 setupInteraction();
                 buildA11yList();
+                buildCommunityLegend(data.stats);
 
                 if (loadingEl) loadingEl.classList.add('hidden');
                 requestRedraw();

--- a/changelog.d/+graph-dark-labels.fixed.md
+++ b/changelog.d/+graph-dark-labels.fixed.md
@@ -1,0 +1,1 @@
+Node labels on the `/graph/` explorer now use the theme's text and background colors in dark mode instead of always rendering near-black on white.

--- a/changelog.d/+graph-pagerank-divergence.fixed.md
+++ b/changelog.d/+graph-pagerank-divergence.fixed.md
@@ -1,0 +1,3 @@
+Page importance scores (PageRank) no longer diverge on large, densely linked sites, where they could blow up to astronomically large values instead of a proper 0–1 distribution.
+
+The random-walk now distributes each page's score across the same set of edges that feed the importance index (links, related posts, section hierarchy, and next/prev navigation), keeping total probability mass conserved so the scores converge.

--- a/changelog.d/+graph-topic-map.added.md
+++ b/changelog.d/+graph-topic-map.added.md
@@ -1,0 +1,3 @@
+The knowledge graph at `/graph/` now reads as a topic map: pages are colored by the cluster they belong to, sized by how central they are to the site, and grouped into separated lobes instead of one dense hairball. A legend lists the largest topics and clicking one isolates that cluster.
+
+Clusters (Louvain communities) and importance (PageRank) are computed at build time and shipped in `graph.json`; cluster colors derive from the active palette's accent hue in OKLCH, so they adapt to every palette and to light/dark automatically. Node positions and cluster ids are deterministic, so the graph output is byte-identical across rebuilds.

--- a/plan/epic-graph-showcase.md
+++ b/plan/epic-graph-showcase.md
@@ -1,0 +1,318 @@
+# Epic: Knowledge Graph — From Utility to Showcase
+
+**Status**: Proposed
+**Created**: 2026-06-18
+**Target**: v0.6.0 / v0.7.0 (rides the Pridelands token landing — already merged, so unblocked now)
+**Source**: 6-dimension survey of the first-party graph engine shipped in PR #554 (visual design, analysis surfacing, explorer UX, render/layout perf, contextual minimap, a11y/responsive), reconciled against an adversarial critique that was verified file-by-file before this plan.
+**Builds on**: `bengal/analysis/graph/` (build-time engine), `bengal-graph-explorer.js` (Canvas2D explorer), `graph-contextual.js` (per-page SVG minimap). Does **not** redo the engine or reintroduce D3.
+**Dependencies**: Pridelands refresh #532 — OKLCH (#534/PR#555) and light-dark() (#535/PR#556) are **merged on main as of 2026-06-18**, so the token-migration phase is unblocked and consumes the shipped anchors directly; custom-elements (#537) is in-flight and the graph does not depend on it.
+
+---
+
+## North Star: What Showcase-Great Looks Like
+
+A reader lands on `/graph/` and sees the whole site **as a living map of topics**: distinct, perceptually-uniform colored lobes (communities) fan apart instead of a gray center-piled hairball, the genuinely authoritative pages glow large and bright (PageRank), and orphans drift dim at the rim. The view settles in with a 400ms zoom-ease, the hubs are already labeled so there are landmarks to steer toward, and a hint invites a click. Clicking a node doesn't eject you — it **spotlights that page's neighborhood**, opens a persistent detail card surfacing the rich analysis we already compute (connectivity, in/out refs, reading time, tags, community), and offers a deliberate "Open page →" CTA. The whole thing is keyboard-operable with a drawn focus ring and announced via aria-live, works under touch and on a phone via a bottom-sheet, honors `prefers-reduced-motion`, and — critically — every color is the **same OKLCH + light-dark() token system as the rest of Pridelands**, so the graph reads as one coherent product across all 6 palettes and both modes. On every content page, the sidebar minimap is the same story in miniature: a real card with a header, size-encoded nodes, weighted edges, and a tooltip that matches the explorer. It stays 60fps at 1208 nodes and has headroom to 5–10×, and the build that bakes it all stays bounded and byte-identical warm==cold.
+
+---
+
+## Top 5 Highest-Leverage Moves (most "great" for least risk)
+
+1. **Community-colored, importance-sized graph (the Obsidian "wow").** Wire the already-computed Louvain communities and PageRank into the bake: color nodes by community, size by PageRank. This is the single biggest visual transformation — flat sea of dots → legible topical map. **Hard prerequisite (P0.5): the determinism floor must be fixed first** — Louvain shuffles via the *global* `random` module (`community_detection.py:212`) and renumbers communities by an order-derived key (`:269-272`), and all three analyses (Louvain/PageRank/path) sit on an unsorted `list(self.site.pages)` (`builder.py:122-134`). [P1, bakes new data]
+
+2. **Community-aware baked layout (kills the hairball geometrically).** Feed those same communities into `compute_force_layout` as ring-distributed centroids + per-community gravity, replacing the single global center pull (`layout.py:307-311`). Tends to *reduce* iterations while separating clusters into lobes. [P1.3, its own PR — changes baked coords]
+
+3. **Migrate graph colors onto Pridelands OKLCH + light-dark() tokens.** Delete the ~150-line per-palette region (`graph.css:566-717`) and the 8 scattered `[data-theme="dark"]` panel blocks (`:100,132,204,238,279,314,495,542`); derive `--graph-node-*` and a deterministic OKLCH community palette from the live theme anchors. Coherence win, deletes the maintenance fork, fixes contrast — foundation every other color-touching item depends on. Pure CSS, no bake. [P0]
+
+4. **Click-to-focus spotlight + persistent detail panel + deep-link.** Turn click from "navigate away" into ego-graph isolation with a theme-tokened detail card and a deliberate CTA; mirror it to `#node=` URL state for shareable focused views and free breadcrumb/back. Converts the explorer from a launcher into a browsing surface, reusing existing dim/highlight/`fitToView` machinery. [P2, runtime only]
+
+5. **Real node depth + entrance settle on the canvas.** Cached radial-gradient node bodies + halos for hubs, connectivity-weighted edges, and a 400ms fade/zoom-settle intro — the dead SVG-only glow CSS (`graph.css:359-401`) finally made real on the canvas. The cheapest "premium product" signal. [P2, runtime only]
+
+---
+
+## Design Principles
+
+1. **Compose with Pridelands, don't fork it.** Every color is an OKLCH primitive or palette semantic token resolved through `light-dark()`. No new hardcoded hex, no new `[data-theme=dark]` override blocks. The graph follows the theme; it never runs a parallel system.
+2. **Surface what we already compute.** The engine computes communities, PageRank, betweenness, bridges, link suggestions. The bias is to *show* baked analysis, not invent new analysis.
+3. **Determinism is load-bearing — and it is not currently guarded.** Anything baked into `graph.json` / `index.json` `.graph` must use a local seeded PRNG (never global `random`), iterate over a **sorted, build-stable node-id order**, and round to fixed precision — mirroring `layout.py` (`_Rng`, `_COORD_PRECISION=4`, `_round`). There is **no existing live `graph.json` parity gate** (the build-snapshot fixture is skipped-by-default and stale, `test_build_snapshot.py:131`; `test_graph_layout.py` only exercises `compute_force_layout` in isolation). Building that gate is part of P0.5, not an assumed backstop.
+4. **Compute once, consume everywhere.** Heavy analysis (Louvain, PageRank, path) is cached on `KnowledgeGraph` (`_pagerank_results:141`, `_community_results:142`) and reused for `graph.json` and the ×1208 per-page `.graph` block, so the minimap path pays zero extra compute.
+5. **60fps now and at 5–10×.** Per-frame work is the budget. New visual richness is cached/bucketed/LOD-gated; build-time layout cost stays bounded.
+6. **Operable without a mouse, motion-safe, mobile-first-capable.** Keyboard focus + aria-live + reduced-motion + touch are first-class, not afterthoughts.
+
+---
+
+## Invariants (stop and reassess if violated)
+
+1. **Byte parity**: warm==cold `graph.json` and every page `index.json` `.graph` block remain byte-identical across two cold builds and warm vs cold. **This must be made true and CI-guarded by P0.5** — today it is asserted-but-unguarded.
+2. **Zero external dependencies** for default builds — no CDN, no npm, no vendored libs. Runtime JS stays vanilla.
+3. **Build-time layout cost stays bounded** for the 5–10× target. *(The previously circulated 6.2s@1208 / 54s@6000 figures are unsourced — they appear nowhere in the repo. P5 must **re-measure** on the docs site before any of them are used as a gate; until then, acceptance is stated relatively, not against those numbers.)*
+4. **Explorer stays ~60fps** at 1208 nodes and degrades gracefully (LOD) at 5–10×.
+
+---
+
+## Roadmap
+
+Each phase is independently shippable. Phases that bake new data or change baked coordinates are flagged **[BAKES DATA]** and carry the full seeded/sorted/rounded determinism treatment plus an in-PR fixture re-record. The determinism floor (P0.5) is a hard gate on every bake.
+
+---
+
+### P0 — Token Migration + Coherence Foundation (CSS-only, no bake)
+
+**Sequencing:** unblocked now (#534/#535 merged). Lands the one correct color foundation that every later color-touching item builds on. Its standalone label-token fix can ship even earlier (see Issues).
+
+**Deliverables**
+- **Pull-forward, standalone bug fix:** `bengal-graph-explorer.js:90-91` reads `--color-text` / `--color-bg`, which **do not exist** as Pridelands tokens — labels always fall back to `#222`/`#fff` (broken in every dark palette). Switch to `--color-text-primary` / `--color-bg-primary`. Ship this independently first; it has zero dependency on the palette work.
+- Replace the parallel per-palette region (`graph.css:566-717`, ~150 lines, currently `[data-palette=…]` × `[data-theme=dark]`) with a single `:root` definition of `--graph-node-*` / `--graph-link-*` as `light-dark(...)` over the palette's own semantic tokens: hub → `var(--color-accent)`, orphan → `var(--color-error)`, generated → `var(--color-success)`/`--color-info`, regular → `color-mix(in oklab, var(--color-text-secondary), var(--color-bg-primary) 35%)`. Derive glows via `color-mix(... transparent 60%)` (retire the `--graph-node-*-glow` hex vars at `:359-401`). Per-palette hue + dark mode now come for free.
+- Define a deterministic **OKLCH categorical community palette** as tokens `--graph-community-0..N`, generated by rotating the Pridelands accent hue in OKLCH hue space (even hue steps → perceptually-balanced, light-dark()-adaptive). Communities beyond the palette fall to a muted "other" token. (Consumed by P1; the color-index assignment must use the same stable rank-sort as the ids — see P1.1.)
+- **Fix regular-node contrast**: ensure `--graph-node-regular` clears ≥3:1 non-text contrast against each palette's actual `--color-bg-primary` in both schemes. Add an optional 1px node rim stroke in `--color-bg-primary` drawn in `draw()` for robustness on any background.
+- Modernize control/legend/tooltip panels (`graph.css:108-143, 292-325, 460-506`) onto `--color-bg-elevated`/`--color-surface`, `--elevation-popover/modal`, `--radius-soft-*`, `--space-*`; tie `backdrop-filter` tint to `color-mix(in oklab, var(--color-bg-elevated), transparent 12%)`; delete the **8 scattered** `[data-theme="dark"]` panel blocks (`:100,132,204,238,279,314,495,542`).
+- Migrate `graph-contextual.css` (minimap) in lockstep: kill `#1976d2` and the literal `drop-shadow` glows and the `[data-theme=dark]` dependence; express current-node emphasis via a `--graph-current` token.
+
+**Files**: `bengal/themes/default/assets/css/components/graph.css`, `graph-contextual.css`, `bengal/themes/default/assets/js/bengal-graph-explorer.js`
+
+**Constraints**: C3 (this *is* the adoption) · C2 (pure CSS/one-line JS) · **C1: none — runtime-resolved, nothing baked**.
+
+**New baked data**: none.
+
+**Landmines**:
+- **#535 cascade tie-break** (memory: ~16% of "redundant" dark-override deletions are actually unsafe — base token loses to a later equal-specificity dark sibling). This applies to **all** the scattered panel blocks, not just the per-palette region. Land token definitions first, switch consumers in lockstep, run the conservative second-pass verify before deleting any dark block; keep hex fallbacks in `v(name, fallback)` during transition.
+- **Canvas color-string support floor (named, not hand-waved):** `ctx.fillStyle` must accept the `getComputedStyle`-resolved string. Modern engines evaluate `oklch()`/`color-mix()` in `getComputedStyle` output, so the canvas gets a concrete color — but if Bengal's support matrix includes an engine that returns an unevaluated string, nodes silently fall back to the hex `v()` defaults P0 is deleting. **Action: keep the `v()` hex fallbacks in the JS color table (do not delete them) and confirm the canvas path against the theme's stated minimum browser before removing any.**
+- light-dark() is color-only — node glow *shadows* stay in a retained `[data-theme=dark]` block.
+
+**Acceptance**: all 6 palettes × {light,dark} render the graph from theme tokens; explorer labels are palette/dark-correct; regular nodes pass ≥3:1 contrast per palette; panels match other Pridelands surfaces; CSS minifier round-trips the OKLCH/color-mix; only the color-only-exempt shadow block remains as a `[data-theme=dark]` graph block; JS retains hex fallbacks but hardcodes no live colors.
+
+---
+
+### P0.5 — Determinism Floor (build-only, no new fields shipped) **[GATE for all of P1/P4 bakes]**
+
+This is the non-negotiable prerequisite the previous draft folded into "P1.0." It is promoted to its own phase because the hazard is **broader than Louvain** and because the proof harness it relies on **does not exist yet**.
+
+**Root cause (verified):** all three analyses pull pages through `KnowledgeGraph.get_analysis_pages()` → `GraphBuilder.get_analysis_pages()` → `list(self.site.pages)` (`builder.py:122-134`, `knowledge_graph.py:240-248`), which is **never sorted**. On top of that:
+- Louvain shuffles via the **global** `random` module (`community_detection.py:212`) and only `random.seed`s when a seed is passed (`:167`) — **no build caller passes one** — and renumbers communities by an `enumerate(pages)`-derived integer key (`:186,269-272`), so ids inherit page order.
+- PageRank power-iterates over that same unsorted list (`page_rank.py:184,217,224,234`); its dict order and float-accumulation order ride on it.
+- Path analysis (P4's source) selects pivots via `rng.sample(pages, …)` over the same unsorted list (`path_analysis.py:321-322`) — `random.Random(42)` is fixed but `sample` output is *input-order-sensitive*, so which pivots (and thus betweenness scores) are chosen is non-reproducible.
+
+**Deliverables**
+- **Establish one build-stable canonical page order.** Either sort `get_analysis_pages()` by the baked node-id (`visualizer.py:_get_page_id`, verified build-stable: site-relative-path hash, `:148-193`), or prove `site.pages` iteration order is itself build-deterministic and document that as a shared precondition. Prefer the explicit sort — it removes the dependency entirely. Every downstream analysis iterates this order.
+- **Louvain → local seeded PRNG + stable ids.** Replace global `random.shuffle` with a local PRNG seeded from a fixed constant (mirror `layout.py:_Rng`); shuffle through it; renumber communities by **`(size desc, min member node-id)`** keyed on the baked node-ids (not on `Page` identity or enumerate order); round any emitted float.
+- **PageRank → sorted iteration + round-before-serialize.** Iterate the canonical order; round scores at fixed precision before any are baked.
+- **Path pivots → sort before sample.** Sort `pages` (or node-ids) before `rng.sample` in the approximate path (`path_analysis.py:321`); round emitted scores. (1208 > the `auto_approximate_threshold=500`, so the approximate path *will* run on the docs site.)
+- **Build the missing live parity gate.** Add a test that does two cold builds of a fixed root and asserts the **emitted `graph.json` is byte-identical**, exercising the *real unseeded build path* with communities + PageRank + (when P4 lands) path top-N. Add an id-level community-stability assertion. Do **not** rely on `test_community_detection.py:test_random_seed_reproducibility` — it is vacuous for this epic: it only asserts equal community *count* + modularity, always passes `random_seed=42` (the path the build never takes), and never asserts stable ids.
+
+**Files**: `community_detection.py`, `page_rank.py`, `path_analysis.py`, `builder.py`/`knowledge_graph.py` (page-order), new test under `tests/` (live `graph.json` parity).
+
+**Constraints**: **C1 (the whole point)** · C4 (sorting is O(N log N), negligible vs Louvain's per-pass edge scan).
+
+**New baked data**: none yet — this phase changes *internal* determinism only; field/coordinate changes ship in P1. Shipping the parity gate before any consumer means P1 lands against a real backstop.
+
+**Acceptance**: two cold builds of the docs site produce byte-identical `graph.json`; community ids are stable across runs on the unseeded build path; the new parity test fails loudly if global `random` or an unsorted page list is reintroduced (assertion proven to discriminate, not vacuous).
+
+---
+
+### P1 — Surface the Analysis: Community + PageRank (the visual transformation) **[BAKES DATA]**
+
+The single biggest "wow." Gated on P0 (community palette tokens) and P0.5 (determinism floor + parity gate). Split into independently-bakeable, separately-reviewable PRs — field additions (P1.1/P1.2) are distinct byte-parity events from the geometry change (P1.3) and must **not** share one fixture re-record.
+
+**P1.1 — Bake community id + community color per node:**
+- Wire `detect_communities()` (cached, `knowledge_graph.py:647-684`) into `generate_graph_data()` (`visualizer.py:195`). Add `community` (stable int id from P0.5) + `community_color` (index into the P0 `--graph-community-*` tokens, **assigned by the same `(size desc, min member node-id)` rank-sort** so which communities get a distinct color vs the "other" bucket is itself deterministic). Color nodes by community; keep type as a secondary signal (ring/stroke for hub/orphan). Emit a `communities` stats block (id, label, size, color). Derive labels deterministically (most-frequent shared tag with sorted tie-break, or highest-PageRank member title). Explorer `nodeColor` (`bengal-graph-explorer.js:94`) switches to `n.community_color`, still resolved from CSS tokens.
+
+**P1.2 — Bake PageRank → importance sizing:**
+- Wire `compute_pagerank()` (cached, `:514-551`) into `generate_graph_data()`. Add `pagerank` per node, **rounded to fixed precision** (iteration is deterministic *given* P0.5's sorted order — round before serialize to also guard cross-platform float drift). Recompute `size` (currently degree-based, `visualizer.py:234-241`) from normalized PageRank (dominant) blended with reading_time (depth). Keep connectivity/in/out refs for tooltips.
+- **Cross-effect flag:** `size` is copied straight through into the per-page `.graph` block by `json_generator.py` (`_get_page_connections`, ~`:176-179/331-334`). The ×1208 minimap currently **hardcodes** its node radius (`graph-contextual.js:110`, `n.isCurrent ? 8 : …`), so this P1.2 change does **not** alter the minimap's appearance — but it *does* re-bake all 1208 `.graph` blocks (fixture churn) and changes the value the minimap *will* read once P4 rewires it. Note this explicitly in the PR.
+
+**P1.3 — Community-aware baked layout (kills the hairball) — SEPARATE PR, after P1.1/P1.2 stabilize:**
+- Extend `compute_force_layout` to accept the community map + scores. Scatter each community around a **deterministic ring centroid** (`angle = 2π · sorted_index / num_communities`); replace the single global gravity (`layout.py:308-311`) with per-community gravity + a weak global cohesion. Cap centroids (merge sub-min-size communities into a "misc" ring).
+- **Edge-weight springs:** pass `(s,t,weight)` (sorted incl. weight) and scale attraction by `min(weight,3)` so bidirectional pairs sit adjacent (`layout.py:239,293-305`; weights already emitted by the visualizer).
+- This is a pure geometry change → its own fixture re-record, reviewed as one coordinate diff, not entangled with P1.1/P1.2 field additions.
+
+**Files**: `visualizer.py`, `layout.py`, `bengal-graph-explorer.js`, `graph_visualizer.html` (+ the P0.5-fixed analysis modules, consumed, not re-edited)
+
+**Constraints**: **C1 (load-bearing)** — every sub-item rounds + iterates the P0.5 canonical order; **each baked-field/coord change re-records fixtures + passes the P0.5 parity gate in the same PR**. C4 — Louvain/PageRank computed once via the shared cache; community seeding *may* converge the layout faster (**measure once, in P1.3 — do not also bank this speedup in P5**). C3 — community colors come only from P0 OKLCH tokens.
+
+**New baked data**: per-node `community` (int), `community_color` (int index), `pagerank` (rounded float); recomputed `size`; `communities` stats block; revised normalized `(x,y)` (P1.3 only). Determinism: stable ids/rank-sort from P0.5, rounded floats, sorted iteration, centroid angles from sorted index.
+
+**Landmines**: community color-index rank-sort must match the id rank-sort or color/label desync; keep `pagerank` precision tight to bound ×1208 `.graph` JSON growth; cap Louvain passes if 1208-node build cost spikes.
+
+**Acceptance**: graph renders as distinct colored topical lobes (not a center-piled blob); `x_std`/`y_std` *improves* after P1.3; hubs visually dominate by size; the P0.5 parity test stays green after each re-record; ×1208 minimap build cost unchanged (no new compute on that path).
+
+---
+
+### P2 — Explorer Interaction + Depth (runtime only, no bake)
+
+Turns the pretty map into a browsing surface and lands the visual-depth polish. All runtime — zero byte-parity exposure. **Every motion added here ships with its own reduced-motion gate in the same PR** (see P3 note).
+
+**Deliverables**
+- **Click-to-focus spotlight + detail panel** (`bengal-graph-explorer.js:329-334`): click PINS a node and enters focus state (generalize the hover dim path to `activeSet = focused ? adjacency[focused.id] : …`), eases camera to center the ego-graph (reuse `fitToView` math, `:230-245`). New `.graph-detail` aside (theme-tokened) shows title, type badge, reading_time, in/out counts, connectivity, tags, clickable neighbor list, **community label** ("Part of: Performance · 47 pages"), and an "Open page →" CTA. Escape/empty-space exits.
+- **Deep-link focus** via `#node=<id>` (and `?focus=`): read on boot alongside the existing `?tag=` path (`:383`); `replaceState` on hover-driven change, `pushState` only on explicit click-focus; `popstate` gives breadcrumb/back for free. Validate id against `nodeById`, fall back to `fitToView`.
+- **Community/tag exploration affordances**: clickable legend filters a cluster (reuse `?tag=` machinery); add `?community=` mirroring `?tag=`; minimap tints the current page's ring by community color.
+- **Node depth on canvas** (`draw()` `:183-212`): per-type radial-gradient body + halo for hubs and the hovered/focused set, scaled by baked `connectivity`. **Cache gradient templates per type+radius bucket** (not per node); LOD fallback to flat fill above ~4000 visible or when nodes render <3px. Finally uses the depth `graph.css:359-401` faked for the never-created SVG.
+- **Entrance settle**: replace the dead `graphFadeIn` CSS animation with a real 350–450ms rAF tween (global alpha 0→1 + camera ease 0.85→fit), optionally staggering node alpha by connectivity. Cancel on first interaction. **Gate behind `matchMedia('(prefers-reduced-motion: reduce)')` → snap to final frame.**
+- **Edge depth**: map base-edge alpha/width to `edge.weight` + endpoint connectivity (low base alpha ~0.25 so structure reads as a constellation); two-stop gradient strokes for the **highlighted subset only** (never global — frame budget).
+
+**Files**: `bengal-graph-explorer.js`, `graph_visualizer.html`, `graph.css`, `graph-contextual.js`
+
+**Constraints**: C2 (vanilla Canvas/DOM/History) · **C1: none baked** · C3 — all new chrome from P0 tokens · C4 — per-node `createRadialGradient` is the classic Canvas trap: bucketed caching + LOD are **mandatory**; profile at 1208 and 5–10×.
+
+**New baked data**: none.
+
+**Landmines**: camera-ease + entrance tween must check reduced-motion and snap to final frame; focus state must clear on themechange/resize redraw or panel desyncs; full-graph per-edge gradients blow the budget — highlighted subset only.
+
+**Acceptance**: click isolates ego-graph + opens a populated theme-tokened panel without navigating; focused views are shareable via `#node=`, back/forward works; hubs read luminous, orphans dim; 1208-node draw ~60fps with depth on; LOD verified at 5–10×; the reduced-motion path is the literal final frame.
+
+---
+
+### P3 — Accessibility, Motion-Safety, Mobile (runtime/CSS, no bake)
+
+Closes the headline operability gaps. Keyboard nav + aria-live consume the `focused`-node concept P2 introduces, so they follow P2 — **but the reduced-motion gate for P2's specific animations ships inside P2, not here** (anything else is a live vestibular regression in the interim). P3 owns the *global* reduced-motion block (incl. the pre-existing `nodeGlow` hazard) and the operability surface.
+
+**Deliverables**
+- **Keyboard-navigable canvas + focus ring**: `tabindex=0` + `role=application` on the canvas (`boot()` `:451`); Tab/Shift-Tab cycles visible nodes (reuse `buildA11yList` order); arrows move to nearest visible neighbor (adjacency first, then picking grid `:100`); Enter/Space navigates; Home/End jump first/last; snap-center (no motion). Draw a focus ring in `--color-accent` around `focused`, driving the existing highlight path off `focused || hovered`. Scope node-nav keys to `document.activeElement === canvas` so they don't fight the search box.
+- **aria-live status region**: add `<div role="status" aria-live="polite" class="sr-only">` to `graph_visualizer.html`; on focus change announce "Spelling Rules — hub, 12 incoming, 4 outgoing, 6 min read" from the already-formatted tooltip fields; debounce ~120ms; announce filter/search counts.
+- **Global reduced-motion gate**: add `@media (prefers-reduced-motion: reduce)` to `graph.css` and `graph-contextual.css` (currently **none exist**) — `animation:none` on `graphFadeIn`, `tooltipFadeIn`, and especially the **four infinite `nodeGlow` hover rules** (`:412,417,422,427`). **Gate, don't delete** — confirm the SVG minimap still consumes the `.graph-node-*` classes first (it does, `graph-contextual.js:110-123`). Update the stale JS comment.
+- **Responsive bottom-sheet**: add `@media (max-width:768px)` (currently **none** in graph.css); convert the free-floating absolute `.graph-controls`/`.graph-legend` into one bottom sheet (max-height ~45vh, scrollable, toggle handle with `aria-expanded`), eliminating the controls/legend collision; desktop unchanged; surfaces from P0 tokens.
+- **Touch pan/pinch**: `setupInteraction()` (`:302-356`) wires no touch despite `touch-action:none` (`:31`) killing native gestures — the canvas is **dead on mobile today**. Add touchstart/move/end (or Pointer Events): one-finger pan, two-finger pinch → `zoomAt` midpoint, tap → pick+navigate. Non-passive touchmove for `preventDefault`.
+- **Camera controls**: bind the already-defined-but-unbound `fitToView` to a Fit button; add +/− zoom buttons (reuse `zoomAt`); Escape steps out of focus then fits.
+- **Onboarding + hub labels at fit scale**: always label top ~15–20 hubs by connectivity even below `LABEL_SCALE` (precompute sorted once, screen-space spacing skip) so first paint has landmarks; dismissible hint overlay auto-hiding on first interaction.
+
+**Files**: `bengal-graph-explorer.js`, `graph.css`, `graph-contextual.css`, `graph_visualizer.html`
+
+**Constraints**: C2 (vanilla) · **C1: none baked** · C3 (chrome from P0 tokens) · C4 — focus ring is one arc/frame; key-nav reuses the picking grid; touch reuses rAF coalescing; hub labels capped + precomputed.
+
+**New baked data**: none.
+
+**Landmines**: scope key handling to canvas focus (don't capture while typing in search); pinch/tap/pan disambiguation is fiddly — test on real iOS/Android, not emulation; gate `nodeGlow`, never delete (SVG minimap consumes the classes).
+
+**Acceptance**: graph fully operable by keyboard with a visible focus ring; SR announces focused-node analysis; zero un-gated animations under reduced-motion; phone shows a usable bottom-sheet with no panel collision and working touch pan/pinch; first paint shows labeled hub landmarks + a hint.
+
+---
+
+### P4 — Minimap Parity + Insights Panel (mixed; one optional bake)
+
+Brings the per-page minimap up to explorer parity and surfaces site-structure intelligence. Mostly zero-bake; the Insights node lists inherit P0.5 ordering; one optional flagged 2-hop bake.
+
+**Deliverables (no new coordinates)**
+- **Minimap as a real card** (`graph-contextual.js:78-141`): node radius from baked `n.size` (a real renderer change — currently hardcoded `8/6/5` at `:110`; the data already ships, but post-P1 that value is PageRank-based, so the minimap node sizing *changes* the moment this rewire lands); edge stroke-width from baked `e.weight`; replace native `<title>` with the **already-styled-but-dead** `.graph-contextual-tooltip` (`graph-contextual.css:173-194`) populated like the explorer (reading_time + in/out refs + tag chips); render the **already-styled-but-dead** `.graph-contextual-section-header` with page title + "N connected pages." Clean up listeners in `cleanup()`.
+- **Inline "Related pages" list** beside the minimap: ranked `<a>` links (sorted by connectivity) with role/affinity hints; doubles as the visible surface on narrow sidebars and the a11y fallback; capped at the existing ≤15.
+- **Orphan empty-state**: instead of hiding on the 348 orphan pages (`graph-contextual.js:156-159` style early-return), render a small "This page isn't linked from elsewhere yet" card (keyed off baked `type==='orphan'`) linking to `/graph/` or the section index — surfacing orphan-detection exactly where it matters.
+- **Insights panel on `/graph/` (stats-only bake):** extend the `stats` block with deterministically-sorted top-N lists from `reporter.py`/`analyzer.py` — top hubs, top PageRank, bridge pages (betweenness), modularity/community count — as a collapsible linked "Insights" panel. Top-N is bounded so JSON growth is trivial. **The betweenness/bridge list inherits P0.5's pivot-sort fix as a hard dependency** (it is the same `path_analysis.py:321` approximate path) — sort all lists by `(score desc, node-id)`, round emitted scores, and add them to the P0.5 parity test.
+
+**Deliverable (optional, flagged, default-off) [BAKES DATA]**
+- **2-hop minimap neighborhood**: optional faint outer ring of neighbors-of-neighbors in the baked `.graph` block + `compute_radial_layout` (`layout.py:362` already two-ring-capable). **Strictly cap** (15 direct + ≤10 second-hop); seed/sort/round exactly like the existing radial path; gate behind `theme.features` default-off; extend the P0.5 parity test to the new fields before enabling.
+
+**Files**: `graph-contextual.js`, `graph-contextual.css`, `partials/graph-contextual.html`, `visualizer.py`, `reporter.py`, `json_generator.py`, `layout.py`, `graph_visualizer.html`
+
+**Constraints**: C2 (vanilla) · C4 — ≤15 elements/page, trivial ×1208; Insights computed once via the shared cache; 2-hop hard-capped · C3 (P0 tokens) · **C1** — minimap card/list/orphan + Insights lists ship **no new coordinates** (Insights = bounded rounded scalar lists, gated on P0.5 ordering); **2-hop is the only new-coordinate bake** → full `_Rng`/sorted/`_round` + parity test, default-off.
+
+**New baked data**: Insights top-N scalar lists in `stats` (rounded, P0.5-ordered); optionally 2-hop neighborhood coords in `.graph` (capped, seeded, default-off).
+
+**Acceptance**: minimap shows header + count, size-encoded nodes, weighted edges, styled tooltip matching the explorer; orphan pages show a meaningful card instead of vanishing; Insights lists deterministically-sorted key pages as working links and pass the parity gate; 2-hop (if enabled) passes parity and stays under its node cap.
+
+---
+
+### P5 — Scale Headroom (5–10×) (runtime + bounded build)
+
+Pure scale work; lands once the 1208 experience is great. **Re-measure the build-layout baseline first** — the circulated 6.2s/54s figures are unsourced. Each coordinate-changing layout tweak is a **separate, separately-revertable PR** so an `x_std` regression is attributable.
+
+**Deliverables**
+- **Edge LOD + path batching (runtime, no bake)** (`draw()` `:159-181`): batch same-style edges into `Path2D`/`beginPath..stroke` split into a few alpha tiers (weight-1 / weight-2 / highlighted) instead of per-edge `beginPath`; fade (don't hard-cut) non-highlighted edges when sub-pixel; additive low-alpha density for a "mass" read. Hoist `isVisible()` into a precomputed `visibleSet` recomputed only on query/filter change (currently called twice per edge per frame, `:165`).
+- **Bounded build-layout cost — three SEPARATE measured PRs [each BAKES DATA]:** (a) rebuild the Barnes-Hut quadtree every K=2–4 iterations and reuse repulsion between (`force_on` is the hot path; tree rebuilt every iter `:257-266`); (b) lower the iteration formula (`:247`, `30·ln N` → tunable, capped) — **only if P1.3's measurement showed convergence headroom actually remains** (do not assume it; the speedup banks once); (c) deterministic early-exit when summed displacement < epsilon (`:313-321`). All constants fixed; convergence sum in sorted order; each re-records fixtures + passes the parity gate independently.
+- **PageRank-driven min on-screen radius (runtime)**: keep hubs/high-PageRank nodes above a minimum radius when zoomed out (cap to the ~88 hubs) so the zoomed-out view reads as a labeled constellation (`bengal-graph-explorer.js:201`).
+
+**Files**: `bengal-graph-explorer.js`, `layout.py`
+
+**Constraints**: C4 (this *is* the scale lever) · **C1** — edge LOD/batching: none baked; the three layout PRs each change coords → re-record + parity in the same PR · C2 (Canvas only).
+
+**New baked data**: revised normalized `(x,y)` from each of the three layout PRs (constants fixed, sums sorted, rounded).
+
+**Landmines**: one `Path2D` can't vary per-edge alpha — split into tiers; edge LOD must fade not pop; early-exit epsilon too large → under-converged hairball, so validate `x_std` *improves*, not just that build is faster; any iteration/K change fails every pinned `graph.json` fixture — re-record in the same PR.
+
+**Acceptance**: explorer holds ~60fps at 5–10× with edge batching + LOD; **re-measured** build-layout baseline drops and the superlinear curve flattens; parity holds after each re-record; zoomed-out view shows a legible hub constellation.
+
+---
+
+## Dependency / Sequencing Summary
+
+```
+P0 (tokens, unblocked now) ──┐
+                             ├─> P1 (community/PageRank bake)   [palette needs P0; bake needs P0.5]
+P0.5 (determinism floor) ────┘        ├─ P1.1 community id+color   [field bake]
+   = HARD GATE + builds the           ├─ P1.2 pagerank→size        [field bake]
+     missing live parity test         └─ P1.3 community-aware layout + weight springs  [SEPARATE PR, geometry bake]
+                             │
+P0 ──> P2 (focus/depth/deep-link)  [community label/color needs P1; tokens need P0; motion gated in-PR]
+              └──> P3 (a11y/motion/mobile)  [keyboard nav consumes P2 focused-node]
+P0 ──> P4 (minimap parity + insights)  [tokens P0; community tint needs P1; betweenness list needs P0.5 pivot-sort]
+P1.3 ──> P5 (scale)  [measure P1.3 convergence BEFORE banking it for P5(b); ships last]
+```
+
+- **P0 is unblocked now** (#534/#535 merged). The explorer label-token fix can ship even ahead of the full migration.
+- **P0.5 is the non-negotiable gate** before any community/PageRank/path data is baked, and it must *build* the live `graph.json` parity test (it does not exist today).
+- **P1.3 and the three P5 layout tweaks are each their own coordinate-bake PR** — never bundled.
+- P2/P3/P4 proceed after their listed deps; P5 ships last.
+
+## Cross-Cutting Risks
+
+1. **No existing parity backstop (P0.5)** — the build-snapshot fixture is skipped/stale; the layout test is isolated. P0.5 must construct a real two-cold-build `graph.json` parity gate before P1 bakes anything.
+2. **Determinism root cause is the shared unsorted `site.pages` (P0.5)** — Louvain, PageRank, and path-pivot sampling all ride on it; fix the page order once and apply consistently, or P1.2/P4 bake non-reproducible fields too.
+3. **Vacuous existing test** — `test_community_detection.py:test_random_seed_reproducibility` proves nothing for the unseeded build path; the new assertion must discriminate at the id level.
+4. **#535 cascade tie-break (P0)** — applies to all 8 scattered dark panel blocks; conservative second-pass verify before deleting any.
+5. **Canvas gradient/edge perf traps (P2/P5)** — bucketed caching + LOD mandatory; profile at 1208 and 5–10×.
+6. **Coordinate-bake fixture churn (P1.3, P5×3)** — every baked-coord change re-records its fixture in the same PR; never bundle with unrelated drift.
+7. **Convergence-speedup double-count (P1.3 vs P5b)** — measure after P1.3; P5's iteration-cap cut is conditional on remaining headroom, not assumed.
+8. **P1 silently re-bakes the ×1208 `.graph` blocks and changes the size the minimap will read (P1.2 → P4)** — declared as a cross-effect in both phases.
+
+---
+
+## Proposed Issues / Sagas (issues-first)
+
+**Epic:** "Knowledge graph: from utility to showcase" (parent; references #532 Pridelands for the color foundation).
+
+**P0 — token migration (siblings under #532):**
+- `graph: fix explorer label tokens (--color-text → --color-text-primary)` — standalone, ship first, no deps.
+- `graph: migrate node/link palette to OKLCH + light-dark() tokens` (delete graph.css:566-717).
+- `graph: migrate control/legend/tooltip panels to elevation tokens` (delete the 8 dark panel blocks).
+- `graph: define deterministic OKLCH community palette tokens`.
+- `graph: regular-node contrast + rim stroke`.
+- `graph: minimap CSS → theme tokens (--graph-current)`.
+
+**P0.5 — determinism floor (GATE):**
+- `graph: canonical build-stable page order for all analyses` (sort by node-id).
+- `graph: Louvain local PRNG + stable community renumber` (fixes community_detection.py:167,212,269-272).
+- `graph: PageRank sorted iteration + round-before-serialize`.
+- `graph: path-analysis sort pages before pivot sample` (fixes path_analysis.py:321).
+- `graph: add live two-cold-build graph.json byte-parity test + id-stability assertion` (the missing gate).
+
+**P1 — analysis surfacing [bakes data]:**
+- `graph: bake community id + color, color graph by cluster` (P1.1).
+- `graph: bake PageRank → node size` (P1.2).
+- `graph: community-aware layout + edge-weight springs` (P1.3, separate PR, geometry re-record).
+
+**P2 — interaction + depth (runtime):**
+- `graph: click-to-focus spotlight + detail panel` (top pick).
+- `graph: deep-linkable #node= focus + popstate back`.
+- `graph: canvas node depth (cached bucketed gradients + LOD)`.
+- `graph: entrance settle animation (reduced-motion gated)`.
+- `graph: community/legend filter affordances (?community=)`.
+- `graph: edge depth weighting (highlighted-subset gradients)`.
+
+**P3 — a11y / motion / mobile (runtime/CSS):**
+- `graph: keyboard nav + focus ring + aria-live status` (ship together).
+- `graph: global reduced-motion gate (graph.css/graph-contextual.css, incl. nodeGlow)`.
+- `graph: mobile bottom-sheet panels (@media max-width:768px)`.
+- `graph: touch pan/pinch (canvas is dead on mobile today)`.
+- `graph: camera control cluster (Fit / zoom buttons / Escape)`.
+- `graph: hub labels at fit scale + onboarding hint`.
+
+**P4 — minimap parity + insights:**
+- `graph: minimap real card (size/weight/tooltip/header)` (top pick for this dimension).
+- `graph: minimap related-pages list`.
+- `graph: minimap orphan empty-state`.
+- `graph: Insights/site-health panel on /graph/` (betweenness list depends on P0.5 pivot-sort).
+- `graph: 2-hop minimap ring (feature-flagged, default-off)` [optional, bakes data].
+
+**P5 — scale headroom:**
+- `graph: edge LOD + Path2D batching + visibleSet hoist` (runtime).
+- `graph: re-measure build-layout baseline on docs site` (prerequisite; no figures exist).
+- `graph: bound BH rebuild cadence (K)` [bakes coords].
+- `graph: iteration-cap cut` [bakes coords; conditional on P1.3 convergence measurement].
+- `graph: layout early-exit epsilon` [bakes coords].
+- `graph: PageRank min on-screen radius for zoomed-out legibility` (runtime).

--- a/tests/integration/test_graph_determinism.py
+++ b/tests/integration/test_graph_determinism.py
@@ -1,0 +1,105 @@
+"""
+Live byte-parity gate for the knowledge graph's emitted ``graph.json``.
+
+Determinism is load-bearing: the graph viz bakes node ids, force-layout
+coordinates and (from #-graph-showcase P1) PageRank scores + Louvain community
+ids straight into ``graph.json`` and each page's ``index.json`` ``.graph``
+block, and Bengal guards warm==cold byte parity.
+
+Before this gate existed there was **no live check**: ``graph.json`` was only in
+the skipped/stale build-snapshot fixture and was explicitly listed in
+``test_isolated_render_parity.py``'s ``VOLATILE_PATTERNS`` (i.e. treated as
+non-reproducible). ``test_graph_layout.py`` only exercises ``compute_force_layout``
+in isolation, never the real emitted file with communities/pagerank.
+
+This builds a link-dense root **twice, in two clean subprocesses with different
+``PYTHONHASHSEED`` values**, and asserts the emitted ``graph.json`` is
+byte-identical. Different hash seeds is the harshest test of any latent
+dict/set-iteration-order dependence (e.g. an unsorted page list, or a Louvain
+shuffle on the global ``random`` module): if anything in the bake rode on
+process-local hashing or RNG state, the two files would diverge.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.serial
+
+# Link-dense enough to form real Louvain communities and a non-uniform PageRank
+# distribution (28 nodes / 117 edges), so the byte-parity assertion meaningfully
+# exercises the community + pagerank bake — not just a trivial 3-node graph.
+_ROOT = Path(__file__).parents[1] / "roots" / "test-blog-paginated"
+
+_CHILD = """
+import sys
+from pathlib import Path
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+
+root, out = Path(sys.argv[1]), Path(sys.argv[2])
+site = Site.from_config(root)
+site.output_dir = out
+site.build(BuildOptions(quiet=True))
+"""
+
+
+def _build_graph_json(work: Path, tag: str, hashseed: str) -> Path:
+    """Build a fresh copy of the root in a clean subprocess; return graph.json."""
+    site_root = work / f"site_{tag}"
+    shutil.copytree(_ROOT, site_root)
+    out = work / f"out_{tag}"
+
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = hashseed
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD, str(site_root), str(out)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    graph_json = out / "graph" / "graph.json"
+    if proc.returncode != 0 or not graph_json.exists():
+        raise AssertionError(
+            f"build ({tag}) failed or produced no graph.json; rc={proc.returncode}\n"
+            f"stderr tail:\n{proc.stderr[-2000:]}"
+        )
+    return graph_json
+
+
+def test_graph_json_is_byte_identical_across_builds(tmp_path: Path) -> None:
+    a = _build_graph_json(tmp_path, "a", "0")
+    b = _build_graph_json(tmp_path, "b", "1")  # different hash seed on purpose
+
+    bytes_a, bytes_b = a.read_bytes(), b.read_bytes()
+
+    # Guard against a vacuous pass: the graph must be non-trivial, or "identical"
+    # would prove nothing (the #130 manifest-count lesson).
+    data = json.loads(bytes_a)
+    assert len(data["nodes"]) >= 10, "root too small to exercise the bake meaningfully"
+    assert len(data["edges"]) >= 10
+
+    if bytes_a != bytes_b:
+        # Surface the first structural divergence to make failures debuggable.
+        da, db = json.loads(bytes_a), json.loads(bytes_b)
+        ids_a = [n["id"] for n in da["nodes"]]
+        ids_b = [n["id"] for n in db["nodes"]]
+        first = next(
+            (i for i, (x, y) in enumerate(zip(ids_a, ids_b, strict=False)) if x != y),
+            None,
+        )
+        raise AssertionError(
+            "graph.json differs across two cold builds (different PYTHONHASHSEED) — "
+            "a determinism regression in the graph bake.\n"
+            f"node count a={len(ids_a)} b={len(ids_b)}; first id divergence at index {first}"
+        )

--- a/tests/integration/test_isolated_render_parity.py
+++ b/tests/integration/test_isolated_render_parity.py
@@ -42,10 +42,13 @@ VOLATILE_PATTERNS: tuple[str, ...] = (
     # Top-level site index + its hash.
     "index.json",
     "index.json.hash",
-    # Per-page JSON output: embeds a build-time `last_modified` timestamp and
-    # knowledge-graph node ids derived from object identity, both of which differ
-    # across any two build processes (not fork-specific) — same accepted
-    # volatility as graph.json. fnmatch `*` spans `/`, so this covers all depths.
+    # Per-page JSON output embeds a build-time `last_modified` timestamp, which
+    # differs across any two build processes (not fork-specific). fnmatch `*`
+    # spans `/`, so this covers all depths. NOTE: the `.graph` neighborhood block
+    # *inside* index.json is reproducible (node ids are site-relative-path
+    # hashes, not object identity); only the timestamp makes the whole file
+    # volatile. graph.json itself carries no timestamp and IS guarded for byte
+    # parity here + in tests/integration/test_graph_determinism.py.
     "*/index.json",
     "*/index.json.hash",
     "sitemap.xml",
@@ -55,8 +58,6 @@ VOLATILE_PATTERNS: tuple[str, ...] = (
     ".well-known/content-signals.json",
     "**/.bengal-cache/**",
     "**/.bengal/**",
-    "graph.json",
-    "graph/*.json",
 )
 
 _ROOT = Path(__file__).parents[1] / "roots" / "test-product"

--- a/tests/unit/analysis/test_community_detection.py
+++ b/tests/unit/analysis/test_community_detection.py
@@ -12,6 +12,44 @@ from bengal.analysis.graph.community_detection import (
     LouvainCommunityDetector,
     detect_communities,
 )
+from bengal.analysis.utils.pages import stable_page_id
+
+
+def _ring_graph(n=24):
+    """An undirected ring of ``n`` nodes.
+
+    Deliberately shuffle-order sensitive: a ring has no unambiguous community
+    structure, so WHERE Louvain places the community boundaries depends on the
+    order nodes are visited. (A cleanly-separable graph like two dense cliques
+    converges to the same partition regardless of visit order and would make a
+    determinism assertion vacuous.) Verified to discriminate: with the global
+    ``random`` module two runs of this fixture diverge; with a local seeded PRNG
+    they are identical.
+    """
+    pages = [Mock(source_path=Path(f"r{i:02d}.md"), metadata={}) for i in range(n)]
+
+    site = Mock()
+    site.pages = pages
+    site.root_path = None
+
+    graph = Mock()
+    graph.site = site
+    graph.outgoing_refs = defaultdict(set)
+    graph.get_analysis_pages.return_value = pages
+
+    for i in range(n):
+        graph.outgoing_refs[pages[i]].add(pages[(i + 1) % n])
+        graph.outgoing_refs[pages[(i + 1) % n]].add(pages[i])
+    return graph, site, pages
+
+
+def _community_by_stable_id(results, site):
+    """Map each page's stable id -> its community id (the bake-relevant view)."""
+    out = {}
+    for community in results.communities:
+        for page in community.pages:
+            out[stable_page_id(site, page)] = community.id
+    return out
 
 
 class TestCommunity:
@@ -318,32 +356,42 @@ class TestLouvainCommunityDetector:
         # Higher resolution should produce at least as many communities
         assert len(results_high.communities) >= len(results_low.communities)
 
-    def test_random_seed_reproducibility(self):
-        """Test that random seed makes results reproducible."""
-        pages = [Mock(source_path=Path(f"page{i}.md"), metadata={}) for i in range(10)]
+    def test_seeded_runs_are_id_stable(self):
+        """Same seed yields the same community id for every page (not just count).
 
-        site = Mock()
-        site.pages = pages
+        The old test only compared community *count* + modularity, which can match
+        even when individual pages land in different communities — useless as a
+        guard for baking community ids into ``graph.json``. This asserts the
+        bake-relevant invariant: the stable-id -> community-id map is identical.
+        """
+        graph, site, _ = _ring_graph()
 
-        # Create some connections
-        graph = Mock()
-        graph.site = site
-        graph.outgoing_refs = defaultdict(set)
-        graph.get_analysis_pages.return_value = pages
+        results1 = LouvainCommunityDetector(graph, random_seed=42).detect()
+        results2 = LouvainCommunityDetector(graph, random_seed=42).detect()
 
-        for i in range(len(pages) - 1):
-            graph.outgoing_refs[pages[i]].add(pages[i + 1])
+        assert _community_by_stable_id(results1, site) == _community_by_stable_id(results2, site)
 
-        # Run twice with same seed
-        detector1 = LouvainCommunityDetector(graph, random_seed=42)
-        results1 = detector1.detect()
+    def test_unseeded_build_path_is_reproducible(self):
+        """The path the BUILD actually takes (no explicit seed) must reproduce.
 
-        detector2 = LouvainCommunityDetector(graph, random_seed=42)
-        results2 = detector2.detect()
+        No build caller passes ``random_seed``, so determinism on the unseeded
+        path is what protects the warm==cold byte-parity of baked community ids.
+        This is the discriminating guard: if Louvain reverts to the *global*
+        ``random`` module (whose state advances between the two runs in this same
+        process), the two community maps diverge and this fails. With a local
+        seeded PRNG they are identical.
+        """
+        graph, site, _ = _ring_graph()
 
-        # Should get same number of communities
-        assert len(results1.communities) == len(results2.communities)
-        assert results1.modularity == results2.modularity
+        results1 = LouvainCommunityDetector(graph).detect()  # no seed = build path
+        results2 = LouvainCommunityDetector(graph).detect()
+
+        map1 = _community_by_stable_id(results1, site)
+        map2 = _community_by_stable_id(results2, site)
+        assert map1 == map2
+        # And community ids are rank-ordered (0 = largest), so the assignment is
+        # meaningful and stable to bake as a color index.
+        assert results1.communities[0].size >= results1.communities[-1].size
 
     def test_filters_generated_pages(self):
         """Test that generated pages are excluded."""


### PR DESCRIPTION
## Knowledge graph: from utility to showcase (phase 1)

First slice of `plan/epic-graph-showcase.md` — turns the `/graph/` page from a flat scatter of dots into a **topic map**, on top of the just-shipped first-party (D3-free) engine.

### What changed for the reader
- **Color by topic cluster, size by importance.** Nodes are colored by their Louvain community and sized by PageRank, and the layout pulls each community into a separated lobe instead of one center-piled hairball.
- **Cluster legend.** The legend now lists the largest topics (deterministically labeled from each cluster's dominant tag) with their colors; clicking one isolates that cluster.
- **Theme-coherent colors.** Community colors derive from the active palette's `--color-accent` hue in OKLCH + `light-dark()`, so they adapt to every palette and to light/dark with no hardcoded fork. Hover tooltips name the cluster.
- **Dark-mode label fix.** Explorer labels read `--color-text-primary` / `--color-bg-primary` (the tokens that exist) instead of always rendering near-black on white.

### Determinism floor (this is load-bearing — positions + community ids ship in `graph.json`)
There was **no live byte-parity gate** for `graph.json` before this (it was excluded from the only parity test), and baking community/PageRank exposed real ordering hazards:
- One **build-stable page order** via a shared `stable_page_id` key in `GraphBuilder.get_analysis_pages` — fixes Louvain / PageRank / path-pivot ordering and node-emission order at a single chokepoint.
- Louvain: global `random` → **local seeded PRNG**; communities renumbered by a stable rank (0 = largest).
- **New `tests/integration/test_graph_determinism.py`**: two cold builds (different `PYTHONHASHSEED`) → byte-identical `graph.json`; plus id-stability community unit tests **proven discriminating** (they fail when reverted to global `random`). `graph.json` is also un-excluded from the thread-vs-fork parity test.

### Bugs fixed (exposed by wiring the analysis into the build)
- **PageRank divergence** on dense sites — scores blew up to ~1e10 on the docs site. The walk now distributes each page's score across the same edge set that feeds the incoming-edges index, conserving probability mass so it converges to a proper 0–1 distribution.
- **Louvain build cost**: inner loop was O(N²·degree) → now O(E)/iteration via an adjacency index + incremental community-degree totals. Docs-scale `detect()` (1208 nodes): **>30 min → 0.28 s**.

### Verification
- 262 graph/analysis/postprocess tests green; broad sweep (717 + 262) clean.
- Full docs build (1208 pages) succeeds in ~101 s; only pre-existing autodoc broken-link health errors remain (unrelated).
- `graph.json` at docs scale: PageRank a proper distribution (sum 0.998, max 0.064), 17 distinct node sizes, meaningful clusters ("Reference", "Building", "Onboarding", …).

### Deferred to follow-up phases (in the epic)
Full control/legend/tooltip panel migration to elevation tokens; explorer node depth + entrance settle; click-to-focus / deep-link; keyboard nav + reduced-motion + mobile; minimap parity. Each is independently shippable.

### Perf evidence
Louvain detect() at 1208 nodes: >30 min (hung) before; 0.28 s after. Full docs build ~101 s. graph.json byte-identical across two cold builds (different PYTHONHASHSEED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
