### PR TITLE
fix(theme): restore header theme dropdown popover positioning

### DIFF
--- a/bengal/themes/default/assets/css/layouts/header.css
+++ b/bengal/themes/default/assets/css/layouts/header.css
@@ -979,19 +979,6 @@ header[role="banner"][data-sticky="false"] {
 .theme-option__swatch[data-palette-swatch="charcoal-bengal"] { background: oklch(0.35 0.02 250); }
 .theme-option__swatch[data-palette-swatch="blue-bengal"] { background: oklch(0.55 0.14 250); }
 
-@supports (position-anchor: --theme-anchor) {
-  .theme-dropdown__button {
-    anchor-name: --theme-anchor;
-  }
-
-  .theme-dropdown__menu--popover {
-    position-anchor: --theme-anchor;
-    inset-block-start: anchor(bottom);
-    inset-inline-end: anchor(end);
-    margin-block-start: var(--space-2);
-  }
-}
-
 .theme-dropdown__menu--popover .theme-option:hover {
   background: var(--color-bg-secondary);
   color: var(--color-primary);

--- a/changelog.d/+theme-dropdown-anchor.fixed.md
+++ b/changelog.d/+theme-dropdown-anchor.fixed.md
@@ -1,0 +1,3 @@
+The header theme dropdown shows its palette/mode options again on desktop.
+
+Desktop and mobile theme triggers both used the same CSS anchor name, so the popover anchored to the hidden mobile trigger and appeared off-screen.

--- a/tests/unit/themes/test_unified_primitives.py
+++ b/tests/unit/themes/test_unified_primitives.py
@@ -75,3 +75,11 @@ def test_prose_links_use_scope() -> None:
     typography = (THEME / "assets" / "css" / "base" / "typography.css").read_text(encoding="utf-8")
     assert "@scope (.prose) to (" in typography
     assert "@scope (.prose) {\n  to (" not in typography
+
+
+def test_theme_dropdown_popover_uses_implicit_anchor() -> None:
+    """Desktop + mobile theme menus must not share one anchor-name (breaks positioning)."""
+    header = (THEME / "assets" / "css" / "layouts" / "header.css").read_text(encoding="utf-8")
+    assert "anchor-name: --theme-anchor" not in header
+    assert "position-anchor: --theme-anchor" not in header
+    assert "position-anchor: auto" in header


### PR DESCRIPTION
## Summary

- Remove shared `anchor-name: --theme-anchor` from desktop and mobile theme triggers so the header popover anchors to its own button instead of the hidden mobile menu.
- Rely on `position-anchor: auto` (Popover Invoker Link implicit anchor) for correct dropdown placement.
- Add a regression test and `changelog.d/+theme-dropdown-anchor.fixed.md`.

## Proof

- [x] Focused tests: `pytest tests/unit/themes/test_unified_primitives.py::test_theme_dropdown_popover_uses_implicit_anchor tests/unit/themes/test_theme_controls.py`
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/+theme-dropdown-anchor.fixed.md` — header theme dropdown shows palette/mode options again on desktop; duplicate anchor name anchored popover to hidden mobile trigger.

## Performance Evidence

not applicable

## Steward Notes

Regression introduced in Pridelands Phase 3 (#638) when palette swatches added a `@supports (position-anchor: --theme-anchor)` block applied to both theme-control instances in `base.html`.


Made with [Cursor](https://cursor.com)