### PR TITLE
feat(theme): Pridelands Phase 3–4 showcase polish (#542–#544)

### DIFF
--- a/bengal/postprocess/static_markup.py
+++ b/bengal/postprocess/static_markup.py
@@ -6,11 +6,18 @@ import re
 from urllib.parse import urlparse
 
 _COPY_BUTTON = (
-    '<button type="button" class="code-copy-button copy-success-burst" aria-label="Copy">'
+    '<button type="button" class="code-copy-button copy-success-burst" aria-label="Copy code to clipboard">'
     '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
     'stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>'
     '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>'
     "<span>Copy</span></button>"
+)
+
+_WRAP_BUTTON = (
+    '<button type="button" class="code-wrap-toggle" aria-label="Enable word wrap" aria-pressed="false">'
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+    'stroke-width="2"><path d="M4 6h16M4 12h10M4 18h16"/></svg>'
+    "<span>Wrap</span></button>"
 )
 
 _LANG_RE = re.compile(r"language-(\w+)|hljs-(\w+)")
@@ -101,7 +108,7 @@ def _wrap_pre_code(match: re.Match[str]) -> str:
     open_pre = match.group(1)
     lang = _language_from_code_tag(open_pre)
     lang_label = f'<span class="code-language">{lang}</span>' if lang else "<span></span>"
-    header = f'<div class="code-header-inline">{lang_label}{_COPY_BUTTON}</div>'
+    header = f'<div class="code-header-inline">{lang_label}{_WRAP_BUTTON}{_COPY_BUTTON}</div>'
     return (
         f'<div class="code-block-wrapper">{open_pre}{match.group(2)}{match.group(3)}{header}</div>'
     )

--- a/bengal/themes/default/assets/css/components/announcement.css
+++ b/bengal/themes/default/assets/css/components/announcement.css
@@ -1,0 +1,126 @@
+/**
+ * Site-wide announcement bar — full-width promo/info strip above the header.
+ * Opt-in via [params.announcement]; hidden when dismissed (localStorage).
+ */
+
+.site-announcement {
+  --announcement-color: var(--color-info);
+  position: relative;
+  z-index: calc(var(--z-fixed, 1000) + 1);
+  width: 100%;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--color-info-text);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--announcement-color) 12%, var(--color-bg-primary)),
+    color-mix(in srgb, var(--announcement-color) 6%, var(--color-bg-secondary))
+  );
+  border-block-end: 1px solid color-mix(in srgb, var(--announcement-color) 25%, transparent);
+}
+
+.site-announcement[hidden] {
+  display: none !important;
+}
+
+.site-announcement--info {
+  --announcement-color: var(--color-info);
+  color: var(--color-info-text);
+}
+
+.site-announcement--warning {
+  --announcement-color: var(--color-warning);
+  color: var(--color-warning-text);
+}
+
+.site-announcement--promo {
+  --announcement-color: var(--color-primary);
+  color: var(--color-text-primary);
+}
+
+.site-announcement__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-block: var(--space-2);
+  padding-inline: var(--space-4);
+}
+
+.site-announcement__content {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  flex: 1;
+  min-width: 0;
+}
+
+.site-announcement__icon {
+  flex-shrink: 0;
+  color: var(--announcement-color);
+}
+
+.site-announcement__message {
+  margin: 0;
+  font-weight: var(--weight-medium);
+}
+
+.site-announcement__link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-weight: var(--weight-semibold);
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  white-space: nowrap;
+}
+
+.site-announcement__link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.site-announcement__dismiss {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--announcement-color) 20%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-bg-primary) 60%, transparent);
+  color: inherit;
+  cursor: pointer;
+  transition:
+    background var(--motion-fast),
+    border-color var(--motion-fast),
+    transform var(--motion-fast);
+}
+
+.site-announcement__dismiss:hover {
+  background: var(--color-bg-hover);
+  border-color: color-mix(in srgb, var(--announcement-color) 35%, transparent);
+}
+
+.site-announcement__dismiss:active {
+  transform: scale(0.96);
+}
+
+@media (max-width: 640px) {
+  .site-announcement__inner {
+    padding-inline: var(--space-3);
+  }
+
+  .site-announcement__content {
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .site-announcement__dismiss {
+    transition: none;
+  }
+}

--- a/bengal/themes/default/assets/css/components/code.css
+++ b/bengal/themes/default/assets/css/components/code.css
@@ -428,6 +428,48 @@ pre.code-block--wrap,
   display: none;
 }
 
+.code-wrap-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  color: var(--color-text-secondary);
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast), opacity 0.15s ease;
+  flex-shrink: 0;
+  pointer-events: auto;
+  opacity: 0;
+}
+
+.code-wrap-toggle > span {
+  display: none;
+}
+
+pre:hover .code-wrap-toggle,
+.code-block-wrapper:hover .code-wrap-toggle,
+.highlight:hover .code-wrap-toggle,
+.code-wrap-toggle:focus-visible,
+.code-wrap-toggle[aria-pressed="true"] {
+  opacity: 1;
+}
+
+.code-wrap-toggle[aria-pressed="true"] {
+  color: var(--color-primary);
+  border-color: color-mix(in srgb, var(--color-primary) 40%, transparent);
+}
+
+[data-theme="dark"] .code-wrap-toggle {
+  background: rgba(0, 0, 0, 0.2);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
 /* Tooltip */
 .code-copy-button::after {
   content: attr(aria-label);

--- a/bengal/themes/default/assets/css/components/forms.css
+++ b/bengal/themes/default/assets/css/components/forms.css
@@ -234,7 +234,7 @@
 
 .form-group:has(.form-icon) .form-icon {
   position: absolute;
-  left: 0.875rem;
+  inset-inline-start: 0.875rem;
   top: 50%;
   transform: translateY(-50%);
   width: 1.25rem;
@@ -258,7 +258,7 @@
 
 .form-group:has(.error-icon) .error-icon {
   position: absolute;
-  right: 0.875rem;
+  inset-inline-end: 0.875rem;
   top: 50%;
   transform: translateY(-50%);
   width: 1.25rem;

--- a/bengal/themes/default/assets/css/components/gallery.css
+++ b/bengal/themes/default/assets/css/components/gallery.css
@@ -67,8 +67,7 @@
 .gallery__caption {
   position: absolute;
   bottom: 0;
-  left: 0;
-  right: 0;
+  inset-inline: 0;
   padding: 0.75rem 1rem;
   background: linear-gradient(to top, rgba(0, 0, 0, 0.75) 0%, transparent 100%);
   color: #fff;

--- a/bengal/themes/default/assets/css/components/interactive.css
+++ b/bengal/themes/default/assets/css/components/interactive.css
@@ -16,7 +16,7 @@
 .back-to-top {
   position: fixed;
   bottom: 5rem;
-  right: 2rem;
+  inset-inline-end: 2rem;
   width: 3rem;
   height: 3rem;
   min-width: 3rem;

--- a/bengal/themes/default/assets/css/components/language-switcher.css
+++ b/bengal/themes/default/assets/css/components/language-switcher.css
@@ -66,7 +66,7 @@
 .language-switcher__menu {
   position: absolute;
   top: 100%;
-  right: 0;
+  inset-inline-end: 0;
   z-index: 50;
   min-width: 140px;
   margin-top: 0.25rem;
@@ -139,11 +139,6 @@
 }
 
 /* RTL Support */
-[dir="rtl"] .language-switcher__menu {
-  right: auto;
-  left: 0;
-}
-
 [dir="rtl"] .language-switcher__toggle {
   flex-direction: row-reverse;
 }

--- a/bengal/themes/default/assets/css/components/tutorial.css
+++ b/bengal/themes/default/assets/css/components/tutorial.css
@@ -418,6 +418,112 @@
     overflow-y: auto;
 }
 
+/* Scroll-synced tutorial progress (tracks pattern) */
+.tutorial-progress-host {
+    margin: var(--space-4) 0 var(--space-6);
+}
+
+.tutorial-progress {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-4) 0;
+}
+
+.tutorial-progress__steps {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0;
+}
+
+.tutorial-progress__step {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--color-surface-elevated);
+    border: 2px solid var(--color-border);
+    transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tutorial-progress__step--current {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+}
+
+.tutorial-progress__step--complete {
+    background: var(--color-success-bg);
+    border-color: var(--color-success);
+}
+
+.tutorial-progress__number {
+    font-size: var(--text-xs);
+    font-weight: var(--weight-bold);
+    color: var(--color-text-muted);
+}
+
+.tutorial-progress__step--current .tutorial-progress__number,
+.tutorial-progress__step--complete .tutorial-progress__number {
+    color: var(--color-text-inverse);
+}
+
+.tutorial-progress__connector {
+    width: 28px;
+    height: 3px;
+    background: var(--color-border);
+}
+
+.tutorial-progress__connector--complete {
+    background: var(--color-success);
+}
+
+.tutorial-progress__label {
+    font-size: var(--text-sm);
+    font-weight: var(--weight-medium);
+    color: var(--color-text-secondary);
+}
+
+.tutorial-progress__bar {
+    width: 100%;
+    max-width: 320px;
+    height: 4px;
+    background: var(--color-border-light);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+}
+
+.tutorial-progress__fill {
+    height: 100%;
+    width: 0;
+    background: var(--color-primary);
+    border-radius: inherit;
+    transition: width var(--transition-fast);
+}
+
+.tutorial-sidebar .toc a.is-active {
+    color: var(--color-primary);
+    font-weight: var(--weight-semibold);
+}
+
+.tutorial-sidebar .toc a[data-tutorial-visited]::before {
+    content: '✓ ';
+    color: var(--color-success);
+    font-size: 0.85em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tutorial-progress__step,
+    .tutorial-progress__connector,
+    .tutorial-progress__fill {
+        transition: none;
+    }
+}
+
 /* Mobile Responsive */
 @media (max-width: 768px) {
     .tutorial-card,

--- a/bengal/themes/default/assets/css/components/widgets.css
+++ b/bengal/themes/default/assets/css/components/widgets.css
@@ -572,6 +572,10 @@
   font-size: var(--text-sm);
 }
 
+[dir="rtl"] .content-tiles--minimal li::before {
+  content: '←';
+}
+
 .content-tiles--minimal a {
   color: var(--color-text-primary);
   text-decoration: none;
@@ -586,6 +590,10 @@
 .content-tiles--minimal .content-tile--related::before {
   content: '↗';
   color: var(--color-accent, var(--color-text-muted));
+}
+
+[dir="rtl"] .content-tiles--minimal .content-tile--related::before {
+  content: '↖';
 }
 
 /* Responsive */

--- a/bengal/themes/default/assets/css/layouts/changelog.css
+++ b/bengal/themes/default/assets/css/layouts/changelog.css
@@ -46,13 +46,12 @@
 .timeline-item {
     margin-bottom: var(--space-10);
     padding-inline-start: var(--space-6);
-    /* Changed from padding-left */
     border-inline-start: 2px solid var(--color-border-light);
-    /* Changed from border-left */
     position: relative;
+    display: grid;
+    grid-template-columns: 1fr;
     transition: transform var(--transition-fast) var(--ease-out),
         border-color var(--transition-fast) var(--ease-out);
-
 }
 
 .timeline-item:last-child {
@@ -199,6 +198,36 @@
    CHANGELOG CATEGORIES
    ============================================ */
 
+/* Category grid — subgrid when supported, auto-fit fallback */
+.changelog-categories {
+    display: grid;
+    gap: var(--space-4);
+    margin-top: var(--space-2);
+}
+
+@supports (grid-template-columns: subgrid) {
+    .changelog-timeline .timeline {
+        display: grid;
+        grid-template-columns: 1fr;
+    }
+
+    .changelog-timeline .timeline-item {
+        grid-template-columns: subgrid;
+        grid-column: 1 / -1;
+    }
+
+    .changelog-categories {
+        grid-column: 1 / -1;
+        grid-template-columns: subgrid;
+    }
+}
+
+@media (min-width: 768px) {
+    .changelog-categories {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+}
+
 .changelog-category {
     margin: var(--space-4) 0;
     padding: var(--space-4);
@@ -246,6 +275,19 @@
     display: flex;
     align-items: center;
     gap: var(--space-2);
+}
+
+.category-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: var(--color-primary);
+}
+
+.changelog-category--breaking .category-icon,
+.category-title--breaking .category-icon {
+    color: var(--color-danger);
 }
 
 .changelog-breaking .category-title,

--- a/bengal/themes/default/assets/css/layouts/resume.css
+++ b/bengal/themes/default/assets/css/layouts/resume.css
@@ -11,12 +11,32 @@
    ============================================ */
 
 .resume {
+    container-type: inline-size;
+    container-name: resume;
     max-width: 850px;
     margin: 0 auto;
     padding: var(--space-8) var(--space-6);
     font-family: var(--font-sans);
     line-height: var(--leading-relaxed);
     color: var(--color-text-primary);
+}
+
+@container resume (min-width: 720px) {
+    .resume-header {
+        text-align: start;
+    }
+
+    .resume-contact {
+        justify-content: flex-start;
+    }
+
+    .skills-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .timeline-header {
+        flex-direction: row;
+    }
 }
 
 /* ============================================
@@ -74,7 +94,9 @@
   }
 
 .contact-icon {
-    font-size: var(--text-base);
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-text-tertiary);
 }
 
 /* ============================================
@@ -676,29 +698,95 @@
     .resume {
         max-width: 100%;
         padding: 0;
-        font-size: var(--text-body);
+        font-size: 10.5pt;
+        line-height: 1.35;
+        color: #000;
+    }
+
+    .resume-header {
+        border-block-end-color: #ccc;
+        padding-bottom: var(--space-4);
+        margin-bottom: var(--space-6);
+    }
+
+    .resume-name {
+        font-size: 18pt;
+    }
+
+    .resume-headline {
+        font-size: 11pt;
+        color: #333;
     }
 
     .resume-section {
+        margin: var(--space-6) 0;
         page-break-inside: avoid;
     }
 
-    .timeline-item {
+    .resume-section .section-title {
+        font-size: 12pt;
+        border-block-end-color: #ccc;
+    }
+
+    .timeline-item,
+    .skill-group,
+    .certification-item,
+    .award-item,
+    .language-item {
         page-break-inside: avoid;
+        box-shadow: none !important;
+        backdrop-filter: none !important;
+        background: transparent !important;
+        border: none !important;
+        padding: 0 0 var(--space-4) var(--space-4);
+        transform: none !important;
+    }
+
+    .timeline-item::before {
+        box-shadow: none;
+        background: #000;
+        border-color: #fff;
+    }
+
+    .resume-summary {
+        background: transparent !important;
+        box-shadow: none !important;
+        border-inline-start-color: #666;
+        padding: var(--space-3) var(--space-4);
     }
 
     .tech-tag,
     .skill-tag {
-        border: 1px solid var(--color-border);
+        border: 1px solid #999;
+        background: transparent !important;
+        color: #000 !important;
         print-color-adjust: exact;
         -webkit-print-color-adjust: exact;
     }
 
     .project-link,
     .certification-link {
-        color: var(--color-text-primary) !important;
+        color: #000 !important;
         background: transparent !important;
-        border: 1px solid var(--color-border);
+        border: none !important;
+        padding: 0;
+        text-decoration: underline;
+    }
+
+    .contact-item {
+        color: #333 !important;
+    }
+
+    a[href^="http"]::after,
+    a[href^="mailto"]::after {
+        content: " (" attr(href) ")";
+        font-size: 8pt;
+        color: #555;
+        word-break: break-all;
+    }
+
+    a[href^="http"]:not(.contact-item)::after {
+        display: inline;
     }
 }
 

--- a/bengal/themes/default/assets/css/pages/landing.css
+++ b/bengal/themes/default/assets/css/pages/landing.css
@@ -43,7 +43,7 @@
 .features {
   padding: var(--space-16) var(--space-6);
   max-width: var(--container-xl);
-  margin: 0 auto;
+  margin-inline: auto;
 }
 
 .features-grid {
@@ -164,7 +164,7 @@
 .stats {
   padding: var(--space-12) var(--space-6);
   max-width: var(--container-lg);
-  margin: 0 auto;
+  margin-inline: auto;
 }
 
 .stats-grid {
@@ -227,7 +227,7 @@
 .quick-links {
   padding: var(--space-12) var(--space-6);
   max-width: var(--container-xl);
-  margin: 0 auto;
+  margin-inline: auto;
 }
 
 .quick-links h2 {
@@ -497,6 +497,75 @@
 .home .card-grid {
   max-width: var(--container-xl);
   margin: var(--space-8) auto;
+}
+
+/* ============================================
+   SPLASH LANDING (zero-config home)
+   Distinct from generic section index / gallery grids
+   ============================================ */
+
+.home--splash {
+  view-transition-name: landing-splash;
+}
+
+.hero--splash {
+  padding-block: clamp(var(--space-12), 8vw, var(--space-20)) clamp(var(--space-10), 6vw, var(--space-16));
+}
+
+.hero--splash .hero__title {
+  background: linear-gradient(
+    135deg,
+    var(--color-text-primary) 0%,
+    color-mix(in oklab, var(--color-primary) 70%, var(--color-text-primary)) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+[data-theme="dark"] .hero--splash .hero__title {
+  background: linear-gradient(
+    135deg,
+    var(--color-text-primary) 0%,
+    color-mix(in oklab, var(--color-primary) 85%, white) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.home--splash .features-grid {
+  counter-reset: feature;
+}
+
+.home--splash .feature-card {
+  animation: fade-in-up var(--motion-medium) var(--ease-out) both;
+  animation-timeline: view();
+  animation-range: entry 0% cover 30%;
+}
+
+.home--splash .feature-card:nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.home--splash .feature-card:nth-child(3) {
+  animation-delay: 160ms;
+}
+
+.home--splash .feature-card:nth-child(4) {
+  animation-delay: 240ms;
+}
+
+.home--splash .read-more,
+.home--splash .feature-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home--splash .feature-card {
+    animation: none;
+  }
 }
 
 .home .card {

--- a/bengal/themes/default/assets/css/style.css
+++ b/bengal/themes/default/assets/css/style.css
@@ -154,6 +154,7 @@
 
 @layer components {
   @import url('components/cards.css');
+  @import url('components/gallery.css');
 }
 
 @layer components {
@@ -289,6 +290,7 @@
 @layer components {
   @import url('components/versioning.css');
   @import url('components/stale-banner.css');
+  @import url('components/announcement.css');
 }
 
 @layer components {

--- a/bengal/themes/default/assets/js/enhancements/announcement.js
+++ b/bengal/themes/default/assets/js/enhancements/announcement.js
@@ -1,0 +1,44 @@
+/**
+ * Site announcement bar — localStorage-persisted dismiss.
+ */
+(function () {
+  'use strict';
+
+  if (!window.Bengal?.define) return;
+
+  const STORAGE_PREFIX = 'bengal-announcement-dismissed:';
+
+  window.Bengal.define('bengal-site-announcement', class extends window.Bengal.Base {
+    connectedCallback() {
+      if (this._wired) return;
+      this._wired = true;
+
+      const id = this.dataset.announcementId || 'default';
+      const dismissible = this.dataset.dismissible !== 'false';
+      const storageKey = STORAGE_PREFIX + id;
+
+      try {
+        if (dismissible && localStorage.getItem(storageKey) === '1') {
+          this.hidden = true;
+          return;
+        }
+      } catch (e) {
+        /* localStorage unavailable — show bar */
+      }
+
+      this.hidden = false;
+
+      if (!dismissible) return;
+
+      const dismissBtn = this.querySelector('.site-announcement__dismiss');
+      dismissBtn?.addEventListener('click', () => {
+        this.hidden = true;
+        try {
+          localStorage.setItem(storageKey, '1');
+        } catch (e) {
+          /* ignore */
+        }
+      });
+    }
+  });
+})();

--- a/bengal/themes/default/assets/js/enhancements/interactive.js
+++ b/bengal/themes/default/assets/js/enhancements/interactive.js
@@ -240,6 +240,50 @@
   }
 
   /**
+   * Persist docs-nav <details> open/closed state per page (localStorage).
+   */
+  function setupDocsNavPersistence(root) {
+    const storageKey = `bengal_docs_nav_${window.location.pathname}`;
+    const detailsList = Array.from(root.querySelectorAll('.docs-nav-details'));
+
+    if (detailsList.length === 0) {
+      return;
+    }
+
+    const groupKey = (details) => {
+      const group = details.closest('.docs-nav-group');
+      const link = group?.querySelector('.docs-nav-group-link[href], .docs-nav-link[href]');
+      return link?.getAttribute('href') || details.closest('.docs-nav-group')?.dataset.depth || '';
+    };
+
+    let saved = {};
+    try {
+      saved = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    } catch (_e) {
+      saved = {};
+    }
+
+    detailsList.forEach((details) => {
+      const key = groupKey(details);
+      if (!key) {
+        return;
+      }
+      if (Object.prototype.hasOwnProperty.call(saved, key)) {
+        details.open = Boolean(saved[key]);
+      }
+      details.addEventListener('toggle', () => {
+        try {
+          const state = JSON.parse(localStorage.getItem(storageKey) || '{}');
+          state[key] = details.open;
+          localStorage.setItem(storageKey, JSON.stringify(state));
+        } catch (_e) {
+          /* storage unavailable */
+        }
+      });
+    });
+  }
+
+  /**
    * Documentation Navigation Enhancement
    *
    * Uses native <details>/<summary> for expand/collapse (no JS required for toggle).
@@ -445,6 +489,7 @@
       init() {
         this._docsNavCleanup = [];
         setupScrollSpy(this, this._docsNavCleanup);
+        setupDocsNavPersistence(this);
         setupDocsNavigation(this);
       }
       teardown() {

--- a/bengal/themes/default/assets/js/enhancements/tutorials.js
+++ b/bengal/themes/default/assets/js/enhancements/tutorials.js
@@ -1,0 +1,207 @@
+/**
+ * Tutorial page enhancements — scroll-driven step progress + localStorage (#543).
+ *
+ * Custom element: <bengal-tutorial-progress>
+ * Data attributes:
+ *   data-tutorial-id — localStorage key suffix
+ *   data-tutorial-step — TOC/sidebar step link (1-based index)
+ */
+(function () {
+  'use strict';
+
+  if (!window.BengalUtils) {
+    console.error('BengalUtils not loaded - tutorials.js requires utils.js');
+    return;
+  }
+
+  const { throttleScroll, ready } = window.BengalUtils;
+  const STORAGE_PREFIX = 'bengal_tutorial_progress_';
+
+  let root = null;
+  let tutorialId = null;
+  let steps = [];
+  let stepLinks = [];
+  let progressBar = null;
+  let progressLabel = null;
+  let currentIndex = -1;
+  let scrollHandler = null;
+  let progress = { visited: [], lastStep: 0 };
+
+  function storageKey() {
+    return STORAGE_PREFIX + (tutorialId || 'default');
+  }
+
+  function loadProgress() {
+    try {
+      const stored = localStorage.getItem(storageKey());
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        progress = {
+          visited: Array.isArray(parsed.visited) ? parsed.visited : [],
+          lastStep: typeof parsed.lastStep === 'number' ? parsed.lastStep : 0
+        };
+      }
+    } catch (_e) {
+      progress = { visited: [], lastStep: 0 };
+    }
+  }
+
+  function saveProgress() {
+    try {
+      localStorage.setItem(storageKey(), JSON.stringify(progress));
+    } catch (_e) {
+      /* storage full or unavailable */
+    }
+  }
+
+  function markVisited(index) {
+    if (!progress.visited.includes(index)) {
+      progress.visited.push(index);
+      saveProgress();
+    }
+    const link = stepLinks[index];
+    if (link) {
+      link.setAttribute('data-tutorial-visited', '');
+    }
+  }
+
+  function restoreVisited() {
+    progress.visited.forEach((index) => {
+      const link = stepLinks[index];
+      if (link) {
+        link.setAttribute('data-tutorial-visited', '');
+      }
+    });
+  }
+
+  function getCurrentIndex() {
+    const offset = 150;
+    for (let i = steps.length - 1; i >= 0; i--) {
+      const rect = steps[i].getBoundingClientRect();
+      if (rect.top <= offset) {
+        return i;
+      }
+    }
+    return 0;
+  }
+
+  function updateHeader(index) {
+    const total = steps.length;
+    const current = index + 1;
+    const pct = total > 0 ? (current / total) * 100 : 0;
+
+    if (progressLabel) {
+      progressLabel.textContent = `Step ${current} of ${total}`;
+    }
+
+    document.querySelectorAll('#tutorial-header-progress .tutorial-progress__step').forEach((el, i) => {
+      const stepNum = i + 1;
+      el.classList.toggle('tutorial-progress__step--current', stepNum === current);
+      el.classList.toggle('tutorial-progress__step--complete', stepNum < current);
+      const num = el.querySelector('.tutorial-progress__number');
+      if (num) {
+        num.textContent = stepNum < current ? '✓' : String(stepNum);
+      }
+    });
+
+    document.querySelectorAll('#tutorial-header-progress .tutorial-progress__connector').forEach((conn, i) => {
+      conn.classList.toggle('tutorial-progress__connector--complete', i < index);
+    });
+
+    if (progressBar) {
+      progressBar.style.width = `${pct}%`;
+      progressBar.setAttribute('aria-valuenow', String(Math.round(pct)));
+      const host = progressBar.closest('[role="progressbar"]');
+      if (host) {
+        host.setAttribute('aria-valuenow', String(Math.round(pct)));
+      }
+    }
+  }
+
+  function updateActiveStep() {
+    const index = getCurrentIndex();
+    if (index === currentIndex) {
+      return;
+    }
+    currentIndex = index;
+    progress.lastStep = currentIndex;
+    saveProgress();
+    markVisited(currentIndex);
+    updateHeader(currentIndex);
+
+    stepLinks.forEach((link, i) => {
+      const active = i === currentIndex;
+      link.classList.toggle('is-active', active);
+      link.toggleAttribute('aria-current', active);
+    });
+  }
+
+  function initTutorialProgress(element) {
+    root = element || document.querySelector('bengal-tutorial-progress');
+    if (!root) {
+      return;
+    }
+
+    tutorialId = root.getAttribute('data-tutorial-id') || window.location.pathname;
+    stepLinks = Array.from(root.querySelectorAll('.tutorial-sidebar .toc a[href^="#"], .toc a[href^="#"]'));
+    steps = stepLinks.map((link) => {
+      const id = (link.getAttribute('href') || '').slice(1);
+      return id ? document.getElementById(id) : null;
+    }).filter(Boolean);
+    if (!steps.length) {
+      steps = Array.from(document.querySelectorAll('.tutorial-content h2[id]'));
+    }
+    progressBar = document.getElementById('tutorial-progress-bar');
+    progressLabel = document.querySelector('#tutorial-header-progress .tutorial-progress__label');
+
+    if (!steps.length) {
+      return;
+    }
+
+    loadProgress();
+    restoreVisited();
+
+    scrollHandler = throttleScroll(updateActiveStep);
+    window.addEventListener('scroll', scrollHandler, { passive: true });
+    updateActiveStep();
+
+    stepLinks.forEach((link) => {
+      link.addEventListener('click', () => {
+        currentIndex = -1;
+        window.setTimeout(updateActiveStep, 100);
+      });
+    });
+
+    root.setAttribute('data-enhanced', 'true');
+  }
+
+  function cleanup() {
+    if (scrollHandler) {
+      window.removeEventListener('scroll', scrollHandler);
+      scrollHandler = null;
+    }
+  }
+
+  if (window.Bengal && window.Bengal.define) {
+    window.Bengal.define('bengal-tutorial-progress', class extends window.Bengal.Base {
+      init() {
+        initTutorialProgress(this);
+      }
+      teardown() {
+        cleanup();
+      }
+    });
+  }
+
+  ready(function () {
+    if (!document.querySelector('bengal-tutorial-progress')) {
+      initTutorialProgress(null);
+    }
+  });
+
+  window.BengalTutorials = {
+    init: initTutorialProgress,
+    cleanup,
+    getProgress: () => ({ ...progress })
+  };
+})();

--- a/bengal/themes/default/assets/js/main.js
+++ b/bengal/themes/default/assets/js/main.js
@@ -38,6 +38,19 @@
   /**
    * Delegated copy handler for build-time code copy buttons.
    */
+  function announceCopy(message) {
+    let region = document.getElementById('code-copy-live-region');
+    if (!region) {
+      region = document.createElement('div');
+      region.id = 'code-copy-live-region';
+      region.className = 'visually-hidden';
+      region.setAttribute('aria-live', 'polite');
+      region.setAttribute('aria-atomic', 'true');
+      document.body.appendChild(region);
+    }
+    region.textContent = message;
+  }
+
   function setupDelegatedCodeCopy() {
     document.addEventListener('click', function (e) {
       const wrapButton = e.target.closest('.code-wrap-toggle');
@@ -74,6 +87,7 @@
           `;
         button.classList.add('copied');
         button.setAttribute('aria-label', 'Code copied!');
+        announceCopy('Code copied to clipboard');
 
         setTimeout(function () {
           button.innerHTML = `
@@ -84,7 +98,7 @@
               <span>Copy</span>
             `;
           button.classList.remove('copied');
-          button.setAttribute('aria-label', 'Copy');
+          button.setAttribute('aria-label', 'Copy code to clipboard');
         }, 2000);
       }).catch(function (err) {
         log('Failed to copy code:', err);

--- a/bengal/themes/default/css_manifest.py
+++ b/bengal/themes/default/css_manifest.py
@@ -73,6 +73,7 @@ CSS_SHARED: list[str] = [
     "components/buttons.css",
     "components/forms.css",
     "components/cards.css",
+    "components/gallery.css",
     "components/badges.css",
     "components/labels.css",
     "components/icons.css",
@@ -102,6 +103,7 @@ CSS_SHARED: list[str] = [
     "components/_figure.css",
     "components/_terminal-embed.css",
     "components/link-preview.css",
+    "components/announcement.css",
 ]
 
 # ============================================================================

--- a/bengal/themes/default/templates/author.html
+++ b/bengal/themes/default/templates/author.html
@@ -80,7 +80,7 @@ Context variables:
         <a href="https://twitter.com/{{ social.twitter.lstrip('@') }}"
            class="social-link"
            aria-label="Twitter">
-          {{ icon('external', size=16) }}
+          {{ icon('twitter-logo', size=18) }}
           <span class="sr-only">Twitter</span>
         </a>
         {% end %}
@@ -89,7 +89,7 @@ Context variables:
         <a href="https://github.com/{{ social.github }}"
            class="social-link"
            aria-label="GitHub">
-          {{ icon('code', size=16) }}
+          {{ icon('github-logo', size=18) }}
           <span class="sr-only">GitHub</span>
         </a>
         {% end %}
@@ -98,7 +98,7 @@ Context variables:
         <a href="https://linkedin.com/in/{{ social.linkedin }}"
            class="social-link"
            aria-label="LinkedIn">
-          {{ icon('user', size=16) }}
+          {{ icon('linkedin-logo', size=18) }}
           <span class="sr-only">LinkedIn</span>
         </a>
         {% end %}
@@ -107,7 +107,7 @@ Context variables:
         <a href="{{ social.website }}"
            class="social-link"
            aria-label="Website">
-          {{ icon('link', size=16) }}
+          {{ icon('globe', size=18) }}
           <span class="sr-only">Website</span>
         </a>
         {% end %}
@@ -116,7 +116,7 @@ Context variables:
         <a href="mailto:{{ social.email }}"
            class="social-link"
            aria-label="Email">
-          {{ icon('file-text', size=16) }}
+          {{ icon('envelope-simple', size=18) }}
           <span class="sr-only">Email</span>
         </a>
         {% end %}

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -305,6 +305,8 @@ HELPER: Render a menu item (desktop/mobile)
 
     <p class="sr-only" data-agent-directive>For a complete page index, fetch <a href="{{ _llms_txt_url }}">{{ _llms_txt_url }}</a>.</p>
 
+    {% include 'partials/site-announcement.html' %}
+
     {# Header #}
     {% let _header_sticky = theme.header_sticky ?? true %}
     {% let _header_nav_position = theme.header_nav_position ?? 'left' %}
@@ -546,9 +548,11 @@ HELPER: Render a menu item (desktop/mobile)
     <script defer src="{{ asset_url('js/enhancements/tabs.js') }}"></script>
     <script defer src="{{ asset_url('js/enhancements/toc.js') }}"></script>
     <script defer src="{{ asset_url('js/enhancements/tracks.js') }}"></script>
+    <script defer src="{{ asset_url('js/enhancements/tutorials.js') }}"></script>
     <script defer src="{{ asset_url('js/enhancements/action-bar.js') }}"></script>
     <script defer src="{{ asset_url('js/enhancements/copy-link.js') }}"></script>
     <script defer src="{{ asset_url('js/enhancements/page-feedback.js') }}"></script>
+    <script defer src="{{ asset_url('js/enhancements/announcement.js') }}"></script>
     <script defer src="{{ asset_url('js/enhancements/author-view.js') }}"></script>
     {# <bengal-api-catalog> custom element (openapi pages); inert no-op elsewhere #}
     <script defer src="{{ asset_url('js/enhancements/api-catalog.js') }}"></script>

--- a/bengal/themes/default/templates/changelog/list.html
+++ b/bengal/themes/default/templates/changelog/list.html
@@ -24,21 +24,7 @@ Set `type: changelog` in section _index.md
 ================================================================================
 #}
 
-{# =============================================================================
-CHANGE CATEGORY COMPONENT
-============================================================================= #}
-{% def change_category(title, icon, items, is_breaking=false) %}
-{% if items and items | length > 0 %}
-<div class="{{ ['changelog-category', 'changelog-category--breaking' if is_breaking] | classes }}">
-  <h3 class="{{ ['category-title', 'category-title--breaking' if is_breaking] | classes }}">{{ icon }} {{ title }}</h3>
-  <ul class="changelog-list{{ ' changelog-list--breaking' if is_breaking else '' }}">
-    {% for item in items %}
-    <li class="{{ 'changelog-item--breaking' if is_breaking else '' }}">{{ item }}</li>
-    {% end %}
-  </ul>
-</div>
-{% end %}
-{% end %}
+{% from 'partials/changelog/_macros.html' import change_category %}
 
 {# =============================================================================
 RELEASE ITEM COMPONENT - Unified with ReleaseView
@@ -73,13 +59,15 @@ RELEASE ITEM COMPONENT - Unified with ReleaseView
   <p class="timeline-description">{{ rel_summary }}</p>
   {% end %}
 
-  {{ change_category('Added', '', rel.added) }}
-  {{ change_category('Changed', '', rel.changed) }}
-  {{ change_category('Fixed', '', rel.fixed) }}
-  {{ change_category('Deprecated', '', rel.deprecated) }}
-  {{ change_category('Removed', '', rel.removed) }}
-  {{ change_category('Security', '', rel.security) }}
-  {{ change_category('Breaking Changes', '', rel.breaking, is_breaking=true) }}
+  <div class="changelog-categories">
+  {{ change_category('Added', 'star', rel.added) }}
+  {{ change_category('Changed', 'arrow-clockwise', rel.changed) }}
+  {{ change_category('Fixed', 'bug', rel.fixed) }}
+  {{ change_category('Deprecated', 'warning', rel.deprecated) }}
+  {{ change_category('Removed', 'trash', rel.removed) }}
+  {{ change_category('Security', 'shield', rel.security) }}
+  {{ change_category('Breaking Changes', 'danger', rel.breaking, is_breaking=true) }}
+  </div>
 
   {% if rel.href %}
   <a href="{{ rel.href }}" class="changelog-read-more">View full release notes →</a>

--- a/bengal/themes/default/templates/changelog/single.html
+++ b/bengal/themes/default/templates/changelog/single.html
@@ -34,21 +34,7 @@ KIDA FEATURES USED:
 
 {% from 'partials/navigation-components.html' import breadcrumbs, page_navigation %}
 
-{# =============================================================================
-   CHANGE CATEGORY COMPONENT
-   ============================================================================= #}
-{% def change_category(title, icon, items, is_breaking=false) %}
-{% if items and items is iterable and items is not string and items | length > 0 %}
-<section class="changelog-category{{ ' changelog-breaking' if is_breaking else '' }}">
-  <h2 class="category-title">{{ icon }} {{ title }}</h2>
-  <ul class="changelog-list">
-    {% for item in items %}
-    <li>{{ item }}</li>
-    {% end %}
-  </ul>
-</section>
-{% end %}
-{% end %}
+{% from 'partials/changelog/_macros.html' import change_category %}
 
 {# =============================================================================
    MAIN TEMPLATE
@@ -107,13 +93,15 @@ KIDA FEATURES USED:
 
   <div class="release-content">
     {# Change Categories #}
-    {{ change_category('Added', '', changes_added) }}
-    {{ change_category('Changed', '', changes_changed) }}
-    {{ change_category('Fixed', '', changes_fixed) }}
-    {{ change_category('Deprecated', '', changes_deprecated) }}
-    {{ change_category('Removed', '', changes_removed) }}
-    {{ change_category('Security', '', changes_security) }}
-    {{ change_category('Breaking Changes', '', changes_breaking, is_breaking=true) }}
+    <div class="changelog-categories">
+    {{ change_category('Added', 'star', changes_added) }}
+    {{ change_category('Changed', 'arrow-clockwise', changes_changed) }}
+    {{ change_category('Fixed', 'bug', changes_fixed) }}
+    {{ change_category('Deprecated', 'warning', changes_deprecated) }}
+    {{ change_category('Removed', 'trash', changes_removed) }}
+    {{ change_category('Security', 'shield', changes_security) }}
+    {{ change_category('Breaking Changes', 'danger', changes_breaking, is_breaking=true) }}
+    </div>
 
     {# Main content (detailed release notes) #}
     {% if content and content.strip() %}

--- a/bengal/themes/default/templates/home.html
+++ b/bengal/themes/default/templates/home.html
@@ -5,7 +5,9 @@
 Site Home Page Template (Kida-Native)
 ================================================================================
 
-Landing page for the site with hero, features, stats, and recent posts.
+Opinionated marketing landing for the site root. Zero-config: when frontmatter
+omits features/CTAs, the template fills in a polished splash from site.title
+and site.description — distinct from the generic section index (gallery) layout.
 
 KIDA FEATURES USED:
 - {% let %} for template-scoped variables
@@ -14,9 +16,6 @@ KIDA FEATURES USED:
 - Pipeline operator (|>) for filter chains
 - {% def %} for reusable components
 - {% cache %} for recent posts computation
-
-USAGE:
-Auto-selected for site home page (index.html)
 ================================================================================
 #}
 
@@ -49,7 +48,10 @@ POST CARD COMPONENT
         {% if post_desc %}
         <p class="post-card-excerpt">{{ post_desc | truncate(150) }}</p>
         {% end %}
-        <a href="{{ post_href }}" class="read-more">Read more →</a>
+        <a href="{{ post_href }}" class="read-more">
+            {{ t('home.read_more', default='Read more') }}
+            {{ icon('arrow-right', size=14, css_class='nav-arrow') }}
+        </a>
     </div>
 </article>
 {% end %}
@@ -65,16 +67,22 @@ FEATURE CARD COMPONENT
 
 <article class="feature-card">
     {% if feat_icon %}
-    <div class="feature-icon" aria-hidden="true">{{ feat_icon }}</div>
+    <div class="feature-icon" aria-hidden="true">
+        {% if feat_icon | length <= 24 and not (feat_icon.startswith('<') or feat_icon.startswith('http')) %}
+        {{ icon(feat_icon, size=32) }}
+        {% else %}
+        {{ feat_icon }}
+        {% end %}
+    </div>
     {% end %}
-    <h3 class="feature-title">{{ feat_title }}</h3>
-    <p class="feature-description">{{ feat_desc }}</p>
+    <h3 class="feature-title"><bdi>{{ feat_title }}</bdi></h3>
+    <p class="feature-description"><bdi>{{ feat_desc }}</bdi></p>
     {% if feat_link %}
     {% let link_url = feat_link?.href ?? feat_link?.url ?? '#' %}
-    {% let link_text = feat_link?.text ?? 'Learn more' %}
+    {% let link_text = feat_link?.text ?? t('home.learn_more', default='Learn more') %}
     <a href="{{ link_url | absolute_url }}" class="feature-link">
-        {{ link_text }}
-        <span aria-hidden="true">→</span>
+        <bdi>{{ link_text }}</bdi>
+        {{ icon('arrow-right', size=14, css_class='nav-arrow') }}
     </a>
     {% end %}
 </article>
@@ -85,20 +93,46 @@ MAIN TEMPLATE
 ============================================================================= #}
 
 {% block content %}
-{# Template-scoped variables with null-safe access #}
-{% let page_title = page?.title ?? config?.title ?? 'Home' %}
-{% let page_desc = params?.description ?? '' %}
-{% let blob_background = params?.blob_background ?? false %}
-{% let cta_buttons = params?.cta_buttons ?? [] %}
-{% let features = params?.features ?? [] %}
-{% let quick_links = params?.quick_links ?? [] %}
+{% let page_title = page?.title ?? site.title ?? 'Home' %}
+{% let page_desc = params?.description ?? site.description ?? '' %}
+{% let _auto_nav = get_auto_nav() %}
+{% let _first_section = _auto_nav[0] if _auto_nav | length > 0 else none %}
+
+{% let _default_features = [
+  {'icon': 'star', 'title': t('home.feature_speed_title', default='Lightning fast'), 'description': t('home.feature_speed_desc', default='Static HTML, zero runtime overhead, and builds that finish in seconds.')},
+  {'icon': 'palette', 'title': t('home.feature_theme_title', default='Beautiful by default'), 'description': t('home.feature_theme_desc', default='Named palettes, view transitions, and a polished theme with no configuration required.')},
+  {'icon': 'puzzle-piece', 'title': t('home.feature_zero_dep_title', default='Zero dependencies'), 'description': t('home.feature_zero_dep_desc', default='No npm, no CDN — self-hosted assets and dependency-free enhancements.')},
+  {'icon': 'code', 'title': t('home.feature_python_title', default='Python native'), 'description': t('home.feature_python_desc', default='Content, templates, and tooling written in pure Python for modern free-threaded runtimes.')}
+] %}
+
+{% let _default_ctas = [
+  {'text': t('home.cta_explore', default='Explore'), 'href': (_first_section?.href ?? '/docs/'), 'style': 'primary'},
+  {'text': t('home.cta_search', default='Search'), 'href': '/search/', 'style': 'secondary'}
+] %}
+
+{% let _default_quick_links = [] %}
+{% for item in _auto_nav | take(6) %}
+{% set _ = _default_quick_links.append({'title': item?.name ?? 'Section', 'href': item?.href ?? '#', 'icon': 'folder', 'description': ''}) %}
+{% end %}
+
+{% let _has_custom_landing = (params?.features ?? none) is not none
+  or (params?.cta_buttons ?? none) is not none
+  or (params?.quick_links ?? none) is not none
+  or (params?.stats ?? none) is not none
+  or (params?.blob_background ?? none) is not none
+  or (content and content.strip()) %}
+
+{% let features = params?.features ?? (_default_features if not _has_custom_landing else []) %}
+{% let cta_buttons = params?.cta_buttons ?? (_default_ctas if not _has_custom_landing else []) %}
+{% let quick_links = params?.quick_links ?? (_default_quick_links if not _has_custom_landing and (_default_quick_links | length > 0) else []) %}
 {% let stats = params?.stats ?? [] %}
+{% let blob_background = params?.blob_background ?? (not _has_custom_landing) %}
 {% let show_recent = params?.show_recent_posts ?? true %}
 {% let blog_section_name = params?.blog_section ?? 'blog' %}
 
-<div class="home">
+<div class="home home--splash">
     {# Hero Section #}
-    {% let hero_classes = ['hero', 'hero--large'] %}
+    {% let hero_classes = ['hero', 'hero--large', 'hero--splash'] %}
     {% if blob_background %}{% set _ = hero_classes.append('hero--blob-background') %}{% end %}
 
     <header class="{{ hero_classes | join(' ') }}">
@@ -112,11 +146,14 @@ MAIN TEMPLATE
         {% end %}
         <div class="hero__container">
             <div class="hero__content">
+                {% if not _has_custom_landing %}
+                <p class="hero__eyebrow">{{ t('home.eyebrow', default='Welcome') }}</p>
+                {% end %}
                 <h1 class="hero__title">
-                    <span class="fluid-text">{{ page_title }}</span>
+                    <span class="fluid-text"><bdi>{{ page_title }}</bdi></span>
                 </h1>
                 {% if page_desc %}
-                <p class="hero__subtitle">{{ page_desc }}</p>
+                <p class="hero__subtitle"><bdi>{{ page_desc }}</bdi></p>
                 {% end %}
 
                 {% if cta_buttons | length > 0 %}
@@ -127,7 +164,7 @@ MAIN TEMPLATE
                     {% let btn_style = button?.style ?? 'primary' %}
                     <a href="{{ btn_url | absolute_url }}"
                         class="{{ ['hero__button', 'hero__button--' ~ btn_style, 'gradient-border' if btn_style != 'primary'] | classes }}">
-                        {{ btn_text }}
+                        <bdi>{{ btn_text }}</bdi>
                     </a>
                     {% end %}
                 </div>
@@ -138,7 +175,7 @@ MAIN TEMPLATE
 
     {# Feature Highlights #}
     {% if features | length > 0 %}
-    <section class="features" aria-label="Key features">
+    <section class="features" aria-label="{{ t('home.features_aria', default='Key features') }}">
         <div class="features-grid">
             {% for feature in features %}
             {{ feature_card(feature) }}
@@ -156,21 +193,27 @@ MAIN TEMPLATE
 
     {# Quick Links Section #}
     {% if quick_links | length > 0 %}
-    <section class="quick-links" aria-label="Quick navigation">
-        <h2>Quick Links</h2>
+    <section class="quick-links" id="explore" aria-label="{{ t('home.quick_links_aria', default='Quick navigation') }}">
+        <h2>{{ t('home.quick_links_title', default='Explore') }}</h2>
         <div class="quick-links-grid">
             {% for link in quick_links %}
             {% let link_url = link?.href ?? link?.url ?? '#' %}
-            {% let link_title = link?.title ?? 'Link' %}
-            {% let link_icon = link?.icon ?? '' %}
+            {% let link_title = link?.title ?? link?.name ?? 'Link' %}
+            {% let link_icon = link?.icon ?? 'folder' %}
             {% let link_desc = link?.description ?? '' %}
             <a href="{{ link_url | absolute_url }}" class="quick-link-card">
                 {% if link_icon %}
-                <div class="quick-link-icon" aria-hidden="true">{{ link_icon }}</div>
+                <div class="quick-link-icon" aria-hidden="true">
+                    {% if link_icon | length <= 24 and not (link_icon.startswith('<') or link_icon.startswith('http')) %}
+                    {{ icon(link_icon, size=24) }}
+                    {% else %}
+                    {{ link_icon }}
+                    {% end %}
+                </div>
                 {% end %}
-                <h3>{{ link_title }}</h3>
+                <h3><bdi>{{ link_title }}</bdi></h3>
                 {% if link_desc %}
-                <p>{{ link_desc }}</p>
+                <p><bdi>{{ link_desc }}</bdi></p>
                 {% end %}
             </a>
             {% end %}
@@ -180,12 +223,12 @@ MAIN TEMPLATE
 
     {# Statistics/Metrics Section #}
     {% if stats | length > 0 %}
-    <section class="stats" aria-label="Key metrics">
+    <section class="stats" aria-label="{{ t('home.stats_aria', default='Key metrics') }}">
         <div class="stats-grid">
             {% for stat in stats %}
             <div class="stat-card">
                 <div class="stat-value">{{ stat?.value ?? '0' }}</div>
-                <div class="stat-label">{{ stat?.label ?? '' }}</div>
+                <div class="stat-label"><bdi>{{ stat?.label ?? '' }}</bdi></div>
             </div>
             {% end %}
         </div>
@@ -195,10 +238,7 @@ MAIN TEMPLATE
     {# Recent Posts Section - cached for performance #}
     {% if show_recent %}
     {% cache 'home-recent-posts-' ~ (site.nav_version ?? '') %}
-    {# Find blog section - O(1) dict lookup via get_section() #}
     {% let blog_section = get_section(blog_section_name) %}
-
-    {# Get recent posts from section pages #}
     {% let recent = [] %}
     {% if blog_section %}
     {% let recent = (blog_section.pages ?? [])
@@ -209,7 +249,7 @@ MAIN TEMPLATE
 
     {% if recent | length > 0 %}
     <section class="recent-posts">
-        <h2 class="recent-posts-title">Recent Posts</h2>
+        <h2 class="recent-posts-title">{{ t('home.recent_posts', default='Recent Posts') }}</h2>
         <div class="posts-grid">
             {% for post in recent %}
             {{ post_card(post) }}

--- a/bengal/themes/default/templates/partials/changelog/_macros.html
+++ b/bengal/themes/default/templates/partials/changelog/_macros.html
@@ -1,0 +1,19 @@
+{#
+Shared changelog category macro — iconified headings + subgrid-ready markup (#543).
+#}
+
+{% def change_category(title, icon_name, items, is_breaking=false) %}
+{% if items and items is iterable and items is not string and items | length > 0 %}
+<div class="{{ ['changelog-category', 'changelog-category--breaking' if is_breaking] | classes }}" data-category="{{ title | lower | replace(' ', '-') }}">
+  <h3 class="{{ ['category-title', 'category-title--breaking' if is_breaking] | classes }}">
+    <span class="category-icon" aria-hidden="true">{{ icon(icon_name, size=18) }}</span>
+    {{ title }}
+  </h3>
+  <ul class="changelog-list{{ ' changelog-list--breaking' if is_breaking else '' }}">
+    {% for item in items %}
+    <li class="{{ 'changelog-item--breaking' if is_breaking else '' }}">{{ item }}</li>
+    {% end %}
+  </ul>
+</div>
+{% end %}
+{% end %}

--- a/bengal/themes/default/templates/partials/site-announcement.html
+++ b/bengal/themes/default/templates/partials/site-announcement.html
@@ -1,0 +1,58 @@
+{#
+  Site-wide announcement bar (opt-in via [params.announcement] in bengal.toml).
+
+  Invisible when unconfigured. Dismiss state persisted in localStorage by
+  <bengal-site-announcement> (see enhancements/announcement.js).
+
+  Config shape:
+    [params.announcement]
+    message = "Welcome!"
+    href = "/docs/"           # optional
+    link_text = "Learn more"  # optional
+    variant = "info"          # info | warning | promo
+    id = "launch-2026"        # optional dismiss key
+    dismissible = true        # default true
+#}
+{% let _announcement = site?.params?.announcement ?? none %}
+{% if _announcement %}
+{% let _message = _announcement?.message ?? _announcement?.text ?? '' %}
+{% if _message %}
+{% let _variant = _announcement?.variant ?? 'info' %}
+{% let _href = _announcement?.href ?? _announcement?.url ?? none %}
+{% let _link_text = _announcement?.link_text ?? _announcement?.linkText ?? t('announcement.learn_more', default='Learn more') %}
+{% let _announcement_id = _announcement?.id ?? (_message | slugify) %}
+{% let _dismissible = _announcement?.dismissible ?? true %}
+
+<bengal-site-announcement
+  class="site-announcement site-announcement--{{ _variant }}"
+  data-announcement-id="{{ _announcement_id }}"
+  {% if _dismissible %}data-dismissible="true"{% end %}
+  role="region"
+  aria-label="{{ t('announcement.aria_label', default='Site announcement') }}">
+  <div class="site-announcement__inner container">
+    <div class="site-announcement__content">
+      {% if _variant == 'warning' %}
+      {{ icon('warning', size=18, css_class='site-announcement__icon') }}
+      {% elif _variant == 'promo' %}
+      {{ icon('star', size=18, css_class='site-announcement__icon') }}
+      {% else %}
+      {{ icon('info', size=18, css_class='site-announcement__icon') }}
+      {% end %}
+      <p class="site-announcement__message"><bdi>{{ _message }}</bdi></p>
+      {% if _href %}
+      <a href="{{ _href | absolute_url }}" class="site-announcement__link">
+        <bdi>{{ _link_text }}</bdi>
+        {{ icon('arrow-right', size=14, css_class='nav-arrow') }}
+      </a>
+      {% end %}
+    </div>
+    {% if _dismissible %}
+    <button type="button" class="site-announcement__dismiss"
+      aria-label="{{ t('announcement.dismiss', default='Dismiss announcement') }}">
+      {{ icon('x', size=16) }}
+    </button>
+    {% end %}
+  </div>
+</bengal-site-announcement>
+{% end %}
+{% end %}

--- a/bengal/themes/default/templates/post.html
+++ b/bengal/themes/default/templates/post.html
@@ -1,45 +1,29 @@
 {% extends "base.html" %}
 
 {#
-================================================================================
-Generic Post Template (Kida-Native)
-================================================================================
-
-Default template for blog posts and articles.
-
-KIDA FEATURES USED:
-- {% let %} for template-scoped variables
-- Optional chaining (?.) for null-safe access
-- Null coalescing (??) for smart defaults
-- {% def %} for reusable components
-
-USAGE:
-Auto-selected for posts without a specific type
-================================================================================
+Generic Post Template — unified editorial hero (#542).
 #}
 
-{% from 'partials/navigation-components.html' import breadcrumbs %}
+{% from 'partials/navigation-components.html' import breadcrumbs, page_navigation, toc as toc_macro %}
 {% from 'partials/components/tags.html' import tag_list %}
 {% from 'partials/components/related-posts-simple.html' import related_posts_simple %}
-
-{# =============================================================================
-   MAIN TEMPLATE
-   ============================================================================= #}
+{% from 'partials/page-hero/_macros.html' import hero_editorial %}
 
 {% block content %}
-{# Template-scoped variables #}
 {% let page_title = page?.title ?? 'Post' %}
 {% let page_tags = page?.tags ?? [] %}
 {% let css_class = params?.css_class ?? '' %}
+{% let toc_items_list = toc_items ?? [] %}
+{% let show_toc = page?.toc and (toc_items_list | length >= 3) %}
 
 <div class="container">
-  <div class="{{ ['page-layout', 'page-with-toc' if toc] | classes }}">
-    <article class="post">
-      <header class="post-header">
-        <h1>{{ page_title }}</h1>
-      </header>
+  {% include 'partials/action-bar.html' %}
 
-      <div class="post-content prose">
+  <div class="{{ ['page-layout', 'page-with-toc' if show_toc else ''] | classes }}">
+    <article class="post prose {{ css_class }}">
+      {{ hero_editorial(page, params, theme) }}
+
+      <div class="post-content">
         {{ content | safe }}
       </div>
 
@@ -51,16 +35,13 @@ Auto-selected for posts without a specific type
         </div>
       </footer>
       {% end %}
+
+      {{ page_navigation(page) }}
     </article>
 
-    {% if toc %}
-    <aside class="page-sidebar">
-      <nav class="toc" aria-label="Table of contents">
-        <h2 class="toc-title">On This Page</h2>
-        <div class="toc-content">
-          {{ toc | safe }}
-        </div>
-      </nav>
+    {% if show_toc %}
+    <aside class="page-sidebar" role="complementary" aria-label="Table of contents">
+      {{ toc_macro(toc_items=toc_items, toc=page.toc, page=page) }}
     </aside>
     {% end %}
   </div>

--- a/bengal/themes/default/templates/resume/list.html
+++ b/bengal/themes/default/templates/resume/list.html
@@ -86,7 +86,7 @@ MAIN TEMPLATE
 {% let resume_languages = resume?.languages ?? [] %}
 {% let resume_volunteer = resume?.volunteer ?? [] %}
 
-<div class="resume">
+<div class="resume" data-print-cv>
     {# Header Section #}
     <header class="resume-header">
         <h1 class="resume-name">{{ resume_name }}</h1>
@@ -99,33 +99,33 @@ MAIN TEMPLATE
         <div class="resume-contact">
             {% if resume_contact?.email %}
             <a href="mailto:{{ resume_contact.email }}" class="contact-item">
-                <span class="contact-icon">✉</span> {{ resume_contact.email }}
+                <span class="contact-icon" aria-hidden="true">{{ icon('envelope-simple', size=16) }}</span> {{ resume_contact.email }}
             </a>
             {% end %}
             {% if resume_contact?.phone %}
             <span class="contact-item">
-                <span class="contact-icon">📱</span> {{ resume_contact.phone }}
+                <span class="contact-icon" aria-hidden="true">{{ icon('link', size=16) }}</span> {{ resume_contact.phone }}
             </span>
             {% end %}
             {% if resume_contact?.location %}
             <span class="contact-item">
-                <span class="contact-icon">📍</span> {{ resume_contact.location }}
+                <span class="contact-icon" aria-hidden="true">{{ icon('map', size=16) }}</span> {{ resume_contact.location }}
             </span>
             {% end %}
             {% if resume_contact?.website %}
             {% let website_display = resume_contact.website | replace('https://', '') | replace('http://', '') %}
-            <a href="{{ resume_contact.website }}" class="contact-item" target="_blank">
-                <span class="contact-icon">🌐</span> {{ website_display }}
+            <a href="{{ resume_contact.website }}" class="contact-item" target="_blank" rel="noopener noreferrer">
+                <span class="contact-icon" aria-hidden="true">{{ icon('globe', size=16) }}</span> {{ website_display }}
             </a>
             {% end %}
             {% if resume_contact?.linkedin %}
-            <a href="{{ resume_contact.linkedin }}" class="contact-item" target="_blank">
-                <span class="contact-icon">💼</span> LinkedIn
+            <a href="{{ resume_contact.linkedin }}" class="contact-item" target="_blank" rel="noopener noreferrer">
+                <span class="contact-icon" aria-hidden="true">{{ icon('linkedin-logo', size=16) }}</span> LinkedIn
             </a>
             {% end %}
             {% if resume_contact?.github %}
-            <a href="{{ resume_contact.github }}" class="contact-item" target="_blank">
-                <span class="contact-icon">🔗</span> GitHub
+            <a href="{{ resume_contact.github }}" class="contact-item" target="_blank" rel="noopener noreferrer">
+                <span class="contact-icon" aria-hidden="true">{{ icon('github-logo', size=16) }}</span> GitHub
             </a>
             {% end %}
         </div>

--- a/bengal/themes/default/templates/tutorial/single.html
+++ b/bengal/themes/default/templates/tutorial/single.html
@@ -20,6 +20,33 @@ Set `type: tutorial` in frontmatter or use cascade from section
 
 {% from 'partials/navigation-components.html' import breadcrumbs, page_navigation %}
 
+{# Scroll-synced step progress (mirrors track pattern) #}
+{% def tutorial_progress_indicator(total_steps, current_step=1) %}
+<div class="tutorial-progress" role="progressbar" aria-valuenow="{{ current_step }}" aria-valuemin="1" aria-valuemax="{{ total_steps }}">
+  <div class="tutorial-progress__steps">
+    {% let step = 1 %}
+    {% while step <= total_steps %}
+      {% let is_complete = step < current_step %}
+      {% let is_current = step == current_step %}
+      {% let step_class = 'tutorial-progress__step' %}
+      {% if is_complete %}{% let step_class = step_class ~ ' tutorial-progress__step--complete' %}{% end %}
+      {% if is_current %}{% let step_class = step_class ~ ' tutorial-progress__step--current' %}{% end %}
+      <div class="{{ step_class }}" data-step="{{ step }}">
+        <span class="tutorial-progress__number">{% if is_complete %}✓{% else %}{{ step }}{% end %}</span>
+      </div>
+      {% if step < total_steps %}
+      <div class="tutorial-progress__connector{{ ' tutorial-progress__connector--complete' if is_complete else '' }}"></div>
+      {% end %}
+      {% let step = step + 1 %}
+    {% end %}
+  </div>
+  <div class="tutorial-progress__label">Step {{ current_step }} of {{ total_steps }}</div>
+  <div class="tutorial-progress__bar" aria-hidden="true">
+    <div class="tutorial-progress__fill" id="tutorial-progress-bar"></div>
+  </div>
+</div>
+{% end %}
+
 {# =============================================================================
    RELATED TUTORIAL CARD
    ============================================================================= #}
@@ -71,6 +98,9 @@ Set `type: tutorial` in frontmatter or use cascade from section
 {% let tut_objectives = params?.learning_objectives ?? params?.objectives ?? [] %}
 {% let tut_next_steps = params?.next_steps ?? [] %}
 {% let tut_further_reading = params?.further_reading ?? [] %}
+{% let toc_items_list = toc_items ?? [] %}
+{% let tutorial_step_count = toc_items_list | length %}
+{% let tutorial_id = page?.slug ?? page?._path ?? '' %}
 
 <div class="container">
   {# Action Bar: Breadcrumbs + Share #}
@@ -113,6 +143,13 @@ Set `type: tutorial` in frontmatter or use cascade from section
           </span>
           {% end %}
         </div>
+
+        {# Scroll-driven progress — updated by tutorials.js #}
+        {% if tutorial_step_count >= 2 %}
+        <div class="tutorial-progress-host" id="tutorial-header-progress" data-tutorial-total="{{ tutorial_step_count }}">
+          {{ tutorial_progress_indicator(tutorial_step_count, 1) }}
+        </div>
+        {% end %}
 
         {# Prerequisites #}
         {% if tut_prereqs | length > 0 %}
@@ -184,8 +221,9 @@ Set `type: tutorial` in frontmatter or use cascade from section
       {% end %}
     </article>
 
-    {# Right Sidebar: TOC #}
+    {# Right Sidebar: TOC + scroll-synced step nav #}
     {% if toc %}
+    <bengal-tutorial-progress data-tutorial-id="{{ tutorial_id }}">
     <aside class="tutorial-sidebar">
       <nav class="toc" aria-label="Table of contents">
         <h2 class="toc-title">Tutorial Steps</h2>
@@ -194,6 +232,7 @@ Set `type: tutorial` in frontmatter or use cascade from section
         </div>
       </nav>
     </aside>
+    </bengal-tutorial-progress>
     {% end %}
   </div>
 </div>

--- a/bengal/themes/default/theme.yaml
+++ b/bengal/themes/default/theme.yaml
@@ -87,6 +87,13 @@ icons:
     trash: trash
     download: download
     upload: upload
+    bug: bug
+    shield: shield
+    globe: globe
+    envelope-simple: envelope-simple
+    twitter-logo: twitter-logo
+    github-logo: github-logo
+    linkedin-logo: linkedin-logo
     # UI & Metadata
     settings: settings
     star: star

--- a/changelog.d/+pridelands-phase3-remainder.changed.md
+++ b/changelog.d/+pridelands-phase3-remainder.changed.md
@@ -1,1 +1,1 @@
-Theme Phase 3 remainder: changelog category icons, author/resume iconify, tutorial scroll progress, post hero unification, code-block word-wrap toggle + copy SR announce, docs-nav persistence.
+Default theme: changelog category icons, author/resume iconify, tutorial scroll progress, post hero unification, code-block word-wrap toggle + copy SR announce, docs-nav persistence.

--- a/changelog.d/+pridelands-phase3-remainder.changed.md
+++ b/changelog.d/+pridelands-phase3-remainder.changed.md
@@ -1,0 +1,1 @@
+Theme Phase 3 remainder: changelog category icons, author/resume iconify, tutorial scroll progress, post hero unification, code-block word-wrap toggle + copy SR announce, docs-nav persistence.

--- a/changelog.d/+pridelands-phase4-first-impression.changed.md
+++ b/changelog.d/+pridelands-phase4-first-impression.changed.md
@@ -1,0 +1,1 @@
+Zero-config splash landing, dismissible site announcement bar, and RTL finish (logical properties, directional icons, gallery regression view).

--- a/tests/integration/test_i18n_rtl.py
+++ b/tests/integration/test_i18n_rtl.py
@@ -416,3 +416,135 @@ class TestCSSLogicalProperties:
             f"Found {len(violations)} physical padding-left/right properties:\n"
             + "\n".join(violations[:10])
         )
+
+
+@pytest.mark.bengal(testroot="test-i18n-rtl")
+class TestRTLGalleryView:
+    """RTL regression checkpoint for card-grid gallery layouts."""
+
+    def test_arabic_gallery_page_discovered(self, shared_site) -> None:
+        """Arabic gallery section index should be discovered."""
+        ar_gallery = [
+            p
+            for p in shared_site.pages
+            if getattr(p, "lang", None) == "ar" and "/gallery" in getattr(p, "_path", "")
+        ]
+        assert len(ar_gallery) >= 1, "Arabic gallery index should exist"
+
+    def test_arabic_gallery_renders_rtl(self, shared_site) -> None:
+        """Built Arabic gallery page should render dir=rtl with card tiles."""
+        ar_gallery = next(
+            (
+                p
+                for p in shared_site.pages
+                if getattr(p, "lang", None) == "ar"
+                and "gallery" in getattr(p, "_path", "")
+                and getattr(p, "source_path", None)
+                and getattr(p.source_path, "stem", "") == "_index"
+            ),
+            None,
+        )
+        assert ar_gallery is not None
+
+        output_candidates = list((shared_site.output_dir / "ar").rglob("gallery/index.html"))
+        assert output_candidates, "Expected built Arabic gallery index.html"
+        html = output_candidates[0].read_text(encoding="utf-8")
+        assert 'dir="rtl"' in html
+        assert "content-tiles" in html
+
+
+class TestSiteAnnouncement:
+    """Site-wide announcement bar partial."""
+
+    def test_announcement_partial_exists(self) -> None:
+        from pathlib import Path
+
+        partial = Path("bengal/themes/default/templates/partials/site-announcement.html")
+        assert partial.is_file()
+        text = partial.read_text(encoding="utf-8")
+        assert "bengal-site-announcement" in text
+        assert "site.params.announcement" in text or "params?.announcement" in text
+
+    def test_announcement_in_base_template(self) -> None:
+        from pathlib import Path
+
+        base = Path("bengal/themes/default/templates/base.html").read_text(encoding="utf-8")
+        assert "partials/site-announcement.html" in base
+        assert "enhancements/announcement.js" in base
+
+    def test_announcement_renders_when_configured(self, tmp_path) -> None:
+        from pathlib import Path
+
+        from bengal.core.site import Site
+        from bengal.rendering.template_engine import TemplateEngine
+
+        config = {
+            "params": {
+                "announcement": {
+                    "message": "Welcome to the beta!",
+                    "href": "/docs/",
+                    "variant": "promo",
+                    "id": "beta-launch",
+                }
+            }
+        }
+        site = Site(root_path=tmp_path, config=config)
+        engine = TemplateEngine(site)
+
+        class Page:
+            lang = "en"
+            title = "Home"
+
+        partial = Path("bengal/themes/default/templates/partials/site-announcement.html").read_text(
+            encoding="utf-8"
+        )
+        html = engine.render_string(partial, {"page": Page(), "site": site})
+        assert "bengal-site-announcement" in html
+        assert "Welcome to the beta!" in html
+        assert 'data-announcement-id="beta-launch"' in html
+
+    def test_announcement_hidden_when_unconfigured(self, tmp_path) -> None:
+        from pathlib import Path
+
+        from bengal.core.site import Site
+        from bengal.rendering.template_engine import TemplateEngine
+
+        site = Site(root_path=tmp_path, config={})
+        engine = TemplateEngine(site)
+
+        class Page:
+            lang = "en"
+
+        partial = Path("bengal/themes/default/templates/partials/site-announcement.html").read_text(
+            encoding="utf-8"
+        )
+        html = engine.render_string(partial, {"page": Page(), "site": site})
+        assert "bengal-site-announcement" not in html
+
+
+class TestRTLPhysicalPropertyFinish:
+    """Remaining directional affordance conversions for #544."""
+
+    def test_back_to_top_uses_logical_inset(self) -> None:
+        from pathlib import Path
+
+        css = Path("bengal/themes/default/assets/css/components/interactive.css").read_text(
+            encoding="utf-8"
+        )
+        assert "inset-inline-end:" in css
+        assert ".back-to-top" in css
+
+    def test_minimal_tiles_rtl_arrow_flip(self) -> None:
+        from pathlib import Path
+
+        css = Path("bengal/themes/default/assets/css/components/widgets.css").read_text(
+            encoding="utf-8"
+        )
+        assert '[dir="rtl"] .content-tiles--minimal li::before' in css
+
+    def test_home_landing_uses_nav_arrow(self) -> None:
+        from pathlib import Path
+
+        template = Path("bengal/themes/default/templates/home.html").read_text(encoding="utf-8")
+        assert "nav-arrow" in template
+        assert "home--splash" in template

--- a/tests/roots/test-i18n-rtl/content/ar/gallery/_index.md
+++ b/tests/roots/test-i18n-rtl/content/ar/gallery/_index.md
@@ -1,0 +1,11 @@
+---
+title: المعرض
+lang: ar
+translation_key: gallery
+discover:
+  children:
+    title: "تصفح"
+    variant: cards
+---
+
+فهرس المعرض للتحقق من تخطيط RTL.

--- a/tests/roots/test-i18n-rtl/content/ar/gallery/alpha.md
+++ b/tests/roots/test-i18n-rtl/content/ar/gallery/alpha.md
@@ -1,0 +1,8 @@
+---
+title: ألفا
+lang: ar
+translation_key: gallery-alpha
+description: البطاقة الأولى
+---
+
+محتوى صفحة ألفا.

--- a/tests/roots/test-i18n-rtl/content/ar/gallery/beta.md
+++ b/tests/roots/test-i18n-rtl/content/ar/gallery/beta.md
@@ -1,0 +1,8 @@
+---
+title: بيتا
+lang: ar
+translation_key: gallery-beta
+description: البطاقة الثانية
+---
+
+محتوى صفحة بيتا.

--- a/tests/roots/test-i18n-rtl/content/en/gallery/_index.md
+++ b/tests/roots/test-i18n-rtl/content/en/gallery/_index.md
@@ -1,0 +1,11 @@
+---
+title: Gallery
+lang: en
+translation_key: gallery
+discover:
+  children:
+    title: "Browse"
+    variant: cards
+---
+
+Section index gallery layout for RTL regression checks.

--- a/tests/roots/test-i18n-rtl/content/en/gallery/alpha.md
+++ b/tests/roots/test-i18n-rtl/content/en/gallery/alpha.md
@@ -1,0 +1,8 @@
+---
+title: Alpha
+lang: en
+translation_key: gallery-alpha
+description: First gallery card
+---
+
+Alpha page content.

--- a/tests/roots/test-i18n-rtl/content/en/gallery/beta.md
+++ b/tests/roots/test-i18n-rtl/content/en/gallery/beta.md
@@ -1,0 +1,8 @@
+---
+title: Beta
+lang: en
+translation_key: gallery-beta
+description: Second gallery card
+---
+
+Beta page content.


### PR DESCRIPTION
## Summary

- Finish Pridelands Phase 3 specialized layouts: changelog category icons/subgrid, author/resume iconify, tutorial scroll progress with localStorage, post hero unification, premium code blocks (word-wrap toggle + copy SR announce), and docs-nav `<details>` persistence.
- Ship Phase 4 first impression: zero-config splash landing on `home.html`, opt-in dismissible site announcement bar via `[params.announcement]`, and RTL finish (logical properties, directional icon flips, gallery regression view in `test-i18n-rtl`).
- Add focused tests (118 passed: `tests/integration/test_i18n_rtl.py`, `tests/unit/themes/`, `tests/unit/postprocess/test_static_markup.py`) and `changelog.d/` fragments for both phases.

## Proof

- [x] Focused tests: `pytest tests/integration/test_i18n_rtl.py tests/unit/themes/ tests/unit/postprocess/test_static_markup.py` (118 passed)
- [ ] `poe proof-pr` or scoped equivalent: not run (theme/presentation-only)
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/+pridelands-phase3-remainder.changed.md`, `changelog.d/+pridelands-phase4-first-impression.changed.md`

## Performance Evidence

not applicable

## Steward Notes

Theme/presentation-layer only; no core rendering or perf-path changes. Closes remaining #542/#543 acceptance items and #544 landing/announcement/RTL scope. OpenAPI catalog shell and full premium code block set remain for a follow-up.


Made with [Cursor](https://cursor.com)