### PR TITLE
fix(site): restore GitHub Pages via unified auto-nav menu pipeline

### DIFF
--- a/bengal/orchestration/menu.py
+++ b/bengal/orchestration/menu.py
@@ -40,6 +40,22 @@ if TYPE_CHECKING:
     from bengal.protocols.core import PageLike
 
 
+def _auto_nav_item_to_config(item: dict[str, Any] | Any) -> dict[str, Any]:
+    """Convert auto-nav items into MenuBuilder config dicts."""
+    from bengal.rendering.template_functions.navigation.models import AutoNavItem
+
+    if isinstance(item, AutoNavItem):
+        return {
+            "name": item.name,
+            "url": item.url,
+            "weight": item.weight,
+            "identifier": item.identifier,
+            "parent": item.parent,
+            "icon": item.icon,
+        }
+    return item
+
+
 class MenuOrchestrator:
     """
     Orchestrates navigation menu building with incremental caching.
@@ -562,6 +578,7 @@ class MenuOrchestrator:
         Returns:
             True if item was added, False if duplicate
         """
+        item = _auto_nav_item_to_config(item)
         item_id = item.get("identifier")
         item_url = item.get("url", "").rstrip("/")
         item_name = item.get("name", "").lower()

--- a/bengal/rendering/template_functions/navigation/__init__.py
+++ b/bengal/rendering/template_functions/navigation/__init__.py
@@ -143,7 +143,6 @@ def register(env: TemplateEnvironment, site: SiteLike) -> None:
             "get_pagination_items": get_pagination_items,
             "get_nav_tree": get_nav_tree,
             "get_nav_context": get_nav_context,
-            "get_auto_nav": lambda: get_auto_nav(site),
             "combine_track_toc": combine_track_toc_with_get_page,
             "get_section": get_section_wrapper,
             "section_pages": section_pages_wrapper,

--- a/bengal/rendering/template_functions/navigation/auto_nav.py
+++ b/bengal/rendering/template_functions/navigation/auto_nav.py
@@ -1,8 +1,8 @@
 """
 Auto-navigation discovery functions.
 
-Provides get_auto_nav() for automatic navigation from site sections and
-root-level pages.
+Internal to menu building — templates should use ``get_menu_lang('main')``,
+which reflects the orchestrated menu (auto-discovery, dev bundling, extras).
 
 Performance:
     get_auto_nav() is memoized per-build since the result is identical
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from bengal.rendering.template_functions.memo import site_scoped_memoize
 from bengal.rendering.template_functions.navigation.helpers import get_nav_title
+from bengal.rendering.template_functions.navigation.models import AutoNavItem
 from bengal.rendering.urls import RenderURLContext
 from bengal.rendering.urls import url_for as resolve_url_for
 from bengal.utils.paths.normalize import to_posix
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 
 def _build_section_menu_item(
     section: Any, site: SiteLike, parent_identifier: str | None = None
-) -> dict[str, Any] | None:
+) -> AutoNavItem | None:
     """
     Build a menu item from a section, recursively including subsections.
 
@@ -102,14 +103,14 @@ def _build_section_menu_item(
     if parent_identifier is None and hasattr(section, "parent") and section.parent:
         parent_identifier = section.parent.name
 
-    return {
-        "name": section_title,
-        "url": section_url,
-        "weight": section_weight,
-        "identifier": section_identifier,
-        "parent": parent_identifier,
-        "icon": section_icon,
-    }
+    return AutoNavItem(
+        name=section_title,
+        url=section_url,
+        weight=section_weight,
+        identifier=section_identifier,
+        parent=parent_identifier,
+        icon=section_icon,
+    )
 
 
 def _is_root_level_page(page: Any, content_dir: Path) -> bool:
@@ -131,7 +132,7 @@ def _is_root_level_page(page: Any, content_dir: Path) -> bool:
         return False
 
 
-def _build_root_page_menu_item(page: Any) -> dict[str, Any] | None:
+def _build_root_page_menu_item(page: Any) -> AutoNavItem | None:
     """
     Build a menu item from a root-level page (opt-out: include unless menu: false).
     """
@@ -147,18 +148,18 @@ def _build_root_page_menu_item(page: Any) -> dict[str, Any] | None:
     page_title = get_nav_title(page, getattr(page, "title", "Untitled"))
     page_weight = metadata.get("weight", 999)
     slug = getattr(page, "slug", None) or Path(str(page.source_path)).stem
-    return {
-        "name": page_title,
-        "url": page_url,
-        "weight": page_weight,
-        "identifier": f"page-{slug}",
-        "parent": None,
-        "icon": None,
-    }
+    return AutoNavItem(
+        name=page_title,
+        url=page_url,
+        weight=page_weight,
+        identifier=f"page-{slug}",
+        parent=None,
+        icon=None,
+    )
 
 
 @site_scoped_memoize("auto_nav")
-def get_auto_nav(site: SiteLike) -> list[dict[str, Any]]:
+def get_auto_nav(site: SiteLike) -> list[AutoNavItem]:
     """
     Auto-discover hierarchical navigation from site sections and root-level pages.
 
@@ -182,14 +183,10 @@ def get_auto_nav(site: SiteLike) -> list[dict[str, Any]]:
     Returns:
         List of navigation items with name, url, weight, parent (for hierarchy)
 
-    Example:
-        {# In nav template #}
-        {% set auto_items = get_auto_nav() %}
-        {% if auto_items %}
-          {% for item in auto_items %}
-            <a href="{{ item.href }}">{{ item.name }}</a>
-          {% endfor %}
-        {% endif %}
+    Example (MenuOrchestrator internal use):
+        auto_items = get_auto_nav(site)
+        for item in auto_items:
+            builder.add_from_config([_auto_nav_item_to_config(item)])
 
     Section _index.md frontmatter can control visibility:
         ---
@@ -215,7 +212,7 @@ def get_auto_nav(site: SiteLike) -> list[dict[str, Any]]:
     # sections like those used by autodoc. MenuOrchestrator and templates
     # can then decide how to use these items.
 
-    nav_items: list[dict[str, Any]] = []
+    nav_items: list[AutoNavItem] = []
 
     # Find all top-level sections (those with no parent)
     top_level_sections = []
@@ -251,7 +248,7 @@ def get_auto_nav(site: SiteLike) -> list[dict[str, Any]]:
         if item is None:
             return
 
-        section_identifier = item["identifier"]
+        section_identifier = item.identifier
         nav_items.append(item)
 
         # Recursively add subsections
@@ -274,6 +271,6 @@ def get_auto_nav(site: SiteLike) -> list[dict[str, Any]]:
                     nav_items.append(item)
 
     # Sort by weight (lower weights first)
-    nav_items.sort(key=lambda x: (x["weight"], x["name"]))
+    nav_items.sort(key=lambda x: (x.weight, x.name))
 
     return nav_items

--- a/bengal/rendering/template_functions/navigation/models.py
+++ b/bengal/rendering/template_functions/navigation/models.py
@@ -209,13 +209,10 @@ class AutoNavItem:
         parent: Parent item identifier (for hierarchy)
         icon: Optional icon identifier
 
-    Example (Jinja template):
-        {% set auto_items = get_auto_nav() %}
-        {% for item in auto_items %}
-          <a href="{{ item.href }}"
-             {% if item.icon %}class="icon-{{ item.icon }}"{% endif %}>
-            {{ item.name }}
-          </a>
+    Example (orchestrated menu in templates):
+        {% set nav_items = get_menu_lang('main', current_lang()) %}
+        {% for item in nav_items %}
+          <a href="{{ item.href }}">{{ item.name }}</a>
         {% endfor %}
 
     """
@@ -227,14 +224,31 @@ class AutoNavItem:
     parent: str | None = None
     icon: str | None = None
 
+    @property
+    def href(self) -> str:
+        """Site-relative URL for templates (alias for url)."""
+        return self.url
+
+    @property
+    def _path(self) -> str:
+        """Site-relative path for active-state comparison (alias for url)."""
+        return self.url
+
     def __getitem__(self, key: str) -> Any:
         """Dict-style access for template compatibility."""
+        if key == "href":
+            return self.href
+        if key == "_path":
+            return self._path
         return getattr(self, key)
 
     def keys(self) -> list[str]:
         """Return field names for dict-style iteration."""
-        return ["name", "url", "weight", "identifier", "parent", "icon"]
+        return ["name", "url", "href", "_path", "weight", "identifier", "parent", "icon"]
 
     def get(self, key: str, default: Any = None) -> Any:
         """Dict-style get with default for template compatibility."""
-        return getattr(self, key, default)
+        try:
+            return self[key]
+        except AttributeError:
+            return default

--- a/bengal/themes/default/templates/404.html
+++ b/bengal/themes/default/templates/404.html
@@ -23,9 +23,7 @@ KIDA FEATURES USED:
 {% block content %}
 {# Template-scoped variables #}
 {% let current_language = current_lang() %}
-{% let main_menu = get_menu_lang('main', current_language) %}
-{% let auto_nav = get_auto_nav() if main_menu | length == 0 else [] %}
-{% let nav_items = main_menu if main_menu | length > 0 else auto_nav %}
+{% let nav_items = get_menu_lang('main', current_language) %}
 {% let home_url = '/' | absolute_url %}
 
 {% from "partials/empty-state.html" import empty_state %}

--- a/bengal/themes/default/templates/TEMPLATE-CONTEXT.md
+++ b/bengal/themes/default/templates/TEMPLATE-CONTEXT.md
@@ -77,8 +77,7 @@ Functions available directly in templates:
 | `breadcrumbs(page)` | Generate breadcrumb trail |
 | `page_navigation(page)` | Prev/next page navigation |
 | `toc(toc_items, toc, page)` | Render table of contents |
-| `get_auto_nav()` | Auto-discovered navigation tree |
-| `get_menu('name')` | Get named menu items |
+| `get_menu('name')` | Get named menu items (includes auto-discovered main when unconfigured) |
 | `get_menu_lang('name', 'en')` | Get menu for specific language |
 
 ### Content

--- a/bengal/themes/default/templates/base.html
+++ b/bengal/themes/default/templates/base.html
@@ -41,9 +41,6 @@ _path, kind, tags are always defined - no defensive checks needed.
 {% let _cap_wiring = capability_wiring | default({'cache_key': '', 'stylesheets': [], 'scripts': [], 'lazy_loaders': [], 'runtime_globals': []}) %}
 {% let _cap_cache_key = _cap_wiring.cache_key %}
 
-{# Auto navigation if main menu is empty #}
-{% let _auto_nav = get_auto_nav() if _main_menu | length == 0 else [] %}
-
 {# =============================================================================
 HELPER: Render a menu item (desktop/mobile)
 ============================================================================= #}
@@ -322,20 +319,10 @@ HELPER: Render a menu item (desktop/mobile)
                     {% end %}
                 </a>
 
-                {% if _main_menu or _auto_nav %}
+                {% if _main_menu %}
                 {% spaceless %}
                 <ul class="nav-main hidden-mobile">
                     {% for item in _main_menu %}{{ render_menu_item(item) }}{% end %}
-                    {% if _auto_nav %}
-                    <li class="{{ ['active' if _page_url == '/'] | classes }}"><a href="{{ '/' | absolute_url }}">Home</a>
-                    </li>
-                    {% for item in _auto_nav %}
-                    <li
-                        class="{{ ['active' if (_page_url is string and item._path is string and _page_url.startswith(item._path) and item._path != '/')] | classes }}">
-                        <a href="{{ item.href | absolute_url }}">{{ item.name }}</a>
-                    </li>
-                    {% end %}
-                    {% end %}
                     {% with (site?.params?.repo_url ?? none) as repo_url %}
                     {% if repo_url and not (site._dev_menu_metadata?.github_bundled ?? false) %}
                     <li><a href="{{ repo_url }}" target="_blank" rel="noopener" aria-label="GitHub">{{
@@ -463,17 +450,10 @@ HELPER: Render a menu item (desktop/mobile)
             </div>
         </form>
 
-        {% if _main_menu or _auto_nav %}
+        {% if _main_menu %}
         <nav class="mobile-nav-content" role="navigation">
             <ul>
                 {% for item in _main_menu %}{{ render_menu_item(item, is_mobile=true) }}{% end %}
-                {% if _auto_nav %}
-                <li class="{{ ['active' if _page_url == '/'] | classes }}"><a href="{{ '/' | absolute_url }}">Home</a></li>
-                {% for item in _auto_nav %}<li
-                    class="{{ ['active' if (_page_url.startswith(item._path) if _page_url is string and item._path != '/' else false)] | classes }}">
-                    <a href="{{ item.href | absolute_url }}">{{ item.name }}</a>
-                </li>{% end %}
-                {% end %}
                 {% with (site?.params?.repo_url ?? none) as repo_url %}
                 {% if repo_url and not (site._dev_menu_metadata?.github_bundled ?? false) %}
                 <li><a href="{{ repo_url }}" target="_blank" rel="noopener">{{ icon('github-logo', size=16) }}

--- a/bengal/themes/default/templates/home.html
+++ b/bengal/themes/default/templates/home.html
@@ -95,8 +95,8 @@ MAIN TEMPLATE
 {% block content %}
 {% let page_title = page?.title ?? site.title ?? 'Home' %}
 {% let page_desc = params?.description ?? site.description ?? '' %}
-{% let _auto_nav = get_auto_nav() %}
-{% let _first_section = _auto_nav[0] if _auto_nav | length > 0 else none %}
+{% let _main_nav = get_menu_lang('main', _current_lang) %}
+{% let _first_section = _main_nav[0] if _main_nav | length > 0 else none %}
 
 {% let _default_features = [
   {'icon': 'star', 'title': t('home.feature_speed_title', default='Lightning fast'), 'description': t('home.feature_speed_desc', default='Static HTML, zero runtime overhead, and builds that finish in seconds.')},
@@ -111,7 +111,7 @@ MAIN TEMPLATE
 ] %}
 
 {% let _default_quick_links = [] %}
-{% for item in _auto_nav | take(6) %}
+{% for item in _main_nav | take(6) %}
 {% set _ = _default_quick_links.append({'title': item?.name ?? 'Section', 'href': item?.href ?? '#', 'icon': 'folder', 'description': ''}) %}
 {% end %}
 

--- a/changelog.d/+auto-nav-menu.fixed.md
+++ b/changelog.d/+auto-nav-menu.fixed.md
@@ -1,0 +1,3 @@
+Sites without a manual main menu render the home page again instead of failing during navigation template rendering.
+
+Theme navigation now uses the orchestrated main menu from `get_menu_lang('main')` rather than a separate `get_auto_nav()` template fallback, restoring `index.html` on auto-discovered sites including the Bengal docs site on GitHub Pages.

--- a/site/content/docs/reference/template-functions/reference-generated.md
+++ b/site/content/docs/reference/template-functions/reference-generated.md
@@ -198,7 +198,6 @@ Call directly: `{{ function_name() }}` or `{{ function_name(arg) }}`
 | `file_exists` | `file_exists_with_site` |
 | `file_size` | `file_size_with_site` |
 | `generate_code_sample` | `generate_code_sample` |
-| `get_auto_nav` | `<lambda>` |
 | `get_breadcrumbs` | `get_breadcrumbs` |
 | `get_data` | `get_data_with_site` |
 | `get_element_stats` | `get_element_stats` |

--- a/tests/integration/test_auto_menu_renders_index.py
+++ b/tests/integration/test_auto_menu_renders_index.py
@@ -1,0 +1,44 @@
+"""
+Regression: auto-discovered menus must render the home page.
+
+When no manual ``menu.main`` is configured, MenuOrchestrator builds the main
+menu from sections. Templates must use ``get_menu_lang('main')`` — not a
+separate ``get_auto_nav()`` fallback — so index.html is always emitted.
+"""
+
+from __future__ import annotations
+
+from bengal.orchestration.build.options import BuildOptions
+
+
+def test_auto_menu_site_renders_index_html(site_factory) -> None:
+    """Sites without manual menu.main must produce index.html with nav."""
+    site = site_factory("test-product")
+    site.build(BuildOptions(quiet=True, force_sequential=True))
+
+    index_path = site.output_dir / "index.html"
+    assert index_path.is_file(), "index.html missing — home page render likely failed"
+
+    main_menu = site.menu.get("main", [])
+    assert main_menu, "MenuOrchestrator should populate site.menu['main'] in auto mode"
+
+    html = index_path.read_text(encoding="utf-8")
+    first_item = main_menu[0]
+    assert first_item.name in html, "Orchestrated main menu should appear in rendered nav"
+
+
+def test_home_template_renders_without_get_auto_nav(site_factory) -> None:
+    """home.html splash defaults must work from orchestrated main menu only."""
+    site = site_factory("test-product")
+    (site.root_path / "content" / "_index.md").write_text(
+        """---
+title: Splash Home
+template: home.html
+---
+""",
+        encoding="utf-8",
+    )
+    site.discover_content()
+    site.build(BuildOptions(quiet=True, force_sequential=True))
+
+    assert (site.output_dir / "index.html").is_file()

--- a/tests/unit/rendering/test_navigation_models.py
+++ b/tests/unit/rendering/test_navigation_models.py
@@ -237,6 +237,15 @@ class TestAutoNavItem:
 
         assert item["name"] == "Home"
         assert item["weight"] == 5
+        assert item["href"] == "/"
+        assert item["_path"] == "/"
+
+    def test_href_and_path_properties(self):
+        """Test href/_path aliases for unified URL model."""
+        item = AutoNavItem(name="Docs", url="/docs/")
+
+        assert item.href == "/docs/"
+        assert item._path == "/docs/"
 
     def test_keys_method(self):
         """Test keys() returns all field names."""


### PR DESCRIPTION
## Summary

- Fix broken https://lbliii.github.io/bengal/ by restoring `index.html` generation when sites use auto-discovered navigation (no manual `menu.main`).
- Remove the duplicate `get_auto_nav()` template fallback in `base.html`, `home.html`, and `404.html`; all theme nav now flows through `get_menu_lang('main')` so dev bundling, extras, and dropdown logic stay consistent.
- Return typed `AutoNavItem` objects from `get_auto_nav()` (internal to `MenuOrchestrator` only), add `href`/`_path` aliases, and convert once to `MenuBuilder` config dicts.
- Add integration regression tests ensuring auto-menu sites render `index.html` and `home.html` without calling `get_auto_nav()` in templates.

## Proof

- [x] Focused tests: `pytest tests/integration/test_auto_menu_renders_index.py tests/unit/orchestration/test_menu_orchestrator.py tests/unit/orchestration/test_menu_dev_dropdown_autodoc.py tests/unit/rendering/test_navigation_models.py`
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: TEMPLATE-CONTEXT.md updated; no user-facing API changelog needed (internal template cleanup)

## Performance Evidence

not applicable

## Steward Notes

- Commit was unsigned in this environment (GPG pinentry unavailable in non-TTY); consider re-signing locally if required by repo policy.
- After merge, GitHub Pages deploy on `main` should restore the site homepage (was serving `index.json` because `index.html` was missing).


Made with [Cursor](https://cursor.com)