### PR TITLE
feat(theme): premium code blocks for Pridelands (#542)

### DIFF
--- a/bengal/parsing/backends/patitas/renderers/blocks.py
+++ b/bengal/parsing/backends/patitas/renderers/blocks.py
@@ -33,7 +33,7 @@ from bengal.parsing.backends.patitas.renderers.utils import (
     escape_attr,
     escape_html,
 )
-from bengal.rendering.highlighting.deferred import wrap_code_block_title
+from bengal.rendering.highlighting.deferred import apply_fence_metadata, wrap_code_block_title
 from bengal.utils.primitives.code import CodeFenceAttrs, parse_fence_attrs
 
 if TYPE_CHECKING:
@@ -320,6 +320,7 @@ class BlockRendererMixin:
                 # Rosettes parity: ensure trailing newline before closing tags
                 if highlighted.endswith("</code></pre></div>"):
                     highlighted = highlighted[:-19] + "\n</code></pre></div>"
+                highlighted = apply_fence_metadata(highlighted, fence_attrs)
                 sb.append(wrap_code_block_title(highlighted, fence_attrs.title))
                 return
 

--- a/bengal/postprocess/static_markup.py
+++ b/bengal/postprocess/static_markup.py
@@ -1,7 +1,8 @@
-"""Build-time static markup enhancements for the default theme (#538)."""
+"""Build-time static markup enhancements for the default theme (#538, #542)."""
 
 from __future__ import annotations
 
+import html as html_mod
 import re
 from urllib.parse import urlparse
 
@@ -21,6 +22,7 @@ _WRAP_BUTTON = (
 )
 
 _LANG_RE = re.compile(r"language-(\w+)|hljs-(\w+)")
+_ATTR_RE = re.compile(r'([\w-]+)="([^"]*)"')
 _PRE_CODE_RE = re.compile(
     r"(<pre[^>]*>\s*<code[^>]*>)([\s\S]*?)(</code>\s*</pre>)",
     re.IGNORECASE,
@@ -28,6 +30,18 @@ _PRE_CODE_RE = re.compile(
 _A_HREF_RE = re.compile(
     r"<a(\s[^>]*?href=(['\"])(.*?)\2)([^>]*)>",
     re.IGNORECASE | re.DOTALL,
+)
+_HIGHLIGHTED_BLOCK_RE = re.compile(
+    r'(<div(?=[^>]*\bclass="[^"]*\b(?:rosettes|highlight)\b[^"]*")[^>]*>)'
+    r"([\s\S]*?)"
+    r"(</div>)",
+    re.IGNORECASE,
+)
+_COLLAPSIBLE_BLOCK_RE = re.compile(
+    r'(<div(?=[^>]*\bdata-collapsible="(open|closed)")(?=[^>]*\bclass="[^"]*\b(?:rosettes|highlight)\b[^"]*")[^>]*>)'
+    r"([\s\S]*?)"
+    r"(</div>)",
+    re.IGNORECASE,
 )
 
 
@@ -94,6 +108,13 @@ def mark_external_links(html: str, base_url: str = "") -> str:
     return _A_HREF_RE.sub(repl, html)
 
 
+def _attr_value(attrs: str, name: str) -> str:
+    for attr_match in _ATTR_RE.finditer(attrs):
+        if attr_match.group(1) == name:
+            return attr_match.group(2)
+    return ""
+
+
 def _language_from_code_tag(open_tag: str) -> str:
     match = _LANG_RE.search(open_tag)
     if not match:
@@ -101,31 +122,185 @@ def _language_from_code_tag(open_tag: str) -> str:
     return (match.group(1) or match.group(2) or "").upper()
 
 
-def _wrap_pre_code(match: re.Match[str]) -> str:
-    full = match.group(0)
-    if "code-copy-button" in full:
-        return full
-    open_pre = match.group(1)
-    lang = _language_from_code_tag(open_pre)
+def _parse_annotations(spec: str) -> dict[int, str]:
+    annotations: dict[int, str] = {}
+    if not spec:
+        return annotations
+    for part in spec.split(","):
+        part = part.strip()
+        if not part or ":" not in part:
+            continue
+        line_s, _, text = part.partition(":")
+        try:
+            annotations[int(line_s.strip())] = text.strip()
+        except ValueError:
+            continue
+    return annotations
+
+
+def _build_toolbar(lang: str) -> str:
     lang_label = f'<span class="code-language">{lang}</span>' if lang else "<span></span>"
-    header = f'<div class="code-header-inline">{lang_label}{_WRAP_BUTTON}{_COPY_BUTTON}</div>'
+    return f'<div class="code-header-inline">{lang_label}{_WRAP_BUTTON}{_COPY_BUTTON}</div>'
+
+
+def _wrapper_classes(div_attrs: str, *, in_titled_block: bool = False) -> str:
+    classes = ["code-block-wrapper"]
+    frame = _attr_value(div_attrs, "data-frame")
+    if not frame and in_titled_block:
+        frame = "editor"
+    if frame in {"terminal", "editor"}:
+        classes.append(f"code-block-frame--{frame}")
+    if _attr_value(div_attrs, "data-diff") == "true":
+        classes.append("code-block--diff")
+    return " ".join(classes)
+
+
+def _split_code_lines(code_html: str) -> list[str]:
+    lines = code_html.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def _apply_line_annotations(code_html: str, annotations: dict[int, str]) -> str:
+    if not annotations:
+        return code_html
+
+    lines = _split_code_lines(code_html)
+    rendered: list[str] = []
+    for index, line in enumerate(lines, start=1):
+        note = annotations.get(index)
+        if note:
+            safe_note = html_mod.escape(note)
+            rendered.append(
+                f'<span class="code-line"><span class="code-line__content">{line}</span>'
+                f'<span class="code-line-annotation">{safe_note}</span></span>'
+            )
+        else:
+            rendered.append(line)
+    trailing_newline = "\n" if code_html.endswith("\n") else ""
+    return "\n".join(rendered) + trailing_newline
+
+
+def _wrap_with_linenos(open_pre: str, code_html: str, close_pre: str) -> str:
+    lines = _split_code_lines(code_html)
+    if not lines:
+        return f"{open_pre}{code_html}{close_pre}"
+
+    numbers = "\n".join(str(index) for index in range(1, len(lines) + 1))
     return (
-        f'<div class="code-block-wrapper">{open_pre}{match.group(2)}{match.group(3)}{header}</div>'
+        '<div class="code-block-with-linenos">'
+        f'<pre class="code-linenos" aria-hidden="true">{numbers}\n</pre>'
+        f'<div class="code-block-scroll">{open_pre}{code_html}{close_pre}</div>'
+        "</div>"
     )
 
 
+def _wrap_pre_code(
+    open_pre: str,
+    code_html: str,
+    close_pre: str,
+    *,
+    div_attrs: str = "",
+    in_titled_block: bool = False,
+) -> str:
+    lang = _attr_value(div_attrs, "data-language").upper() or _language_from_code_tag(open_pre)
+    annotations = _parse_annotations(_attr_value(div_attrs, "data-annotate"))
+    code_html = _apply_line_annotations(code_html, annotations)
+
+    if _attr_value(div_attrs, "data-linenos") == "true":
+        body = _wrap_with_linenos(open_pre, code_html, close_pre)
+    else:
+        body = f"{open_pre}{code_html}{close_pre}"
+
+    wrapper_class = _wrapper_classes(div_attrs, in_titled_block=in_titled_block)
+    header = _build_toolbar(lang)
+    frame = _attr_value(div_attrs, "data-frame") or ("editor" if in_titled_block else "")
+    frame_header = ""
+    if frame == "terminal":
+        frame_header = (
+            '<div class="code-block-frame-header code-block-frame-header--terminal" aria-hidden="true">'
+            '<span class="code-block-frame-dot"></span>'
+            '<span class="code-block-frame-dot"></span>'
+            '<span class="code-block-frame-dot"></span>'
+            "</div>"
+        )
+    elif frame == "editor":
+        frame_header = '<div class="code-block-frame-header code-block-frame-header--editor" aria-hidden="true"></div>'
+
+    return f'<div class="{wrapper_class}">{frame_header}{body}{header}</div>'
+
+
+def _enhance_highlighted_block(match: re.Match[str]) -> str:
+    open_div, inner, close_div = match.group(1), match.group(2), match.group(3)
+    if "code-block-wrapper" in inner or "code-copy-button" in inner:
+        return match.group(0)
+
+    pre_match = _PRE_CODE_RE.search(inner)
+    if not pre_match:
+        return match.group(0)
+
+    div_attrs = open_div[4:-1]  # strip <div ...>
+    wrapped = _wrap_pre_code(
+        pre_match.group(1),
+        pre_match.group(2),
+        pre_match.group(3),
+        div_attrs=div_attrs,
+        in_titled_block="code-block-titled" in match.string[: match.start()],
+    )
+    return f"{open_div}{wrapped}{close_div}"
+
+
+def _wrap_plain_pre_code(match: re.Match[str]) -> str:
+    full = match.group(0)
+    if "code-copy-button" in full:
+        return full
+    window = match.string[max(0, match.start() - 160) : match.start()]
+    if (
+        "code-block-wrapper" in window
+        or 'class="rosettes"' in window
+        or 'class="highlight' in window
+    ):
+        return full
+    in_titled = "code-block-titled" in window
+    return _wrap_pre_code(
+        match.group(1),
+        match.group(2),
+        match.group(3),
+        in_titled_block=in_titled,
+    )
+
+
+def _wrap_collapsible_blocks(html: str) -> str:
+    def repl(match: re.Match[str]) -> str:
+        open_div, state, inner, close_div = (
+            match.group(1),
+            match.group(2),
+            match.group(3),
+            match.group(4),
+        )
+        lang = _attr_value(open_div, "data-language") or "Code"
+        summary = html_mod.escape(lang.upper() if lang else "Code")
+        open_attr = "" if state == "closed" else " open"
+        return (
+            f'<details class="code-block-collapsible"{open_attr}>'
+            f'<summary class="code-block-collapsible__summary">{summary}</summary>'
+            f"{open_div}{inner}{close_div}"
+            "</details>"
+        )
+
+    return _COLLAPSIBLE_BLOCK_RE.sub(repl, html)
+
+
 def inject_code_copy_chrome(html: str) -> str:
-    """Wrap standalone pre>code blocks with build-time copy chrome."""
+    """Wrap code blocks with premium build-time chrome (#542)."""
     if not html or "<pre" not in html:
         return html
 
-    def replacer(match: re.Match[str]) -> str:
-        window = html[max(0, match.start() - 120) : match.start()]
-        if "code-block-wrapper" in window:
-            return match.group(0)
-        return _wrap_pre_code(match)
-
-    return _PRE_CODE_RE.sub(replacer, html)
+    html = _HIGHLIGHTED_BLOCK_RE.sub(_enhance_highlighted_block, html)
+    html = _PRE_CODE_RE.sub(_wrap_plain_pre_code, html)
+    html = _wrap_collapsible_blocks(html)
+    return html
 
 
 def enhance_theme_markup(html: str, *, base_url: str = "") -> str:

--- a/bengal/rendering/highlighting/deferred.py
+++ b/bengal/rendering/highlighting/deferred.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING
 
 from bengal.rendering.highlighting.rosettes import RosettesBackend
 from bengal.utils.observability.logger import get_logger
-from bengal.utils.primitives.code import parse_fence_attrs
+from bengal.utils.primitives.code import CodeFenceAttrs, parse_fence_attrs
 
 if TYPE_CHECKING:
     from bengal.rendering.highlighting.cache import HighlightCache
@@ -278,6 +278,31 @@ def wrap_code_block_title(html: str, title: str | None) -> str:
     return _wrap_with_title(html, title)
 
 
+def apply_fence_metadata(html: str, fence_attrs: CodeFenceAttrs) -> str:
+    """Attach fence metadata as data-* attributes on the highlighted root element."""
+    if not html.startswith("<div"):
+        return html
+
+    additions: list[str] = []
+    if fence_attrs.show_linenos:
+        additions.append('data-linenos="true"')
+    if fence_attrs.frame:
+        additions.append(f'data-frame="{html_mod.escape(fence_attrs.frame)}"')
+    if fence_attrs.collapsible:
+        state = "closed" if fence_attrs.collapsed else "open"
+        additions.append(f'data-collapsible="{state}"')
+    if fence_attrs.annotations:
+        spec = ",".join(f"{line}:{text}" for line, text in fence_attrs.annotations)
+        additions.append(f'data-annotate="{html_mod.escape(spec)}"')
+    if fence_attrs.diff:
+        additions.append('data-diff="true"')
+
+    if not additions:
+        return html
+
+    return re.sub(r"^<div ", f"<div {' '.join(additions)} ", html, count=1)
+
+
 def parse_fence_info(info: str) -> tuple[str, list[int], str | None, bool, bool]:
     """Parse a fence info string into highlight kwargs for deferred mode."""
     attrs = parse_fence_attrs(info)
@@ -356,6 +381,7 @@ def flush_deferred_highlighting(content: str) -> str:
 
 # Re-export for backward compatibility
 __all__ = [
+    "apply_fence_metadata",
     "disable_deferred_highlighting",
     "enable_deferred_highlighting",
     "flush_deferred_highlighting",

--- a/bengal/themes/default/assets/css/components/code.css
+++ b/bengal/themes/default/assets/css/components/code.css
@@ -1269,3 +1269,170 @@ pre::-webkit-scrollbar-thumb:hover {
       0 1px 0 0 color-mix(in srgb, var(--color-primary) 4%, transparent);
   }
 }
+
+/* ============================================
+   PREMIUM CODE BLOCKS (#542)
+   Shipped set: copy + SR announce, language label, title bar, terminal/editor
+   frame, line/range highlight, diff markers, collapsible regions, word-wrap
+   toggle, line-number gutter, inline per-line annotations.
+   ============================================ */
+
+.code-block-frame-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-height: 2rem;
+  padding: 0.375rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-light);
+  background: color-mix(in srgb, var(--color-bg-tertiary) 88%, transparent);
+}
+
+.code-block-frame-header--terminal .code-block-frame-dot:nth-child(1) {
+  background: #ff5f57;
+}
+
+.code-block-frame-header--terminal .code-block-frame-dot:nth-child(2) {
+  background: #febc2e;
+}
+
+.code-block-frame-header--terminal .code-block-frame-dot:nth-child(3) {
+  background: #28c840;
+}
+
+.code-block-frame-dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  opacity: 0.95;
+}
+
+.code-block-frame-header--editor {
+  min-height: 1.25rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--color-bg-tertiary) 95%, transparent),
+    color-mix(in srgb, var(--color-bg-code) 95%, transparent)
+  );
+}
+
+.code-block-with-linenos {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: stretch;
+}
+
+.code-linenos {
+  margin: 0;
+  padding: var(--space-6) var(--space-3) var(--space-6) var(--space-4);
+  border: none;
+  border-radius: 0;
+  box-shadow: inset -1px 0 0 var(--color-border-light);
+  background: color-mix(in srgb, var(--color-bg-code) 92%, var(--color-bg-tertiary));
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--line-height-relaxed);
+  text-align: end;
+  user-select: none;
+  animation: none;
+}
+
+.code-block-scroll {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.code-block-scroll pre {
+  margin: 0;
+}
+
+.code-line {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-4);
+  align-items: baseline;
+}
+
+.code-line-annotation {
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  font-size: var(--text-xxs);
+  font-style: italic;
+  white-space: nowrap;
+}
+
+.code-block--diff .syntax-added,
+.rosettes.code-block--diff .syntax-added,
+.code-block-wrapper.code-block--diff .syntax-added {
+  background: color-mix(in srgb, var(--syntax-added, #2ea043) 14%, transparent);
+}
+
+.code-block--diff .syntax-removed,
+.rosettes.code-block--diff .syntax-removed,
+.code-block-wrapper.code-block--diff .syntax-removed {
+  background: color-mix(in srgb, var(--syntax-removed, #f85149) 14%, transparent);
+}
+
+.code-block-collapsible {
+  margin-block: 1.5rem;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-2xl);
+  background: var(--color-bg-code);
+  box-shadow: var(--elevation-card);
+}
+
+.code-block-collapsible__summary {
+  cursor: pointer;
+  padding: var(--space-3) var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  list-style: none;
+}
+
+.code-block-collapsible__summary::-webkit-details-marker {
+  display: none;
+}
+
+.code-block-collapsible[open] > .code-block-collapsible__summary {
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.code-block-collapsible .rosettes,
+.code-block-collapsible .highlight,
+.code-block-collapsible .code-block-wrapper {
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  animation: none;
+}
+
+.code-block-titled .code-block-wrapper {
+  margin: 0;
+  border: none;
+  box-shadow: none;
+  animation: none;
+}
+
+@media (max-width: 639px) {
+  .code-block-with-linenos {
+    grid-template-columns: 1fr;
+  }
+
+  .code-linenos {
+    display: none;
+  }
+
+  .code-line {
+    grid-template-columns: 1fr;
+  }
+
+  .code-line-annotation {
+    display: block;
+    margin-block-start: 0.125rem;
+    white-space: normal;
+  }
+}

--- a/bengal/utils/primitives/code.py
+++ b/bengal/utils/primitives/code.py
@@ -31,7 +31,16 @@ FENCE_INFO_PATTERN = re.compile(
     r'(?:\s+title="(?P<title>[^"]*)")?'
     r"(?:\s*\{(?P<brace>[^}]*)\})?"
     r'(?:\s+title="(?P<title2>[^"]*)")?'
-    r"(?:\s+(?P<linenos>linenos))?$"
+    r"(?:\s+(?P<linenos>linenos))?"
+)
+
+FRAME_PATTERN = re.compile(r"\bframe=(terminal|editor)\b")
+COLLAPSE_PATTERN = re.compile(r"\bcollapse(?:=(open|closed))?\b")
+ANNOTATE_PATTERN = re.compile(r'annotate="([^"]+)"')
+
+# Shell-like languages get an implicit terminal frame unless frame= overrides.
+TERMINAL_FRAME_LANGUAGES = frozenset(
+    {"bash", "sh", "shell", "zsh", "console", "terminal", "powershell", "cmd", "pwsh"}
 )
 
 
@@ -44,6 +53,10 @@ class CodeFenceAttrs:
     title: str | None = None
     diff: bool = False
     show_linenos: bool = False
+    frame: str | None = None
+    collapsible: bool = False
+    collapsed: bool = False
+    annotations: tuple[tuple[int, str], ...] = ()
 
     @property
     def highlight_language(self) -> str:
@@ -138,6 +151,43 @@ def _parse_brace_content(brace: str | None) -> tuple[tuple[int, ...], bool]:
     return hl_lines, diff
 
 
+def parse_annotations(spec: str) -> tuple[tuple[int, str], ...]:
+    """Parse ``1:Setup,3:Run`` annotation pairs from a fence annotate attribute."""
+    if not spec.strip():
+        return ()
+
+    pairs: list[tuple[int, str]] = []
+    for part in spec.split(","):
+        part = part.strip()
+        if not part or ":" not in part:
+            continue
+        line_s, _, text = part.partition(":")
+        try:
+            line_no = int(line_s.strip())
+        except ValueError:
+            continue
+        note = text.strip()
+        if note:
+            pairs.append((line_no, note))
+    return tuple(pairs)
+
+
+def _parse_optional_fence_flags(
+    info: str,
+) -> tuple[str | None, bool, bool, tuple[tuple[int, str], ...]]:
+    frame_match = FRAME_PATTERN.search(info)
+    frame = frame_match.group(1) if frame_match else None
+
+    collapse_match = COLLAPSE_PATTERN.search(info)
+    collapsible = collapse_match is not None
+    collapsed = collapse_match is not None and collapse_match.group(1) == "closed"
+
+    annotate_match = ANNOTATE_PATTERN.search(info)
+    annotations = parse_annotations(annotate_match.group(1)) if annotate_match else ()
+
+    return frame, collapsible, collapsed, annotations
+
+
 def parse_fence_attrs(info: str) -> CodeFenceAttrs:
     """
     Parse a code fence info string into structured highlight attributes.
@@ -148,6 +198,8 @@ def parse_fence_attrs(info: str) -> CodeFenceAttrs:
     - ``python title="app.py" {2}`` -> title + highlights
     - ``python diff`` / ``diff`` -> unified diff rendering
     - ``python linenos`` -> line-number gutter (via rosettes)
+    - ``bash frame=terminal collapse`` -> terminal chrome + collapsible region
+    - ``python annotate="1:Setup,3:Run"`` -> inline per-line annotations
 
     Args:
         info: Code fence info string after the opening backticks.
@@ -159,23 +211,42 @@ def parse_fence_attrs(info: str) -> CodeFenceAttrs:
         return CodeFenceAttrs()
 
     info = info.strip()
+    frame, collapsible, collapsed, annotations = _parse_optional_fence_flags(info)
+    show_linenos = bool(re.search(r"\blinenos\b", info))
     match = FENCE_INFO_PATTERN.match(info)
     if match:
         lang = match.group("lang")
         diff = match.group("diff") is not None or lang.lower() == "diff"
         title = match.group("title") or match.group("title2")
-        show_linenos = match.group("linenos") is not None
+        if match.group("linenos") is not None:
+            show_linenos = True
         hl_lines, brace_diff = _parse_brace_content(match.group("brace"))
+        if frame is None and lang.lower() in TERMINAL_FRAME_LANGUAGES:
+            frame = "terminal"
         return CodeFenceAttrs(
             language=lang,
             hl_lines=hl_lines,
             title=title or None,
             diff=diff or brace_diff,
             show_linenos=show_linenos,
+            frame=frame,
+            collapsible=collapsible,
+            collapsed=collapsed,
+            annotations=annotations,
         )
 
     # Fallback: first token is language, remainder ignored
-    return CodeFenceAttrs(language=info.split()[0])
+    lang = info.split()[0]
+    if frame is None and lang.lower() in TERMINAL_FRAME_LANGUAGES:
+        frame = "terminal"
+    return CodeFenceAttrs(
+        language=lang,
+        show_linenos=show_linenos,
+        frame=frame,
+        collapsible=collapsible,
+        collapsed=collapsed,
+        annotations=annotations,
+    )
 
 
 def parse_code_info(info: str) -> tuple[str, list[int]]:

--- a/changelog.d/+pridelands-premium-code-blocks.changed.md
+++ b/changelog.d/+pridelands-premium-code-blocks.changed.md
@@ -1,0 +1,1 @@
+Premium code blocks: terminal/editor frames, line gutters, annotations, collapsible regions.

--- a/tests/unit/postprocess/test_static_markup.py
+++ b/tests/unit/postprocess/test_static_markup.py
@@ -1,4 +1,4 @@
-"""Tests for build-time static markup enhancements (#538)."""
+"""Tests for build-time static markup enhancements (#538, #542)."""
 
 from __future__ import annotations
 
@@ -31,9 +31,82 @@ def test_inject_code_copy_chrome_wraps_pre_code() -> None:
     assert 'class="code-language">PYTHON' in out
 
 
+def test_inject_code_copy_chrome_uses_rosettes_data_language() -> None:
+    html = (
+        '<div class="rosettes" data-language="python"><pre><code>'
+        '<span class="syntax-name">x</span></code></pre></div>'
+    )
+    out = inject_code_copy_chrome(html)
+    assert 'class="code-language">PYTHON' in out
+    assert out.count("code-block-wrapper") == 1
+
+
+def test_inject_code_copy_chrome_adds_linenos_gutter() -> None:
+    html = (
+        '<div class="rosettes" data-language="python" data-linenos="true">'
+        "<pre><code>line1\nline2\nline3\n</code></pre></div>"
+    )
+    out = inject_code_copy_chrome(html)
+    assert 'class="code-block-with-linenos"' in out
+    assert 'class="code-linenos"' in out
+    assert "1\n2\n3" in out
+
+
+def test_inject_code_copy_chrome_adds_terminal_frame() -> None:
+    html = (
+        '<div class="rosettes" data-language="bash" data-frame="terminal">'
+        "<pre><code>echo hi</code></pre></div>"
+    )
+    out = inject_code_copy_chrome(html)
+    assert "code-block-frame--terminal" in out
+    assert "code-block-frame-header--terminal" in out
+
+
+def test_inject_code_copy_chrome_adds_editor_frame_for_titled_blocks() -> None:
+    html = (
+        '<div class="code-block-titled"><div class="code-block-title">app.py</div>'
+        '<div class="rosettes" data-language="python"><pre><code>x=1</code></pre></div></div>'
+    )
+    out = inject_code_copy_chrome(html)
+    assert "code-block-frame--editor" in out
+
+
+def test_inject_code_copy_chrome_adds_annotations() -> None:
+    html = (
+        '<div class="rosettes" data-language="python" data-annotate="2:Run this step">'
+        "<pre><code>setup\nrun\n</code></pre></div>"
+    )
+    out = inject_code_copy_chrome(html)
+    assert 'class="code-line-annotation"' in out
+    assert "Run this step" in out
+
+
+def test_inject_code_copy_chrome_wraps_collapsible_blocks() -> None:
+    html = (
+        '<div class="rosettes" data-language="python" data-collapsible="closed">'
+        "<pre><code>x=1</code></pre></div>"
+    )
+    out = inject_code_copy_chrome(html)
+    assert "<details" in out
+    assert 'class="code-block-collapsible"' in out
+    assert "data-collapsible" not in out or "<details" in out
+
+
 def test_enhance_theme_markup_is_idempotent_on_wrapped_code() -> None:
     html = "<pre><code>one</code></pre>"
     once = enhance_theme_markup(html, base_url="https://mysite.test")
     twice = enhance_theme_markup(once, base_url="https://mysite.test")
     assert once.count("code-block-wrapper") == 1
     assert twice.count("code-block-wrapper") == 1
+
+
+def test_parser_fence_metadata_reaches_premium_chrome() -> None:
+    from bengal.parsing import PatitasParser
+
+    parser = PatitasParser(enable_highlighting=True)
+    raw = parser.parse('```python linenos annotate="2:Run" collapse\na=1\nb=2\n```', {})
+    out = enhance_theme_markup(raw)
+    assert 'data-linenos="true"' in raw
+    assert 'class="code-linenos"' in out
+    assert 'class="code-line-annotation"' in out
+    assert "<details" in out

--- a/tests/unit/utils/test_code.py
+++ b/tests/unit/utils/test_code.py
@@ -135,6 +135,33 @@ class TestParseFenceAttrs:
         assert attrs.title == "late-title.py"
         assert attrs.hl_lines == (2,)
 
+    def test_frame_terminal(self):
+        attrs = parse_fence_attrs('bash frame=terminal title="deploy.sh"')
+        assert attrs.frame == "terminal"
+        assert attrs.language == "bash"
+
+    def test_implicit_terminal_frame_for_shell(self):
+        attrs = parse_fence_attrs("bash")
+        assert attrs.frame == "terminal"
+
+    def test_editor_frame(self):
+        attrs = parse_fence_attrs('python frame=editor title="app.py"')
+        assert attrs.frame == "editor"
+
+    def test_collapsible_open(self):
+        attrs = parse_fence_attrs("python collapse")
+        assert attrs.collapsible is True
+        assert attrs.collapsed is False
+
+    def test_collapsible_closed(self):
+        attrs = parse_fence_attrs("python collapse=closed")
+        assert attrs.collapsible is True
+        assert attrs.collapsed is True
+
+    def test_annotations(self):
+        attrs = parse_fence_attrs('python annotate="1:Setup,3:Run"')
+        assert attrs.annotations == ((1, "Setup"), (3, "Run"))
+
 
 class TestHlLinesPattern:
     """Tests for the HL_LINES_PATTERN regex."""


### PR DESCRIPTION
## Summary

- Complete the #542 premium code-block tier: new fence attributes (`linenos`, `frame=terminal|editor`, `collapse`, `annotate`) parsed in core and emitted as `data-*` on highlighted blocks.
- Extend build-time `static_markup` to wrap rosettes/highlight output with language labels, copy/wrap toolbar, line gutters, terminal/editor frame headers, inline per-line annotations, and collapsible `<details>` regions.
- Add theme CSS for frames, gutters, diff highlighting, annotations, and collapsible blocks; 41 unit tests cover fence parsing and markup integration.

## Proof

- [x] Focused tests: `pytest tests/unit/postprocess/test_static_markup.py tests/unit/utils/test_code.py` (41 passed)
- [ ] `poe proof-pr` or scoped equivalent: not run (theme/presentation + fence parsing only)
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/+pridelands-premium-code-blocks.changed.md`

## Performance Evidence

not applicable

## Steward Notes

Theme presentation + fence metadata passthrough under epic #532. Line gutters are build-time (rosettes 0.2.0 `show_linenos` is a no-op in HTML output). Closes the code-block slice of #542; motion/palettes/view-transitions landed in prior PRs.


Made with [Cursor](https://cursor.com)