### PR TITLE
fix(theme): label version pill from page.version on section landing pages

### DIFF
--- a/bengal/snapshots/builder.py
+++ b/bengal/snapshots/builder.py
@@ -105,10 +105,15 @@ def create_site_snapshot(site: SiteLike) -> SiteSnapshot:
 
     # Phase 2.5: Set root references on all sections (post-processing)
     def find_root_snapshot(snapshot: SectionSnapshot) -> SectionSnapshot:
-        """Find root section by walking up parent chain."""
+        """Find nav root section, mirroring ``Section.root`` semantics."""
         current = snapshot
         while current.parent is not None:
-            current = current.parent
+            if current.metadata.get("nav_root"):
+                return current
+            parent = current.parent
+            if parent.parent is not None and parent.parent.name == "_versions":
+                return current
+            current = parent
         return current
 
     for orig_section_id, section_snapshot in list(section_cache.items()):

--- a/bengal/themes/default/templates/partials/docs-nav.html
+++ b/bengal/themes/default/templates/partials/docs-nav.html
@@ -67,14 +67,20 @@ per-call overhead of {% include %} (context copy, template lookup).
      Native <details>/<summary> = the disclosure, so versions stay switchable
      with zero JS (each option is a real <a>); CSS rotates the caret via [open];
      version-selector.js only adds close-on-outside-click + Esc + arrow keys. #}
-  {% let vcur = current_version ?? site.latest_version %}
-  {% let vlabel = vcur?.label ?? 'Latest' %}
-  {% let vstatus = vcur?.status ?? 'current' %}
-  {# Identify the active version by the page's own version id (a plain string),
-     not current_version.id: on section-index pages current_version arrives as
-     an unresolved LazyValue and plain attribute access on it throws K-RUN-001,
-     which silently drops every section-index page from the build. #}
+  {# Resolve the pill label/status from page.version + the versions list.
+     Do not read current_version.label: on section-index pages current_version
+     arrives as an unresolved LazyValue and attribute access on it throws
+     K-RUN-001 (dropping the page) or falls back to site.latest_version
+     ("Latest" on older-version pages). The menu already matches by page.version. #}
   {% let cur_version_id = page?.version %}
+  {% let vlabel = site.latest_version?.label ?? 'Latest' %}
+  {% let vstatus = 'current' %}
+  {% for v in versions %}
+  {% if cur_version_id is not none and cur_version_id == v.id %}
+  {% let vlabel = v.label %}
+  {% let vstatus = v.status or (v.deprecated and 'deprecated' or 'legacy') %}
+  {% end %}
+  {% end %}
   <details class="docs-nav-vswitch" data-version-switcher>
     <summary class="docs-nav-group-header docs-nav-vswitch__summary" title="Switch documentation version">
       {% if show_nav_icons %}

--- a/bengal/themes/default/templates/partials/version-selector.html
+++ b/bengal/themes/default/templates/partials/version-selector.html
@@ -52,7 +52,7 @@ engine (Jinja2, Mako, or BYORenderer). No global function dependency.
   <select id="version-select" class="version-selector__select" aria-label="Select documentation version">
     {% for v in versions %}
     <option value="{{ v.url_prefix or '/' }}" data-target="{{ site.get_version_target_url(page, v) }}" data-status="{{ v.status or (v.deprecated and 'deprecated' or 'legacy') }}" {% if
-      current_version and current_version.id==v.id %}selected{% end %} {% if v.deprecated %}class="version-deprecated"
+      page?.version is not none and page.version == v.id %}selected{% end %} {% if v.deprecated %}class="version-deprecated"
       {% end %}>
       {{ v.label }}{% if v.latest %} (Latest){% end %}{% if v.status == 'preview' %} (Preview){% end %}{% if v.deprecated %} ⚠️{% end %}
     </option>

--- a/changelog.d/+version-switcher-pill-label.fixed.md
+++ b/changelog.d/+version-switcher-pill-label.fixed.md
@@ -1,0 +1,3 @@
+The sidebar version switcher pill now shows the correct version label on section landing pages (`_index.md`). It previously read the lazy `current_version` context and fell back to "Latest" even when viewing an older docs version; it now resolves the label from `page.version` and the versions list, matching the dropdown selection.
+
+Section snapshots now compute nav root the same way live sections do (`nav_root` boundaries and the `_versions/` folder stop), so parallel shard renders scope the docs sidebar to the correct parent header instead of the site-wide root.

--- a/tests/unit/rendering/test_docs_nav_version_pill.py
+++ b/tests/unit/rendering/test_docs_nav_version_pill.py
@@ -1,0 +1,88 @@
+"""Tests for docs sidebar version switcher pill labeling."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from bengal.core.site import Site
+from bengal.rendering.context.lazy import make_lazy
+from bengal.rendering.engines import create_engine
+
+
+def _version_pill_template() -> str:
+    """Minimal template mirroring docs-nav version pill resolution."""
+    return """
+{% let cur_version_id = page?.version %}
+{% let vlabel = site.latest_version?.label ?? 'Latest' %}
+{% let vstatus = 'current' %}
+{% for v in versions %}
+{% if cur_version_id is not none and cur_version_id == v.id %}
+{% let vlabel = v.label %}
+{% let vstatus = v.status or (v.deprecated and 'deprecated' or 'legacy') %}
+{% end %}
+{% end %}
+<span class="docs-nav-vswitch__pill" data-status="{{ vstatus }}">{{ vlabel }}</span>
+"""
+
+
+def test_version_pill_uses_page_version_when_current_version_is_lazy(tmp_path) -> None:
+    """Section-index pages must not read lazy current_version for the pill label."""
+    (tmp_path / "content").mkdir()
+    (tmp_path / "bengal.toml").write_text(
+        """
+[site]
+title = "Test Site"
+baseurl = "/"
+""",
+        encoding="utf-8",
+    )
+    site = Site.from_config(tmp_path)
+    engine = create_engine(site)
+
+    page = Mock()
+    page.version = "0.5.1"
+
+    def _raise_if_evaluated() -> dict[str, str]:
+        msg = "current_version should not be evaluated for pill label"
+        raise AssertionError(msg)
+
+    rendered = engine.render_string(
+        _version_pill_template(),
+        {
+            "page": page,
+            "versions": [
+                {"id": "main", "label": "Latest", "latest": True, "status": "current"},
+                {"id": "0.5.1", "label": "0.5.1", "latest": False, "status": "legacy"},
+            ],
+            "site": Mock(latest_version={"label": "Latest"}),
+            "current_version": make_lazy(_raise_if_evaluated),
+        },
+    )
+
+    assert 'class="docs-nav-vswitch__pill" data-status="legacy">0.5.1</span>' in rendered
+
+
+def test_version_pill_falls_back_to_latest_label_without_page_version(tmp_path) -> None:
+    (tmp_path / "content").mkdir()
+    (tmp_path / "bengal.toml").write_text(
+        """
+[site]
+title = "Test Site"
+baseurl = "/"
+""",
+        encoding="utf-8",
+    )
+    site = Site.from_config(tmp_path)
+    engine = create_engine(site)
+
+    rendered = engine.render_string(
+        _version_pill_template(),
+        {
+            "page": Mock(version=None),
+            "versions": [{"id": "main", "label": "Latest", "latest": True}],
+            "site": Mock(latest_version={"label": "Latest"}),
+            "current_version": None,
+        },
+    )
+
+    assert ">Latest</span>" in rendered

--- a/tests/unit/snapshots/test_snapshot_builder.py
+++ b/tests/unit/snapshots/test_snapshot_builder.py
@@ -181,6 +181,21 @@ def test_snapshot_section_hierarchy(site, build_site):
         assert section_snap.root == snapshot.root_section or section_snap == snapshot.root_section
 
 
+@pytest.mark.bengal(testroot="test-versioned")
+def test_snapshot_nav_root_matches_section_root(site, build_site):
+    """Versioned docs sections should use their own docs tree as nav root."""
+    build_site()
+
+    snapshot = create_site_snapshot(site)
+
+    docs_sections = {s.href: s for s in snapshot.sections if s.name == "docs"}
+    assert len(docs_sections) >= 3
+
+    for href, docs in docs_sections.items():
+        assert docs.root is not None, href
+        assert docs.root.href == href
+
+
 # =============================================================================
 # NavTree pre-computation tests
 # =============================================================================


### PR DESCRIPTION
## Summary

- Fix the sidebar version switcher pill so section landing pages (`_index.md`) show the correct version label (e.g. `Documentation · 0.5.1`) instead of always falling back to `Latest`.
- Resolve the pill label from `page.version` and the `versions` list, matching the dropdown fix in #577; apply the same `page.version` selection to the fallback `version-selector.html`.
- Align `SectionSnapshot.root` with live `Section.root` semantics (`nav_root` + `_versions/` boundary) so parallel shard renders scope the docs sidebar to the correct parent header.

## Proof

- [x] Focused tests: `pytest tests/unit/rendering/test_docs_nav_version_pill.py tests/unit/snapshots/test_snapshot_builder.py::test_snapshot_nav_root_matches_section_root`
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/+version-switcher-pill-label.fixed.md`

## Performance Evidence

- Benchmark matrix row: not applicable
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable

## Steward Notes

- Follow-up to #575/#577: the dropdown already matched by `page.version`, but the pill still read lazy `current_version.label` on section-index pages.
- Live symptom: `/docs/0.5.1/content/authoring/` showed `Documentation · Latest` while leaf pages under the same version showed `0.5.1`.