### PR TITLE
fix(theme): restore prose link styling after invalid @scope syntax

### DIFF
--- a/bengal/themes/default/assets/css/base/typography.css
+++ b/bengal/themes/default/assets/css/base/typography.css
@@ -151,8 +151,7 @@ a {
 }
 
 /* Content link styles — @scope bounds prose link treatment (#540) */
-@scope (.prose) {
-  to (.button, .btn, .card, .card-link, [data-no-external-icon]) {
+@scope (.prose) to (.button, .btn, .card, .card-link, [data-no-external-icon]) {
     a {
       color: var(--color-text-link);
       background-image: linear-gradient(
@@ -267,9 +266,17 @@ a {
     a[target="_blank"][href^="http"]:has(code)::after {
       margin-inline-start: 0.3em;
     }
-  }
 
-  to (.button, .btn) {
+    table a[data-external="true"]::after,
+    table a[rel*="external"]::after,
+    table a[target="_blank"][href^="http"]::after {
+      width: 0.65em;
+      height: 0.65em;
+      margin-inline-start: 0.15em;
+    }
+}
+
+@scope (.prose) to (.button, .btn) {
     a[href^="#"] {
       color: var(--color-text-secondary);
       background-image: linear-gradient(
@@ -287,34 +294,21 @@ a {
         var(--color-text-link) 100%
       );
     }
-  }
-
-  table a[data-external="true"]::after,
-  table a[rel*="external"]::after,
-  table a[target="_blank"][href^="http"]::after {
-    width: 0.65em;
-    height: 0.65em;
-    margin-inline-start: 0.15em;
-  }
 }
 
 [data-theme="dark"] {
-  @scope (.prose) {
-    to (.button, .btn) {
-      a:hover {
-        text-shadow: 0 1px 0 rgba(255, 255, 255, 0.15);
-      }
+  @scope (.prose) to (.button, .btn) {
+    a:hover {
+      text-shadow: 0 1px 0 rgba(255, 255, 255, 0.15);
     }
   }
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
-    @scope (.prose) {
-      to (.button, .btn) {
-        a:hover {
-          text-shadow: 0 1px 0 rgba(255, 255, 255, 0.15);
-        }
+    @scope (.prose) to (.button, .btn) {
+      a:hover {
+        text-shadow: 0 1px 0 rgba(255, 255, 255, 0.15);
       }
     }
   }

--- a/bengal/themes/default/assets/css/tokens/palettes/blue-bengal.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/blue-bengal.css
@@ -32,8 +32,8 @@ html[data-palette="blue-bengal"] {
     --color-text-tertiary: light-dark(color-mix(in oklab, var(--color-text-primary), var(--color-bg-primary) 40%), #A4B5C8);
     --color-text-muted: light-dark(color-mix(in oklab, var(--color-text-primary), var(--color-bg-primary) 56%), #738AA1);
     --color-text-inverse: light-dark(oklch(100.00% 0 0), #141B22);
-    --color-text-link: light-dark(var(--color-primary), #9DBDD9);
-    --color-text-link-hover: light-dark(var(--color-primary-hover), #B4CFE6);
+    --color-text-link: var(--color-primary);
+    --color-text-link-hover: var(--color-primary-hover);
 
     /* Borders (gentle blue-grays) */
     --color-border: light-dark(oklch(91.34% 0.0209 248.1), #2A3849);

--- a/bengal/themes/default/assets/css/tokens/palettes/brown-bengal.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/brown-bengal.css
@@ -32,8 +32,8 @@ html[data-palette="brown-bengal"] {
     --color-text-tertiary: light-dark(color-mix(in oklab, var(--color-text-primary), var(--color-bg-primary) 40%), #B39772);
     --color-text-muted: light-dark(color-mix(in oklab, var(--color-text-primary), var(--color-bg-primary) 56%), #8A7455);
     --color-text-inverse: light-dark(oklch(100.00% 0 0), #1F1811);
-    --color-text-link: light-dark(var(--color-primary), #FFAD3D);
-    --color-text-link-hover: light-dark(var(--color-primary-hover), #FFC266);
+    --color-text-link: var(--color-primary);
+    --color-text-link-hover: var(--color-primary-hover);
 
     /* Borders (warm butterscotch) */
     --color-border: light-dark(oklch(87.55% 0.0618 86.4), #3D3630);

--- a/bengal/themes/default/assets/css/tokens/palettes/charcoal-bengal.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/charcoal-bengal.css
@@ -40,8 +40,8 @@ html[data-palette="charcoal-bengal"] {
     --color-text-muted: light-dark(color-mix(in oklab, var(--color-text-primary), var(--color-bg-primary) 56%), #6B655C);
     --color-text-inverse: light-dark(oklch(99.16% 0.0017 67.8), #0C0B0A);
     /* Charcoal's primary is achromatic ink, so links/focus use the bronze accent for affordance */
-    --color-text-link: light-dark(var(--color-accent), #C9A84D);
-    --color-text-link-hover: light-dark(var(--color-accent-hover), #D9BC6D);
+    --color-text-link: var(--color-accent);
+    --color-text-link-hover: var(--color-accent-hover);
 
     /* Borders (warm grays - charcoal mask effect) */
     --color-border: light-dark(oklch(82.49% 0.0094 78.3), #302D28);

--- a/bengal/themes/default/assets/css/tokens/palettes/silver-bengal.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/silver-bengal.css
@@ -33,8 +33,8 @@ html[data-palette="silver-bengal"] {
     --color-text-muted: light-dark(color-mix(in oklab, var(--color-text-primary), var(--color-bg-primary) 56%), #6B7280);
     --color-text-inverse: light-dark(oklch(100.00% 0 0), #111827);
     /* Silver's primary is a near-neutral gray, so links use the deeper accent for affordance */
-    --color-text-link: light-dark(var(--color-accent), #94A3B8);
-    --color-text-link-hover: light-dark(var(--color-accent-hover), #CBD5E1);
+    --color-text-link: var(--color-accent);
+    --color-text-link-hover: var(--color-accent-hover);
 
     /* Borders (neutral grays) */
     --color-border: light-dark(oklch(87.17% 0.0093 258.3), #262626);

--- a/bengal/themes/default/assets/css/tokens/palettes/snow-lynx.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/snow-lynx.css
@@ -39,8 +39,8 @@ html[data-palette="snow-lynx"] {
     --color-text-tertiary: light-dark(color-mix(in oklab, var(--color-text-primary), var(--color-bg-primary) 40%), #9D9B97);
     --color-text-muted: light-dark(color-mix(in oklab, var(--color-text-primary), var(--color-bg-primary) 56%), #75736F);
     --color-text-inverse: light-dark(oklch(100.00% 0 0), #18191A);
-    --color-text-link: light-dark(var(--color-primary), #6EC4BC);
-    --color-text-link-hover: light-dark(var(--color-primary-hover), #87D3CC);
+    --color-text-link: var(--color-primary);
+    --color-text-link-hover: var(--color-primary-hover);
 
     /* Borders (subtle warmth against clean white) */
     --color-border: light-dark(oklch(92.00% 0.0104 81.8), #3A3D40);

--- a/changelog.d/+prose-link-styling.fixed.md
+++ b/changelog.d/+prose-link-styling.fixed.md
@@ -1,0 +1,3 @@
+Prose links in the default theme are visible again: they use the theme link color and hover underline instead of inheriting body text styling.
+
+The #540 `@scope` block had `to (...)` nested inside the rule body (invalid CSS that browsers ignore); it now uses the correct prelude form. Palette link tokens no longer wrap already theme-aware primary/accent colors in a second `light-dark()`.

--- a/tests/unit/themes/test_unified_primitives.py
+++ b/tests/unit/themes/test_unified_primitives.py
@@ -73,4 +73,5 @@ def test_container_queries_on_layout_primitives() -> None:
 
 def test_prose_links_use_scope() -> None:
     typography = (THEME / "assets" / "css" / "base" / "typography.css").read_text(encoding="utf-8")
-    assert "@scope (.prose)" in typography
+    assert "@scope (.prose) to (" in typography
+    assert "@scope (.prose) {\n  to (" not in typography


### PR DESCRIPTION
## Summary

- Fix invalid `@scope` syntax in `typography.css` by moving `to (...)` limits into the at-rule prelude so browsers apply prose link colors, hover underlines, and external-link icons again.
- Simplify palette link tokens across all five Bengal palettes to reference `--color-primary` / `--color-accent` directly instead of double-wrapping them in `light-dark()`.
- Tighten `test_prose_links_use_scope` to reject nested `to (` blocks and add a `changelog.d/+prose-link-styling.fixed.md` fragment.

## Proof

- [x] Focused tests: `pytest tests/unit/themes/test_unified_primitives.py::test_prose_links_use_scope -q`
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/+prose-link-styling.fixed.md`

## Performance Evidence

not applicable

## Steward Notes

- Root cause: the #540 refresh nested `@scope` `to (...)` inside the rule body; browsers dropped the entire block, leaving links at `color: inherit`. The CSS minifier round-trips that shape faithfully—it validates structure, not at-rule semantics.

Made with [Cursor](https://cursor.com)