### PR TITLE
feat(graph): topic atlas layout with semantic zoom for large graphs

### DIFF
--- a/bengal/analysis/graph/layout.py
+++ b/bengal/analysis/graph/layout.py
@@ -19,6 +19,8 @@ Two layouts are provided:
 - :func:`compute_force_layout` — Fruchterman-Reingold for the full-graph explorer.
   Uses a Barnes-Hut quadtree for repulsion so it scales to large graphs; falls
   back to exact O(n^2) repulsion below a threshold (simpler + exact for small N).
+- :func:`compute_hierarchical_layout` — per-community sub-layout packed into an
+  atlas (topic map at scale). Used when Louvain detects multiple communities.
 - :func:`compute_radial_layout` — a concentric layout for the per-page minimap
   neighborhood: the current page pinned dead-center, neighbors placed on rings
   ordered by connectivity. Centered by construction, trivially deterministic.
@@ -52,6 +54,26 @@ _BH_THETA = 0.9
 # this scale the points are effectively the same location, so collapsing them
 # into one aggregate cell is both correct and cheap.
 _MIN_CELL = 1e-6
+
+# Spacing knobs for the full-graph explorer. Large sites (1k+ nodes) otherwise
+# compress into overlapping blobs: FR's ``k = sqrt(1/n)`` shrinks with N, and
+# strong community gravity pulls intra-cluster nodes onto the same spokes.
+_K_SCALE = 2.5  # multiplier on ideal edge length (larger => more spread)
+_REPULSION_SOFTENING = 0.18  # min center-to-center distance as a fraction of k
+_COMMUNITY_RING_R = 0.42  # community centroid ring radius (was 0.35)
+_SEED_SPREAD = 0.22  # initial jitter around each community centroid
+_COMMUNITY_GRAVITY = 0.65  # pull toward community centroid (was 0.9)
+_GLOBAL_GRAVITY = 0.10  # weak pull toward graph center (was 0.12)
+_OVERLAP_MIN_K = 0.45  # post-layout minimum center distance as a fraction of k
+_OVERLAP_PASSES = 5  # relaxation sweeps before normalization
+
+# Hierarchical layout: each Louvain community gets its own local box before packing.
+_COMMUNITY_SLOT_MIN = 0.14  # smallest community footprint (pre-global-normalize)
+_COMMUNITY_SLOT_MAX = 0.52  # largest community footprint
+_COMMUNITY_PACK_RING = 0.38  # ring radius for packed community centers
+_COMMUNITY_PACK_PAD = 0.04  # gap between adjacent community boxes
+_SIZE_RADIUS_MIN = 0.006  # layout collision radius floor (normalized local space)
+_SIZE_RADIUS_MAX = 0.024  # layout collision radius ceiling
 
 
 class _Rng:
@@ -110,6 +132,88 @@ def _normalize(
         nx = off_x + (px - min_x) / span * inner
         ny = off_y + (py - min_y) / span * inner
         out[node_id] = (_round(nx), _round(ny))
+    return out
+
+
+def _relax_overlaps(
+    positions: dict[str, list[float]],
+    ids: Sequence[str],
+    *,
+    min_dist: float,
+    rng: _Rng,
+    passes: int,
+    radii: Mapping[str, float] | None = None,
+) -> None:
+    """Push apart pairs closer than ``min_dist`` (deterministic, in-place)."""
+    if min_dist <= 0.0 or len(ids) < 2 or passes <= 0:
+        return
+
+    n = len(ids)
+    for _ in range(passes):
+        moved = False
+        for i in range(n):
+            a = ids[i]
+            ax, ay = positions[a]
+            ra = radii.get(a, min_dist / 2.0) if radii else min_dist / 2.0
+            for j in range(i + 1, n):
+                b = ids[j]
+                bx, by = positions[b]
+                rb = radii.get(b, min_dist / 2.0) if radii else min_dist / 2.0
+                pair_min = max(min_dist, ra + rb)
+                pair_min2 = pair_min * pair_min
+                dx = ax - bx
+                dy = ay - by
+                dist2 = dx * dx + dy * dy
+                if dist2 >= pair_min2:
+                    continue
+                moved = True
+                if dist2 < 1e-18:
+                    dx = (rng.random() - 0.5) * pair_min
+                    dy = (rng.random() - 0.5) * pair_min
+                    dist2 = dx * dx + dy * dy
+                dist = math.sqrt(dist2)
+                shift = (pair_min - dist) * 0.55
+                ux = dx / dist
+                uy = dy / dist
+                positions[a][0] = ax + ux * shift
+                positions[a][1] = ay + uy * shift
+                positions[b][0] = bx - ux * shift
+                positions[b][1] = by - uy * shift
+                ax, ay = positions[a]
+        if not moved:
+            break
+
+
+def _layout_radius(size: float) -> float:
+    """Map visual node size (8–50) to a layout collision radius in local space."""
+    clamped = max(8.0, min(50.0, float(size)))
+    t = (clamped - 8.0) / 42.0
+    return _SIZE_RADIUS_MIN + t * (_SIZE_RADIUS_MAX - _SIZE_RADIUS_MIN)
+
+
+def compute_community_bounds(
+    coords: Mapping[str, tuple[float, float]],
+    communities: Mapping[str, int],
+) -> dict[int, dict[str, float]]:
+    """Derive centroid + axis-aligned bounds per community id from final coords."""
+    grouped: dict[int, list[tuple[float, float]]] = {}
+    for nid in sorted(coords):
+        cid = int(communities.get(nid, -1))
+        grouped.setdefault(cid, []).append(coords[nid])
+
+    out: dict[int, dict[str, float]] = {}
+    for cid in sorted(grouped):
+        pts = grouped[cid]
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        out[cid] = {
+            "x": _round(sum(xs) / len(xs)),
+            "y": _round(sum(ys) / len(ys)),
+            "min_x": _round(min(xs)),
+            "min_y": _round(min(ys)),
+            "max_x": _round(max(xs)),
+            "max_y": _round(max(ys)),
+        }
     return out
 
 
@@ -177,20 +281,26 @@ class _BHNode:
             self.children[q] = child
         child.insert(x, y)
 
-    def force_on(self, x: float, y: float, k2: float, theta: float) -> tuple[float, float]:
+    def force_on(
+        self,
+        x: float,
+        y: float,
+        k2: float,
+        theta: float,
+        *,
+        soft_dist2: float,
+    ) -> tuple[float, float]:
         """Accumulated repulsion on ``(x, y)`` from this subtree."""
         if self.mass == 0.0:
             return (0.0, 0.0)
 
         dx = x - self.cx
         dy = y - self.cy
-        dist2 = dx * dx + dy * dy
+        dist2 = max(dx * dx + dy * dy, soft_dist2)
 
         children = self.children
         # Treat far/aggregate cells as a single body (Barnes-Hut criterion).
         if children is None or (self.size * self.size < theta * theta * dist2):
-            if dist2 < 1e-12:
-                return (0.0, 0.0)
             inv = k2 * self.mass / dist2
             return (dx * inv, dy * inv)
 
@@ -198,7 +308,7 @@ class _BHNode:
         fy = 0.0
         for child in children:
             if child is not None:
-                cfx, cfy = child.force_on(x, y, k2, theta)
+                cfx, cfy = child.force_on(x, y, k2, theta, soft_dist2=soft_dist2)
                 fx += cfx
                 fy += cfy
         return (fx, fy)
@@ -212,6 +322,7 @@ def compute_force_layout(
     iterations: int | None = None,
     communities: Mapping[str, int] | None = None,
     weights: Mapping[tuple[str, str], float] | None = None,
+    node_sizes: Mapping[str, float] | None = None,
 ) -> dict[str, tuple[float, float]]:
     """Fruchterman-Reingold layout, normalized to ``[0, 1]``.
 
@@ -232,6 +343,8 @@ def compute_force_layout(
         weights: Optional ``(source, target) -> weight`` map (any key order).
             Edge attraction is scaled by the weight (capped), so strongly /
             bidirectionally linked pairs sit closer together.
+        node_sizes: Optional ``node_id -> visual size`` map (8–50). When given,
+            the post-layout overlap pass reserves space proportional to size.
 
     Returns:
         ``dict[node_id, (x, y)]`` with coordinates in ``[0, 1]``. Empty input
@@ -253,7 +366,7 @@ def compute_force_layout(
     if communities:
         comm_ids = sorted({int(communities.get(nid, -1)) for nid in ids})
         num_comms = len(comm_ids)
-        ring_r = 0.35
+        ring_r = _COMMUNITY_RING_R
         for rank, cid in enumerate(comm_ids):
             if num_comms <= 1:
                 centroids[cid] = (0.5, 0.5)
@@ -272,7 +385,10 @@ def compute_force_layout(
     for nid in ids:
         if communities:
             cx, cy = _centroid(nid)
-            pos[nid] = [cx + (rng.random() - 0.5) * 0.12, cy + (rng.random() - 0.5) * 0.12]
+            pos[nid] = [
+                cx + (rng.random() - 0.5) * _SEED_SPREAD,
+                cy + (rng.random() - 0.5) * _SEED_SPREAD,
+            ]
         else:
             pos[nid] = [rng.random(), rng.random()]
 
@@ -285,9 +401,11 @@ def compute_force_layout(
         for (s, t), w in weights.items():
             weight_by_pair[(s, t) if s <= t else (t, s)] = float(w)
 
-    # FR ideal edge length for a unit area.
-    k = math.sqrt(1.0 / n)
+    # FR ideal edge length for a unit area, scaled up so large graphs don't
+    # collapse into overlapping clusters before normalization.
+    k = math.sqrt(_K_SCALE / n)
     k2 = k * k
+    soft_dist2 = (k * _REPULSION_SOFTENING) ** 2
 
     if iterations is None:
         # More nodes need more iterations to settle, but cap for build cost.
@@ -308,7 +426,7 @@ def compute_force_layout(
                 root.insert(px, py)
             for nid in ids:
                 px, py = pos[nid]
-                fx, fy = root.force_on(px, py, k2, _BH_THETA)
+                fx, fy = root.force_on(px, py, k2, _BH_THETA, soft_dist2=soft_dist2)
                 disp[nid][0] += fx
                 disp[nid][1] += fy
         else:
@@ -327,6 +445,7 @@ def compute_force_layout(
                         dx = (rng.random() - 0.5) * 1e-3
                         dy = (rng.random() - 0.5) * 1e-3
                         dist2 = dx * dx + dy * dy
+                    dist2 = max(dist2, soft_dist2)
                     f = k2 / dist2
                     fx = dx * f
                     fy = dy * f
@@ -360,8 +479,12 @@ def compute_force_layout(
             px, py = pos[nid]
             if communities:
                 cx, cy = _centroid(nid)
-                disp[nid][0] += (cx - px) * k * 0.9 + (0.5 - px) * k * 0.12
-                disp[nid][1] += (cy - py) * k * 0.9 + (0.5 - py) * k * 0.12
+                disp[nid][0] += (cx - px) * k * _COMMUNITY_GRAVITY + (
+                    0.5 - px
+                ) * k * _GLOBAL_GRAVITY
+                disp[nid][1] += (cy - py) * k * _COMMUNITY_GRAVITY + (
+                    0.5 - py
+                ) * k * _GLOBAL_GRAVITY
             else:
                 disp[nid][0] += (0.5 - px) * k * 0.5
                 disp[nid][1] += (0.5 - py) * k * 0.5
@@ -377,7 +500,118 @@ def compute_force_layout(
 
         temp -= cooling
 
+    _relax_overlaps(
+        pos,
+        ids,
+        min_dist=k * _OVERLAP_MIN_K,
+        rng=rng,
+        passes=_OVERLAP_PASSES,
+        radii=(
+            {nid: _layout_radius(node_sizes[nid]) for nid in ids if nid in node_sizes}
+            if node_sizes
+            else None
+        ),
+    )
     return _normalize(pos)
+
+
+def compute_hierarchical_layout(
+    node_ids: Sequence[str],
+    edges: Sequence[tuple[str, str]],
+    *,
+    communities: Mapping[str, int],
+    seed: int = 1,
+    weights: Mapping[tuple[str, str], float] | None = None,
+    node_sizes: Mapping[str, float] | None = None,
+) -> dict[str, tuple[float, float]]:
+    """Hierarchical layout: each community laid out locally, then packed into an atlas.
+
+    Phase A — layout each Louvain community independently in its own unit box
+    (so dense topics spread internally instead of fighting for one global centroid).
+    Phase B — pack community boxes on a ring, sized by ``sqrt(node count)``.
+    Phase C — normalize the composed atlas to ``[0, 1]``.
+
+    Deterministic for a given (node set, edge set, communities, weights, seed).
+    """
+    ids = sorted(set(node_ids))
+    if not ids:
+        return {}
+    if len(ids) == 1:
+        return {ids[0]: (0.5, 0.5)}
+
+    # Group members by community id (sorted for determinism).
+    groups: dict[int, list[str]] = {}
+    for nid in ids:
+        cid = int(communities.get(nid, -1))
+        groups.setdefault(cid, []).append(nid)
+
+    valid = set(ids)
+    clean_edges = sorted((s, t) for s, t in edges if s in valid and t in valid and s != t)
+
+    weight_by_pair: dict[tuple[str, str], float] = {}
+    if weights:
+        for (s, t), w in weights.items():
+            weight_by_pair[(s, t) if s <= t else (t, s)] = float(w)
+
+    local_by_comm: dict[int, dict[str, tuple[float, float]]] = {}
+    for cid in sorted(groups):
+        members = groups[cid]
+        if len(members) == 1:
+            local_by_comm[cid] = {members[0]: (0.5, 0.5)}
+            continue
+        member_set = set(members)
+        local_edges = [(s, t) for s, t in clean_edges if s in member_set and t in member_set]
+        local_weights = {
+            pair: weight_by_pair[pair]
+            for pair in weight_by_pair
+            if pair[0] in member_set and pair[1] in member_set
+        }
+        local_sizes = (
+            {nid: node_sizes[nid] for nid in members if nid in node_sizes} if node_sizes else None
+        )
+        # Distinct seed per community so layouts don't mirror each other.
+        local_by_comm[cid] = compute_force_layout(
+            members,
+            local_edges,
+            seed=seed + (cid + 1) * 997,
+            weights=local_weights or None,
+            node_sizes=local_sizes,
+        )
+
+    # Slot size scales with sqrt(n) so large topics get more atlas real estate.
+    comm_ids = sorted(groups)
+    counts = {cid: len(groups[cid]) for cid in comm_ids}
+    max_sqrt = max(math.sqrt(float(counts[cid])) for cid in comm_ids) or 1.0
+
+    rng = _Rng(seed)
+    num_comms = len(comm_ids)
+    centers: dict[int, tuple[float, float]] = {}
+    slots: dict[int, float] = {}
+    for rank, cid in enumerate(comm_ids):
+        sqrt_n = math.sqrt(float(counts[cid]))
+        slot = _COMMUNITY_SLOT_MIN + (_COMMUNITY_SLOT_MAX - _COMMUNITY_SLOT_MIN) * (
+            sqrt_n / max_sqrt
+        )
+        slots[cid] = slot
+        if num_comms <= 1:
+            centers[cid] = (0.5, 0.5)
+        else:
+            angle = 2.0 * math.pi * rank / num_comms + (rng.random() - 0.5) * 0.04
+            centers[cid] = (
+                0.5 + _COMMUNITY_PACK_RING * math.cos(angle),
+                0.5 + _COMMUNITY_PACK_RING * math.sin(angle),
+            )
+
+    composed: dict[str, list[float]] = {}
+    for cid in comm_ids:
+        cx, cy = centers[cid]
+        slot = slots[cid]
+        inner = max(0.05, slot - _COMMUNITY_PACK_PAD)
+        for nid in groups[cid]:
+            lx, ly = local_by_comm[cid][nid]
+            composed[nid] = [cx + (lx - 0.5) * inner, cy + (ly - 0.5) * inner]
+
+    return _normalize(composed)
 
 
 def compute_radial_layout(

--- a/bengal/analysis/graph/visualizer.py
+++ b/bengal/analysis/graph/visualizer.py
@@ -190,6 +190,7 @@ class GraphVisualizer:
         # Louvain local seeded PRNG); we round the PageRank float before baking.
         community_by_page: dict[Any, int] = {}
         communities_summary: list[dict[str, Any]] = []
+        community_results = None
         pr_scores: dict[Any, float] = {}
         pr_max = 0.0
         try:
@@ -392,22 +393,60 @@ class GraphVisualizer:
         # what lets the explorer drop D3 and stop choking at scale). The layout
         # is seeded + reproducible: coordinates ship in graph.json and the build
         # guards warm==cold byte parity.
-        from bengal.analysis.graph.layout import compute_force_layout
+        from bengal.analysis.graph.layout import (
+            compute_community_bounds,
+            compute_force_layout,
+            compute_hierarchical_layout,
+        )
 
         # Community-aware layout: cluster nodes into separated topical lobes
         # (not one center-piled hairball) and pull strongly-linked pairs closer.
         node_community = {n["id"]: n["community"] for n in nodes}
         edge_weights = {(e["source"], e["target"]): e["weight"] for e in edges}
-        coords = compute_force_layout(
-            [n["id"] for n in nodes],
-            [(e["source"], e["target"]) for e in edges],
-            communities=node_community,
-            weights=edge_weights,
-        )
+        node_sizes = {n["id"]: float(n["size"]) for n in nodes}
+        unique_communities = len({c for c in node_community.values() if c >= 0})
+
+        node_id_list = [n["id"] for n in nodes]
+        edge_list = [(e["source"], e["target"]) for e in edges]
+        if unique_communities > 1:
+            coords = compute_hierarchical_layout(
+                node_id_list,
+                edge_list,
+                communities=node_community,
+                weights=edge_weights,
+                node_sizes=node_sizes,
+            )
+        else:
+            coords = compute_force_layout(
+                node_id_list,
+                edge_list,
+                communities=node_community,
+                weights=edge_weights,
+                node_sizes=node_sizes,
+            )
         for n in nodes:
             x, y = coords.get(n["id"], (0.5, 0.5))
             n["x"] = x
             n["y"] = y
+
+        bounds_by_community = compute_community_bounds(coords, node_community)
+        community_regions: list[dict[str, Any]] = []
+        if community_results is not None:
+            for community in community_results.communities:
+                region = {
+                    "id": community.id,
+                    "label": self._community_label(community, pr_scores),
+                    "size": community.size,
+                }
+                region.update(bounds_by_community.get(community.id, {}))
+                community_regions.append(region)
+            for entry in communities_summary:
+                entry.update(bounds_by_community.get(entry["id"], {}))
+        else:
+            for cid, bounds in sorted(bounds_by_community.items()):
+                community_regions.append(
+                    {"id": cid, "label": f"Cluster {cid}", "size": 0, **bounds}
+                )
 
         logger.info(
             "graph_viz_generate_complete",
@@ -425,6 +464,7 @@ class GraphVisualizer:
                 "hubs": self.graph.metrics.hub_count if self.graph.metrics else 0,
                 "orphans": self.graph.metrics.orphan_count if self.graph.metrics else 0,
                 "communities": communities_summary,
+                "community_regions": community_regions,
             },
         }
 

--- a/bengal/themes/default/assets/css/components/graph.css
+++ b/bengal/themes/default/assets/css/components/graph.css
@@ -597,6 +597,83 @@
     background: rgba(255, 255, 255, 0.08);
 }
 
+/* Breadcrumb navigation (atlas → cluster → page) */
+.graph-breadcrumb {
+    position: absolute;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: linear-gradient(
+        145deg,
+        var(--color-bg-elevated, rgba(255, 255, 255, 0.95)),
+        var(--color-bg-secondary, rgba(245, 245, 245, 0.9))
+    );
+    border: 1px solid var(--color-border, rgba(0, 0, 0, 0.1));
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    font-size: 12px;
+    color: var(--color-text-secondary, #757575);
+    z-index: 110;
+    pointer-events: auto;
+}
+
+[data-theme="dark"] .graph-breadcrumb {
+    background: linear-gradient(145deg, rgba(45, 45, 45, 0.95), rgba(30, 30, 30, 0.9));
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
+.graph-crumb-root {
+    border: none;
+    background: none;
+    font: inherit;
+    color: var(--color-accent, #1976d2);
+    cursor: pointer;
+    padding: 0;
+}
+
+.graph-crumb-root:hover {
+    text-decoration: underline;
+}
+
+.graph-crumb-sep {
+    opacity: 0.45;
+}
+
+.graph-crumb-current {
+    color: var(--color-text-primary, #212121);
+    font-weight: 600;
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Minimap inset */
+.graph-minimap {
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
+    width: 120px;
+    height: 120px;
+    border-radius: 10px;
+    border: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+    background: var(--color-bg-elevated, rgba(255, 255, 255, 0.85));
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    z-index: 90;
+    pointer-events: none;
+}
+
+[data-theme="dark"] .graph-minimap {
+    background: rgba(35, 35, 35, 0.9);
+    border-color: rgba(255, 255, 255, 0.08);
+}
+
 /* Node Type Colors - Theme-Aware
  *
  * Graph-specific colors optimized for visual distinction.

--- a/bengal/themes/default/assets/js/bengal-graph-explorer.js
+++ b/bengal/themes/default/assets/js/bengal-graph-explorer.js
@@ -33,23 +33,34 @@
     var MIN_NODE_PX = 3.5;     // minimum on-screen radius (zoomed-out legibility)
     var MIN_HUB_PX = 6;        // minimum for hubs / high-importance nodes
     var HUB_LABEL_COUNT = 18;  // always label the top N hubs, even when zoomed out
+    var LOD_ATLAS = 0.35;      // below: topic blobs + labels (atlas view)
+    var LOD_NEIGHBORHOOD = 0.85; // below: compact dots; above: full node detail
+    var CAMERA_ANIM_MS = 320;  // fly-to duration
+    var MINIMAP_SIZE = 120;    // inset atlas minimap (px)
+    var DOT_NODE_PX = 3.2;     // uniform radius in neighborhood LOD
 
     // Note: fit-to-view snaps instantly (no entrance animation), so there is
     // nothing to gate behind prefers-reduced-motion here.
 
     // ---- State ---------------------------------------------------------------
     var canvas, ctx, container, loadingEl, tooltipEl, searchInput, filterSelect;
+    var minimapCanvas, minimapCtx, breadcrumbEl;
     var dpr = window.devicePixelRatio || 1;
     var nodes = [], edges = [], nodeById = {}, adjacency = {};
     var grid = {};             // picking grid: "cx,cy" -> [node, ...]
     var camera = { scale: 1, tx: 0, ty: 0 };
+    var cameraAnim = null;     // active fly-to animation frame id
     var colors = {};
     var communityColors = [];   // categorical topic-cluster palette (CSS tokens)
     var communityLabels = {};   // community id -> display label (from stats)
+    var communityRegions = [];  // baked bounds + labels for semantic zoom
+    var communityById = {};
     var graphStats = null;      // stats block from graph.json (for legend rebuild)
     var labelHubIds = {};       // node ids that always get a label at fit scale
     var colorProbe = null;      // hidden element for resolving CSS vars → rgb()
     var hovered = null;
+    var hoveredCluster = null;
+    var pinnedNode = null;      // shift+click pins ego-network focus
     var dirty = false;
     var rafPending = false;
     var listeners = [];
@@ -147,6 +158,325 @@
         return (n.incoming_refs || 0) + (n.outgoing_refs || 0) + (n.connectivity || 0);
     }
 
+    function getLodMode() {
+        if (communityFilter !== null) return 'detail';
+        if (camera.scale < LOD_ATLAS) return 'atlas';
+        if (camera.scale < LOD_NEIGHBORHOOD) return 'neighborhood';
+        return 'detail';
+    }
+
+    function cancelCameraAnim() {
+        if (cameraAnim !== null) {
+            cancelAnimationFrame(cameraAnim);
+            cameraAnim = null;
+        }
+    }
+
+    function animateCamera(targetScale, targetTx, targetTy, onDone) {
+        cancelCameraAnim();
+        var startScale = camera.scale;
+        var startTx = camera.tx;
+        var startTy = camera.ty;
+        var t0 = performance.now();
+        function frame(now) {
+            var u = Math.min(1, (now - t0) / CAMERA_ANIM_MS);
+            u = 1 - Math.pow(1 - u, 3);
+            camera.scale = startScale + (targetScale - startScale) * u;
+            camera.tx = startTx + (targetTx - startTx) * u;
+            camera.ty = startTy + (targetTy - startTy) * u;
+            requestRedraw();
+            if (u < 1) {
+                cameraAnim = requestAnimationFrame(frame);
+            } else {
+                cameraAnim = null;
+                if (onDone) onDone();
+            }
+        }
+        cameraAnim = requestAnimationFrame(frame);
+    }
+
+    function flyToBounds(minX, minY, maxX, maxY, pad) {
+        if (!canvas) return;
+        var vw = canvas.width / dpr;
+        var vh = canvas.height / dpr;
+        pad = pad == null ? 80 : pad;
+        var dx = (maxX - minX) || 1;
+        var dy = (maxY - minY) || 1;
+        var scale = Math.min(MAX_SCALE, Math.min((vw - 2 * pad) / dx, (vh - 2 * pad) / dy));
+        scale = Math.max(MIN_SCALE, scale);
+        var tx = vw / 2 - scale * (minX + maxX) / 2;
+        var ty = vh / 2 - scale * (minY + maxY) / 2;
+        animateCamera(scale, tx, ty);
+    }
+
+    function regionWorldBounds(r) {
+        var pad = 24;
+        if (r.min_x == null || r.min_y == null) {
+            var wx = worldX(r.x || 0.5);
+            var wy = worldY(r.y || 0.5);
+            return { minX: wx - 60, minY: wy - 60, maxX: wx + 60, maxY: wy + 60 };
+        }
+        return {
+            minX: worldX(r.min_x) - pad,
+            minY: worldY(r.min_y) - pad,
+            maxX: worldX(r.max_x) + pad,
+            maxY: worldY(r.max_y) + pad
+        };
+    }
+
+    function flyToCommunity(id) {
+        var region = communityById[id];
+        if (!region) return;
+        communityFilter = id;
+        document.querySelectorAll('.graph-legend-community').forEach(function (b) {
+            var cid = parseInt(b.getAttribute('data-community'), 10);
+            var active = cid === id;
+            b.setAttribute('aria-pressed', active ? 'true' : 'false');
+            b.classList.toggle('is-active', active);
+        });
+        updateBreadcrumb();
+        var b = regionWorldBounds(region);
+        flyToBounds(b.minX, b.minY, b.maxX, b.maxY, 60);
+    }
+
+    function flyToNode(n) {
+        if (!n) return;
+        pinnedNode = n;
+        communityFilter = null;
+        document.querySelectorAll('.graph-legend-community').forEach(function (b) {
+            b.setAttribute('aria-pressed', 'false');
+            b.classList.remove('is-active');
+        });
+        updateBreadcrumb();
+        var pad = 120;
+        flyToBounds(n.wx - pad, n.wy - pad, n.wx + pad, n.wy + pad, 40);
+    }
+
+    function buildCommunityRegions(stats) {
+        communityRegions = [];
+        communityById = {};
+        var regions = (stats && stats.community_regions) || [];
+        if (regions.length) {
+            communityRegions = regions.slice();
+        } else if (stats && stats.communities) {
+            communityRegions = stats.communities.slice();
+        }
+        if (!communityRegions.length) {
+            var buckets = {};
+            nodes.forEach(function (n) {
+                if (typeof n.community !== 'number' || n.community < 0) return;
+                (buckets[n.community] || (buckets[n.community] = [])).push(n);
+            });
+            Object.keys(buckets).sort(function (a, b) {
+                return parseInt(a, 10) - parseInt(b, 10);
+            }).forEach(function (key) {
+                var list = buckets[key];
+                var xs = list.map(function (n) { return n.x; });
+                var ys = list.map(function (n) { return n.y; });
+                communityRegions.push({
+                    id: parseInt(key, 10),
+                    label: communityLabels[key] || ('Cluster ' + key),
+                    size: list.length,
+                    x: xs.reduce(function (a, b) { return a + b; }, 0) / xs.length,
+                    y: ys.reduce(function (a, b) { return a + b; }, 0) / ys.length,
+                    min_x: Math.min.apply(null, xs),
+                    min_y: Math.min.apply(null, ys),
+                    max_x: Math.max.apply(null, xs),
+                    max_y: Math.max.apply(null, ys)
+                });
+            });
+        }
+        communityRegions.forEach(function (r) {
+            communityById[r.id] = r;
+            if (!communityLabels[r.id] && r.label) communityLabels[r.id] = r.label;
+        });
+    }
+
+    function updateBreadcrumb() {
+        if (!breadcrumbEl) return;
+        var parts = ['<button type="button" class="graph-crumb graph-crumb-root">All topics</button>'];
+        if (communityFilter !== null && communityLabels[communityFilter]) {
+            parts.push('<span class="graph-crumb-sep">›</span>');
+            parts.push('<span class="graph-crumb-current">' + escapeHtml(communityLabels[communityFilter]) + '</span>');
+        } else if (pinnedNode) {
+            parts.push('<span class="graph-crumb-sep">›</span>');
+            parts.push('<span class="graph-crumb-current">' + escapeHtml(pinnedNode.label || pinnedNode.id) + '</span>');
+        }
+        breadcrumbEl.innerHTML = parts.join('');
+    }
+
+    function ensureBreadcrumb() {
+        if (breadcrumbEl) return breadcrumbEl;
+        breadcrumbEl = document.createElement('div');
+        breadcrumbEl.className = 'graph-breadcrumb';
+        breadcrumbEl.setAttribute('aria-label', 'Graph navigation');
+        on(breadcrumbEl, 'click', function (e) {
+            if (e.target.classList.contains('graph-crumb-root')) {
+                communityFilter = null;
+                pinnedNode = null;
+                document.querySelectorAll('.graph-legend-community').forEach(function (b) {
+                    b.setAttribute('aria-pressed', 'false');
+                    b.classList.remove('is-active');
+                });
+                fitToView(true);
+                updateBreadcrumb();
+                requestRedraw();
+            }
+        });
+        (document.getElementById('container') || document.body).appendChild(breadcrumbEl);
+        return breadcrumbEl;
+    }
+
+    function ensureMinimap() {
+        if (minimapCanvas) return;
+        minimapCanvas = document.createElement('canvas');
+        minimapCanvas.className = 'graph-minimap';
+        minimapCanvas.width = MINIMAP_SIZE;
+        minimapCanvas.height = MINIMAP_SIZE;
+        minimapCanvas.setAttribute('aria-hidden', 'true');
+        minimapCtx = minimapCanvas.getContext('2d');
+        (document.getElementById('container') || document.body).appendChild(minimapCanvas);
+    }
+
+    function pickCluster(sx, sy) {
+        if (!communityRegions.length) return null;
+        var wx = toWorldX(sx);
+        var wy = toWorldY(sy);
+        var best = null;
+        var bestArea = Infinity;
+        for (var i = 0; i < communityRegions.length; i++) {
+            var r = communityRegions[i];
+            if (communityFilter !== null && r.id !== communityFilter) continue;
+            var b = regionWorldBounds(r);
+            if (wx >= b.minX && wx <= b.maxX && wy >= b.minY && wy <= b.maxY) {
+                var area = (b.maxX - b.minX) * (b.maxY - b.minY);
+                if (area < bestArea) {
+                    bestArea = area;
+                    best = r;
+                }
+            }
+        }
+        return best;
+    }
+
+    function nodeDrawRadius(n, mode) {
+        if (mode === 'atlas') return 0;
+        if (mode === 'neighborhood') return DOT_NODE_PX;
+        return nodeScreenRadius(n);
+    }
+
+    function shouldDrawEdge(e, mode) {
+        if (!e._s || !e._t) return false;
+        if (mode === 'atlas') return false;
+        if (communityFilter !== null) {
+            return e._s.community === communityFilter || e._t.community === communityFilter;
+        }
+        if (mode === 'neighborhood') {
+            return e._s.community === e._t.community;
+        }
+        return true;
+    }
+
+    function drawClusterHulls(vw, vh, pad, mode) {
+        if (!communityRegions.length || mode === 'detail') return;
+        for (var i = 0; i < communityRegions.length; i++) {
+            var r = communityRegions[i];
+            if (communityFilter !== null && r.id !== communityFilter) continue;
+            var b = regionWorldBounds(r);
+            var sx0 = toScreenX(b.minX);
+            var sy0 = toScreenY(b.minY);
+            var sx1 = toScreenX(b.maxX);
+            var sy1 = toScreenY(b.maxY);
+            if (sx1 < -pad || sx0 > vw + pad || sy1 < -pad || sy0 > vh + pad) continue;
+
+            var col = communityColorFor(r.id);
+            var w = sx1 - sx0;
+            var h = sy1 - sy0;
+            var rad = Math.min(18, w * 0.12, h * 0.12);
+            ctx.fillStyle = col;
+            ctx.globalAlpha = hoveredCluster && hoveredCluster.id === r.id ? 0.22 : 0.12;
+            ctx.beginPath();
+            if (ctx.roundRect) {
+                ctx.roundRect(sx0, sy0, w, h, rad);
+            } else {
+                ctx.rect(sx0, sy0, w, h);
+            }
+            ctx.fill();
+            ctx.strokeStyle = col;
+            ctx.lineWidth = hoveredCluster && hoveredCluster.id === r.id ? 2 : 1;
+            ctx.globalAlpha = hoveredCluster && hoveredCluster.id === r.id ? 0.55 : 0.28;
+            ctx.stroke();
+
+            if (mode === 'atlas') {
+                var lx = toScreenX(worldX(r.x || 0.5));
+                var ly = toScreenY(worldY(r.y || 0.5));
+                var label = r.label || ('Cluster ' + r.id);
+                ctx.font = '600 12px system-ui, sans-serif';
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillStyle = colors.label;
+                ctx.globalAlpha = 0.95;
+                ctx.fillText(label, lx, ly - 8);
+                ctx.font = '500 10px system-ui, sans-serif';
+                ctx.fillStyle = colors.label;
+                ctx.globalAlpha = 0.65;
+                ctx.fillText(String(r.size || 0) + ' pages', lx, ly + 10);
+            }
+        }
+        ctx.globalAlpha = 1;
+    }
+
+    function drawMinimap() {
+        if (!minimapCanvas || !minimapCtx || !nodes.length) return;
+        var m = MINIMAP_SIZE;
+        minimapCtx.clearRect(0, 0, m, m);
+        var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+        nodes.forEach(function (n) {
+            minX = Math.min(minX, n.wx); maxX = Math.max(maxX, n.wx);
+            minY = Math.min(minY, n.wy); maxY = Math.max(maxY, n.wy);
+        });
+        var spanX = (maxX - minX) || 1;
+        var spanY = (maxY - minY) || 1;
+        var inset = 8;
+        var scale = Math.min((m - 2 * inset) / spanX, (m - 2 * inset) / spanY);
+
+        function mx(wx) { return inset + (wx - minX) * scale; }
+        function my(wy) { return inset + (wy - minY) * scale; }
+
+        minimapCtx.fillStyle = 'rgba(128,128,128,0.08)';
+        minimapCtx.fillRect(0, 0, m, m);
+
+        if (communityRegions.length) {
+            communityRegions.forEach(function (r) {
+                if (r.min_x == null) return;
+                var b = regionWorldBounds(r);
+                minimapCtx.fillStyle = communityColorFor(r.id);
+                minimapCtx.globalAlpha = 0.35;
+                minimapCtx.fillRect(mx(b.minX), my(b.minY), mx(b.maxX) - mx(b.minX), my(b.maxY) - my(b.minY));
+            });
+            minimapCtx.globalAlpha = 1;
+        } else {
+            nodes.forEach(function (n) {
+                minimapCtx.fillStyle = nodeColor(n);
+                minimapCtx.globalAlpha = 0.7;
+                minimapCtx.beginPath();
+                minimapCtx.arc(mx(n.wx), my(n.wy), 1.2, 0, Math.PI * 2);
+                minimapCtx.fill();
+            });
+            minimapCtx.globalAlpha = 1;
+        }
+
+        var vw = canvas.width / dpr;
+        var vh = canvas.height / dpr;
+        var vwx0 = toWorldX(0);
+        var vwy0 = toWorldY(0);
+        var vwx1 = toWorldX(vw);
+        var vwy1 = toWorldY(vh);
+        minimapCtx.strokeStyle = 'rgba(255,255,255,0.85)';
+        minimapCtx.lineWidth = 1.5;
+        minimapCtx.strokeRect(mx(vwx0), my(vwy0), mx(vwx1) - mx(vwx0), my(vwy1) - my(vwy0));
+    }
+
     function nodeScreenRadius(n) {
         var scaled = n.size * Math.min(1, camera.scale * 1.2);
         var floor = (n.type === 'hub' || n.size >= 22) ? MIN_HUB_PX : MIN_NODE_PX;
@@ -206,6 +536,8 @@
         });
     }
     function pick(sx, sy) {
+        var mode = getLodMode();
+        if (mode === 'atlas') return null;
         var wx = toWorldX(sx), wy = toWorldY(sy);
         var cx = Math.floor(wx / GRID_CELL), cy = Math.floor(wy / GRID_CELL);
         var best = null, bestD = Infinity;
@@ -215,9 +547,10 @@
                 if (!bucket) continue;
                 for (var i = 0; i < bucket.length; i++) {
                     var n = bucket[i];
+                    if (!isVisible(n)) continue;
                     var dx = n.wx - wx, dy = n.wy - wy;
                     var d2 = dx * dx + dy * dy;
-                    var r = nodeScreenRadius(n) + 4;
+                    var r = nodeDrawRadius(n, mode) + 4;
                     if (d2 <= r * r && d2 < bestD) { bestD = d2; best = n; }
                 }
             }
@@ -269,13 +602,16 @@
         legend.querySelectorAll('.graph-legend-community').forEach(function (btn) {
             on(btn, 'click', function () {
                 var id = parseInt(btn.getAttribute('data-community'), 10);
-                communityFilter = (communityFilter === id) ? null : id;
-                legend.querySelectorAll('.graph-legend-community').forEach(function (b) {
-                    var on2 = (communityFilter !== null) &&
-                        (parseInt(b.getAttribute('data-community'), 10) === communityFilter);
-                    b.setAttribute('aria-pressed', on2 ? 'true' : 'false');
-                    b.classList.toggle('is-active', on2);
-                });
+                if (communityFilter === id) {
+                    communityFilter = null;
+                    pinnedNode = null;
+                    btn.setAttribute('aria-pressed', 'false');
+                    btn.classList.remove('is-active');
+                    fitToView(true);
+                    updateBreadcrumb();
+                } else {
+                    flyToCommunity(id);
+                }
                 requestRedraw();
             });
         });
@@ -291,29 +627,34 @@
 
         var vw = W / dpr, vh = H / dpr;
         var pad = 50;
+        var mode = getLodMode();
+        var focusNode = pinnedNode || hovered;
 
         var hoverSet = null;
-        if (hovered) {
-            hoverSet = adjacency[hovered.id] || {};
+        if (focusNode) {
+            hoverSet = adjacency[focusNode.id] || {};
         }
 
-        // Edges
+        drawClusterHulls(vw, vh, pad, mode);
+
+        // Edges (LOD: hidden at atlas, intra-community at neighborhood)
         for (var i = 0; i < edges.length; i++) {
             var e = edges[i];
             var s = e._s, t = e._t;
             if (!s || !t) continue;
+            if (!shouldDrawEdge(e, mode)) continue;
             var sVis = isVisible(s), tVis = isVisible(t);
             if (!sVis || !tVis) continue;
             var sx = toScreenX(s.wx), sy = toScreenY(s.wy);
             var tx = toScreenX(t.wx), ty = toScreenY(t.wy);
-            // cull: both endpoints off the same side
             if ((sx < -pad && tx < -pad) || (sx > vw + pad && tx > vw + pad) ||
                 (sy < -pad && ty < -pad) || (sy > vh + pad && ty > vh + pad)) continue;
 
-            var isHi = hovered && (e.source === hovered.id || e.target === hovered.id);
+            var isHi = focusNode && (e.source === focusNode.id || e.target === focusNode.id);
             ctx.strokeStyle = isHi ? colors.linkHi : colors.link;
             ctx.lineWidth = isHi ? 1.5 : (e.weight === 2 ? 1.1 : 0.9);
-            ctx.globalAlpha = hovered ? (isHi ? 1 : 0.15) : (e.weight === 2 ? 0.85 : 0.7);
+            var baseAlpha = mode === 'neighborhood' ? 0.35 : (e.weight === 2 ? 0.85 : 0.7);
+            ctx.globalAlpha = focusNode ? (isHi ? 1 : 0.12) : baseAlpha;
             ctx.beginPath();
             ctx.moveTo(sx, sy);
             ctx.lineTo(tx, ty);
@@ -321,77 +662,102 @@
         }
         ctx.globalAlpha = 1;
 
-        // Nodes — batch by color to minimize fillStyle churn.
-        var batches = {};
-        for (var j = 0; j < nodes.length; j++) {
-            var n = nodes[j];
-            var sxn = toScreenX(n.wx), syn = toScreenY(n.wy);
-            if (sxn < -pad || sxn > vw + pad || syn < -pad || syn > vh + pad) continue;
-            var col = nodeColor(n);
-            (batches[col] || (batches[col] = [])).push(n);
-        }
-        for (var col2 in batches) {
-            if (!Object.prototype.hasOwnProperty.call(batches, col2)) continue;
-            ctx.fillStyle = col2;
-            var list = batches[col2];
-            for (var b = 0; b < list.length; b++) {
-                var nd = list[b];
-                var visible = isVisible(nd);
-                var dim = (!visible) || (hovered && hovered.id !== nd.id && !(hoverSet && hoverSet[nd.id]));
-                ctx.globalAlpha = visible ? (dim ? (tagParam ? 0 : 0.18) : 1) : (tagParam ? 0 : 0.18);
-                var r = nodeScreenRadius(nd);
-                var sxNd = toScreenX(nd.wx);
-                var syNd = toScreenY(nd.wy);
-                ctx.beginPath();
-                ctx.arc(sxNd, syNd, r, 0, Math.PI * 2);
-                ctx.fill();
-                if (!dim && r >= 2.5) {
-                    ctx.strokeStyle = colors.nodeRim;
-                    ctx.lineWidth = 1;
-                    ctx.globalAlpha = visible ? 0.35 : ctx.globalAlpha;
-                    ctx.stroke();
+        // Nodes — hidden at atlas LOD (cluster hulls carry the view).
+        if (mode !== 'atlas') {
+            var batches = {};
+            for (var j = 0; j < nodes.length; j++) {
+                var n = nodes[j];
+                var sxn = toScreenX(n.wx), syn = toScreenY(n.wy);
+                if (sxn < -pad || sxn > vw + pad || syn < -pad || syn > vh + pad) continue;
+                var col = nodeColor(n);
+                (batches[col] || (batches[col] = [])).push(n);
+            }
+            for (var col2 in batches) {
+                if (!Object.prototype.hasOwnProperty.call(batches, col2)) continue;
+                ctx.fillStyle = col2;
+                var list = batches[col2];
+                for (var b = 0; b < list.length; b++) {
+                    var nd = list[b];
+                    var visible = isVisible(nd);
+                    var dim = (!visible) || (focusNode && focusNode.id !== nd.id &&
+                        !(hoverSet && hoverSet[nd.id]));
+                    ctx.globalAlpha = visible ? (dim ? (tagParam ? 0 : 0.15) : 1) : (tagParam ? 0 : 0.15);
+                    var r = nodeDrawRadius(nd, mode);
+                    var sxNd = toScreenX(nd.wx);
+                    var syNd = toScreenY(nd.wy);
+                    ctx.beginPath();
+                    ctx.arc(sxNd, syNd, r, 0, Math.PI * 2);
+                    ctx.fill();
+                    if (!dim && r >= 2.5 && mode === 'detail') {
+                        ctx.strokeStyle = colors.nodeRim;
+                        ctx.lineWidth = 1;
+                        ctx.globalAlpha = visible ? 0.35 : ctx.globalAlpha;
+                        ctx.stroke();
+                    }
                 }
             }
+            ctx.globalAlpha = 1;
         }
-        ctx.globalAlpha = 1;
 
-        // Labels — top hubs always; more appear as you zoom in or on hover.
-        var showLabels = camera.scale >= LABEL_SCALE;
-        if (showLabels || hovered || Object.keys(labelHubIds).length) {
+        // Labels — detail LOD only (plus pinned/hover focus).
+        var showLabels = mode === 'detail' && camera.scale >= LABEL_SCALE;
+        if (mode === 'detail' && (showLabels || focusNode || Object.keys(labelHubIds).length)) {
             for (var l = 0; l < nodes.length; l++) {
                 var ln = nodes[l];
                 if (!isVisible(ln)) continue;
-                var labelThis = (hovered && (ln.id === hovered.id || (hoverSet && hoverSet[ln.id]))) ||
+                var labelThis = (focusNode && (ln.id === focusNode.id || (hoverSet && hoverSet[ln.id]))) ||
                                 labelHubIds[ln.id] ||
                                 (showLabels && (ln.type === 'hub' || camera.scale >= 1.6));
                 if (!labelThis) continue;
                 var lx = toScreenX(ln.wx);
                 var ly = toScreenY(ln.wy);
                 if (lx < -pad || lx > vw + pad || ly < -pad || ly > vh + pad) continue;
-                drawNodeLabel(ln.label || '', lx, ly, nodeScreenRadius(ln));
+                drawNodeLabel(ln.label || '', lx, ly, nodeDrawRadius(ln, mode));
             }
         }
+
+        drawMinimap();
     }
 
     // ---- Camera --------------------------------------------------------------
-    function fitToView() {
+    function fitToView(animate) {
         if (!nodes.length) return;
         var minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
         nodes.forEach(function (n) {
             minX = Math.min(minX, n.wx); maxX = Math.max(maxX, n.wx);
             minY = Math.min(minY, n.wy); maxY = Math.max(maxY, n.wy);
         });
+        if (animate) {
+            var vw = canvas.width / dpr;
+            var vh = canvas.height / dpr;
+            var pad = 80;
+            var dx = (maxX - minX) || 1;
+            var dy = (maxY - minY) || 1;
+            var scale = Math.min(MAX_SCALE, Math.min((vw - 2 * pad) / dx, (vh - 2 * pad) / dy));
+            scale = Math.max(MIN_SCALE, scale);
+            if (communityRegions.length > 1 && nodes.length > 80) {
+                scale = Math.min(scale, LOD_ATLAS * 0.92);
+            }
+            var tx = vw / 2 - scale * (minX + maxX) / 2;
+            var ty = vh / 2 - scale * (minY + maxY) / 2;
+            animateCamera(scale, tx, ty);
+            return;
+        }
         var vw = canvas.width / dpr, vh = canvas.height / dpr;
         var pad = 80;
         var dx = (maxX - minX) || 1, dy = (maxY - minY) || 1;
         var scale = Math.min(MAX_SCALE, Math.min((vw - 2 * pad) / dx, (vh - 2 * pad) / dy));
         scale = Math.max(MIN_SCALE, scale);
+        if (communityRegions.length > 1 && nodes.length > 80) {
+            scale = Math.min(scale, LOD_ATLAS * 0.92);
+        }
         camera.scale = scale;
         camera.tx = vw / 2 - scale * (minX + maxX) / 2;
         camera.ty = vh / 2 - scale * (minY + maxY) / 2;
     }
 
     function zoomAt(sx, sy, factor) {
+        cancelCameraAnim();
         var newScale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, camera.scale * factor));
         var wx = toWorldX(sx), wy = toWorldY(sy);
         camera.scale = newScale;
@@ -456,6 +822,7 @@
         var dragging = false, moved = false, lastX = 0, lastY = 0;
 
         on(canvas, 'mousedown', function (e) {
+            cancelCameraAnim();
             dragging = true; moved = false; lastX = e.clientX; lastY = e.clientY;
         });
         on(window, 'mouseup', function () { dragging = false; });
@@ -470,19 +837,58 @@
                 requestRedraw();
                 return;
             }
-            var n = pick(e.clientX - rect.left, e.clientY - rect.top);
-            if (n !== hovered) {
-                hovered = n;
-                canvas.style.cursor = n ? 'pointer' : 'grab';
+            var sx = e.clientX - rect.left;
+            var sy = e.clientY - rect.top;
+            var mode = getLodMode();
+            var cluster = mode === 'atlas' ? pickCluster(sx, sy) : null;
+            var n = cluster ? null : pick(sx, sy);
+            if (cluster !== hoveredCluster) {
+                hoveredCluster = cluster;
                 requestRedraw();
             }
-            if (n) showTooltip(e, n); else hideTooltip();
+            if (n !== hovered) {
+                hovered = n;
+                canvas.style.cursor = (n || cluster) ? 'pointer' : 'grab';
+                if (!pinnedNode) requestRedraw();
+            }
+            if (n) showTooltip(e, n);
+            else if (cluster) {
+                if (tooltipEl) {
+                    tooltipEl.style.display = 'block';
+                    tooltipEl.style.left = (e.clientX + 12) + 'px';
+                    tooltipEl.style.top = (e.clientY + 12) + 'px';
+                    tooltipEl.innerHTML = '<h4>' + escapeHtml(cluster.label || ('Cluster ' + cluster.id)) + '</h4>' +
+                        '<p>' + (cluster.size || 0) + ' pages — click to explore</p>';
+                }
+            } else hideTooltip();
         });
-        on(canvas, 'mouseleave', function () { hovered = null; hideTooltip(); requestRedraw(); });
+        on(canvas, 'mouseleave', function () {
+            hovered = null;
+            hoveredCluster = null;
+            hideTooltip();
+            requestRedraw();
+        });
         on(canvas, 'click', function (e) {
             if (moved) return;
             var rect = canvas.getBoundingClientRect();
-            var n = pick(e.clientX - rect.left, e.clientY - rect.top);
+            var sx = e.clientX - rect.left;
+            var sy = e.clientY - rect.top;
+            var mode = getLodMode();
+            if (mode === 'atlas') {
+                var cluster = pickCluster(sx, sy);
+                if (cluster) {
+                    flyToCommunity(cluster.id);
+                    return;
+                }
+            }
+            var n = pick(sx, sy);
+            if (e.shiftKey && n) {
+                pinnedNode = n;
+                communityFilter = null;
+                updateBreadcrumb();
+                requestRedraw();
+                return;
+            }
             if (n && n.url) window.location.href = normalizeUrl(n.url);
         });
         on(canvas, 'wheel', function (e) {
@@ -511,10 +917,13 @@
                 if (searchInput) searchInput.value = '';
                 if (filterSelect) filterSelect.value = 'all';
                 query = ''; typeFilter = 'all'; communityFilter = null;
+                pinnedNode = null;
                 document.querySelectorAll('.graph-legend-community').forEach(function (b) {
                     b.setAttribute('aria-pressed', 'false');
                     b.classList.remove('is-active');
                 });
+                fitToView(true);
+                updateBreadcrumb();
                 requestRedraw();
             }
         });
@@ -535,8 +944,24 @@
         if (searchInput) {
             on(searchInput, 'input', debounce(function () {
                 query = searchInput.value.toLowerCase();
+                if (query.length >= 2) {
+                    var matches = nodes.filter(function (n) {
+                        return isVisible(n) && (
+                            (n.label || '').toLowerCase().indexOf(query) !== -1 ||
+                            (n.tags || []).some(function (t) { return t.toLowerCase().indexOf(query) !== -1; })
+                        );
+                    });
+                    if (matches.length === 1) {
+                        flyToNode(matches[0]);
+                    } else if (matches.length > 1) {
+                        matches.sort(function (a, b) {
+                            return nodeImportance(b) - nodeImportance(a);
+                        });
+                        flyToNode(matches[0]);
+                    }
+                }
                 requestRedraw();
-            }, 150));
+            }, 200));
         }
         if (filterSelect) {
             on(filterSelect, 'change', function () {
@@ -623,12 +1048,16 @@
 
                 resolveColors();
                 resize();
-                fitToView();
+                ensureBreadcrumb();
+                ensureMinimap();
+                buildCommunityRegions(data.stats);
+                fitToView(false);
                 setupControls();
                 setupInteraction();
                 buildA11yList();
                 graphStats = data.stats;
                 buildCommunityLegend(data.stats);
+                updateBreadcrumb();
 
                 if (loadingEl) loadingEl.classList.add('hidden');
                 requestRedraw();

--- a/changelog.d/+graph-atlas-semantic-zoom.added.md
+++ b/changelog.d/+graph-atlas-semantic-zoom.added.md
@@ -1,0 +1,3 @@
+The knowledge graph at `/graph/` now opens as a topic atlas on large sites: labeled cluster regions at default zoom, click-to-explore a topic, and search that flies to matching pages. Zoom in to reveal individual nodes and labels instead of a dense hairball at fit-to-view.
+
+Build time lays out each topic cluster in its own space and bakes cluster bounds into `graph.json`; the canvas explorer uses semantic zoom (atlas → neighborhood → detail), animated cluster focus, a minimap, and edge level-of-detail.

--- a/tests/unit/analysis/test_graph_layout.py
+++ b/tests/unit/analysis/test_graph_layout.py
@@ -17,6 +17,7 @@ import math
 from bengal.analysis.graph.layout import (
     _BARNES_HUT_THRESHOLD,
     compute_force_layout,
+    compute_hierarchical_layout,
     compute_radial_layout,
 )
 
@@ -127,3 +128,31 @@ class TestRadialLayout:
             round(math.hypot(x - 0.5, y - 0.5), 2) for nid, (x, y) in coords.items() if nid != "me"
         )
         assert radii[0] < radii[-1]  # more than one ring distance present
+
+
+class TestHierarchicalLayout:
+    def test_multi_community_spreads_clusters(self):
+        ids = [f"n{i:04d}" for i in range(120)]
+        edges = [(ids[i], ids[i + 1]) for i in range(119)]
+        comms = {nid: i % 4 for i, nid in enumerate(ids)}
+        coords = compute_hierarchical_layout(ids, edges, communities=comms)
+        assert _in_unit_box(coords)
+        # Nearest-neighbor spacing should stay readable within packed atlas.
+        nn = []
+        pts = list(coords.values())
+        for i, (x1, y1) in enumerate(pts):
+            best = float("inf")
+            for j, (x2, y2) in enumerate(pts):
+                if i == j:
+                    continue
+                best = min(best, math.hypot(x1 - x2, y1 - y2))
+            nn.append(best)
+        assert min(nn) > 0.005
+
+    def test_deterministic(self):
+        ids = [f"n{i:04d}" for i in range(40)]
+        edges = [(ids[i], ids[(i + 1) % 40]) for i in range(40)]
+        comms = {nid: i % 3 for i, nid in enumerate(ids)}
+        a = compute_hierarchical_layout(ids, edges, communities=comms, seed=7)
+        b = compute_hierarchical_layout(ids, edges, communities=comms, seed=7)
+        assert a == b


### PR DESCRIPTION
## Summary

- Large knowledge graphs now open in an **atlas view**: labeled topic-cluster blobs instead of a dense node hairball at fit-to-view.
- Build time adds **hierarchical per-community layout** with size-aware spacing and bakes cluster bounds into `graph.json` (`stats.community_regions`).
- The canvas explorer gains **semantic zoom** (atlas → neighborhood → detail), animated cluster focus, edge LOD, minimap, search teleport, and breadcrumb navigation.

## Proof

- [x] Focused tests: `pytest tests/unit/analysis/test_graph_layout.py -q` (15 passed)
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: no-impact — user-facing graph UX improvement; no config/API/docs changes required

## Performance Evidence

not applicable

## Steward Notes

- Rebuild the site to regenerate `graph.json` before validating visually on `/graph/`.
- Default atlas zoom applies when the graph has >80 nodes and multiple Louvain communities.


Made with [Cursor](https://cursor.com)