### PR TITLE
docs(site): Phase 2 splits, CLI drift guards, autodoc & directive tables

### DIFF
--- a/scripts/update_cli_help_snapshot.py
+++ b/scripts/update_cli_help_snapshot.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Regenerate committed CLI help snapshots for docs drift guards (issue #628).
+
+Updates:
+- tests/unit/docs/fixtures/cli_root_help_commands.txt
+- site/content/docs/reference/architecture/tooling/cli.md (inventory + root help)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from tests._testing.cli_help_snapshot import (  # noqa: E402
+    update_cli_doc_inventory,
+    update_cli_doc_root_help,
+    write_snapshot,
+)
+
+
+def main() -> int:
+    snapshot = write_snapshot()
+    doc_inventory_changed = update_cli_doc_inventory()
+    doc_help_changed = update_cli_doc_root_help()
+    print(f"Wrote {snapshot.relative_to(_REPO_ROOT)}")
+    if doc_inventory_changed:
+        print("Updated cli.md command inventory")
+    if doc_help_changed:
+        print("Updated cli.md root help snapshot")
+    if not doc_inventory_changed and not doc_help_changed:
+        print("cli.md already matched live CLI output")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_directive_options_snapshot.py
+++ b/scripts/update_directive_options_snapshot.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Regenerate directive option tables from create_default_registry() (issue #626)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from tests._testing.directive_options_snapshot import (  # noqa: E402
+    registry_option_tables,
+    write_registry_options_doc,
+    write_snapshot,
+)
+
+
+def main() -> int:
+    payload = registry_option_tables()
+    snapshot = write_snapshot()
+    doc = write_registry_options_doc(payload=payload)
+    print(f"Wrote {snapshot.relative_to(_REPO_ROOT)} ({len(payload)} handlers)")
+    print(f"Wrote {doc.relative_to(_REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/content/docs/reference/architecture/tooling/_index.md
+++ b/site/content/docs/reference/architecture/tooling/_index.md
@@ -11,7 +11,7 @@ Developer interfaces for working with Bengal.
 
 | Component | Purpose | Key Features |
 |-----------|---------|--------------|
-| **CLI** | Command interface | Click-based, auto-generated help |
+| **CLI** | Command interface | Milo registry, autodoc `/cli/` reference |
 | **Dev Server** | Local development | Live reload, SSE hot updates |
 | **Config** | Settings loader | TOML/YAML, environment merging |
 | **Utils** | Shared utilities | Progress reporting, file handling |
@@ -30,5 +30,6 @@ bengal
 ```
 
 :::{tip}
-See [CLI Reference](cli/) for complete command documentation.
+See [[/cli/|Bengal CLI Reference]] (autodoc, generated from Milo) for complete
+command and flag lookup. This page covers architecture and contributor internals.
 :::

--- a/site/content/docs/reference/architecture/tooling/cli-commands.md
+++ b/site/content/docs/reference/architecture/tooling/cli-commands.md
@@ -21,9 +21,10 @@ keywords:
 Command examples and flags for day-to-day Bengal workflows.
 
 :::{note}
-**Do I need this?** Use when you need a specific command or flag. For CLI
-architecture and registration internals, see
-[[docs/reference/architecture/tooling/cli|CLI Architecture]].
+**Do I need this?** Use when you need a specific command or flag. Exhaustive
+command and flag lookup lives in the autodoc [[/cli/|Bengal CLI Reference]]
+(generated from Milo at build time). For CLI architecture and registration
+internals, see [[docs/reference/architecture/tooling/cli|CLI Architecture]].
 :::
 
 ## Core Commands {#commands}

--- a/site/content/docs/reference/architecture/tooling/cli.md
+++ b/site/content/docs/reference/architecture/tooling/cli.md
@@ -107,74 +107,75 @@ new.lazy_command(
 
 The public command inventory is generated from the Milo registry and guarded by
 unit tests against this documentation, `--llms-txt`, README command snippets,
-and runtime smoke coverage.
+and runtime smoke coverage. Exhaustive per-command flags and arguments are
+autodoc-generated at [[/cli/|Bengal CLI Reference]] during site builds.
 
 ```text cli-command-inventory
-build
-serve
-preview
-clean
-check
 audit
-health
-fix
-upgrade
+build
+cache.hash
+cache.inputs
+capability.info
+capability.list
+capability.validate
+check
+clean
 codemod
-new.site
-new.theme
-new.page
-new.layout
-new.partial
-new.content-type
-config.show
-config.doctor
 config.diff
+config.doctor
 config.init
 config.inspect
-theme.list
-theme.info
+config.show
+content.collections
+content.fetch
+content.schemas
+content.sources
+debug.delta
+debug.deps
+debug.incremental
+debug.migrate
+debug.sandbox
+fix
+health
+i18n.compile
+i18n.extract
+i18n.init
+i18n.status
+i18n.sync
+inspect.graph
+inspect.links
+inspect.page
+inspect.perf
+new.content-type
+new.layout
+new.page
+new.partial
+new.site
+new.theme
+plugin.info
+plugin.list
+plugin.validate
+preview
+serve
+theme.assets
+theme.debug
+theme.directives
 theme.discover
+theme.info
+theme.install
+theme.list
+theme.new
 theme.preview
 theme.swizzle
 theme.swizzle-list
 theme.swizzle-update
-theme.install
-theme.validate
-theme.new
-theme.debug
-theme.directives
 theme.test
-theme.assets
-content.sources
-content.fetch
-content.collections
-content.schemas
-version.list
-version.info
+theme.validate
+upgrade
 version.create
 version.diff
-i18n.init
-i18n.extract
-i18n.compile
-i18n.sync
-i18n.status
-plugin.list
-plugin.info
-plugin.validate
-capability.list
-capability.info
-capability.validate
-inspect.page
-inspect.links
-inspect.graph
-inspect.perf
-debug.incremental
-debug.delta
-debug.deps
-debug.migrate
-debug.sandbox
-cache.inputs
-cache.hash
+version.info
+version.list
 ```
 
 Root aliases are part of the contract: `b` for `build`, `s` and `dev` for
@@ -194,7 +195,8 @@ annotated command signatures.
 
 ```bash
 $ bengal --help
-bengal 0.5.1
+bengal VERSION
+
 Static site generator for Python teams — every layer pure Python, scales with your cores
 
 Core workflow

--- a/site/content/docs/reference/architecture/tooling/cli.md
+++ b/site/content/docs/reference/architecture/tooling/cli.md
@@ -195,7 +195,7 @@ annotated command signatures.
 
 ```bash
 $ bengal --help
-bengal VERSION
+# bengal VERSION
 
 Static site generator for Python teams — every layer pure Python, scales with your cores
 

--- a/site/content/docs/reference/directives/_index.md
+++ b/site/content/docs/reference/directives/_index.md
@@ -14,6 +14,8 @@ Bengal extends Markdown with powerful directives using `:::{name}` or ` ```{name
 
 :::{tip}
 **See everything live:** [[docs/reference/directives/kitchen-sink|Directive Kitchen Sink]] — a gallery of all directive types with working examples.
+
+**Option defaults:** [[docs/reference/directives/_registry-options|Registry Options Reference]] — auto-generated tables from `create_default_registry()`.
 :::
 
 ## Key Terms

--- a/site/content/docs/reference/directives/_registry-options.md
+++ b/site/content/docs/reference/directives/_registry-options.md
@@ -1,0 +1,738 @@
+---
+title: Directive Options (Registry)
+nav_title: Registry Options
+description: Auto-generated directive option tables from create_default_registry()
+weight: 90
+tags:
+- reference
+- directives
+---
+
+# Directive Options (Registry)
+
+Auto-generated from `create_default_registry()`. Regenerate with:
+
+```bash
+python scripts/update_directive_options_snapshot.py
+```
+
+For usage examples, see the category pages under [[docs/reference/directives|Directives Reference]].
+
+## `admonition` {#admonition}
+
+**Directives:** `{caution}`, `{danger}`, `{error}`, `{example}`, `{important}`, `{info}`, `{note}`, `{seealso}`, `{success}`, `{tip}`, `{warning}`
+
+**Options class:** `AdmonitionOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:collapsible:` | false | — |
+| `:open:` | true | — |
+
+## `asciinema_embed` {#asciinema_embed}
+
+**Directives:** `{asciinema}`
+
+**Options class:** `AsciinemaOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:cols:` | 80 | — |
+| `:rows:` | 24 | — |
+| `:speed:` | 1.0 | — |
+| `:autoplay:` | false | — |
+| `:loop:` | false | — |
+| `:theme:` | asciinema | — |
+| `:poster:` | npt:0:0 | — |
+| `:idle_time_limit:` | none | — |
+| `:start_at:` | "" | — |
+| `:css_class:` | "" | — |
+| `:recording_id:` | "" | — |
+| `:is_local_file:` | false | — |
+| `:error:` | "" | — |
+
+## `audio_embed` {#audio_embed}
+
+**Directives:** `{audio}`
+
+**Options class:** `AudioOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:controls:` | true | — |
+| `:autoplay:` | false | — |
+| `:loop:` | false | — |
+| `:muted:` | false | — |
+| `:preload:` | metadata | — |
+| `:css_class:` | "" | — |
+
+## `badge` {#badge}
+
+**Directives:** `{badge}`, `{bdg}`
+
+**Options class:** `BadgeOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:css_class:` | badge badge-secondary | — |
+| `:label:` | "" | — |
+
+## `breadcrumbs` {#breadcrumbs}
+
+**Directives:** `{breadcrumbs}`
+
+**Options class:** `BreadcrumbsOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:separator:` | › | — |
+| `:show_home:` | true | — |
+| `:home_text:` | Home | — |
+| `:home_url:` | / | — |
+
+## `build` {#build}
+
+**Directives:** `{build}`
+
+**Options class:** `BuildOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:json:` | false | — |
+| `:inline:` | false | — |
+| `:align:` | "" | — |
+| `:css_class:` | "" | — |
+| `:alt:` | Built in badge | — |
+| `:dir_name:` | bengal | — |
+
+## `button` {#button}
+
+**Directives:** `{button}`
+
+**Options class:** `ButtonOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:color:` | primary | — |
+| `:style:` | default | — |
+| `:size:` | medium | — |
+| `:icon:` | "" | — |
+| `:target:` | "" | — |
+| `:url:` | # | — |
+| `:label:` | Button | — |
+
+## `card` {#card}
+
+**Directives:** `{card}`
+
+**Options class:** `CardOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:icon:` | "" | — |
+| `:link:` | "" | — |
+| `:description:` | "" | — |
+| `:badge:` | "" | — |
+| `:color:` | "" | — |
+| `:image:` | "" | — |
+| `:footer:` | "" | — |
+| `:pull:` | "" | — |
+| `:layout:` | "" | — |
+
+## `cards_grid` {#cards_grid}
+
+**Directives:** `{cards}`
+
+**Options class:** `CardsOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:columns:` | auto | — |
+| `:gap:` | medium | — |
+| `:style:` | default | — |
+| `:variant:` | navigation | — |
+| `:layout:` | default | — |
+
+## `changed` {#changed}
+
+**Directives:** `{changed}`, `{versionchanged}`
+
+**Options class:** `ChangedOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:css_class:` | version-changed | — |
+| `:version:` | "" | — |
+| `:has_content:` | false | — |
+
+## `checklist` {#checklist}
+
+**Directives:** `{checklist}`
+
+**Options class:** `ChecklistOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:style:` | default | — |
+| `:show-progress:` | false | — |
+| `:compact:` | false | — |
+| `:class:` | "" | — |
+
+## `child_cards` {#child_cards}
+
+**Directives:** `{child-cards}`
+
+**Options class:** `ChildCardsOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:columns:` | auto | — |
+| `:gap:` | medium | — |
+| `:include:` | all | — |
+| `:fields:` | title, description | — |
+| `:layout:` | default | — |
+| `:style:` | default | — |
+
+## `code_tabs` {#code_tabs}
+
+**Directives:** `{code-tabs}`, `{code_tabs}`
+
+**Options class:** `CodeTabsOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:sync:` | language | — |
+| `:linenos:` | none | — |
+| `:tabs:` | none | — |
+
+## `codepen_embed` {#codepen_embed}
+
+**Directives:** `{codepen}`
+
+**Options class:** `CodePenOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:default-tab:` | result | — |
+| `:height:` | 300 | — |
+| `:theme:` | dark | — |
+| `:editable:` | false | — |
+| `:preview:` | true | — |
+| `:class:` | "" | — |
+| `:username:` | "" | — |
+| `:pen_id:` | "" | — |
+| `:error:` | "" | — |
+
+## `codesandbox_embed` {#codesandbox_embed}
+
+**Directives:** `{codesandbox}`
+
+**Options class:** `CodeSandboxOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:module:` | "" | — |
+| `:view:` | split | — |
+| `:height:` | 500 | — |
+| `:fontsize:` | 14 | — |
+| `:hidenavigation:` | false | — |
+| `:theme:` | dark | — |
+| `:css_class:` | "" | — |
+| `:sandbox_id:` | "" | — |
+| `:error:` | "" | — |
+
+## `container` {#container}
+
+**Directives:** `{container}`, `{div}`
+
+**Options class:** `ContainerOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+
+## `data_table` {#data_table}
+
+**Directives:** `{data-table}`
+
+**Options class:** `DataTableOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:search:` | true | — |
+| `:filter:` | true | — |
+| `:sort:` | true | — |
+| `:pagination:` | 50 | — |
+| `:height:` | auto | — |
+| `:columns:` | "" | — |
+| `:file_path:` | "" | — |
+| `:table_id:` | "" | — |
+| `:visible_columns:` | none | — |
+| `:error:` | "" | — |
+| `:table_columns:` | — | — |
+| `:table_data:` | — | — |
+
+## `deprecated` {#deprecated}
+
+**Directives:** `{deprecated}`, `{versionremoved}`
+
+**Options class:** `DeprecatedOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:css_class:` | version-deprecated | — |
+| `:version:` | "" | — |
+| `:has_content:` | false | — |
+
+## `dropdown` {#dropdown}
+
+**Directives:** `{details}`, `{dropdown}`
+
+**Options class:** `DropdownOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:open:` | false | — |
+| `:icon:` | none | — |
+| `:badge:` | none | — |
+| `:color:` | none | — |
+| `:description:` | none | — |
+
+## `example_label` {#example_label}
+
+**Directives:** `{example-label}`
+
+**Options class:** `ExampleLabelOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:css_class:` | "" | — |
+| `:prefix:` | Example | — |
+| `:no_prefix:` | false | — |
+
+## `excerpt_break` {#excerpt_break}
+
+**Directives:** `{excerpt-break}`
+
+**Options class:** `DirectiveOptions`
+
+_No typed options._
+
+## `figure` {#figure}
+
+**Directives:** `{figure}`
+
+**Options class:** `FigureOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:alt:` | "" | — |
+| `:caption:` | "" | — |
+| `:width:` | "" | — |
+| `:height:` | "" | — |
+| `:align:` | "" | — |
+| `:link:` | "" | — |
+| `:target:` | _self | — |
+| `:loading:` | lazy | — |
+| `:class:` | "" | — |
+
+## `gallery` {#gallery}
+
+**Directives:** `{gallery}`
+
+**Options class:** `GalleryOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:columns:` | 3 | — |
+| `:lightbox:` | true | — |
+| `:gap:` | 1rem | — |
+| `:aspect_ratio:` | 4/3 | — |
+| `:css_class:` | "" | — |
+
+## `gist_embed` {#gist_embed}
+
+**Directives:** `{gist}`
+
+**Options class:** `GistOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:file:` | "" | — |
+| `:css_class:` | "" | — |
+| `:gist_ref:` | "" | — |
+| `:error:` | "" | — |
+
+## `glossary` {#glossary}
+
+**Directives:** `{glossary}`
+
+**Options class:** `GlossaryOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:tags:` | "" | — |
+| `:sorted:` | false | — |
+| `:show_tags:` | false | — |
+| `:collapsed:` | false | — |
+| `:limit:` | 0 | — |
+| `:source:` | data/glossary.yaml | — |
+
+## `icon` {#icon}
+
+**Directives:** `{icon}`, `{svg-icon}`
+
+**Options class:** `IconOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:size:` | 24 | — |
+| `:class:` | "" | — |
+| `:aria-label:` | "" | — |
+| `:icon_name:` | "" | — |
+| `:error:` | "" | — |
+
+## `include` {#include}
+
+**Directives:** `{include}`
+
+**Options class:** `IncludeOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:file:` | "" | — |
+| `:start_line:` | none | — |
+| `:end_line:` | none | — |
+| `:file_path:` | "" | — |
+| `:error:` | "" | — |
+
+## `list_table` {#list_table}
+
+**Directives:** `{list-table}`
+
+**Options class:** `ListTableOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:header-rows:` | 0 | — |
+| `:widths:` | "" | — |
+| `:class:` | "" | — |
+
+## `literalinclude` {#literalinclude}
+
+**Directives:** `{literalinclude}`
+
+**Options class:** `LiteralIncludeOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:file:` | "" | — |
+| `:language:` | "" | — |
+| `:start_line:` | none | — |
+| `:end_line:` | none | — |
+| `:emphasize_lines:` | "" | — |
+| `:linenos:` | false | — |
+| `:caption:` | "" | — |
+| `:file_path:` | "" | — |
+| `:code:` | "" | — |
+| `:error:` | "" | — |
+
+## `marimo_cell` {#marimo_cell}
+
+**Directives:** `{marimo}`
+
+**Options class:** `MarimoOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:show-code:` | true | — |
+| `:cache:` | true | — |
+| `:label:` | "" | — |
+| `:code:` | "" | — |
+| `:cell_id:` | 0 | — |
+| `:error:` | "" | — |
+
+## `prev_next` {#prev_next}
+
+**Directives:** `{prev-next}`
+
+**Options class:** `PrevNextOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:show_title:` | true | — |
+| `:show_section:` | false | — |
+
+## `related` {#related}
+
+**Directives:** `{related}`
+
+**Options class:** `RelatedOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:limit:` | 5 | — |
+| `:section_title:` | Related Articles | — |
+| `:show_tags:` | false | — |
+
+## `rubric` {#rubric}
+
+**Directives:** `{rubric}`
+
+**Options class:** `RubricOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:css_class:` | "" | — |
+
+## `self_hosted_video` {#self_hosted_video}
+
+**Directives:** `{video}`
+
+**Options class:** `SelfHostedVideoOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:poster:` | "" | — |
+| `:controls:` | true | — |
+| `:autoplay:` | false | — |
+| `:muted:` | false | — |
+| `:loop:` | false | — |
+| `:preload:` | metadata | — |
+| `:width:` | 100% | — |
+| `:aspect:` | 16/9 | — |
+| `:css_class:` | "" | — |
+| `:video_path:` | "" | — |
+| `:mime_type:` | "" | — |
+| `:error:` | "" | — |
+
+## `siblings` {#siblings}
+
+**Directives:** `{siblings}`
+
+**Options class:** `SiblingsOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:limit:` | 0 | — |
+| `:exclude_current:` | true | — |
+| `:show_description:` | false | — |
+
+## `since` {#since}
+
+**Directives:** `{since}`, `{versionadded}`
+
+**Options class:** `SinceOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:css_class:` | version-since | — |
+| `:version:` | "" | — |
+| `:has_content:` | false | — |
+
+## `soundcloud_embed` {#soundcloud_embed}
+
+**Directives:** `{soundcloud}`
+
+**Options class:** `SoundCloudOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:type:` | track | — |
+| `:height:` | 0 | — |
+| `:color:` | ff5500 | — |
+| `:autoplay:` | false | — |
+| `:hide_related:` | false | — |
+| `:show_comments:` | true | — |
+| `:show_user:` | true | — |
+| `:show_reposts:` | false | — |
+| `:visual:` | false | — |
+| `:css_class:` | "" | — |
+| `:url_path:` | "" | — |
+| `:error:` | "" | — |
+
+## `spotify_embed` {#spotify_embed}
+
+**Directives:** `{spotify}`
+
+**Options class:** `SpotifyOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:type:` | track | — |
+| `:height:` | 0 | — |
+| `:theme:` | 0 | — |
+| `:css_class:` | "" | — |
+| `:spotify_id:` | "" | — |
+| `:error:` | "" | — |
+
+## `stackblitz_embed` {#stackblitz_embed}
+
+**Directives:** `{stackblitz}`
+
+**Options class:** `StackBlitzOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:file:` | "" | — |
+| `:view:` | both | — |
+| `:height:` | 500 | — |
+| `:hidenavigation:` | false | — |
+| `:hidedevtools:` | false | — |
+| `:css_class:` | "" | — |
+| `:project_id:` | "" | — |
+| `:error:` | "" | — |
+
+## `step` {#step}
+
+**Directives:** `{step}`
+
+**Options class:** `StepOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:description:` | none | — |
+| `:optional:` | false | — |
+| `:duration:` | none | — |
+| `:step_number:` | none | — |
+| `:heading_level:` | none | — |
+
+## `steps` {#steps}
+
+**Directives:** `{steps}`
+
+**Options class:** `StepsOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:style:` | none | — |
+| `:start:` | 1 | — |
+
+## `tab_item` {#tab_item}
+
+**Directives:** `{tab}`, `{tab-item}`
+
+**Options class:** `TabItemOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:selected:` | false | — |
+| `:icon:` | none | — |
+| `:badge:` | none | — |
+| `:disabled:` | false | — |
+| `:sync:` | none | — |
+
+## `tab_set` {#tab_set}
+
+**Directives:** `{tab-set}`, `{tabs}`
+
+**Options class:** `TabSetOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:class:` | none | — |
+| `:name:` | none | — |
+| `:id:` | none | — |
+| `:sync:` | none | — |
+| `:mode:` | none | — |
+
+## `target` {#target}
+
+**Directives:** `{anchor}`, `{target}`
+
+**Options class:** `TargetOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:id:` | none | — |
+| `:error:` | none | — |
+
+## `tiktok_video` {#tiktok_video}
+
+**Directives:** `{tiktok}`
+
+**Options class:** `TikTokOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:width:` | "" | — |
+| `:aspect:` | 9/16 | — |
+| `:css_class:` | "" | — |
+| `:autoplay:` | false | — |
+| `:loop:` | false | — |
+| `:muted:` | false | — |
+| `:video_id:` | "" | — |
+| `:embed_url:` | "" | — |
+| `:error:` | "" | — |
+
+## `vimeo_video` {#vimeo_video}
+
+**Directives:** `{vimeo}`
+
+**Options class:** `VimeoOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:width:` | "" | — |
+| `:aspect:` | 16/9 | — |
+| `:css_class:` | "" | — |
+| `:autoplay:` | false | — |
+| `:loop:` | false | — |
+| `:muted:` | false | — |
+| `:color:` | "" | — |
+| `:autopause:` | true | — |
+| `:dnt:` | true | — |
+| `:background:` | false | — |
+| `:video_id:` | "" | — |
+| `:embed_url:` | "" | — |
+| `:error:` | "" | — |
+
+## `youtube_video` {#youtube_video}
+
+**Directives:** `{youtube}`
+
+**Options class:** `YouTubeOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `:title:` | "" | — |
+| `:width:` | "" | — |
+| `:aspect:` | 16/9 | — |
+| `:class:` | "" | — |
+| `:autoplay:` | false | — |
+| `:loop:` | false | — |
+| `:muted:` | false | — |
+| `:start:` | 0 | — |
+| `:end:` | none | — |
+| `:privacy:` | true | — |
+| `:controls:` | true | — |
+| `:video_id:` | "" | — |
+| `:embed_url:` | "" | — |
+| `:error:` | "" | — |

--- a/site/content/docs/reference/kida-syntax.md
+++ b/site/content/docs/reference/kida-syntax.md
@@ -150,40 +150,12 @@ Kida's native pattern matching replaces long `if/elif` chains:
 {% end %}
 ```
 
-**With expressions**:
-
-```kida
-{% match page.status %}
-  {% case "published" %}
-    <span class="status-published">Published</span>
-  {% case "draft" %}
-    <span class="status-draft">Draft</span>
-  {% case _ %}
-    <span class="status-unknown">Unknown</span>
-{% end %}
-```
-
 ## Variables and Scoping
 
-**Scoping**: `{% let %}` is template-scoped, `{% set %}` is block-scoped, and `{% export %}` promotes variables to template scope. See the [Variables documentation](../theming/templating/kida/syntax/variables.md) for details.
-
-### Template-Scoped Variables (`{% let %}`)
-
-Variables available throughout the entire template:
+**Scoping**: `{% let %}` is template-scoped, `{% set %}` is block-scoped, and `{% export %}` promotes variables to template scope.
 
 ```kida
 {% let site_title = site.config.title %}
-{% let nav_items = site.menus.main %}
-
-{# Available anywhere in template #}
-<h1>{{ site_title }}</h1>
-```
-
-### Block-Scoped Variables (`{% set %}`)
-
-Variables scoped to the current block:
-
-```kida
 {% if page.published %}
   {% set status = "Published" %}
   <span>{{ status }}</span>
@@ -191,62 +163,8 @@ Variables scoped to the current block:
 {# status not available here #}
 ```
 
-### Multi-let (Comma-Separated)
-
-Assign multiple variables in a single `{% let %}` block:
-
-```kida
-{# Single-line multi-let #}
-{% let a = 1, b = 2, c = 3 %}
-
-{# Multi-line multi-let (recommended for readability) #}
-{% let
-    _site_title = config?.title ?? 'Untitled Site',
-    _page_title = page?.title ?? config?.title ?? 'Page',
-    _description = page?.description ?? '' %}
-```
-
-**Recommended pattern** for template setup:
-
-```kida
-{% extends "base.html" %}
-
-{# Group related configuration at template start #}
-{% let
-    _show_sidebar = page?.sidebar ?? true,
-    _show_toc = page?.toc ?? true,
-    _prev = get_prev_page(page),
-    _next = get_next_page(page) %}
-
-{% block content %}
-  {# Variables available throughout #}
-  {% if _show_sidebar %}...{% end %}
-{% end %}
-```
-
-### Tuple Unpacking
-
-Destructure tuples into separate variables:
-
-```kida
-{% let (title, subtitle) = (page.title, page.subtitle) %}
-{% let (first, second) = get_pair() %}
-```
-
-### Exporting from Inner Scope (`{% export %}`)
-
-Make a variable from an inner scope available to the outer scope:
-
-```kida
-{% for post in posts %}
-  {% if post.featured %}
-    {% export featured_post = post %}
-  {% end %}
-{% end %}
-
-{# featured_post available here #}
-{{ featured_post.title }}
-```
+Multi-let, tuple unpacking, and export patterns are documented in
+[[docs/theming/templating/kida/syntax/variables|Variables and Scoping]].
 
 ## Template Structure
 
@@ -326,86 +244,20 @@ Kida functions can access variables from their surrounding context automatically
 {{ button("Default", "/page") }}
 ```
 
-### Calling Functions with Blocks
-
-```kida
-{% def card(item) %}
-  <div class="card">
-    <h3>{{ item.title }}</h3>
-    {% slot %}
-      {# Content passed via call block #}
-    {% endslot %}
-  </div>
-{% end %}
-
-{% call card(page) %}
-  <p>Custom content here</p>
-{% end %}
-```
-
 ## Filters and Pipeline
 
-### Functions vs Filters
-
-Kida templates support both **filters** (transform values) and **functions** (standalone operations).
-
-**Filters** transform a value using `|` or `|>`:
-```kida
-{{ page.title | upper }}                    {# Transform text #}
-{{ site.pages |> where('draft', false) }}  {# Transform collection #}
-```
-
-**Functions** are called directly without a value:
-```kida
-{{ get_page('docs/about') }}               {# Retrieve page #}
-{{ get_data('data/authors.json') }}        {# Load data #}
-{{ ref('docs/getting-started') }}          {# Generate link #}
-```
-
-**When to use which:**
-- **Filter**: You have a value to transform (`{{ value | filter }}`)
-- **Function**: You're performing an operation (`{{ function() }}`)
-
-See [Template Functions Reference](/docs/reference/template-functions/#functions-vs-filters-understanding-the-difference) for details.
-
-### Filter Syntax
+Kida supports **filters** (transform a value with `|` or `|>`) and **functions**
+(called directly). Use `|>` for left-to-right chains of three or more filters:
 
 ```kida
-{{ text | upper }}
-{{ text | truncate(100) }}
-{{ text | default("N/A") }}
-```
-
-### Pipeline Operator (`|>`)
-
-Kida's pipeline operator provides left-to-right readability for complex filter chains:
-
-```kida
-{# Kida: Read left-to-right #}
+{{ page.title | upper }}
 {{ items |> where('published', true) |> sort_by('date') |> take(5) }}
-
-{# Jinja2: Read inside-out #}
-{{ items | selectattr('published') | sort(attribute='date') | first(5) }}
+{{ get_page('docs/about') }}
 ```
 
-**Chaining filters**:
-
-```kida
-{{ page.content
-   |> markdownify
-   |> truncate(200)
-   |> strip_tags }}
-```
-
-:::{tip}
-Use `|>` for chains of 3+ filters. For simple single-filter cases, `|` is fine:
-
-```kida
-{{ text | upper }}           {# Simple: use | #}
-{{ data |> filter |> sort |> take(5) }}  {# Complex: use |> #}
-```
-
-:::
+See [[docs/reference/template-functions|Template Functions]] for the full
+functions-vs-filters guide and [[docs/reference/kida-syntax-reference|Kida Syntax Reference (detailed)]]
+for exhaustive filter and operator lookup.
 
 :::{dropdown} Exhaustive filter, operator, and caching reference
 :icon: book-open

--- a/site/content/docs/tutorials/user-scenarios.md
+++ b/site/content/docs/tutorials/user-scenarios.md
@@ -159,23 +159,8 @@ content/
 
 ### 3. Configure Search
 
-Search is enabled by default for docs template. Output includes `index.json` for search.
-
-To customize search settings, edit `config/_default/features.yaml`:
-
-```yaml
-features:
-  search: true  # Generates search index (index.json)
-
-# Optional: customize search behavior in config/_default/site.yaml
-search:
-  enabled: true
-  lunr:
-    max_results: 50
-    min_query_length: 2
-```
-
-See [Configuration](/docs/building/configuration/) for search and other config options.
+Search is enabled by default for the docs template (`index.json` output). See
+[[docs/building/configuration|Configuration]] to customize search behavior.
 
 ### 4. Add Navigation
 
@@ -195,8 +180,6 @@ menu:
         url: "/reference/"
         weight: 30
 ```
-
-**Note**: Menu items can also reference pages by path. If a page exists at `content/getting-started/_index.md`, you can use `url: "/getting-started/"` or reference it directly.
 
 ---
 
@@ -392,195 +375,11 @@ bengal build --environment enterprise
 Deploy each build to its own URL (e.g., `docs.example.com` and `enterprise.example.com`). Use CI matrix jobs or separate workflows per variant.
 
 :::{seealso}
-[Multi-Variant Builds](/docs/building/configuration/variants) — Full guide with cascade, CI/CD, and env overrides
+[[docs/building/configuration/variants|Multi-Variant Builds]] — cascade, CI/CD, and env overrides
 :::
-
----
-
-## Multi-Language Site {#international-site}
-
-Create content in multiple languages using directory-based structure.
-
-**What you'll get**: A multilingual site with language-specific content directories, SEO-friendly hreflang tags, and language switcher support.
-
-### Content Organization
-
-Bengal supports directory-based i18n for content organization:
-
-```tree
-content/
-├── en/
-│   ├── _index.md       # lang: en
-│   ├── about.md
-│   └── docs/
-│       └── guide.md
-└── fr/
-    ├── _index.md       # lang: fr
-    ├── about.md
-    └── docs/
-        └── guide.md
-```
-
-### Configuration
-
-In `bengal.toml` or `config/_default/i18n.yaml`:
-
-```yaml
-i18n:
-  default_language: en
-  content_structure: dir
-  languages:
-    - code: en
-      name: English
-      weight: 1
-    - code: fr
-      name: Français
-      weight: 2
-```
-
-### Template Functions
-
-Use these in templates for language switching:
-
-- `languages()` - Get list of configured languages
-- `alternate_links(page)` - Generate hreflang tags for SEO (takes optional page parameter)
-
-### Limitations
-
-- UI translation (strings) requires separate i18n YAML files
-- See [[docs/content/i18n|i18n documentation]] for full details
-
----
-
-## Landing Page {#landing-page}
-
-Build a marketing or product landing page.
-
-**What you'll get**: A single-page marketing site with hero section, feature highlights, and call-to-action elements.
-
-### 1. Scaffold Landing
-
-```bash
-bengal new site mylanding --template landing
-cd mylanding
-```
-
-### 2. Customize Hero Section
-
-Edit `content/index.md`:
-
-```markdown
----
-title: "Welcome to MyProduct"
-type: landing
-layout: landing
-hero:
-  title: "Build Faster"
-  subtitle: "The modern way to create static sites"
-  cta:
-    text: "Get Started"
-    url: "/docs/getting-started/"
----
-```
-
-### 3. Add Sections
-
-Use shortcodes and directives for landing page sections:
-
-```markdown
-:::{features}
-- title: Fast
-  icon: rocket
-  description: Builds in seconds
-
-- title: Flexible
-  icon: puzzle
-  description: Customize everything
-:::
-```
-
----
-
-## Resume/CV Site {#resume-site}
-
-Build a professional resume or CV site.
-
-**What you'll get**: A professional resume site with structured data for experience, education, and contact information.
-
-### 1. Scaffold Resume
-
-```bash
-bengal new site myresume --template resume
-cd myresume
-```
-
-### 2. Edit Resume Data
-
-Update `data/resume.yaml` with your information:
-
-```yaml
-name: "Jane Developer"
-title: "Senior Software Engineer"
-contact:
-  email: "jane@example.com"
-  github: "janedeveloper"
-  linkedin: "in/janedeveloper"
-
-experience:
-  - title: "Senior Engineer"
-    company: "Tech Corp"
-    dates: "2022 - Present"
-    description: "Led development of..."
-
-education:
-  - degree: "B.S. Computer Science"
-    school: "University"
-    year: 2018
-```
-
----
-
-## Changelog Site {#changelog-site}
-
-Maintain a project changelog with releases.
-
-**What you'll get**: A changelog site with versioned releases, categorized changes (added, fixed, changed), and chronological organization.
-
-### 1. Scaffold Changelog
-
-```bash
-bengal new site mychangelog --template changelog
-cd mychangelog
-```
-
-### 2. Add Releases
-
-Update `data/changelog.yaml`:
-
-```yaml
-releases:
-  - version: "1.2.0"
-    date: 2025-06-15
-    changes:
-      - type: added
-        description: "New feature X"
-      - type: fixed
-        description: "Bug in Y"
-      - type: changed
-        description: "Updated Z"
-
-  - version: "1.1.0"
-    date: 2025-05-01
-    changes:
-      - type: added
-        description: "Initial feature set"
-```
-
----
 
 ## Next Steps
 
 - See [[docs/reference/site-templates|Templates Reference]] for template details
 - Read [[docs/building/configuration|Configuration Guide]] for advanced settings
 - Explore [[docs/theming|Theming]] for customization
-- Check out [[docs/tutorials|Tutorials]] for step-by-step guides

--- a/tests/_testing/cli_help_snapshot.py
+++ b/tests/_testing/cli_help_snapshot.py
@@ -25,12 +25,21 @@ def normalize_root_help(text: str) -> str:
     """Normalize help text for stable comparison (version-agnostic)."""
     lines: list[str] = []
     for line in text.splitlines():
-        if _VERSION_LINE_RE.match(line):
+        stripped = line.strip()
+        if stripped in {"bengal VERSION", "# bengal VERSION"} or _VERSION_LINE_RE.match(line):
             lines.append("bengal VERSION")
         else:
             lines.append(line.rstrip())
     normalized = "\n".join(lines).strip()
     return f"{normalized}\n" if normalized else ""
+
+
+def format_doc_embedded_help(help_text: str) -> str:
+    """Format normalized help for cli.md without triggering CLI contract lint."""
+    lines = help_text.rstrip("\n").splitlines()
+    if lines and lines[0] == "bengal VERSION":
+        lines[0] = "# bengal VERSION"
+    return "\n".join(lines) + "\n"
 
 
 def capture_root_help_command_sections(cli_app: BengalCLI | None = None) -> str:
@@ -87,7 +96,7 @@ def update_cli_doc_root_help(doc_path: Path | None = None) -> bool:
     """Replace the embedded root help block in cli.md. Returns True if changed."""
     path = doc_path or _CLI_DOC
     text = path.read_text(encoding="utf-8")
-    help_text = capture_root_help_command_sections().rstrip("\n")
+    help_text = format_doc_embedded_help(capture_root_help_command_sections())
     updated, count = re.subn(
         r"(\$ bengal --help\n)(.*?)(```)",
         lambda match: f"{match.group(1)}{help_text}\n{match.group(3)}",

--- a/tests/_testing/cli_help_snapshot.py
+++ b/tests/_testing/cli_help_snapshot.py
@@ -1,0 +1,123 @@
+"""Capture and normalize Bengal CLI help for docs drift guards (issue #628)."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+from bengal.cli.milo_app import BengalCLI, cli
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_SNAPSHOT = (
+    _REPO_ROOT / "tests" / "unit" / "docs" / "fixtures" / "cli_root_help_commands.txt"
+)
+_CLI_DOC = (
+    _REPO_ROOT / "site" / "content" / "docs" / "reference" / "architecture" / "tooling" / "cli.md"
+)
+
+_VERSION_LINE_RE = re.compile(r"^(?:ᓚᘏᗢ )?bengal \d+\.\d+\.\d+\S*")
+
+
+def normalize_root_help(text: str) -> str:
+    """Normalize help text for stable comparison (version-agnostic)."""
+    lines: list[str] = []
+    for line in text.splitlines():
+        if _VERSION_LINE_RE.match(line):
+            lines.append("bengal VERSION")
+        else:
+            lines.append(line.rstrip())
+    normalized = "\n".join(lines).strip()
+    return f"{normalized}\n" if normalized else ""
+
+
+def capture_root_help_command_sections(cli_app: BengalCLI | None = None) -> str:
+    """Return curated root help command sections (excludes flags and examples)."""
+    app = cli_app or cli
+    buffer = io.StringIO()
+    with patch.object(app, "_write_stdout", side_effect=lambda text: buffer.write(text)):
+        app._format_root_help()
+    text = buffer.getvalue()
+    if "\nUseful flags" in text:
+        text = text.split("\nUseful flags", maxsplit=1)[0]
+    return normalize_root_help(text)
+
+
+def registered_command_inventory() -> list[str]:
+    """Leaf command paths from the Milo registry."""
+    app = cli
+    return sorted(path for path, _command in app.walk_commands())
+
+
+def parse_cli_doc_inventory(doc_text: str) -> list[str]:
+    """Parse the cli-command-inventory fenced block from cli.md."""
+    match = re.search(r"```text cli-command-inventory\n(.*?)```", doc_text, re.DOTALL)
+    if match is None:
+        raise ValueError("cli.md is missing a ```text cli-command-inventory block")
+    return [line.strip() for line in match.group(1).splitlines() if line.strip()]
+
+
+def parse_cli_doc_root_help(doc_text: str) -> str:
+    """Parse the embedded `$ bengal --help` snapshot from cli.md."""
+    match = re.search(r"\$ bengal --help\n(.*?)```", doc_text, re.DOTALL)
+    if match is None:
+        raise ValueError("cli.md is missing a `$ bengal --help` fenced block")
+    return normalize_root_help(match.group(1))
+
+
+def snapshot_path(path: Path | None = None) -> Path:
+    return path or _DEFAULT_SNAPSHOT
+
+
+def write_snapshot(path: Path | None = None) -> Path:
+    """Write the current command-section help snapshot to disk."""
+    target = snapshot_path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(capture_root_help_command_sections(), encoding="utf-8")
+    return target
+
+
+def snapshot_hash(path: Path | None = None) -> str:
+    return hashlib.sha256(snapshot_path(path).read_bytes()).hexdigest()
+
+
+def update_cli_doc_root_help(doc_path: Path | None = None) -> bool:
+    """Replace the embedded root help block in cli.md. Returns True if changed."""
+    path = doc_path or _CLI_DOC
+    text = path.read_text(encoding="utf-8")
+    help_text = capture_root_help_command_sections().rstrip("\n")
+    updated, count = re.subn(
+        r"(\$ bengal --help\n)(.*?)(```)",
+        lambda match: f"{match.group(1)}{help_text}\n{match.group(3)}",
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+    if count != 1:
+        raise ValueError(f"Could not update root help block in {path}")
+    if updated == text:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def update_cli_doc_inventory(doc_path: Path | None = None) -> bool:
+    """Replace the cli-command-inventory block in cli.md. Returns True if changed."""
+    path = doc_path or _CLI_DOC
+    text = path.read_text(encoding="utf-8")
+    inventory = "\n".join(registered_command_inventory())
+    updated, count = re.subn(
+        r"(```text cli-command-inventory\n)(.*?)(```)",
+        lambda match: f"{match.group(1)}{inventory}\n{match.group(3)}",
+        text,
+        count=1,
+        flags=re.DOTALL,
+    )
+    if count != 1:
+        raise ValueError(f"Could not update cli-command-inventory block in {path}")
+    if updated == text:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True

--- a/tests/_testing/directive_options_snapshot.py
+++ b/tests/_testing/directive_options_snapshot.py
@@ -1,0 +1,153 @@
+"""Capture directive option tables from the Patitas registry (issue #626)."""
+
+from __future__ import annotations
+
+from dataclasses import MISSING, fields
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from bengal.parsing.backends.patitas.directives.registry import create_default_registry
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_SNAPSHOT = (
+    _REPO_ROOT / "tests" / "unit" / "docs" / "fixtures" / "directive_options_snapshot.yaml"
+)
+_DEFAULT_DOC = (
+    _REPO_ROOT / "site" / "content" / "docs" / "reference" / "directives" / "_registry-options.md"
+)
+
+
+def _option_display_name(field_name: str, aliases: dict[str, str]) -> str:
+    reverse = {value: key for key, value in aliases.items()}
+    public_name = reverse.get(
+        field_name, field_name.rstrip("_") if field_name.endswith("_") else field_name
+    )
+    return f":{public_name}:"
+
+
+def _format_default(value: Any) -> str:
+    if value is MISSING:
+        return "—"
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value == "":
+        return '""'
+    return str(value)
+
+
+def options_table_for_class(options_class: type) -> str:
+    """Render a markdown option table from a directive options dataclass."""
+    aliases = getattr(options_class, "_aliases", {})
+    rows: list[tuple[str, str, str]] = []
+    for field in fields(options_class):
+        if field.name.startswith("_"):
+            continue
+        rows.append(
+            (
+                _option_display_name(field.name, aliases),
+                _format_default(field.default),
+                "—",
+            )
+        )
+    if not rows:
+        return "_No typed options._"
+
+    lines = [
+        "| Option | Default | Description |",
+        "|--------|---------|-------------|",
+    ]
+    lines.extend(
+        f"| `{option}` | {default} | {description} |" for option, default, description in rows
+    )
+    return "\n".join(lines)
+
+
+def registry_option_tables() -> dict[str, dict[str, str]]:
+    """Build snapshot payload keyed by token_type."""
+    registry = create_default_registry()
+    payload: dict[str, dict[str, str]] = {}
+    for handler in registry.handlers:
+        options_class = getattr(handler, "options_class", None)
+        if options_class is None:
+            continue
+        names = ", ".join(f"`{{{name}}}`" for name in sorted(handler.names))
+        payload[handler.token_type] = {
+            "names": names,
+            "options_class": options_class.__name__,
+            "table": options_table_for_class(options_class),
+        }
+    return dict(sorted(payload.items()))
+
+
+def snapshot_path(path: Path | None = None) -> Path:
+    return path or _DEFAULT_SNAPSHOT
+
+
+def write_snapshot(path: Path | None = None) -> Path:
+    target = snapshot_path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = registry_option_tables()
+    target.write_text(
+        yaml.safe_dump(payload, sort_keys=True, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return target
+
+
+def load_snapshot(path: Path | None = None) -> dict[str, dict[str, str]]:
+    return yaml.safe_load(snapshot_path(path).read_text(encoding="utf-8"))
+
+
+def render_registry_options_doc(payload: dict[str, dict[str, str]] | None = None) -> str:
+    """Render the generated directives options reference page."""
+    data = payload or registry_option_tables()
+    sections: list[str] = [
+        "---",
+        "title: Directive Options (Registry)",
+        "nav_title: Registry Options",
+        "description: Auto-generated directive option tables from create_default_registry()",
+        "weight: 90",
+        "tags:",
+        "- reference",
+        "- directives",
+        "---",
+        "",
+        "# Directive Options (Registry)",
+        "",
+        "Auto-generated from `create_default_registry()`. Regenerate with:",
+        "",
+        "```bash",
+        "python scripts/update_directive_options_snapshot.py",
+        "```",
+        "",
+        "For usage examples, see the category pages under [[docs/reference/directives|Directives Reference]].",
+        "",
+    ]
+    for token_type, entry in data.items():
+        sections.extend(
+            [
+                f"## `{token_type}` {{#{token_type}}}",
+                "",
+                f"**Directives:** {entry['names']}",
+                "",
+                f"**Options class:** `{entry['options_class']}`",
+                "",
+                entry["table"],
+                "",
+            ]
+        )
+    return "\n".join(sections).rstrip() + "\n"
+
+
+def write_registry_options_doc(
+    doc_path: Path | None = None,
+    payload: dict[str, dict[str, str]] | None = None,
+) -> Path:
+    target = doc_path or _DEFAULT_DOC
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(render_registry_options_doc(payload), encoding="utf-8")
+    return target

--- a/tests/integration/test_autodoc_cli_extraction.py
+++ b/tests/integration/test_autodoc_cli_extraction.py
@@ -1,0 +1,66 @@
+"""Integration tests that Bengal CLI autodoc generates virtual pages (issue #621)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bengal.core.site import Site
+
+
+@pytest.fixture
+def site_with_bengal_cli_autodoc(tmp_path: Path) -> Site:
+    """Minimal site with real Bengal CLI autodoc enabled."""
+    from bengal.core.site import Site
+
+    content_dir = tmp_path / "content"
+    content_dir.mkdir()
+    (content_dir / "_index.md").write_text("---\ntitle: Home\n---\n# Home\n")
+
+    config_dir = tmp_path / "config" / "_default"
+    config_dir.mkdir(parents=True)
+    (config_dir / "site.yaml").write_text("site:\n  title: CLI Autodoc Test\n  baseurl: ''\n")
+    (config_dir / "autodoc.yaml").write_text(
+        """
+autodoc:
+  cli:
+    enabled: true
+    app_module: bengal.cli:cli
+    framework: milo
+    output_prefix: cli
+  python:
+    enabled: false
+  openapi:
+    enabled: false
+"""
+    )
+
+    return Site.from_config(tmp_path)
+
+
+def test_bengal_cli_autodoc_generates_virtual_pages(site_with_bengal_cli_autodoc: Site) -> None:
+    """Real Milo CLI autodoc should emit build/theme leaf pages under /cli/."""
+    from bengal.autodoc.orchestration import VirtualAutodocOrchestrator
+    from bengal.orchestration.content import ContentOrchestrator
+
+    content = ContentOrchestrator(site_with_bengal_cli_autodoc)
+    content.discover_content()
+
+    orchestrator = VirtualAutodocOrchestrator(site_with_bengal_cli_autodoc)
+    pages, sections, _result = orchestrator.generate()
+
+    page_urls = {page.href for page in pages}
+    section_urls = {section.href for section in sections}
+
+    assert "/cli/" in section_urls
+    assert "/cli/build/" in page_urls
+    assert "/cli/theme/list/" in page_urls
+    assert "/cli/bengal/build/" not in page_urls
+
+    build_pages = [page for page in pages if page.href == "/cli/build/"]
+    assert build_pages
+    assert build_pages[0].title

--- a/tests/unit/autodoc/test_bengal_cli_extraction.py
+++ b/tests/unit/autodoc/test_bengal_cli_extraction.py
@@ -1,0 +1,32 @@
+"""Autodoc CLI extraction tests for the real Bengal Milo app (issue #621)."""
+
+from __future__ import annotations
+
+from bengal.autodoc.extractors.cli import CLIExtractor
+from bengal.cli import cli
+from tests._testing.cli_help_snapshot import registered_command_inventory
+
+
+def test_bengal_cli_extractor_matches_registered_inventory() -> None:
+    """Autodoc CLI extraction must cover every advertised leaf command."""
+    elements = CLIExtractor(framework="milo").extract(cli)
+    extracted = sorted(
+        element.qualified_name.removeprefix("bengal.")
+        for element in elements
+        if element.element_type == "command"
+    )
+    registered = registered_command_inventory()
+    assert extracted == registered, (
+        "Autodoc CLI extraction drifted from Milo registry.\n"
+        f"  autodoc-only: {sorted(set(extracted) - set(registered))}\n"
+        f"  registry-only: {sorted(set(registered) - set(extracted))}"
+    )
+
+
+def test_bengal_cli_extractor_includes_option_metadata() -> None:
+    """Leaf commands should expose Milo JSON Schema options for autodoc pages."""
+    elements = CLIExtractor(framework="milo").extract(cli)
+    build = next(element for element in elements if element.qualified_name == "bengal.build")
+    option_names = {child.name for child in build.children if child.element_type == "option"}
+    assert "strict" in option_names
+    assert "incremental" in option_names

--- a/tests/unit/docs/fixtures/cli_root_help_commands.txt
+++ b/tests/unit/docs/fixtures/cli_root_help_commands.txt
@@ -1,0 +1,33 @@
+bengal VERSION
+
+Static site generator for Python teams — every layer pure Python, scales with your cores
+
+Core workflow
+  build (b)               Build your site
+  serve (s, dev)          Start dev server with hot reload
+  preview                 Build and serve completed output
+  check (v)               Validate your site
+  audit                   Audit generated artifacts
+  fix                     Auto-fix issues
+  clean (c)               Clean output directory and cache
+
+Create
+  new (n)                 Create new site, theme, or content [group]
+
+Site systems
+  config                  Configuration management [group]
+  theme                   Theme development, directives, and assets [group]
+  content                 Content sources and collections [group]
+  version                 Documentation versioning [group]
+  i18n                    Internationalization (PO/MO) [group]
+  plugin (plugins)        Plugin discovery and readiness [group]
+  capability (capabilities) Runtime capability registry inspection [group]
+
+Inspect and debug
+  inspect                 Analyze and inspect your site [group]
+  debug                   Debug builds and dependencies [group]
+
+Infrastructure
+  cache                   CI cache management [group]
+  upgrade                 Check for and install Bengal updates
+  codemod                 Run automated code migrations

--- a/tests/unit/docs/fixtures/directive_options_snapshot.yaml
+++ b/tests/unit/docs/fixtures/directive_options_snapshot.yaml
@@ -1,0 +1,875 @@
+admonition:
+  names: '`{caution}`, `{danger}`, `{error}`, `{example}`, `{important}`, `{info}`,
+    `{note}`, `{seealso}`, `{success}`, `{tip}`, `{warning}`'
+  options_class: AdmonitionOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:collapsible:` | false | — |
+
+    | `:open:` | true | — |'
+asciinema_embed:
+  names: '`{asciinema}`'
+  options_class: AsciinemaOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:cols:` | 80 | — |
+
+    | `:rows:` | 24 | — |
+
+    | `:speed:` | 1.0 | — |
+
+    | `:autoplay:` | false | — |
+
+    | `:loop:` | false | — |
+
+    | `:theme:` | asciinema | — |
+
+    | `:poster:` | npt:0:0 | — |
+
+    | `:idle_time_limit:` | none | — |
+
+    | `:start_at:` | "" | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:recording_id:` | "" | — |
+
+    | `:is_local_file:` | false | — |
+
+    | `:error:` | "" | — |'
+audio_embed:
+  names: '`{audio}`'
+  options_class: AudioOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:controls:` | true | — |
+
+    | `:autoplay:` | false | — |
+
+    | `:loop:` | false | — |
+
+    | `:muted:` | false | — |
+
+    | `:preload:` | metadata | — |
+
+    | `:css_class:` | "" | — |'
+badge:
+  names: '`{badge}`, `{bdg}`'
+  options_class: BadgeOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:css_class:` | badge badge-secondary | — |
+
+    | `:label:` | "" | — |'
+breadcrumbs:
+  names: '`{breadcrumbs}`'
+  options_class: BreadcrumbsOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:separator:` | › | — |
+
+    | `:show_home:` | true | — |
+
+    | `:home_text:` | Home | — |
+
+    | `:home_url:` | / | — |'
+build:
+  names: '`{build}`'
+  options_class: BuildOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:json:` | false | — |
+
+    | `:inline:` | false | — |
+
+    | `:align:` | "" | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:alt:` | Built in badge | — |
+
+    | `:dir_name:` | bengal | — |'
+button:
+  names: '`{button}`'
+  options_class: ButtonOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:color:` | primary | — |
+
+    | `:style:` | default | — |
+
+    | `:size:` | medium | — |
+
+    | `:icon:` | "" | — |
+
+    | `:target:` | "" | — |
+
+    | `:url:` | # | — |
+
+    | `:label:` | Button | — |'
+card:
+  names: '`{card}`'
+  options_class: CardOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:icon:` | "" | — |
+
+    | `:link:` | "" | — |
+
+    | `:description:` | "" | — |
+
+    | `:badge:` | "" | — |
+
+    | `:color:` | "" | — |
+
+    | `:image:` | "" | — |
+
+    | `:footer:` | "" | — |
+
+    | `:pull:` | "" | — |
+
+    | `:layout:` | "" | — |'
+cards_grid:
+  names: '`{cards}`'
+  options_class: CardsOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:columns:` | auto | — |
+
+    | `:gap:` | medium | — |
+
+    | `:style:` | default | — |
+
+    | `:variant:` | navigation | — |
+
+    | `:layout:` | default | — |'
+changed:
+  names: '`{changed}`, `{versionchanged}`'
+  options_class: ChangedOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:css_class:` | version-changed | — |
+
+    | `:version:` | "" | — |
+
+    | `:has_content:` | false | — |'
+checklist:
+  names: '`{checklist}`'
+  options_class: ChecklistOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:style:` | default | — |
+
+    | `:show-progress:` | false | — |
+
+    | `:compact:` | false | — |
+
+    | `:class:` | "" | — |'
+child_cards:
+  names: '`{child-cards}`'
+  options_class: ChildCardsOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:columns:` | auto | — |
+
+    | `:gap:` | medium | — |
+
+    | `:include:` | all | — |
+
+    | `:fields:` | title, description | — |
+
+    | `:layout:` | default | — |
+
+    | `:style:` | default | — |'
+code_tabs:
+  names: '`{code-tabs}`, `{code_tabs}`'
+  options_class: CodeTabsOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:sync:` | language | — |
+
+    | `:linenos:` | none | — |
+
+    | `:tabs:` | none | — |'
+codepen_embed:
+  names: '`{codepen}`'
+  options_class: CodePenOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:default-tab:` | result | — |
+
+    | `:height:` | 300 | — |
+
+    | `:theme:` | dark | — |
+
+    | `:editable:` | false | — |
+
+    | `:preview:` | true | — |
+
+    | `:class:` | "" | — |
+
+    | `:username:` | "" | — |
+
+    | `:pen_id:` | "" | — |
+
+    | `:error:` | "" | — |'
+codesandbox_embed:
+  names: '`{codesandbox}`'
+  options_class: CodeSandboxOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:module:` | "" | — |
+
+    | `:view:` | split | — |
+
+    | `:height:` | 500 | — |
+
+    | `:fontsize:` | 14 | — |
+
+    | `:hidenavigation:` | false | — |
+
+    | `:theme:` | dark | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:sandbox_id:` | "" | — |
+
+    | `:error:` | "" | — |'
+container:
+  names: '`{container}`, `{div}`'
+  options_class: ContainerOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |'
+data_table:
+  names: '`{data-table}`'
+  options_class: DataTableOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:search:` | true | — |
+
+    | `:filter:` | true | — |
+
+    | `:sort:` | true | — |
+
+    | `:pagination:` | 50 | — |
+
+    | `:height:` | auto | — |
+
+    | `:columns:` | "" | — |
+
+    | `:file_path:` | "" | — |
+
+    | `:table_id:` | "" | — |
+
+    | `:visible_columns:` | none | — |
+
+    | `:error:` | "" | — |
+
+    | `:table_columns:` | — | — |
+
+    | `:table_data:` | — | — |'
+deprecated:
+  names: '`{deprecated}`, `{versionremoved}`'
+  options_class: DeprecatedOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:css_class:` | version-deprecated | — |
+
+    | `:version:` | "" | — |
+
+    | `:has_content:` | false | — |'
+dropdown:
+  names: '`{details}`, `{dropdown}`'
+  options_class: DropdownOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:open:` | false | — |
+
+    | `:icon:` | none | — |
+
+    | `:badge:` | none | — |
+
+    | `:color:` | none | — |
+
+    | `:description:` | none | — |'
+example_label:
+  names: '`{example-label}`'
+  options_class: ExampleLabelOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:css_class:` | "" | — |
+
+    | `:prefix:` | Example | — |
+
+    | `:no_prefix:` | false | — |'
+excerpt_break:
+  names: '`{excerpt-break}`'
+  options_class: DirectiveOptions
+  table: _No typed options._
+figure:
+  names: '`{figure}`'
+  options_class: FigureOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:alt:` | "" | — |
+
+    | `:caption:` | "" | — |
+
+    | `:width:` | "" | — |
+
+    | `:height:` | "" | — |
+
+    | `:align:` | "" | — |
+
+    | `:link:` | "" | — |
+
+    | `:target:` | _self | — |
+
+    | `:loading:` | lazy | — |
+
+    | `:class:` | "" | — |'
+gallery:
+  names: '`{gallery}`'
+  options_class: GalleryOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:columns:` | 3 | — |
+
+    | `:lightbox:` | true | — |
+
+    | `:gap:` | 1rem | — |
+
+    | `:aspect_ratio:` | 4/3 | — |
+
+    | `:css_class:` | "" | — |'
+gist_embed:
+  names: '`{gist}`'
+  options_class: GistOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:file:` | "" | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:gist_ref:` | "" | — |
+
+    | `:error:` | "" | — |'
+glossary:
+  names: '`{glossary}`'
+  options_class: GlossaryOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:tags:` | "" | — |
+
+    | `:sorted:` | false | — |
+
+    | `:show_tags:` | false | — |
+
+    | `:collapsed:` | false | — |
+
+    | `:limit:` | 0 | — |
+
+    | `:source:` | data/glossary.yaml | — |'
+icon:
+  names: '`{icon}`, `{svg-icon}`'
+  options_class: IconOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:size:` | 24 | — |
+
+    | `:class:` | "" | — |
+
+    | `:aria-label:` | "" | — |
+
+    | `:icon_name:` | "" | — |
+
+    | `:error:` | "" | — |'
+include:
+  names: '`{include}`'
+  options_class: IncludeOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:file:` | "" | — |
+
+    | `:start_line:` | none | — |
+
+    | `:end_line:` | none | — |
+
+    | `:file_path:` | "" | — |
+
+    | `:error:` | "" | — |'
+list_table:
+  names: '`{list-table}`'
+  options_class: ListTableOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:header-rows:` | 0 | — |
+
+    | `:widths:` | "" | — |
+
+    | `:class:` | "" | — |'
+literalinclude:
+  names: '`{literalinclude}`'
+  options_class: LiteralIncludeOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:file:` | "" | — |
+
+    | `:language:` | "" | — |
+
+    | `:start_line:` | none | — |
+
+    | `:end_line:` | none | — |
+
+    | `:emphasize_lines:` | "" | — |
+
+    | `:linenos:` | false | — |
+
+    | `:caption:` | "" | — |
+
+    | `:file_path:` | "" | — |
+
+    | `:code:` | "" | — |
+
+    | `:error:` | "" | — |'
+marimo_cell:
+  names: '`{marimo}`'
+  options_class: MarimoOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:show-code:` | true | — |
+
+    | `:cache:` | true | — |
+
+    | `:label:` | "" | — |
+
+    | `:code:` | "" | — |
+
+    | `:cell_id:` | 0 | — |
+
+    | `:error:` | "" | — |'
+prev_next:
+  names: '`{prev-next}`'
+  options_class: PrevNextOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:show_title:` | true | — |
+
+    | `:show_section:` | false | — |'
+related:
+  names: '`{related}`'
+  options_class: RelatedOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:limit:` | 5 | — |
+
+    | `:section_title:` | Related Articles | — |
+
+    | `:show_tags:` | false | — |'
+rubric:
+  names: '`{rubric}`'
+  options_class: RubricOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:css_class:` | "" | — |'
+self_hosted_video:
+  names: '`{video}`'
+  options_class: SelfHostedVideoOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:poster:` | "" | — |
+
+    | `:controls:` | true | — |
+
+    | `:autoplay:` | false | — |
+
+    | `:muted:` | false | — |
+
+    | `:loop:` | false | — |
+
+    | `:preload:` | metadata | — |
+
+    | `:width:` | 100% | — |
+
+    | `:aspect:` | 16/9 | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:video_path:` | "" | — |
+
+    | `:mime_type:` | "" | — |
+
+    | `:error:` | "" | — |'
+siblings:
+  names: '`{siblings}`'
+  options_class: SiblingsOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:limit:` | 0 | — |
+
+    | `:exclude_current:` | true | — |
+
+    | `:show_description:` | false | — |'
+since:
+  names: '`{since}`, `{versionadded}`'
+  options_class: SinceOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:css_class:` | version-since | — |
+
+    | `:version:` | "" | — |
+
+    | `:has_content:` | false | — |'
+soundcloud_embed:
+  names: '`{soundcloud}`'
+  options_class: SoundCloudOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:type:` | track | — |
+
+    | `:height:` | 0 | — |
+
+    | `:color:` | ff5500 | — |
+
+    | `:autoplay:` | false | — |
+
+    | `:hide_related:` | false | — |
+
+    | `:show_comments:` | true | — |
+
+    | `:show_user:` | true | — |
+
+    | `:show_reposts:` | false | — |
+
+    | `:visual:` | false | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:url_path:` | "" | — |
+
+    | `:error:` | "" | — |'
+spotify_embed:
+  names: '`{spotify}`'
+  options_class: SpotifyOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:type:` | track | — |
+
+    | `:height:` | 0 | — |
+
+    | `:theme:` | 0 | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:spotify_id:` | "" | — |
+
+    | `:error:` | "" | — |'
+stackblitz_embed:
+  names: '`{stackblitz}`'
+  options_class: StackBlitzOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:file:` | "" | — |
+
+    | `:view:` | both | — |
+
+    | `:height:` | 500 | — |
+
+    | `:hidenavigation:` | false | — |
+
+    | `:hidedevtools:` | false | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:project_id:` | "" | — |
+
+    | `:error:` | "" | — |'
+step:
+  names: '`{step}`'
+  options_class: StepOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:description:` | none | — |
+
+    | `:optional:` | false | — |
+
+    | `:duration:` | none | — |
+
+    | `:step_number:` | none | — |
+
+    | `:heading_level:` | none | — |'
+steps:
+  names: '`{steps}`'
+  options_class: StepsOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:style:` | none | — |
+
+    | `:start:` | 1 | — |'
+tab_item:
+  names: '`{tab}`, `{tab-item}`'
+  options_class: TabItemOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:selected:` | false | — |
+
+    | `:icon:` | none | — |
+
+    | `:badge:` | none | — |
+
+    | `:disabled:` | false | — |
+
+    | `:sync:` | none | — |'
+tab_set:
+  names: '`{tab-set}`, `{tabs}`'
+  options_class: TabSetOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:class:` | none | — |
+
+    | `:name:` | none | — |
+
+    | `:id:` | none | — |
+
+    | `:sync:` | none | — |
+
+    | `:mode:` | none | — |'
+target:
+  names: '`{anchor}`, `{target}`'
+  options_class: TargetOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:id:` | none | — |
+
+    | `:error:` | none | — |'
+tiktok_video:
+  names: '`{tiktok}`'
+  options_class: TikTokOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:width:` | "" | — |
+
+    | `:aspect:` | 9/16 | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:autoplay:` | false | — |
+
+    | `:loop:` | false | — |
+
+    | `:muted:` | false | — |
+
+    | `:video_id:` | "" | — |
+
+    | `:embed_url:` | "" | — |
+
+    | `:error:` | "" | — |'
+vimeo_video:
+  names: '`{vimeo}`'
+  options_class: VimeoOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:width:` | "" | — |
+
+    | `:aspect:` | 16/9 | — |
+
+    | `:css_class:` | "" | — |
+
+    | `:autoplay:` | false | — |
+
+    | `:loop:` | false | — |
+
+    | `:muted:` | false | — |
+
+    | `:color:` | "" | — |
+
+    | `:autopause:` | true | — |
+
+    | `:dnt:` | true | — |
+
+    | `:background:` | false | — |
+
+    | `:video_id:` | "" | — |
+
+    | `:embed_url:` | "" | — |
+
+    | `:error:` | "" | — |'
+youtube_video:
+  names: '`{youtube}`'
+  options_class: YouTubeOptions
+  table: '| Option | Default | Description |
+
+    |--------|---------|-------------|
+
+    | `:title:` | "" | — |
+
+    | `:width:` | "" | — |
+
+    | `:aspect:` | 16/9 | — |
+
+    | `:class:` | "" | — |
+
+    | `:autoplay:` | false | — |
+
+    | `:loop:` | false | — |
+
+    | `:muted:` | false | — |
+
+    | `:start:` | 0 | — |
+
+    | `:end:` | none | — |
+
+    | `:privacy:` | true | — |
+
+    | `:controls:` | true | — |
+
+    | `:video_id:` | "" | — |
+
+    | `:embed_url:` | "" | — |
+
+    | `:error:` | "" | — |'

--- a/tests/unit/docs/test_doc_reality_drift.py
+++ b/tests/unit/docs/test_doc_reality_drift.py
@@ -132,8 +132,8 @@ def test_architecture_cli_doc_matches_shipped_version() -> None:
     """The architecture CLI help snapshot is version-agnostic; stale versions must not linger."""
     doc = _DOCS / "reference" / "architecture" / "tooling" / "cli.md"
     text = doc.read_text(encoding="utf-8")
-    assert "bengal VERSION" in text, (
-        "cli.md root help snapshot should use the normalized `bengal VERSION` placeholder. "
+    assert "# bengal VERSION" in text, (
+        "cli.md root help snapshot should use the normalized `# bengal VERSION` placeholder. "
         "Regenerate with: python scripts/update_cli_help_snapshot.py"
     )
     known_stale = ("0.3.3", "0.3.2", "0.3.1", "0.3.0")

--- a/tests/unit/docs/test_doc_reality_drift.py
+++ b/tests/unit/docs/test_doc_reality_drift.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import re
 import subprocess
-import tomllib
 from pathlib import Path
 
 # tests/unit/docs/ -> repo root is three parents up.
@@ -130,12 +129,12 @@ def test_no_bengal_ssg_package_name_in_docs() -> None:
 
 
 def test_architecture_cli_doc_matches_shipped_version() -> None:
-    """The architecture CLI help snapshot must match ``pyproject.toml`` version."""
-    version = tomllib.load((_REPO_ROOT / "pyproject.toml").open("rb"))["project"]["version"]
+    """The architecture CLI help snapshot is version-agnostic; stale versions must not linger."""
     doc = _DOCS / "reference" / "architecture" / "tooling" / "cli.md"
     text = doc.read_text(encoding="utf-8")
-    assert f"bengal {version}" in text, (
-        f"cli.md help snapshot missing shipped version `bengal {version}`"
+    assert "bengal VERSION" in text, (
+        "cli.md root help snapshot should use the normalized `bengal VERSION` placeholder. "
+        "Regenerate with: python scripts/update_cli_help_snapshot.py"
     )
     known_stale = ("0.3.3", "0.3.2", "0.3.1", "0.3.0")
     embedded = re.findall(r"^bengal (\d+\.\d+\.\d+)", text, flags=re.MULTILINE)
@@ -204,4 +203,76 @@ def test_no_phantom_health_linkcheck_subcommand_in_docs() -> None:
     assert not offenders, (
         "Docs reference phantom `bengal health linkcheck`; use `bengal inspect links` or `bengal check`:\n"
         + "\n".join(f"  {p}: lines {ls}" for p, ls in sorted(offenders.items()))
+    )
+
+
+def test_cli_command_inventory_matches_registry() -> None:
+    """Committed cli.md inventory must match the live Milo command registry."""
+    from tests._testing.cli_help_snapshot import (
+        parse_cli_doc_inventory,
+        registered_command_inventory,
+    )
+
+    doc = _DOCS / "reference" / "architecture" / "tooling" / "cli.md"
+    doc_inventory = parse_cli_doc_inventory(doc.read_text(encoding="utf-8"))
+    registered = registered_command_inventory()
+    assert doc_inventory == registered, (
+        "cli.md command inventory drifted from Milo registry.\n"
+        "Regenerate with: python scripts/update_cli_help_snapshot.py\n"
+        f"  doc-only: {sorted(set(doc_inventory) - set(registered))}\n"
+        f"  registry-only: {sorted(set(registered) - set(doc_inventory))}"
+    )
+
+
+def test_cli_root_help_snapshot_matches_live_output() -> None:
+    """Committed CLI help snapshot must match live root help command sections."""
+    from tests._testing.cli_help_snapshot import (
+        capture_root_help_command_sections,
+        snapshot_path,
+    )
+
+    snapshot = snapshot_path()
+    assert snapshot.is_file(), (
+        f"Missing CLI help snapshot at {snapshot.relative_to(_REPO_ROOT)}. "
+        "Generate with: python scripts/update_cli_help_snapshot.py"
+    )
+    expected = snapshot.read_text(encoding="utf-8")
+    live = capture_root_help_command_sections()
+    assert live == expected, (
+        "CLI root help snapshot drifted from live Milo output.\n"
+        "Regenerate with: python scripts/update_cli_help_snapshot.py"
+    )
+
+
+def test_architecture_cli_doc_root_help_matches_snapshot() -> None:
+    """Embedded cli.md help block must match the committed CLI help snapshot."""
+    from tests._testing.cli_help_snapshot import parse_cli_doc_root_help, snapshot_path
+
+    doc = _DOCS / "reference" / "architecture" / "tooling" / "cli.md"
+    doc_help = parse_cli_doc_root_help(doc.read_text(encoding="utf-8"))
+    expected = snapshot_path().read_text(encoding="utf-8")
+    assert doc_help == expected, (
+        "cli.md root help block drifted from committed snapshot.\n"
+        "Regenerate with: python scripts/update_cli_help_snapshot.py"
+    )
+
+
+def test_directive_option_tables_match_registry() -> None:
+    """Committed directive option snapshot must match create_default_registry()."""
+    from tests._testing.directive_options_snapshot import (
+        load_snapshot,
+        registry_option_tables,
+        snapshot_path,
+    )
+
+    snapshot = snapshot_path()
+    assert snapshot.is_file(), (
+        f"Missing directive options snapshot at {snapshot.relative_to(_REPO_ROOT)}. "
+        "Generate with: python scripts/update_directive_options_snapshot.py"
+    )
+    expected = load_snapshot()
+    live = registry_option_tables()
+    assert live == expected, (
+        "Directive option tables drifted from registry.\n"
+        "Regenerate with: python scripts/update_directive_options_snapshot.py"
     )


### PR DESCRIPTION
## Summary

- Finish Phase 2 oversized-page splits: trim `kida-syntax.md` (273 lines) and dedupe `user-scenarios.md` (385 lines) into `user-scenarios-specialized.md`; closes #612 and Phase 2 epic #594.
- Add CLI docs drift guards (#628): committed Milo root-help snapshot + command inventory compared against live registry and `cli.md`, with `scripts/update_cli_help_snapshot.py`.
- Wire autodoc `/cli/` as the canonical exhaustive CLI reference (#621): extraction + virtual-page tests, doc cross-links from tooling pages.
- Generate directive option tables from `create_default_registry()` (#626): `_registry-options.md`, YAML snapshot, CI drift test, and `scripts/update_directive_options_snapshot.py`.

## Proof

- [x] Focused tests: `pytest tests/unit/docs/test_doc_reality_drift.py tests/unit/autodoc/test_bengal_cli_extraction.py tests/integration/test_autodoc_cli_extraction.py -q` (all passed)
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: docs-only; no user-facing product change — no `changelog.d/` fragment

## Performance Evidence

not applicable

## Steward Notes

- After CLI surface changes: `python scripts/update_cli_help_snapshot.py`
- After directive option dataclass changes: `python scripts/update_directive_options_snapshot.py`
- Closes #612, #594, #628, #621, #626


Made with [Cursor](https://cursor.com)