### PR TITLE
feat(capabilities): per-page gating + supply-chain controls (#571, #573)

### DIFF
--- a/bengal/capabilities/__init__.py
+++ b/bengal/capabilities/__init__.py
@@ -1,18 +1,35 @@
 """Opt-in runtime capabilities (Mermaid, KaTeX, Iconify)."""
 
+from bengal.capabilities.detectors import (
+    detect_capabilities_in_html,
+    detect_capabilities_in_source,
+    detect_page_capabilities_needed,
+    resolve_effective_capabilities,
+)
 from bengal.capabilities.runtime import (
     CAPABILITY_NAMES,
     resolve_runtime_capabilities,
     vendor_dir_for_site,
     vendors_present,
 )
-from bengal.capabilities.vendors import CapabilityVendorHelper, VendorProvisionResult
+from bengal.capabilities.vendors import (
+    CapabilityVendorHelper,
+    VendorProvisionResult,
+    load_vendor_integrity,
+    vendor_integrity_for_path,
+)
 
 __all__ = [
     "CAPABILITY_NAMES",
     "CapabilityVendorHelper",
     "VendorProvisionResult",
+    "detect_capabilities_in_html",
+    "detect_capabilities_in_source",
+    "detect_page_capabilities_needed",
+    "load_vendor_integrity",
+    "resolve_effective_capabilities",
     "resolve_runtime_capabilities",
     "vendor_dir_for_site",
+    "vendor_integrity_for_path",
     "vendors_present",
 ]

--- a/bengal/capabilities/detectors.py
+++ b/bengal/capabilities/detectors.py
@@ -1,0 +1,139 @@
+"""
+Content detectors for opt-in runtime capabilities (#571).
+
+Each capability declares how to detect whether a page actually uses it.
+Build-time resolution is: site owner enabled AND vendors provisioned AND
+content detector matched → emit assets for that page.
+
+See plan/rfc-capability-system.md Phase 1.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from bengal.capabilities.runtime import CAPABILITY_NAMES
+from bengal.content.page_source import get_raw_source
+
+if TYPE_CHECKING:
+    from bengal.protocols import PageLike
+
+# Rendered HTML markers (post-parse, most reliable when available).
+_HTML_PATTERNS: dict[str, re.Pattern[str]] = {
+    "mermaid": re.compile(r"""class=["']mermaid["']""", re.IGNORECASE),
+    "katex": re.compile(
+        r"""class=["'](?:math(?:-block)?)["']""",
+        re.IGNORECASE,
+    ),
+}
+
+# Raw markdown / source markers (discovery-time and pre-render fallback).
+_SOURCE_PATTERNS: dict[str, re.Pattern[str]] = {
+    "mermaid": re.compile(r"```mermaid|:::\{mermaid\}", re.IGNORECASE),
+    "katex": re.compile(
+        r"(?:\$\$[\s\S]+?\$\$|(?<!\$)\$(?!\$)[^\n$]+\$(?!\$)|"
+        r"\{math\}`|:::\{math\}|\\begin\{)",
+        re.IGNORECASE,
+    ),
+}
+
+
+def detect_capabilities_in_html(html: str) -> dict[str, bool]:
+    """Detect capability needs from rendered HTML."""
+    needed = dict.fromkeys(CAPABILITY_NAMES, False)
+    if not html:
+        return needed
+
+    for name, pattern in _HTML_PATTERNS.items():
+        if pattern.search(html):
+            needed[name] = True
+
+    if needed["mermaid"]:
+        needed["iconify"] = True
+
+    return needed
+
+
+def detect_capabilities_in_source(source: str) -> dict[str, bool]:
+    """Detect capability needs from raw markdown/source."""
+    needed = dict.fromkeys(CAPABILITY_NAMES, False)
+    if not source:
+        return needed
+
+    for name, pattern in _SOURCE_PATTERNS.items():
+        if pattern.search(source):
+            needed[name] = True
+
+    if needed["mermaid"]:
+        needed["iconify"] = True
+
+    return needed
+
+
+def detect_capabilities_in_metadata(metadata: dict[str, Any] | None) -> dict[str, bool]:
+    """Detect capability needs from explicit page metadata flags."""
+    needed = dict.fromkeys(CAPABILITY_NAMES, False)
+    if not metadata:
+        return needed
+
+    if metadata.get("mermaid"):
+        needed["mermaid"] = True
+        needed["iconify"] = True
+
+    if metadata.get("math") or metadata.get("katex"):
+        needed["katex"] = True
+
+    return needed
+
+
+def detect_page_capabilities_needed(
+    *,
+    page: PageLike | None = None,
+    html_content: str | None = None,
+    source_content: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, bool]:
+    """
+    Detect which capabilities a page needs.
+
+    Prefers rendered HTML (accurate), then raw source, then metadata flags.
+    """
+    needed = dict.fromkeys(CAPABILITY_NAMES, False)
+
+    if metadata is None and page is not None:
+        metadata = getattr(page, "metadata", None) or {}
+
+    if html_content:
+        html_needed = detect_capabilities_in_html(html_content)
+        for name in CAPABILITY_NAMES:
+            needed[name] = needed[name] or html_needed[name]
+
+    if source_content is None and page is not None:
+        source_content = get_raw_source(page)
+
+    if source_content and not any(needed.values()):
+        source_needed = detect_capabilities_in_source(source_content)
+        for name in CAPABILITY_NAMES:
+            needed[name] = needed[name] or source_needed[name]
+
+    meta_needed = detect_capabilities_in_metadata(metadata)
+    for name in CAPABILITY_NAMES:
+        needed[name] = needed[name] or meta_needed[name]
+
+    return needed
+
+
+def resolve_effective_capabilities(
+    site_capabilities: dict[str, bool],
+    page_needed: dict[str, bool],
+) -> dict[str, bool]:
+    """
+    Intersect site-level enabled/provisioned capabilities with page needs.
+
+    Non-vendor capabilities (prebuilt_search, remote_content) pass through unchanged.
+    """
+    result = dict(site_capabilities)
+    for name in CAPABILITY_NAMES:
+        result[name] = bool(site_capabilities.get(name)) and bool(page_needed.get(name))
+    return result

--- a/bengal/capabilities/runtime.py
+++ b/bengal/capabilities/runtime.py
@@ -1,8 +1,10 @@
 """
 Runtime capability resolution for opt-in heavy JS (Mermaid, KaTeX, Iconify).
 
-Capabilities are config-gated and require self-hosted vendor files under
-``assets/vendor/`` (provisioned at build time when enabled).
+Capabilities are config-gated (build-environment decision) and require
+self-hosted vendor files under ``assets/vendor/`` (provisioned at build time
+when enabled). Per-page asset emission is further gated by content detectors
+(#571): a capability must be enabled, provisioned, AND needed on the page.
 
 Note: the knowledge graph (minimap + /graph/ explorer) used to depend on D3 and
 was gated here. It is now a dependency-free, first-party renderer with build-time

--- a/bengal/capabilities/supply_chain.py
+++ b/bengal/capabilities/supply_chain.py
@@ -1,0 +1,193 @@
+"""
+Supply-chain controls for capability vendor assets (#573).
+
+Site owners can override download source (CDN vs local file), force a version
+pin, and require SRI verification. Computed integrity hashes are exposed to
+templates for ``integrity`` attributes on script/link tags.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+SourceMode = Literal["cdn", "local"]
+
+# Default upstream pins (author-owned; overridable by site owner).
+DEFAULT_PINS: dict[str, str] = {
+    "mermaid": "10",
+    "katex": "0.16.11",
+    "iconify": "1",
+}
+
+# Pinned SRI for known vendor files (sha384). Verified on CDN download when enabled.
+# Local copies skip remote verification but still emit integrity when bytes are known.
+VENDOR_SRI: dict[str, dict[str, str]] = {
+    "mermaid": {},
+    "katex": {},
+    "iconify": {},
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilitySourceOverride:
+    """Per-capability owner override from [capabilities.sources.<name>]."""
+
+    source: SourceMode = "cdn"
+    local_path: Path | None = None
+    pin: str | None = None
+    sri: str | None = None
+    require_sri: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedVendorAsset:
+    """Resolved provisioning spec for one vendor file."""
+
+    capability: str
+    rel_path: str
+    source_mode: SourceMode
+    url: str | None
+    local_path: Path | None
+    expected_sri: str | None
+    require_sri: bool
+
+
+def compute_sri(data: bytes, *, algorithm: str = "sha384") -> str:
+    """Return an ``integrity`` attribute value (e.g. ``sha384-...``)."""
+    digest = hashlib.new(algorithm, data).digest()
+    encoded = base64.b64encode(digest).decode("ascii")
+    return f"{algorithm}-{encoded}"
+
+
+def verify_sri(data: bytes, expected: str) -> bool:
+    """Verify bytes against an ``integrity`` attribute value."""
+    if not expected or "-" not in expected:
+        return False
+    algorithm, _encoded = expected.split("-", 1)
+    return compute_sri(data, algorithm=algorithm) == expected
+
+
+def _capability_sources_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    caps = config.get("capabilities")
+    if not isinstance(caps, dict):
+        return {}
+    sources = caps.get("sources")
+    return sources if isinstance(sources, dict) else {}
+
+
+def parse_capability_override(
+    config: Mapping[str, Any],
+    capability: str,
+) -> CapabilitySourceOverride:
+    """Parse owner override for a capability from config."""
+    raw = _capability_sources_config(config).get(capability)
+    if not isinstance(raw, dict):
+        return CapabilitySourceOverride()
+
+    source_raw = str(raw.get("source", "cdn")).strip().lower()
+    source: SourceMode = "local" if source_raw == "local" else "cdn"
+
+    local_path: Path | None = None
+    if raw.get("path"):
+        local_path = Path(str(raw["path"]))
+    elif raw.get("local_path"):
+        local_path = Path(str(raw["local_path"]))
+
+    pin = str(raw["pin"]).strip() if raw.get("pin") else None
+    sri = str(raw["sri"]).strip() if raw.get("sri") else None
+    require_sri = bool(raw.get("require_sri", True))
+
+    return CapabilitySourceOverride(
+        source=source,
+        local_path=local_path,
+        pin=pin,
+        sri=sri,
+        require_sri=require_sri,
+    )
+
+
+def _apply_pin_to_url(url: str, pin: str) -> str:
+    """Substitute version pin placeholders or semver segments in a template URL."""
+    if "{pin}" in url:
+        return url.replace("{pin}", pin)
+    # jsdelivr: .../npm/mermaid@10/dist/... or .../katex@0.16.11/dist/...
+    return re.sub(r"@[^/]+/", f"@{pin}/", url, count=1)
+
+
+def resolve_vendor_asset(
+    config: Mapping[str, Any],
+    capability: str,
+    rel_path: str,
+    default_url: str,
+    *,
+    site_root: Path | None = None,
+) -> ResolvedVendorAsset:
+    """Resolve how to provision one vendor file (CDN download or local copy)."""
+    override = parse_capability_override(config, capability)
+    pin = override.pin or DEFAULT_PINS.get(capability, "")
+    url = _apply_pin_to_url(default_url, pin) if pin else default_url
+
+    expected_sri = override.sri or VENDOR_SRI.get(capability, {}).get(rel_path)
+
+    local_path = override.local_path
+    if local_path and not local_path.is_absolute() and site_root is not None:
+        local_path = site_root / local_path
+
+    if override.source == "local":
+        if local_path is None:
+            msg = f"capabilities.sources.{capability}.path required when source=local"
+            raise ValueError(msg)
+        return ResolvedVendorAsset(
+            capability=capability,
+            rel_path=rel_path,
+            source_mode="local",
+            url=None,
+            local_path=local_path,
+            expected_sri=expected_sri,
+            require_sri=override.require_sri,
+        )
+
+    # CDN mode — optional local_path is ignored; fetch from resolved URL.
+    if not urlparse(url).scheme:
+        msg = f"Invalid vendor URL for {capability}/{rel_path}: {url!r}"
+        raise ValueError(msg)
+
+    return ResolvedVendorAsset(
+        capability=capability,
+        rel_path=rel_path,
+        source_mode="cdn",
+        url=url,
+        local_path=None,
+        expected_sri=expected_sri,
+        require_sri=override.require_sri,
+    )
+
+
+def record_vendor_integrity(
+    store: dict[str, str],
+    rel_path: str,
+    data: bytes,
+    *,
+    expected_sri: str | None = None,
+    require_sri: bool = True,
+) -> str:
+    """
+    Verify optional expected SRI, compute integrity hash, and record for templates.
+
+    Returns the integrity attribute value.
+    """
+    if expected_sri and require_sri and not verify_sri(data, expected_sri):
+        msg = f"SRI mismatch for {rel_path}"
+        raise ValueError(msg)
+    integrity = compute_sri(data)
+    store[rel_path] = integrity
+    return integrity

--- a/bengal/capabilities/vendors.py
+++ b/bengal/capabilities/vendors.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bengal import __version__ as BENGAL_VERSION
@@ -31,7 +32,6 @@ from bengal.utils.observability.logger import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from pathlib import Path
 
 logger = get_logger(__name__)
 
@@ -164,12 +164,17 @@ class CapabilityVendorHelper:
 
 def load_vendor_integrity(vendor_dir: Path) -> dict[str, str]:
     """Load SRI hashes written during vendor provisioning."""
+    if not isinstance(vendor_dir, Path):
+        return {}
     manifest_path = vendor_dir / _INTEGRITY_MANIFEST
     if not manifest_path.is_file():
         return {}
     try:
-        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except OSError, json.JSONDecodeError:
+        text = manifest_path.read_text(encoding="utf-8")
+        if not isinstance(text, str):
+            return {}
+        raw = json.loads(text)
+    except OSError, json.JSONDecodeError, TypeError, ValueError:
         return {}
     if not isinstance(raw, dict):
         return {}

--- a/bengal/capabilities/vendors.py
+++ b/bengal/capabilities/vendors.py
@@ -4,11 +4,15 @@ Build-time vendor provisioning for opt-in diagram/math capabilities.
 Downloads pinned vendor assets into ``assets/vendor/`` when a capability is
 enabled in config. Network I/O happens at build time only — runtime output
 uses self-hosted same-origin URLs.
+
+Supply-chain controls (#573): SRI verification, CDN/local source override,
+and version pin override via ``[capabilities.sources.<name>]``.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from bengal import __version__ as BENGAL_VERSION
@@ -16,6 +20,10 @@ from bengal.capabilities.runtime import (
     VENDOR_FILES,
     is_capability_requested,
     vendor_dir_for_site,
+)
+from bengal.capabilities.supply_chain import (
+    record_vendor_integrity,
+    resolve_vendor_asset,
 )
 from bengal.fonts.utils import urlopen_with_ssl_fallback
 from bengal.utils.io.atomic_write import atomic_write_bytes
@@ -28,20 +36,22 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _VENDOR_USER_AGENT = f"Bengal/{BENGAL_VERSION} (capability-vendor-provisioning)"
+_INTEGRITY_MANIFEST = ".capability-integrity.json"
 
-# Pinned upstream URLs — fetched at build time only, never referenced in HTML output.
+# Pinned upstream URL templates — fetched at build time only, never referenced in HTML output.
+# ``{pin}`` is substituted from DEFAULT_PINS or owner override.
 VENDOR_SOURCES: dict[str, dict[str, str]] = {
     "mermaid": {
-        "mermaid.min.js": "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js",
+        "mermaid.min.js": "https://cdn.jsdelivr.net/npm/mermaid@{pin}/dist/mermaid.min.js",
     },
     "katex": {
-        "katex.min.js": "https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js",
-        "katex.min.css": "https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css",
+        "katex.min.js": "https://cdn.jsdelivr.net/npm/katex@{pin}/dist/katex.min.js",
+        "katex.min.css": "https://cdn.jsdelivr.net/npm/katex@{pin}/dist/katex.min.css",
     },
     "iconify": {
-        "iconify/fa.json": "https://unpkg.com/@iconify-json/fa@1/icons.json",
-        "iconify/mdi.json": "https://unpkg.com/@iconify-json/mdi@1/icons.json",
-        "iconify/logos.json": "https://unpkg.com/@iconify-json/logos@1/icons.json",
+        "iconify/fa.json": "https://unpkg.com/@iconify-json/fa@{pin}/icons.json",
+        "iconify/mdi.json": "https://unpkg.com/@iconify-json/mdi@{pin}/icons.json",
+        "iconify/logos.json": "https://unpkg.com/@iconify-json/logos@{pin}/icons.json",
     },
 }
 
@@ -51,14 +61,17 @@ class VendorProvisionResult:
     downloaded: list[str]
     skipped: list[str]
     errors: list[str]
+    integrity: dict[str, str] = field(default_factory=dict)
 
 
 class CapabilityVendorHelper:
-    """Download missing vendor files for enabled capabilities."""
+    """Download or copy vendor files for enabled capabilities."""
 
     def __init__(self, config: Mapping[str, Any], site_root: Path):
         self.config = config
+        self.site_root = site_root
         self.vendor_dir = vendor_dir_for_site(site_root)
+        self.integrity: dict[str, str] = {}
 
     def process(self) -> VendorProvisionResult:
         downloaded: list[str] = []
@@ -68,32 +81,104 @@ class CapabilityVendorHelper:
         for name, sources in VENDOR_SOURCES.items():
             if not is_capability_requested(self.config, name):
                 continue
-            for rel_path, url in sources.items():
+            for rel_path, default_url in sources.items():
                 dest = self.vendor_dir / rel_path
                 if dest.is_file() and dest.stat().st_size > 0:
-                    skipped.append(rel_path)
+                    try:
+                        data = dest.read_bytes()
+                        record_vendor_integrity(
+                            self.integrity,
+                            rel_path,
+                            data,
+                            require_sri=False,
+                        )
+                        skipped.append(rel_path)
+                    except Exception as exc:
+                        errors.append(f"{rel_path}: {exc}")
                     continue
                 try:
-                    dest.parent.mkdir(parents=True, exist_ok=True)
-                    data = urlopen_with_ssl_fallback(
-                        url,
-                        timeout=30,
-                        user_agent=_VENDOR_USER_AGENT,
-                        decode=False,
+                    resolved = resolve_vendor_asset(
+                        self.config,
+                        name,
+                        rel_path,
+                        default_url,
+                        site_root=self.site_root,
                     )
-                    if not isinstance(data, bytes):
-                        data = data.encode("utf-8")
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    if resolved.source_mode == "local":
+                        if resolved.local_path is None or not resolved.local_path.is_file():
+                            msg = f"local source missing: {resolved.local_path}"
+                            raise FileNotFoundError(msg)
+                        data = resolved.local_path.read_bytes()
+                    else:
+                        raw = urlopen_with_ssl_fallback(
+                            resolved.url or default_url,
+                            timeout=30,
+                            user_agent=_VENDOR_USER_AGENT,
+                            decode=False,
+                        )
+                        data = raw if isinstance(raw, bytes) else raw.encode("utf-8")
+
+                    record_vendor_integrity(
+                        self.integrity,
+                        rel_path,
+                        data,
+                        expected_sri=resolved.expected_sri,
+                        require_sri=resolved.require_sri,
+                    )
                     atomic_write_bytes(dest, data)
                     downloaded.append(rel_path)
-                    logger.info("capability_vendor_downloaded", file=rel_path, capability=name)
+                    logger.info(
+                        "capability_vendor_provisioned",
+                        file=rel_path,
+                        capability=name,
+                        source=resolved.source_mode,
+                    )
                 except Exception as exc:
                     msg = f"{rel_path}: {exc}"
                     errors.append(msg)
                     logger.warning(
-                        "capability_vendor_download_failed", file=rel_path, error=str(exc)
+                        "capability_vendor_provision_failed",
+                        file=rel_path,
+                        error=str(exc),
                     )
 
-        return VendorProvisionResult(downloaded=downloaded, skipped=skipped, errors=errors)
+        self._write_integrity_manifest()
+        return VendorProvisionResult(
+            downloaded=downloaded,
+            skipped=skipped,
+            errors=errors,
+            integrity=dict(self.integrity),
+        )
+
+    def _write_integrity_manifest(self) -> None:
+        if not self.integrity:
+            return
+        manifest_path = self.vendor_dir / _INTEGRITY_MANIFEST
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_bytes(
+            manifest_path,
+            json.dumps(self.integrity, indent=2, sort_keys=True).encode("utf-8"),
+        )
+
+
+def load_vendor_integrity(vendor_dir: Path) -> dict[str, str]:
+    """Load SRI hashes written during vendor provisioning."""
+    manifest_path = vendor_dir / _INTEGRITY_MANIFEST
+    if not manifest_path.is_file():
+        return {}
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except OSError, json.JSONDecodeError:
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items()}
+
+
+def vendor_integrity_for_path(vendor_dir: Path, rel_path: str) -> str | None:
+    """Return integrity attribute for a vendor relative path, if known."""
+    return load_vendor_integrity(vendor_dir).get(rel_path)
 
 
 def required_vendor_paths(config: Mapping[str, Any]) -> list[str]:

--- a/bengal/config/defaults.py
+++ b/bengal/config/defaults.py
@@ -339,11 +339,13 @@ DEFAULTS: dict[str, Any] = {
     # -------------------------------------------------------------------------
     # Runtime capabilities (opt-in heavy JS — self-hosted, off by default)
     # Enable in bengal.toml; vendors download to assets/vendor/ at build time.
+    # Optional owner overrides: [capabilities.sources.<name>] source/pin/path/sri
     # -------------------------------------------------------------------------
     "capabilities": {
         "mermaid": False,
         "katex": False,
         "iconify": False,
+        "sources": {},
     },
     # -------------------------------------------------------------------------
     # i18n

--- a/bengal/rendering/context/__init__.py
+++ b/bengal/rendering/context/__init__.py
@@ -44,6 +44,7 @@ from bengal.rendering.context import build_page_context
 from __future__ import annotations
 
 import threading
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from kida import Markup
@@ -511,6 +512,31 @@ def build_page_context(
             if version_obj:
                 context["current_version"] = version_obj.to_dict()
                 context["is_latest_version"] = version_obj.latest
+
+    # Per-page capability gating (#571): enabled (site) AND needed (content).
+    # bengal is normally an engine global; inject a page-scoped override so
+    # templates gate vendor assets on content detection, not site-wide flags.
+    with suppress(Exception):
+        from bengal.capabilities.detectors import (
+            detect_page_capabilities_needed,
+            resolve_effective_capabilities,
+        )
+        from bengal.rendering.metadata import build_template_metadata
+
+        bengal_meta = build_template_metadata(site)
+        site_caps = bengal_meta.get("capabilities")
+        if isinstance(site_caps, dict):
+            html_for_detection = content if content else None
+            page_needed = detect_page_capabilities_needed(
+                page=page,
+                html_content=html_for_detection,
+                metadata=metadata,
+            )
+            context["bengal"] = {
+                **bengal_meta,
+                "capabilities": resolve_effective_capabilities(site_caps, page_needed),
+            }
+            context["page_capabilities"] = page_needed
 
     # Merge extra context
     if extra:

--- a/bengal/rendering/metadata.py
+++ b/bengal/rendering/metadata.py
@@ -134,6 +134,15 @@ def _get_capabilities(site: SiteLike | None = None) -> dict[str, bool]:
     return capabilities
 
 
+def _get_vendor_integrity(site: SiteLike | None = None) -> dict[str, str]:
+    if site is None:
+        return {}
+    from bengal.capabilities.vendors import load_vendor_integrity, vendor_dir_for_site
+
+    vendor_dir = vendor_dir_for_site(getattr(site, "root_path", Path()))
+    return load_vendor_integrity(vendor_dir)
+
+
 def build_template_metadata(site: SiteLike) -> dict[str, Any]:
     """
     Build a curated, privacy-aware metadata dictionary for templates/JS.
@@ -221,6 +230,7 @@ def build_template_metadata(site: SiteLike) -> dict[str, Any]:
 
     i18n = _get_i18n_info(config)
     capabilities = _get_capabilities(site)
+    vendor_integrity = _get_vendor_integrity(site)
 
     full = {
         "engine": engine,
@@ -230,11 +240,16 @@ def build_template_metadata(site: SiteLike) -> dict[str, Any]:
         "i18n": i18n,
         "site": {"baseurl": getattr(site, "baseurl", None)},
         "capabilities": capabilities,
+        "vendor_integrity": vendor_integrity,
     }
 
     if exposure == "minimal":
         # Capabilities always included (needed for conditional template features)
-        result: dict[str, Any] = {"engine": engine, "capabilities": capabilities}
+        result: dict[str, Any] = {
+            "engine": engine,
+            "capabilities": capabilities,
+            "vendor_integrity": vendor_integrity,
+        }
     elif exposure == "standard":
         result = {
             "engine": engine,
@@ -242,6 +257,7 @@ def build_template_metadata(site: SiteLike) -> dict[str, Any]:
             "build": build,
             "i18n": i18n,
             "capabilities": capabilities,
+            "vendor_integrity": vendor_integrity,
         }
     else:  # extended
         result = full

--- a/bengal/themes/default/assets/js/enhancements/lazy-loaders.js
+++ b/bengal/themes/default/assets/js/enhancements/lazy-loaders.js
@@ -45,6 +45,10 @@
     function loadScript(src, onload, options = {}) {
         const script = document.createElement('script');
         script.src = src;
+        if (options.integrity) {
+            script.integrity = options.integrity;
+            script.crossOrigin = 'anonymous';
+        }
         if (options.async !== false) script.async = true;
         if (onload) script.onload = onload;
         script.onerror = () => {
@@ -106,7 +110,9 @@
         pending.mermaid = true;
         loaded.mermaid = true;
 
-        loadScript(assets.mermaid, initMermaid);
+        loadScript(assets.mermaid, initMermaid, {
+            integrity: assets.mermaidIntegrity || undefined,
+        });
     }
 
     /**

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -36,6 +36,7 @@ _path, kind, tags are always defined - no defensive checks needed.
 {% let _view_transitions = (_doc_app?.enabled ?? false) and (_doc_app_nav?.view_transitions ?? false) %}
 {% let _transition_style = _doc_app_nav?.transition_style ?? none %}
 {% let _llms_txt_url = '/llms.txt' | absolute_url %}
+{% let _cap_cache_key = (bengal?.capabilities?.mermaid ?? false) ~ '-' ~ (bengal?.capabilities?.katex ?? false) ~ '-' ~ (bengal?.capabilities?.iconify ?? false) %}
 
 {# Auto navigation if main menu is empty #}
 {% let _auto_nav = get_auto_nav() if _main_menu | length == 0 else [] %}
@@ -211,8 +212,8 @@ HELPER: Render a menu item (desktop/mobile)
     <link rel="alternate" hreflang="{{ alt.hreflang }}" href="{{ alt.href | absolute_url }}">
     {% end %}
 
-    {# Favicon, preconnect, fonts, stylesheets — site-stable, same for every page in a build #}
-    {% cache 'base-head-assets-' ~ (bengal.build.timestamp ?? '') %}
+    {# Favicon, preconnect, fonts, stylesheets — stable per capability profile #}
+    {% cache 'base-head-assets-' ~ (bengal.build.timestamp ?? '') ~ '-' ~ _cap_cache_key %}
     {# Favicon - use let for safer nil handling #}
     {% let favicon_path = site.favicon ?? none %}
     {% if favicon_path %}
@@ -239,7 +240,8 @@ HELPER: Render a menu item (desktop/mobile)
     <link rel="stylesheet" href="{{ asset_url('css/base/transitions.css') }}">
     {% end %}
     {% if bengal?.capabilities?.katex ?? false %}
-    <link rel="stylesheet" href="{{ asset_url('vendor/katex.min.css') }}">
+    {% let _katex_css_sri = bengal?.vendor_integrity?['katex.min.css'] ?? none %}
+    <link rel="stylesheet" href="{{ asset_url('vendor/katex.min.css') }}"{% if _katex_css_sri %} integrity="{{ _katex_css_sri }}" crossorigin="anonymous"{% end %}>
     {% end %}
     {% end %}{# /cache base-head-assets #}
 
@@ -518,7 +520,7 @@ HELPER: Render a menu item (desktop/mobile)
 
     {# Scripts #}
     {% block site_scripts %}
-    {% cache 'base-scripts-' ~ (bengal.build.timestamp ?? '') %}
+    {% cache 'base-scripts-' ~ (bengal.build.timestamp ?? '') ~ '-' ~ _cap_cache_key %}
     {% if config.assets.bundle_js ?? false %}
     <script defer src="{{ asset_url('js/bundle.js') }}"></script>
     <script defer src="{{ asset_url('js/vendor/lunr.min.js') }}"></script>
@@ -550,7 +552,8 @@ HELPER: Render a menu item (desktop/mobile)
     {% include "partials/link-previews.html" %}
     <script defer src="{{ asset_url('js/vendor/lunr.min.js') }}"></script>
     {% if bengal?.capabilities?.katex ?? false %}
-    <script defer src="{{ asset_url('vendor/katex.min.js') }}"></script>
+    {% let _katex_js_sri = bengal?.vendor_integrity?['katex.min.js'] ?? none %}
+    <script defer src="{{ asset_url('vendor/katex.min.js') }}"{% if _katex_js_sri %} integrity="{{ _katex_js_sri }}" crossorigin="anonymous"{% end %}></script>
     <script defer src="{{ asset_url('js/enhancements/math.js') }}"></script>
     {% end %}
     <script>
@@ -558,7 +561,9 @@ HELPER: Render a menu item (desktop/mobile)
             tabulator: '{{ asset_url("js/tabulator.min.js") }}',
             dataTable: '{{ asset_url("js/data-table.js") }}',
             {% if bengal?.capabilities?.mermaid ?? false %}
+            {% let _mermaid_js_sri = bengal?.vendor_integrity?['mermaid.min.js'] ?? none %}
             mermaid: '{{ asset_url("vendor/mermaid.min.js") }}',
+            mermaidIntegrity: {{ (_mermaid_js_sri ?? '') | tojson }},
             {% end %}
             mermaidToolbar: '{{ asset_url("js/mermaid-toolbar.js") }}',
             mermaidTheme: '{{ asset_url("js/mermaid-theme.js") }}'

--- a/changelog.d/571.changed.md
+++ b/changelog.d/571.changed.md
@@ -1,0 +1,3 @@
+Mermaid, KaTeX, and Iconify vendor assets now load only on pages that actually use them, even when the capability is enabled site-wide.
+
+Build-time content detection gates script and stylesheet emission per page, so globally enabling a diagram or math capability no longer ships those assets on every page.

--- a/changelog.d/573.added.md
+++ b/changelog.d/573.added.md
@@ -1,0 +1,1 @@
+Site owners can control capability vendor provisioning with `[capabilities.sources.<name>]` — choose CDN download or a local file, override the version pin, and verify or emit SRI integrity hashes on vendor script and stylesheet tags.

--- a/tests/integration/test_capability_gating.py
+++ b/tests/integration/test_capability_gating.py
@@ -1,0 +1,116 @@
+"""
+Integration tests for per-page capability gating (#571).
+
+When capabilities are enabled site-wide, vendor assets should only appear
+on pages that actually use the feature.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestPerPageCapabilityGating:
+    def test_katex_only_on_pages_with_math(self, tmp_path: Path) -> None:
+        site_dir = tmp_path / "site"
+        site_dir.mkdir()
+
+        (site_dir / "bengal.toml").write_text("""
+[site]
+title = "Capability Gating Test"
+baseurl = "/"
+
+[build]
+output_dir = "public"
+
+[theme]
+name = "default"
+features = ["content.math"]
+
+[capabilities]
+katex = true
+""")
+
+        content_dir = site_dir / "content"
+        content_dir.mkdir()
+
+        (content_dir / "_index.md").write_text("""---
+title: Home
+---
+Welcome — no math on this page.
+""")
+
+        (content_dir / "math.md").write_text("""---
+title: Math Page
+---
+The equation $E = mc^2$ is famous.
+""")
+
+        site = Site.from_config(site_dir)
+        site.build(BuildOptions(incremental=False))
+
+        home_html = (site_dir / "public" / "index.html").read_text()
+        math_html = (site_dir / "public" / "math" / "index.html").read_text()
+
+        assert "vendor/katex.min" not in home_html
+        assert "enhancements/math" not in home_html
+
+        assert "vendor/katex.min" in math_html
+        assert "enhancements/math" in math_html
+        assert 'class="math"' in math_html
+
+    def test_mermaid_only_on_pages_with_diagrams(self, tmp_path: Path) -> None:
+        site_dir = tmp_path / "site"
+        site_dir.mkdir()
+
+        (site_dir / "bengal.toml").write_text("""
+[site]
+title = "Mermaid Gating Test"
+baseurl = "/"
+
+[build]
+output_dir = "public"
+
+[theme]
+name = "default"
+
+[capabilities]
+mermaid = true
+iconify = true
+""")
+
+        content_dir = site_dir / "content"
+        content_dir.mkdir()
+
+        (content_dir / "_index.md").write_text("""---
+title: Home
+---
+No diagrams here.
+""")
+
+        (content_dir / "diagram.md").write_text("""---
+title: Diagram
+---
+```mermaid
+graph TD
+  A --> B
+```
+""")
+
+        site = Site.from_config(site_dir)
+        site.build(BuildOptions(incremental=False))
+
+        home_html = (site_dir / "public" / "index.html").read_text()
+        diagram_html = (site_dir / "public" / "diagram" / "index.html").read_text()
+
+        assert "vendor/mermaid.min" not in home_html
+        assert 'class="mermaid"' not in home_html
+
+        assert 'class="mermaid"' in diagram_html
+        assert "vendor/mermaid.min" in diagram_html

--- a/tests/unit/capabilities/test_detectors.py
+++ b/tests/unit/capabilities/test_detectors.py
@@ -1,0 +1,167 @@
+"""Tests for capability content detectors (#571)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestDetectCapabilitiesInSource:
+    def test_mermaid_fence(self) -> None:
+        from bengal.capabilities.detectors import detect_capabilities_in_source
+
+        needed = detect_capabilities_in_source("```mermaid\ngraph TD\n  A-->B\n```")
+        assert needed["mermaid"] is True
+        assert needed["iconify"] is True
+        assert needed["katex"] is False
+
+    def test_inline_math(self) -> None:
+        from bengal.capabilities.detectors import detect_capabilities_in_source
+
+        needed = detect_capabilities_in_source("The equation $E = mc^2$ is famous.")
+        assert needed["katex"] is True
+        assert needed["mermaid"] is False
+
+    def test_block_math(self) -> None:
+        from bengal.capabilities.detectors import detect_capabilities_in_source
+
+        needed = detect_capabilities_in_source("$$\n\\int_0^1 x\\,dx\n$$")
+        assert needed["katex"] is True
+
+
+class TestDetectCapabilitiesInHtml:
+    def test_mermaid_div(self) -> None:
+        from bengal.capabilities.detectors import detect_capabilities_in_html
+
+        needed = detect_capabilities_in_html('<div class="mermaid">graph TD\nA-->B</div>')
+        assert needed["mermaid"] is True
+        assert needed["iconify"] is True
+
+    def test_math_span(self) -> None:
+        from bengal.capabilities.detectors import detect_capabilities_in_html
+
+        needed = detect_capabilities_in_html('<span class="math">E = mc^2</span>')
+        assert needed["katex"] is True
+        assert needed["mermaid"] is False
+
+    def test_plain_page(self) -> None:
+        from bengal.capabilities.detectors import detect_capabilities_in_html
+
+        needed = detect_capabilities_in_html("<p>Hello world</p>")
+        assert all(not v for v in needed.values())
+
+
+class TestResolveEffectiveCapabilities:
+    def test_intersects_site_enabled_with_page_needed(self) -> None:
+        from bengal.capabilities.detectors import resolve_effective_capabilities
+
+        site = {
+            "mermaid": True,
+            "katex": True,
+            "iconify": True,
+            "prebuilt_search": True,
+        }
+        needed = {"mermaid": False, "katex": True, "iconify": False}
+        effective = resolve_effective_capabilities(site, needed)
+        assert effective["mermaid"] is False
+        assert effective["katex"] is True
+        assert effective["iconify"] is False
+        assert effective["prebuilt_search"] is True
+
+    def test_disabled_site_capability_stays_off(self) -> None:
+        from bengal.capabilities.detectors import resolve_effective_capabilities
+
+        site = {"mermaid": False, "katex": False, "iconify": False}
+        needed = {"mermaid": True, "katex": True, "iconify": True}
+        effective = resolve_effective_capabilities(site, needed)
+        assert effective == {"mermaid": False, "katex": False, "iconify": False}
+
+
+class TestBuildPageContextCapabilityGating:
+    def test_page_without_mermaid_excludes_mermaid_from_context(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from bengal.capabilities.runtime import resolve_runtime_capabilities
+        from bengal.rendering.context import build_page_context
+
+        vendor_dir = tmp_path / "assets" / "vendor"
+        vendor_dir.mkdir(parents=True)
+        (vendor_dir / "mermaid.min.js").write_bytes(b"mermaid")
+        (vendor_dir / "katex.min.js").write_bytes(b"katex")
+        (vendor_dir / "katex.min.css").write_bytes(b"css")
+
+        site = MagicMock()
+        site.dev_mode = True
+        site.theme = "default"
+        site.baseurl = ""
+        site.build_time = None
+        site.root_path = tmp_path
+        site.config = {
+            "expose_metadata": "minimal",
+            "capabilities": {"mermaid": True, "katex": True},
+        }
+        site.versioning_enabled = False
+        site.versions = []
+
+        page = MagicMock()
+        page.metadata = {"title": "Plain"}
+        page.title = "Plain"
+        page.source_path = tmp_path / "plain.md"
+        page.source_path.write_text("# Plain\n\nNo diagrams here.\n")
+
+        context = build_page_context(
+            page,
+            site,
+            content="<p>No diagrams here.</p>",
+            lazy=False,
+        )
+
+        assert context["page_capabilities"]["mermaid"] is False
+        assert context["page_capabilities"]["katex"] is False
+        assert context["bengal"]["capabilities"]["mermaid"] is False
+        assert context["bengal"]["capabilities"]["katex"] is False
+
+        # Sanity: site-level resolution would still be active
+        site_caps = resolve_runtime_capabilities(site.config, vendor_dir)
+        assert site_caps["mermaid"] is True
+        assert site_caps["katex"] is True
+
+    def test_page_with_mermaid_includes_mermaid_in_context(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from bengal.rendering.context import build_page_context
+
+        vendor_dir = tmp_path / "assets" / "vendor"
+        vendor_dir.mkdir(parents=True)
+        (vendor_dir / "mermaid.min.js").write_bytes(b"mermaid")
+
+        site = MagicMock()
+        site.dev_mode = True
+        site.theme = "default"
+        site.baseurl = ""
+        site.build_time = None
+        site.root_path = tmp_path
+        site.config = {
+            "expose_metadata": "minimal",
+            "capabilities": {"mermaid": True},
+        }
+        site.versioning_enabled = False
+        site.versions = []
+
+        page = MagicMock()
+        page.metadata = {"title": "Diagram"}
+        page.title = "Diagram"
+        page.source_path = tmp_path / "diagram.md"
+        page.source_path.write_text("```mermaid\ngraph TD\n  A-->B\n```\n")
+
+        context = build_page_context(
+            page,
+            site,
+            content='<div class="mermaid">graph TD\n  A-->B</div>',
+            lazy=False,
+        )
+
+        assert context["page_capabilities"]["mermaid"] is True
+        assert context["bengal"]["capabilities"]["mermaid"] is True

--- a/tests/unit/capabilities/test_supply_chain.py
+++ b/tests/unit/capabilities/test_supply_chain.py
@@ -1,0 +1,117 @@
+"""Tests for capability supply-chain controls (#573)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestComputeSri:
+    def test_known_payload(self) -> None:
+        from bengal.capabilities.supply_chain import compute_sri, verify_sri
+
+        data = b"hello world"
+        integrity = compute_sri(data)
+        assert integrity.startswith("sha384-")
+        assert verify_sri(data, integrity)
+
+
+class TestResolveVendorAsset:
+    def test_cdn_default_with_pin_substitution(self, tmp_path: Path) -> None:
+        from bengal.capabilities.supply_chain import resolve_vendor_asset
+
+        resolved = resolve_vendor_asset(
+            {"capabilities": {"mermaid": True}},
+            "mermaid",
+            "mermaid.min.js",
+            "https://cdn.jsdelivr.net/npm/mermaid@{pin}/dist/mermaid.min.js",
+            site_root=tmp_path,
+        )
+        assert resolved.source_mode == "cdn"
+        assert resolved.url is not None
+        assert "@10/" in resolved.url
+
+    def test_pin_override(self, tmp_path: Path) -> None:
+        from bengal.capabilities.supply_chain import resolve_vendor_asset
+
+        config = {
+            "capabilities": {
+                "mermaid": True,
+                "sources": {"mermaid": {"pin": "9.4.3"}},
+            }
+        }
+        resolved = resolve_vendor_asset(
+            config,
+            "mermaid",
+            "mermaid.min.js",
+            "https://cdn.jsdelivr.net/npm/mermaid@{pin}/dist/mermaid.min.js",
+            site_root=tmp_path,
+        )
+        assert "@9.4.3/" in (resolved.url or "")
+
+    def test_local_source_requires_path(self, tmp_path: Path) -> None:
+        import pytest
+
+        from bengal.capabilities.supply_chain import resolve_vendor_asset
+
+        config = {
+            "capabilities": {
+                "mermaid": True,
+                "sources": {"mermaid": {"source": "local"}},
+            }
+        }
+        with pytest.raises(ValueError, match="path required"):
+            resolve_vendor_asset(
+                config,
+                "mermaid",
+                "mermaid.min.js",
+                "https://cdn.jsdelivr.net/npm/mermaid@{pin}/dist/mermaid.min.js",
+                site_root=tmp_path,
+            )
+
+
+class TestCapabilityVendorHelperLocalSource:
+    def test_provisions_from_local_path(self, tmp_path: Path) -> None:
+        from bengal.capabilities.supply_chain import compute_sri
+        from bengal.capabilities.vendors import CapabilityVendorHelper, load_vendor_integrity
+
+        site_root = tmp_path / "site"
+        site_root.mkdir()
+        local_js = site_root / "vendor" / "mermaid.min.js"
+        local_js.parent.mkdir(parents=True)
+        payload = b"local mermaid payload"
+        local_js.write_bytes(payload)
+
+        config = {
+            "capabilities": {
+                "mermaid": True,
+                "sources": {
+                    "mermaid": {
+                        "source": "local",
+                        "path": "vendor/mermaid.min.js",
+                        "require_sri": False,
+                    }
+                },
+            }
+        }
+
+        helper = CapabilityVendorHelper(config, site_root)
+        result = helper.process()
+
+        dest = site_root / "assets" / "vendor" / "mermaid.min.js"
+        assert dest.is_file()
+        assert dest.read_bytes() == payload
+        assert "mermaid.min.js" in result.downloaded
+        assert load_vendor_integrity(dest.parent)["mermaid.min.js"] == compute_sri(payload)
+
+    def test_sri_mismatch_raises(self, tmp_path: Path) -> None:
+        import pytest
+
+        from bengal.capabilities.supply_chain import compute_sri, record_vendor_integrity
+
+        data = b"payload"
+        wrong = compute_sri(b"other")
+        with pytest.raises(ValueError, match="SRI mismatch"):
+            record_vendor_integrity({}, "x.js", data, expected_sri=wrong, require_sri=True)

--- a/tests/unit/rendering/test_metadata_exposure.py
+++ b/tests/unit/rendering/test_metadata_exposure.py
@@ -19,7 +19,7 @@ def test_bengal_global_minimal_exposure():
     assert isinstance(meta, dict)
     assert meta["engine"]["name"] == "Bengal SSG"
     # minimal exposes engine + capabilities (runtime feature detection)
-    assert set(meta.keys()) == {"engine", "capabilities"}
+    assert set(meta.keys()) == {"engine", "capabilities", "vendor_integrity"}
 
 
 def test_bengal_global_standard_exposure_includes_theme_and_build_and_i18n():


### PR DESCRIPTION
## Summary

- **#571 — Content detection:** Mermaid/KaTeX/Iconify vendor assets now emit only on pages that actually use them, even when enabled site-wide. Adds declarative detectors, per-page `bengal.capabilities` resolution in `build_page_context`, and capability-aware template cache keys.
- **#573 — Supply-chain controls:** Site owners can override vendor provisioning via `[capabilities.sources.<name>]` (CDN vs local file, version pin, SRI verify). Build writes `.capability-integrity.json`; templates and lazy-loaders emit `integrity`/`crossorigin` on vendor tags.

## Proof

- [x] Focused tests: `uv run pytest tests/unit/capabilities tests/integration/test_capability_gating.py tests/integration/test_math_feature.py` — 27 passed
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/571.changed.md`, `changelog.d/573.added.md`

## Performance Evidence

not applicable

## Steward Notes

- Part of capability epic #570; #572 (entry-point registry) remains next.
- Template `{% cache %}` keys now include a capability profile suffix so head/script blocks are not shared across pages with different vendor needs.

Made with [Cursor](https://cursor.com)