### PR TITLE
perf(workers): FT CPU_BOUND caps + palette RTL dots (#381, #544)

### DIFF
--- a/bengal/themes/default/assets/css/tokens/palettes/blue-bengal.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/blue-bengal.css
@@ -89,7 +89,7 @@ html[data-palette="blue-bengal"] {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: linear-gradient(135deg, #6B8CAF 0%, #8DACC9 50%, #F8FAFC 100%);
     border: 1px solid rgba(107, 140, 175, 0.3);
     vertical-align: middle;

--- a/bengal/themes/default/assets/css/tokens/palettes/brown-bengal.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/brown-bengal.css
@@ -89,7 +89,7 @@ html[data-palette="brown-bengal"] {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: linear-gradient(135deg, #C17817 0%, #D4954D 50%, #FBF8F3 100%);
     border: 1px solid rgba(193, 120, 23, 0.3);
     vertical-align: middle;

--- a/bengal/themes/default/assets/css/tokens/palettes/charcoal-bengal.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/charcoal-bengal.css
@@ -98,7 +98,7 @@ html[data-palette="charcoal-bengal"] {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     /* Charcoal base with bronze glitter accent */
     background: linear-gradient(135deg, #1A1D21 0%, #36322E 40%, #8B6914 80%, #C9A84D 100%);
     border: 1px solid rgba(139, 105, 20, 0.4);

--- a/bengal/themes/default/assets/css/tokens/palettes/silver-bengal.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/silver-bengal.css
@@ -90,7 +90,7 @@ html[data-palette="silver-bengal"] {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: linear-gradient(135deg, #5A6A7A 0%, #7C8B9B 50%, #FAFBFC 100%);
     border: 1px solid rgba(90, 106, 122, 0.3);
     vertical-align: middle;

--- a/bengal/themes/default/assets/css/tokens/palettes/snow-lynx.css
+++ b/bengal/themes/default/assets/css/tokens/palettes/snow-lynx.css
@@ -96,7 +96,7 @@ html[data-palette="snow-lynx"] {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     /* Clean white center fading to cream with teal accent */
     background: linear-gradient(135deg, #FFFFFF 0%, #F4F0EA 40%, #4FA8A0 100%);
     border: 1px solid rgba(79, 168, 160, 0.3);
@@ -110,7 +110,7 @@ html[data-palette="snow-lynx"] {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: linear-gradient(135deg, #2196f3 0%, #1976d2 100%);
     border: 1px solid rgba(33, 150, 243, 0.3);
     vertical-align: middle;

--- a/bengal/utils/concurrency/workers.py
+++ b/bengal/utils/concurrency/workers.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from bengal.utils.concurrency.gil import is_gil_disabled
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -44,7 +46,8 @@ class WorkloadType(Enum):
 
     Attributes:
         CPU_BOUND: CPU-intensive work (parsing, rendering, similarity).
-            Limited by GIL in standard Python; benefits from few workers.
+            GIL builds cap workers conservatively; free-threaded builds use
+            the elevated ``_FT_PROFILES`` CPU_BOUND entries (#381).
         IO_BOUND: I/O-intensive work (file stats, asset copying).
             Can use more workers as threads wait on I/O.
         MIXED: Combined I/O and CPU work (template rendering).
@@ -100,7 +103,7 @@ class WorkloadProfile:
 # Based on benchmark data from rfc-benchmark-refresh-and-worker-optimization.md
 _PROFILES: dict[tuple[WorkloadType, Environment], WorkloadProfile] = {
     # CPU-bound workloads (parsing, similarity, graph building)
-    # Conservative because GIL limits parallelism
+    # GIL builds: conservative caps — threads do not parallelize CPU work.
     (WorkloadType.CPU_BOUND, Environment.CI): WorkloadProfile(5, 2, 2, 1.0),
     (WorkloadType.CPU_BOUND, Environment.LOCAL): WorkloadProfile(5, 2, 4, 0.5),
     (WorkloadType.CPU_BOUND, Environment.PRODUCTION): WorkloadProfile(5, 2, 8, 0.5),
@@ -116,6 +119,22 @@ _PROFILES: dict[tuple[WorkloadType, Environment], WorkloadProfile] = {
     (WorkloadType.MIXED, Environment.LOCAL): WorkloadProfile(5, 2, 12, 0.75),
     (WorkloadType.MIXED, Environment.PRODUCTION): WorkloadProfile(5, 2, 16, 0.75),
 }
+
+# Free-threaded CPU_BOUND overrides (#381 finding 5).
+# Magnitude aligned with the IO_BOUND profile ladder: autodoc extraction and the
+# analysis graph are embarrassingly-parallel CPU work on 3.14t+, unlike render.
+_FT_PROFILES: dict[tuple[WorkloadType, Environment], WorkloadProfile] = {
+    (WorkloadType.CPU_BOUND, Environment.CI): WorkloadProfile(5, 2, 2, 1.0),
+    (WorkloadType.CPU_BOUND, Environment.LOCAL): WorkloadProfile(5, 2, 8, 0.75),
+    (WorkloadType.CPU_BOUND, Environment.PRODUCTION): WorkloadProfile(5, 2, 10, 0.75),
+}
+
+
+def _profile_table() -> dict[tuple[WorkloadType, Environment], WorkloadProfile]:
+    """Return GIL or free-threaded profile table."""
+    if is_gil_disabled():
+        return {**_PROFILES, **_FT_PROFILES}
+    return _PROFILES
 
 
 def detect_environment() -> Environment:
@@ -223,7 +242,7 @@ def get_optimal_workers(
         environment = detect_environment()
 
     # Get profile for workload type + environment
-    profile = _PROFILES[(workload_type, environment)]
+    profile = _profile_table()[(workload_type, environment)]
 
     # Calculate CPU-based optimal
     cpu_count = os.cpu_count() or 2
@@ -273,7 +292,7 @@ def should_parallelize(
     if environment is None:
         environment = detect_environment()
 
-    profile = _PROFILES[(workload_type, environment)]
+    profile = _profile_table()[(workload_type, environment)]
 
     # Fast path: below task threshold
     if task_count < profile.parallel_threshold:
@@ -393,4 +412,4 @@ def get_profile(
     """
     if environment is None:
         environment = detect_environment()
-    return _PROFILES[(workload_type, environment)]
+    return _profile_table()[(workload_type, environment)]

--- a/changelog.d/381.changed.md
+++ b/changelog.d/381.changed.md
@@ -1,0 +1,3 @@
+Autodoc extraction and analysis graph builds use more parallel workers when Bengal runs on free-threaded Python 3.14+.
+
+CPU-bound worker auto-tuning no longer caps at four threads on multi-core machines in that mode. The default theme palette picker color dots also use logical margins so they align correctly in RTL layouts.

--- a/tests/unit/utils/test_workers.py
+++ b/tests/unit/utils/test_workers.py
@@ -561,6 +561,38 @@ class TestIntegration:
             assert workers == 12  # Ignores CI cap
 
 
+class TestFreeThreadingCpuBoundWorkers:
+    """Free-threaded CPU_BOUND profile lift (#381 finding 5)."""
+
+    def test_ft_cpu_bound_local_uses_more_workers_than_gil(self) -> None:
+        with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=False):
+            gil_workers = get_optimal_workers(
+                100,
+                workload_type=WorkloadType.CPU_BOUND,
+                environment=Environment.LOCAL,
+            )
+        with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=True):
+            ft_workers = get_optimal_workers(
+                100,
+                workload_type=WorkloadType.CPU_BOUND,
+                environment=Environment.LOCAL,
+            )
+        assert ft_workers > gil_workers
+        assert ft_workers > 4
+
+    def test_ft_cpu_bound_profile_max_workers(self) -> None:
+        with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=True):
+            profile = get_profile(WorkloadType.CPU_BOUND, Environment.LOCAL)
+        assert profile.max_workers == 8
+        assert profile.cpu_fraction == 0.75
+
+    def test_gil_cpu_bound_profile_unchanged(self) -> None:
+        with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=False):
+            profile = get_profile(WorkloadType.CPU_BOUND, Environment.LOCAL)
+        assert profile.max_workers == 4
+        assert profile.cpu_fraction == 0.5
+
+
 class TestGilDetectionConsolidation:
     """Guard: GIL detection lives only in bengal.utils.concurrency (issue #381)."""
 

--- a/tests/unit/utils/test_workers.py
+++ b/tests/unit/utils/test_workers.py
@@ -214,8 +214,11 @@ class TestGetOptimalWorkers:
         assert result_weighted >= result_normal
 
     def test_local_cpu_bound_moderate_workers(self) -> None:
-        """Local CPU-bound uses moderate workers."""
-        with patch("os.cpu_count", return_value=12):
+        """Local CPU-bound uses moderate workers (GIL-era cap)."""
+        with (
+            patch("os.cpu_count", return_value=12),
+            patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=False),
+        ):
             result = get_optimal_workers(
                 100,
                 workload_type=WorkloadType.CPU_BOUND,
@@ -440,8 +443,9 @@ class TestGetProfile:
         assert isinstance(profile, WorkloadProfile)
 
     def test_cpu_bound_local_profile(self) -> None:
-        """CPU_BOUND + LOCAL has expected values."""
-        profile = get_profile(WorkloadType.CPU_BOUND, Environment.LOCAL)
+        """CPU_BOUND + LOCAL has expected GIL-era values."""
+        with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=False):
+            profile = get_profile(WorkloadType.CPU_BOUND, Environment.LOCAL)
         assert profile.parallel_threshold == 5
         assert profile.min_workers == 2
         assert profile.max_workers == 4
@@ -536,8 +540,12 @@ class TestIntegration:
             assert workers <= 4  # CI caps at 4 (free-threaded Python)
 
     def test_full_workflow_local(self) -> None:
-        """Full workflow in local environment."""
-        with patch.dict(os.environ, {}, clear=True), patch("os.cpu_count", return_value=8):
+        """Full workflow in local environment (GIL-era CPU_BOUND cap)."""
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("os.cpu_count", return_value=8),
+            patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=False),
+        ):
             # Detect environment
             env = detect_environment()
             assert env == Environment.LOCAL
@@ -565,20 +573,22 @@ class TestFreeThreadingCpuBoundWorkers:
     """Free-threaded CPU_BOUND profile lift (#381 finding 5)."""
 
     def test_ft_cpu_bound_local_uses_more_workers_than_gil(self) -> None:
-        with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=False):
-            gil_workers = get_optimal_workers(
-                100,
-                workload_type=WorkloadType.CPU_BOUND,
-                environment=Environment.LOCAL,
-            )
-        with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=True):
-            ft_workers = get_optimal_workers(
-                100,
-                workload_type=WorkloadType.CPU_BOUND,
-                environment=Environment.LOCAL,
-            )
+        with patch("os.cpu_count", return_value=12):
+            with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=False):
+                gil_workers = get_optimal_workers(
+                    100,
+                    workload_type=WorkloadType.CPU_BOUND,
+                    environment=Environment.LOCAL,
+                )
+            with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=True):
+                ft_workers = get_optimal_workers(
+                    100,
+                    workload_type=WorkloadType.CPU_BOUND,
+                    environment=Environment.LOCAL,
+                )
         assert ft_workers > gil_workers
-        assert ft_workers > 4
+        assert gil_workers == 4
+        assert ft_workers == 8
 
     def test_ft_cpu_bound_profile_max_workers(self) -> None:
         with patch("bengal.utils.concurrency.workers.is_gil_disabled", return_value=True):


### PR DESCRIPTION
## Summary

- Lift CPU_BOUND worker caps when `is_gil_disabled()` is true (#381 finding 5): LOCAL max 8 @ 0.75 cpu_fraction, PRODUCTION max 10 @ 0.75, wired through `_profile_table()` for `get_optimal_workers`, `should_parallelize`, and `get_profile`.
- Convert theme palette picker indicator dots from `margin-right` to `margin-inline-end` across all five palette token files (#544 RTL tail).
- Add three unit tests asserting FT profiles yield more CPU_BOUND workers than GIL-era caps.

## Proof

- [x] Focused tests: `pytest tests/unit/utils/test_workers.py::TestFreeThreadingCpuBoundWorkers -q`
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: no user-facing behavior change beyond faster autodoc/graph parallelism on 3.14t+; no changelog fragment (internal tuning)

## Performance Evidence

Required when this PR makes a performance claim, changes a hot path, or changes
free-threaded/concurrent behavior.

- Benchmark matrix row: pending — #381 acceptance still gates magnitude on an idle `benchmark_gil_speedup.py` autodoc sweep
- Command: `pytest tests/unit/utils/test_workers.py::TestFreeThreadingCpuBoundWorkers -q`
- Python build: 3.14.2 (dev)
- Machine/OS: darwin
- Baseline commit or saved result: GIL-era CPU_BOUND LOCAL cap = 4 workers (`workers.py` pre-change)
- Current commit or saved result: FT CPU_BOUND LOCAL cap = 8 workers (unit-tested via patch)
- Artifact path: `tests/unit/utils/test_workers.py::TestFreeThreadingCpuBoundWorkers`
- Interpretation: profile selection is correct; measured autodoc speedup is follow-on work before closing #381

## Steward Notes

- Finding 7 (GIL consolidation) was already shipped; this PR completes Finding 5 only.
- #544 remains open — RTL gallery regression view not in scope here.


Made with [Cursor](https://cursor.com)