### PR TITLE
feat(theme): editor code blocks get IDE-style tab bar chrome

### DIFF
--- a/bengal/postprocess/static_markup.py
+++ b/bengal/postprocess/static_markup.py
@@ -43,6 +43,15 @@ _COLLAPSIBLE_BLOCK_RE = re.compile(
     r"(</div>)",
     re.IGNORECASE,
 )
+_TITLE_BEFORE_RE = re.compile(
+    r'<div class="code-block-title">([^<]*)</div>\s*$',
+    re.IGNORECASE,
+)
+_DEDUPE_EDITOR_TITLE_RE = re.compile(
+    r'(<div class="code-block-titled">\s*)<div class="code-block-title">[^<]*</div>\s*'
+    r'(<div class="code-block-wrapper[^"]*\bcode-block-frame--editor\b[^"]*")',
+    re.IGNORECASE,
+)
 _ENHANCED_CODE_MARKER = "data-bengal-code-chrome"
 _HIGHLIGHT_ROOT_CLASSES = frozenset({"rosettes", "highlight"})
 
@@ -213,8 +222,8 @@ def _parse_annotations(spec: str) -> dict[int, str]:
     return annotations
 
 
-def _build_toolbar(lang: str, *, overlay: bool = False) -> str:
-    lang_label = f'<span class="code-language">{lang}</span>' if lang else ""
+def _build_toolbar(lang: str, *, overlay: bool = False, show_lang: bool = True) -> str:
+    lang_label = f'<span class="code-language">{lang}</span>' if lang and show_lang else ""
     overlay_classes = " code-block-toolbar--overlay code-header-inline" if overlay else ""
     return (
         f'<div class="code-block-toolbar{overlay_classes}">'
@@ -223,18 +232,64 @@ def _build_toolbar(lang: str, *, overlay: bool = False) -> str:
     )
 
 
-def _build_frame_chrome(frame: str, lang: str) -> str:
-    dots = ""
+def _frame_dots() -> str:
+    return (
+        '<div class="code-block-frame-dots" aria-hidden="true">'
+        '<span class="code-block-frame-dot"></span>'
+        '<span class="code-block-frame-dot"></span>'
+        '<span class="code-block-frame-dot"></span>'
+        "</div>"
+    )
+
+
+def _editor_tab_label(filename: str, lang: str) -> str:
+    if filename:
+        return filename
+    if lang:
+        return lang.lower()
+    return "untitled"
+
+
+def _build_editor_tab(filename: str, lang: str) -> str:
+    label = html_mod.escape(_editor_tab_label(filename, lang))
+    return (
+        '<div class="code-block-tabs" role="presentation">'
+        f'<div class="code-block-tab code-block-tab--active">'
+        f'<span class="code-block-tab__icon" aria-hidden="true"></span>'
+        f'<span class="code-block-tab__label">{label}</span>'
+        "</div>"
+        "</div>"
+    )
+
+
+def _extract_title_from_context(html: str, pos: int) -> str:
+    window = html[max(0, pos - 500) : pos]
+    if "code-block-titled" not in window:
+        return ""
+    match = _TITLE_BEFORE_RE.search(window)
+    if not match:
+        return ""
+    return html_mod.unescape(match.group(1).strip())
+
+
+def _resolve_editor_filename(div_attrs: str, html: str, pos: int) -> str:
+    return _attr_value(div_attrs, "data-title") or _extract_title_from_context(html, pos)
+
+
+def _build_frame_chrome(frame: str, lang: str, *, filename: str = "") -> str:
     if frame == "terminal":
-        dots = (
-            '<div class="code-block-frame-dots" aria-hidden="true">'
-            '<span class="code-block-frame-dot"></span>'
-            '<span class="code-block-frame-dot"></span>'
-            '<span class="code-block-frame-dot"></span>'
-            "</div>"
+        toolbar = _build_toolbar(lang, overlay=False)
+        return (
+            f'<div class="code-block-chrome code-block-chrome--{frame}">'
+            f"{_frame_dots()}{toolbar}</div>"
         )
-    toolbar = _build_toolbar(lang, overlay=False)
-    return f'<div class="code-block-chrome code-block-chrome--{frame}">{dots}{toolbar}</div>'
+
+    tab = _build_editor_tab(filename, lang)
+    toolbar = _build_toolbar(lang, overlay=False, show_lang=not filename)
+    return (
+        f'<div class="code-block-chrome code-block-chrome--editor">'
+        f"{_frame_dots()}{tab}{toolbar}</div>"
+    )
 
 
 def _wrapper_classes(div_attrs: str, *, in_titled_block: bool = False) -> str:
@@ -297,6 +352,8 @@ def _wrap_pre_code(
     *,
     div_attrs: str = "",
     in_titled_block: bool = False,
+    source_html: str = "",
+    source_pos: int = 0,
 ) -> str:
     lang = _attr_value(div_attrs, "data-language").upper() or _language_from_code_tag(open_pre)
     annotations = _parse_annotations(_attr_value(div_attrs, "data-annotate"))
@@ -311,7 +368,12 @@ def _wrap_pre_code(
     frame = _attr_value(div_attrs, "data-frame") or ("editor" if in_titled_block else "")
 
     if frame:
-        chrome = _build_frame_chrome(frame, lang)
+        filename = (
+            _resolve_editor_filename(div_attrs, source_html, source_pos)
+            if frame == "editor"
+            else ""
+        )
+        chrome = _build_frame_chrome(frame, lang, filename=filename)
         return (
             f'<div class="{wrapper_class}" {_ENHANCED_CODE_MARKER}="true">'
             f'{chrome}<div class="code-block-body">{body}</div></div>'
@@ -339,6 +401,8 @@ def _enhance_highlighted_block(match: re.Match[str]) -> str:
         pre_match.group(3),
         div_attrs=div_attrs,
         in_titled_block="code-block-titled" in match.string[: match.start()],
+        source_html=match.string,
+        source_pos=match.start(),
     )
     return _absorb_highlight_root(open_div, wrapped)
 
@@ -357,6 +421,8 @@ def _wrap_plain_pre_code(match: re.Match[str]) -> str:
         match.group(2),
         match.group(3),
         in_titled_block=in_titled,
+        source_html=match.string,
+        source_pos=match.start(),
     )
 
 
@@ -388,6 +454,7 @@ def inject_code_copy_chrome(html: str) -> str:
 
     html = _HIGHLIGHTED_BLOCK_RE.sub(_enhance_highlighted_block, html)
     html = _PRE_CODE_RE.sub(_wrap_plain_pre_code, html)
+    html = _DEDUPE_EDITOR_TITLE_RE.sub(r"\1\2", html)
     html = _wrap_collapsible_blocks(html)
     return html
 

--- a/bengal/rendering/highlighting/deferred.py
+++ b/bengal/rendering/highlighting/deferred.py
@@ -296,6 +296,8 @@ def apply_fence_metadata(html: str, fence_attrs: CodeFenceAttrs) -> str:
         additions.append(f'data-annotate="{html_mod.escape(spec)}"')
     if fence_attrs.diff:
         additions.append('data-diff="true"')
+    if fence_attrs.title:
+        additions.append(f'data-title="{html_mod.escape(fence_attrs.title)}"')
 
     if not additions:
         return html

--- a/bengal/themes/default/assets/css/components/code.css
+++ b/bengal/themes/default/assets/css/components/code.css
@@ -1288,13 +1288,124 @@ pre::-webkit-scrollbar-thumb:hover {
 }
 
 .code-block-chrome--editor {
-  min-height: 1.25rem;
-  justify-content: flex-end;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--color-bg-tertiary) 95%, transparent),
-    color-mix(in srgb, var(--color-bg-code) 95%, transparent)
-  );
+  min-height: 2rem;
+  padding: 0;
+  gap: 0;
+  justify-content: flex-start;
+  background: color-mix(in srgb, var(--color-bg-tertiary) 92%, var(--color-bg-code));
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.code-block-chrome--editor .code-block-frame-dots {
+  padding-inline: 0.75rem;
+  flex-shrink: 0;
+}
+
+.code-block-chrome--editor .code-block-frame-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  opacity: 0.85;
+}
+
+.code-block-chrome--editor .code-block-frame-dot:nth-child(1) {
+  background: #ff5f57;
+}
+
+.code-block-chrome--editor .code-block-frame-dot:nth-child(2) {
+  background: #febc2e;
+}
+
+.code-block-chrome--editor .code-block-frame-dot:nth-child(3) {
+  background: #28c840;
+}
+
+.code-block-tabs {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.125rem;
+  min-width: 0;
+  flex: 1;
+  padding-block-start: 0.375rem;
+  overflow: hidden;
+}
+
+.code-block-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  max-width: min(16rem, 55vw);
+  padding: 0.375rem 0.75rem;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xxs);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.code-block-tab--active {
+  position: relative;
+  z-index: 1;
+  margin-block-end: -1px;
+  border-color: var(--color-border-light);
+  border-bottom-color: var(--color-bg-code);
+  background: var(--color-bg-code);
+  color: var(--color-text-secondary);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--color-text-primary) 6%, transparent),
+    0 -1px 0 color-mix(in srgb, var(--color-primary) 8%, transparent);
+}
+
+.code-block-tab__icon {
+  display: inline-block;
+  width: 0.875rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  opacity: 0.75;
+}
+
+[data-theme="dark"] .code-block-tab__icon {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3C/svg%3E");
+}
+
+.code-block-tab__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.code-block-chrome--editor .code-block-toolbar {
+  padding-inline: 0.75rem;
+  padding-block: 0.375rem;
+  flex-shrink: 0;
+}
+
+.code-block-titled:has(.code-block-frame--editor) > .code-block-title {
+  display: none;
+}
+
+.code-block-titled:has(.code-block-frame--editor) {
+  border: none;
+  box-shadow: none;
+  animation: none;
+  background: transparent;
+}
+
+.code-block-titled:has(.code-block-frame--editor) > .code-block-wrapper {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: var(--radius-2xl);
+  box-shadow: var(--elevation-card);
+  animation: code-border-glow 8s ease-in-out infinite;
+}
+
+[data-theme="dark"] .code-block-titled:has(.code-block-frame--editor) > .code-block-wrapper {
+  border-color: rgba(255, 255, 255, 0.1);
+  animation: code-border-glow-dark 8s ease-in-out infinite;
 }
 
 .code-block-frame-dots {
@@ -1363,6 +1474,10 @@ pre::-webkit-scrollbar-thumb:hover {
 .code-block-wrapper.code-block-frame--terminal,
 .code-block-wrapper.code-block-frame--editor {
   overflow: hidden;
+}
+
+.code-block-wrapper.code-block-frame--editor > .code-block-chrome {
+  border-radius: calc(var(--radius-2xl) - 1px) calc(var(--radius-2xl) - 1px) 0 0;
 }
 
 .code-block-wrapper.code-block-frame--terminal > .code-block-body > pre:last-child,

--- a/changelog.d/+editor-code-block-tab-bar.changed.md
+++ b/changelog.d/+editor-code-block-tab-bar.changed.md
@@ -1,0 +1,3 @@
+Editor code blocks now show IDE-style window chrome with traffic lights, an active file tab, and toolbar actions.
+
+Titled fences and `frame=editor` blocks fold the filename into the tab bar via `data-title`, dedupe the legacy title strip, and fall back to the language name when no title is set.

--- a/tests/unit/postprocess/test_static_markup.py
+++ b/tests/unit/postprocess/test_static_markup.py
@@ -76,6 +76,29 @@ def test_inject_code_copy_chrome_adds_editor_frame_for_titled_blocks() -> None:
     )
     out = inject_code_copy_chrome(html)
     assert "code-block-frame--editor" in out
+    assert "code-block-chrome--editor" in out
+    assert "code-block-tab--active" in out
+    assert "app.py" in out
+    assert '<div class="code-block-title">' not in out
+
+
+def test_inject_code_copy_chrome_editor_frame_uses_data_title() -> None:
+    html = (
+        '<div class="rosettes" data-language="python" data-frame="editor" '
+        'data-title="config.py"><pre><code>x=1</code></pre></div>'
+    )
+    out = inject_code_copy_chrome(html)
+    assert 'class="code-block-tab__label">config.py</span>' in out
+    assert "code-block-frame--editor" in out
+
+
+def test_inject_code_copy_chrome_editor_frame_without_title_uses_language() -> None:
+    html = (
+        '<div class="rosettes" data-language="python" data-frame="editor">'
+        "<pre><code>x=1</code></pre></div>"
+    )
+    out = inject_code_copy_chrome(html)
+    assert 'class="code-block-tab__label">python</span>' in out
 
 
 def test_inject_code_copy_chrome_adds_annotations() -> None:


### PR DESCRIPTION
## Summary

- Editor code blocks (`frame=editor` and titled fences) now use IDE-style window chrome: traffic lights, an active file tab, and wrap/copy actions on the right.
- Filenames from `title="..."` fold into the tab bar via `data-title`, with the legacy title strip removed and a language-name fallback when no title is set.
- Terminal frames are unchanged; overlay chrome remains the default for other languages.

## Proof

- [x] Focused tests: `uv run pytest tests/unit/postprocess/test_static_markup.py -q`
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: `changelog.d/+editor-code-block-tab-bar.changed.md`

## Performance Evidence

not applicable

## Steward Notes

- Editor and terminal frames now share the traffic-light window metaphor; overlay blocks are unchanged.

Made with [Cursor](https://cursor.com)