### PR TITLE
docs(site): fix blank snippet includes on docs pages

### DIFF
--- a/site/content/docs/building/deployment/_index.md
+++ b/site/content/docs/building/deployment/_index.md
@@ -39,8 +39,8 @@ the `public/` directory, and point your host at it.
 
 When you are ready to ship, run the production build:
 
-```{include} _snippets/deploy/production-build.md
-```
+:::{include} _snippets/deploy/production-build.md
+:::
 
 This command:
 

--- a/site/content/docs/content/reuse/_index.md
+++ b/site/content/docs/content/reuse/_index.md
@@ -66,8 +66,8 @@ _snippets/
 
 Include in any page:
 ````markdown
-```{include} _snippets/install/pip.md
-```
+:::{include} _snippets/install/pip.md
+:::
 ````
 :::
 

--- a/site/content/docs/content/reuse/snippets.md
+++ b/site/content/docs/content/reuse/snippets.md
@@ -45,8 +45,8 @@ Include it in any page:
 
 Here is some content.
 
-```{include} snippets/warning.md
-```
+:::{include} snippets/warning.md
+:::
 
 More content.
 ````
@@ -56,10 +56,10 @@ More content.
 Include only a portion of a file:
 
 ````markdown
-```{include} snippets/api-example.md
+:::{include} snippets/api-example.md
 :start-line: 5
 :end-line: 20
-```
+:::
 ````
 
 This includes lines 5-20 from the file.
@@ -77,8 +77,8 @@ Use the `{literalinclude}` directive to include code files as syntax-highlighted
 ### Basic Usage
 
 ````markdown
-```{literalinclude} examples/api.py
-```
+:::{literalinclude} examples/api.py
+:::
 ````
 
 This automatically:
@@ -91,10 +91,10 @@ This automatically:
 Include only a portion of a code file:
 
 ````markdown
-```{literalinclude} examples/api.py
+:::{literalinclude} examples/api.py
 :start-line: 10
 :end-line: 25
-```
+:::
 ````
 
 ### Emphasize Lines
@@ -102,29 +102,29 @@ Include only a portion of a code file:
 Highlight specific lines:
 
 ````markdown
-```{literalinclude} examples/api.py
+:::{literalinclude} examples/api.py
 :emphasize-lines: 7,8,9
-```
+:::
 ````
 
 Or a range:
 
 ````markdown
-```{literalinclude} examples/api.py
+:::{literalinclude} examples/api.py
 :emphasize-lines: 7-9
-```
+:::
 ````
 
 ### Complete Example
 
 ````markdown
-```{literalinclude} examples/api.py
+:::{literalinclude} examples/api.py
 :language: python
 :start-line: 10
 :end-line: 30
 :emphasize-lines: 15,16,17
 :linenos: true
-```
+:::
 ````
 
 ## Supported Languages

--- a/site/content/docs/get-started/_index.md
+++ b/site/content/docs/get-started/_index.md
@@ -39,8 +39,8 @@ Requires Python 3.14 or later. See [[docs/get-started/installation|installation 
 
 ## Create a Site
 
-```{include} _snippets/scaffold/new-site.md
-```
+:::{include} _snippets/scaffold/new-site.md
+:::
 
 ## Pick a Path {#pick-a-path}
 

--- a/site/content/docs/get-started/installation.md
+++ b/site/content/docs/get-started/installation.md
@@ -38,24 +38,24 @@ Bengal requires **Python 3.14 or later**. For best performance, use the free-thr
 :icon: rocket
 :badge: Recommended
 
-```{include} _snippets/install/uv.md
-```
+:::{include} _snippets/install/uv.md
+:::
 
 :::{/tab-item}
 
 :::{tab-item} pip
 :icon: package
 
-```{include} _snippets/install/pip.md
-```
+:::{include} _snippets/install/pip.md
+:::
 
 :::{/tab-item}
 
 :::{tab-item} pipx
 :icon: terminal
 
-```{include} _snippets/install/pipx.md
-```
+:::{include} _snippets/install/pipx.md
+:::
 
 This installs Bengal in an isolated environment while making the `bengal` command available globally.
 :::{/tab-item}
@@ -64,8 +64,8 @@ This installs Bengal in an isolated environment while making the `bengal` comman
 :icon: code
 :badge: Development
 
-```{include} _snippets/install/from-source.md
-```
+:::{include} _snippets/install/from-source.md
+:::
 
 This installs Bengal in editable mode with development dependencies.
 :::{/tab-item}

--- a/site/content/docs/get-started/quickstart-writer.md
+++ b/site/content/docs/get-started/quickstart-writer.md
@@ -41,8 +41,8 @@ with the default theme. Skip if you are customizing templates — see
 
 ## Create Your Site
 
-```{include} _snippets/scaffold/blog-site.md
-```
+:::{include} _snippets/scaffold/blog-site.md
+:::
 
 :::{dropdown} Or use a custom skeleton YAML
 :icon: file-text
@@ -84,8 +84,8 @@ See [[docs/tutorials/sites/skeleton-quickstart|Skeleton YAML Quickstart]] for mo
 :::{target} hot-reload
 :::
 
-```{include} _snippets/scaffold/serve.md
-```
+:::{include} _snippets/scaffold/serve.md
+:::
 
 ## Create Your First Post
 
@@ -144,8 +144,8 @@ See [[docs/building/configuration|Configuration Reference]] for details.
 
 ## Build and Deploy
 
-```{include} _snippets/deploy/production-build.md
-```
+:::{include} _snippets/deploy/production-build.md
+:::
 
 Deploy to any static host:
 

--- a/site/content/docs/tutorials/migration/_index.md
+++ b/site/content/docs/tutorials/migration/_index.md
@@ -26,8 +26,8 @@ convert syntax, update config, then verify with `bengal build` and
 
 ## Common Migration Steps
 
-```{include} _snippets/migration/common-steps.md
-```
+:::{include} _snippets/migration/common-steps.md
+:::
 
 ## Universal Conversions
 

--- a/site/content/docs/tutorials/user-scenarios.md
+++ b/site/content/docs/tutorials/user-scenarios.md
@@ -120,8 +120,8 @@ features:
 
 ### 5. Build and Preview
 
-```{include} _snippets/scaffold/serve.md
-```
+:::{include} _snippets/scaffold/serve.md
+:::
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace backtick `{include}` / `{literalinclude}` fences with colon-fence `:::{include}` syntax across eight site docs pages so shared snippets render instead of empty code blocks.
- Affected onboarding and reuse pages include Writer Quickstart, Installation, Get Started, Deployment, migration/user-scenario tutorials, and the snippets guide examples.

## Proof

- [x] Focused tests: Verified colon-fence includes expand snippet content via `PatitasParser.parse_with_context`; backtick fences still produce empty `language-{include}` blocks.
- [ ] `poe proof-pr` or scoped equivalent: not applicable (docs-only markdown change).
- [x] Docs/examples/changelog updated or no-impact noted: Updated docs/examples in place; no changelog fragment needed for internal site docs syntax correction.

## Performance Evidence

not applicable

## Steward Notes

Patitas only parses colon-fence directives (`:::{include}`); backtick fences were treated as empty fenced code blocks with language `{include}`. After deploy, blank blocks on `/docs/get-started/quickstart-writer/` and `/docs/get-started/installation/` should show scaffold, serve, and install commands.

Made with [Cursor](https://cursor.com)