### PR TITLE
perf(warm-build): wire build_cache + cache discovery facts (#332)

### DIFF
--- a/bengal/cache/build_cache/parsed_content_cache.py
+++ b/bengal/cache/build_cache/parsed_content_cache.py
@@ -175,6 +175,15 @@ class ParsedContentCacheMixin:
             "target_anchors": list(cached.get("target_anchors") or []),
         }
 
+    def get_cached_template(self, file_path: Path) -> str | None:
+        """Return the template name stored with a parsed cache entry, if any."""
+        key = self._cache_key(file_path)
+        cached = self.parsed_content.get(key)
+        if not cached:
+            return None
+        template = cached.get("template")
+        return str(template) if template else None
+
     def get_parsed_content(
         self, file_path: Path, metadata: dict[str, Any], template: str, parser_version: str
     ) -> dict[str, Any] | Any:

--- a/bengal/cache/build_cache/parsed_content_cache.py
+++ b/bengal/cache/build_cache/parsed_content_cache.py
@@ -87,6 +87,8 @@ class ParsedContentCacheMixin:
         plain_text: str = "",
         word_count: int = 0,
         reading_time: int = 0,
+        detected_features: list[str] | None = None,
+        target_anchors: list[str] | None = None,
     ) -> None:
         """
         Store parsed content in cache (Optimization #2 + AST caching).
@@ -152,6 +154,25 @@ class ParsedContentCacheMixin:
             "parser_version": parser_version,
             "timestamp": datetime.now(UTC).isoformat(),
             "size_bytes": size_bytes,
+        }
+        if detected_features is not None:
+            self.parsed_content[key]["detected_features"] = detected_features
+        if target_anchors is not None:
+            self.parsed_content[key]["target_anchors"] = target_anchors
+
+    def get_parsed_discovery_facts(self, file_path: Path) -> dict[str, list[str]] | None:
+        """Return cached per-page discovery facts when the parsed entry exists.
+
+        Used during warm discovery to avoid re-scanning unchanged pages for
+        CSS features and target-directive anchors (#332).
+        """
+        key = self._cache_key(file_path)
+        cached = self.parsed_content.get(key)
+        if not cached:
+            return None
+        return {
+            "detected_features": list(cached.get("detected_features") or []),
+            "target_anchors": list(cached.get("target_anchors") or []),
         }
 
     def get_parsed_content(
@@ -254,6 +275,9 @@ class ParsedContentCacheMixin:
         metadata: dict[str, Any],
         template: str,
         parser_version: str,
+        *,
+        detected_features: list[str] | None = None,
+        target_anchors: list[str] | None = None,
     ) -> None:
         """Store a ``ParsedPage`` record in the parsed content cache.
 
@@ -275,6 +299,8 @@ class ParsedContentCacheMixin:
             plain_text=parsed_page.plain_text,
             word_count=parsed_page.word_count,
             reading_time=parsed_page.reading_time,
+            detected_features=detected_features,
+            target_anchors=target_anchors,
         )
 
     def get_excerpt_for_path(self, file_path: Path) -> str:

--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -396,6 +396,10 @@ class ContentDiscovery:
                 if not is_explicitly_changed:
                     # CACHE HIT: Reconstruct full Page from cache (Sprint 5)
                     build_cache = getattr(self, "_build_cache", None)
+                    if build_cache is not None and build_cache.is_changed(file_path):
+                        # Source changed since last build — stale parsed content must
+                        # not be seeded onto the Page or rendering skips re-parse.
+                        return None
                     if build_cache is not None:
                         page = self._create_page_from_cache(
                             file_path,

--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -460,6 +460,10 @@ class ContentDiscovery:
             # pipeline retrieves it from the build cache if needed.
             apply_parsed_page_to_page(page, parsed_page, seed_ast=False)
 
+            cached_template = build_cache.get_cached_template(file_path)
+            if cached_template:
+                page.metadata["template"] = cached_template
+
             facts = build_cache.get_parsed_discovery_facts(file_path)
             if facts is not None:
                 if facts["target_anchors"]:

--- a/bengal/content/discovery/content_discovery.py
+++ b/bengal/content/discovery/content_discovery.py
@@ -456,6 +456,13 @@ class ContentDiscovery:
             # pipeline retrieves it from the build cache if needed.
             apply_parsed_page_to_page(page, parsed_page, seed_ast=False)
 
+            facts = build_cache.get_parsed_discovery_facts(file_path)
+            if facts is not None:
+                if facts["target_anchors"]:
+                    page._target_anchors_cache = facts["target_anchors"]  # type: ignore[attr-defined]
+                if facts["detected_features"]:
+                    page._detected_features_cache = facts["detected_features"]  # type: ignore[attr-defined]
+
             return page
         except Exception:
             # Any failure during cache reconstruction falls through to full parse.

--- a/bengal/content/discovery_facts.py
+++ b/bengal/content/discovery_facts.py
@@ -1,0 +1,92 @@
+"""Per-page discovery facts used by warm-build cache and orchestration."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, ClassVar
+
+from bengal.content.page_source import get_raw_source
+
+if TYPE_CHECKING:
+    from bengal.protocols import PageLike
+
+
+class DiscoveryFactsExtractor:
+    """Extract CSS features and target anchors from page source."""
+
+    PATTERNS: ClassVar[dict[str, re.Pattern[str]]] = {
+        "mermaid": re.compile(r"```mermaid", re.IGNORECASE),
+        "data_tables": re.compile(
+            r"(tabulator|DataTable|data-table|\.datatable)",
+            re.IGNORECASE,
+        ),
+        "graph": re.compile(
+            r"(graph[-_]?vis|d3[-.]|force[-_]?graph|network[-_]?graph)", re.IGNORECASE
+        ),
+        "interactive": re.compile(r"(interactive|widget|marimo)", re.IGNORECASE),
+        "holo_cards": re.compile(r"(holo[-_]?card|holographic)", re.IGNORECASE),
+    }
+
+    DIRECTIVE_PATTERNS: ClassVar[dict[str, re.Pattern[str]]] = {
+        "mermaid": re.compile(r":::\{mermaid\}", re.IGNORECASE),
+        "data_tables": re.compile(r":::\{(datatable|tabulator)\}", re.IGNORECASE),
+    }
+
+    @classmethod
+    def detect_features_in_content(cls, content: str) -> set[str]:
+        features: set[str] = set()
+        if not content:
+            return features
+        for feature, pattern in cls.PATTERNS.items():
+            if pattern.search(content):
+                features.add(feature)
+        for feature, pattern in cls.DIRECTIVE_PATTERNS.items():
+            if pattern.search(content):
+                features.add(feature)
+        return features
+
+    @classmethod
+    def detect_features_in_page(cls, page: PageLike) -> set[str]:
+        features: set[str] = set()
+        source = get_raw_source(page)
+        if source:
+            features.update(cls.detect_features_in_content(source))
+        else:
+            plain_text = getattr(page, "_plain_text_cache", None)
+            if isinstance(plain_text, str) and plain_text:
+                features.update(cls.detect_features_in_content(plain_text))
+
+        metadata = page.metadata or {}
+        if metadata.get("mermaid"):
+            features.add("mermaid")
+        if metadata.get("interactive"):
+            features.add("interactive")
+        if metadata.get("graph"):
+            features.add("graph")
+        return features
+
+
+def extract_target_directives_from_content(content: str) -> list[str]:
+    """Extract target directive anchor IDs from markdown content."""
+    anchor_ids: list[str] = []
+    pattern = r"^(\s*):{3,}\{(?:target|anchor)\}([^\n]*)$"
+    for line in content.split("\n"):
+        match = re.match(pattern, line)
+        if not match:
+            continue
+        indent = len(match.group(1))
+        if indent >= 4:
+            continue
+        title = match.group(2).strip()
+        if title and re.match(r"^[a-zA-Z][a-zA-Z0-9_-]*$", title):
+            anchor_ids.append(title)
+    return anchor_ids
+
+
+def collect_parsed_discovery_facts(page: PageLike) -> dict[str, list[str]]:
+    """Collect per-page facts to persist alongside parsed content cache."""
+    raw_source = get_raw_source(page)
+    return {
+        "detected_features": sorted(DiscoveryFactsExtractor.detect_features_in_page(page)),
+        "target_anchors": extract_target_directives_from_content(raw_source) if raw_source else [],
+    }

--- a/bengal/orchestration/build/__init__.py
+++ b/bengal/orchestration/build/__init__.py
@@ -418,6 +418,7 @@ class BuildOrchestrator:
             stats=self.stats,
             cancellation_token=CancellationToken(timeout=300.0),
         )
+        early_ctx.cache = self.incremental.cache
 
         # Create output collector for hot reload tracking
         # This collector tracks all written files (HTML, CSS, assets) for typed reload decisions.

--- a/bengal/orchestration/build/rendering.py
+++ b/bengal/orchestration/build/rendering.py
@@ -528,6 +528,16 @@ def phase_render(
     """
     quiet_mode = quiet and not verbose
 
+    # Pages selected for incremental rebuild must bypass rendered/parsed caches even
+    # when their source file hash is unchanged (e.g. data file or template deps).
+    if incremental and pages_to_build:
+        render_changed = set(changed_sources or ())
+        for page in pages_to_build:
+            source_path = getattr(page, "source_path", None)
+            if source_path is not None:
+                render_changed.add(source_path)
+        changed_sources = render_changed
+
     # Log template introspection insights (verbose mode, Kida only)
     _log_template_introspection(orchestrator, verbose)
 

--- a/bengal/orchestration/build/rendering.py
+++ b/bengal/orchestration/build/rendering.py
@@ -585,6 +585,7 @@ def phase_render(
                     profile_templates=profile_templates,
                     incremental=bool(incremental),
                     output_collector=collector,
+                    cache=getattr(orchestrator.site, "_cache", None),
                 )
                 # Transfer cached content from early context (build-integrated validation)
                 if early_context and early_context.has_cached_content:
@@ -624,6 +625,7 @@ def phase_render(
                     profile_templates=profile_templates,
                     incremental=bool(incremental),
                     output_collector=collector,
+                    cache=getattr(orchestrator.site, "_cache", None),
                 )
                 # Transfer cached content from early context (build-integrated validation)
                 if early_context and early_context.has_cached_content:

--- a/bengal/orchestration/content.py
+++ b/bengal/orchestration/content.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from bengal.build.contracts.keys import xref_path_key
+from bengal.content.discovery_facts import extract_target_directives_from_content
 from bengal.content.page_source import get_raw_source
 from bengal.core.diagnostics import emit as emit_diagnostic
 from bengal.core.page_site import set_page_site
@@ -338,7 +339,7 @@ class ContentOrchestrator:
         # only necessary CSS files. Runs efficiently O(n) over all pages.
         # See: plan/drafted/rfc-css-tree-shaking.md
         t0 = time.perf_counter()
-        self._detect_features()
+        self._detect_features(build_cache=build_cache)
         breakdown_ms["feature_detection"] = (time.perf_counter() - t0) * 1000
         logger.debug(
             "features_detected",
@@ -1249,10 +1250,17 @@ class ContentOrchestrator:
         rule), the opposite of :meth:`_index_headings`.
         """
         source = get_raw_source(page)
-        if not (hasattr(page, "content") and source):
+        if not source:
+            cached_anchors = getattr(page, "_target_anchors_cache", None)
+            if cached_anchors:
+                target_anchors = list(cached_anchors)
+            else:
+                return
+        elif hasattr(page, "content") and source:
+            target_anchors = self._extract_target_directives(source)
+        else:
             return
 
-        target_anchors = self._extract_target_directives(source)
         page_version = getattr(page, "version", None)
         for anchor_id in target_anchors:
             anchor_key = anchor_id.lower()
@@ -1322,30 +1330,9 @@ class ContentOrchestrator:
         Returns:
             List of anchor IDs found in target directives
         """
-        import re
+        return extract_target_directives_from_content(content)
 
-        anchor_ids = []
-        # Pattern matches :::{target} id or :::{anchor} id
-        # Handles optional whitespace and closing ::: on same or next line
-        pattern = r"^(\s*):{3,}\{(?:target|anchor)\}([^\n]*)$"
-        lines = content.split("\n")
-        i = 0
-        while i < len(lines):
-            match = re.match(pattern, lines[i])
-            if match:
-                indent = len(match.group(1))
-                # Skip if indented 4+ spaces (code block)
-                if indent < 4:
-                    # Extract anchor ID from title (everything after directive name)
-                    title = match.group(2).strip()
-                    # Validate it looks like an anchor ID (starts with letter)
-                    if title and re.match(r"^[a-zA-Z][a-zA-Z0-9_-]*$", title):
-                        anchor_ids.append(title)
-            i += 1
-
-        return anchor_ids
-
-    def _detect_features(self) -> None:
+    def _detect_features(self, build_cache: BuildCache | None = None) -> None:
         """
         Detect CSS-requiring features in all pages.
 
@@ -1365,8 +1352,14 @@ class ContentOrchestrator:
         detector = FeatureDetector()
 
         for page in self.site.pages:
-            # Detect features in page content
-            features = detector.detect_features_in_page(page)
+            cached_features = getattr(page, "_detected_features_cache", None)
+            if cached_features:
+                features = set(cached_features)
+            elif getattr(page, "_from_cache", False) and build_cache is not None:
+                facts = build_cache.get_parsed_discovery_facts(page.source_path)
+                features = set(facts["detected_features"]) if facts else set()
+            else:
+                features = detector.detect_features_in_page(page)
             # Prefer BuildState (fresh each build), fall back to Site field
             _bs = self.site.build_state
             target = _bs.features_detected if _bs is not None else self.site.features_detected

--- a/bengal/orchestration/feature_detector.py
+++ b/bengal/orchestration/feature_detector.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, ClassVar
 
-from bengal.content.page_source import get_raw_source
+from bengal.content.discovery_facts import DiscoveryFactsExtractor
 
 if TYPE_CHECKING:
     from bengal.protocols import PageLike, SiteContent
@@ -84,22 +84,7 @@ class FeatureDetector:
         Returns:
             Set of detected feature names
         """
-        features: set[str] = set()
-
-        if not content:
-            return features
-
-        # Check content patterns
-        for feature, pattern in self.PATTERNS.items():
-            if pattern.search(content):
-                features.add(feature)
-
-        # Check directive patterns
-        for feature, pattern in self.DIRECTIVE_PATTERNS.items():
-            if pattern.search(content):
-                features.add(feature)
-
-        return features
+        return DiscoveryFactsExtractor.detect_features_in_content(content)
 
     def detect_features_in_page(self, page: PageLike) -> set[str]:
         """
@@ -113,28 +98,7 @@ class FeatureDetector:
         Returns:
             Set of detected feature names
         """
-        features: set[str] = set()
-
-        # Detect from content
-        source = get_raw_source(page)
-        if source:
-            features.update(self.detect_features_in_content(source))
-
-        # Check metadata for explicit feature flags
-        if page.metadata:
-            # Check for mermaid in metadata
-            if page.metadata.get("mermaid"):
-                features.add("mermaid")
-
-            # Check for interactive features
-            if page.metadata.get("interactive"):
-                features.add("interactive")
-
-            # Check for graph features
-            if page.metadata.get("graph"):
-                features.add("graph")
-
-        return features
+        return DiscoveryFactsExtractor.detect_features_in_page(page)
 
 
 def detect_site_features(site: SiteContent) -> set[str]:

--- a/bengal/orchestration/incremental/cleanup.py
+++ b/bengal/orchestration/incremental/cleanup.py
@@ -29,6 +29,19 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _resolve_tracked_source_path(source_path_str: str, site_root: Path) -> Path:
+    """Resolve a tracked source path to an absolute filesystem path.
+
+    ``output_sources`` stores canonical cache keys (e.g. ``content/page.md``)
+    relative to the site root. Cleanup must resolve those keys before checking
+    whether the source file still exists on disk.
+    """
+    source_path = Path(source_path_str)
+    if source_path.is_absolute():
+        return source_path
+    return site_root / source_path
+
+
 def cleanup_deleted_files(site: Site, cache: BuildCache) -> int:
     """
     Clean up output files for deleted source files.
@@ -56,8 +69,9 @@ def cleanup_deleted_files(site: Site, cache: BuildCache) -> int:
     # Build set of current source paths from output_sources
     deleted_sources = []
 
+    site_root = site.root_path
     for output_path_str, source_path_str in cache.output_sources.items():
-        source_path = Path(source_path_str)
+        source_path = _resolve_tracked_source_path(source_path_str, site_root)
         # Check if source file still exists on disk
         if not source_path.exists():
             deleted_sources.append((output_path_str, source_path_str))

--- a/bengal/orchestration/render/pipeline_runner.py
+++ b/bengal/orchestration/render/pipeline_runner.py
@@ -23,10 +23,21 @@ from .parallel import thread_local as _thread_local
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bengal.cache.build_cache import BuildCache
     from bengal.core.site import Site
     from bengal.orchestration.build_context import BuildContext
     from bengal.orchestration.stats import BuildStats
     from bengal.protocols.core import PageLike
+
+
+def _resolve_build_cache(
+    build_context: BuildContext | None,
+    site: Site,
+) -> BuildCache | None:
+    """Resolve the build cache from context or the site warm-build slot."""
+    if build_context is not None and build_context.cache is not None:
+        return build_context.cache
+    return getattr(site, "_cache", None)
 
 
 def process_page_with_pipeline(
@@ -83,6 +94,7 @@ def process_page_with_pipeline(
             block_cache=block_cache,
             highlight_cache=highlight_cache,
             write_behind=write_behind,
+            build_cache=_resolve_build_cache(build_context, site),
         )
         if current_generation is not None:
             _thread_local.pipeline_generation = current_generation

--- a/bengal/orchestration/render/sequential.py
+++ b/bengal/orchestration/render/sequential.py
@@ -64,6 +64,12 @@ class SequentialRenderMixin:
 
         token = build_context.cancellation_token if build_context else None
 
+        build_cache = (
+            build_context.cache
+            if build_context is not None and build_context.cache is not None
+            else getattr(self.site, "_cache", None)
+        )
+
         if progress_manager:
             import time
 
@@ -75,6 +81,7 @@ class SequentialRenderMixin:
                 changed_sources=changed_sources,
                 block_cache=self._block_cache,
                 highlight_cache=self._highlight_cache,
+                build_cache=build_cache,
             )
             last_update_time = time.time()
             update_interval = 0.1
@@ -106,6 +113,7 @@ class SequentialRenderMixin:
             changed_sources=changed_sources,
             block_cache=self._block_cache,
             highlight_cache=self._highlight_cache,
+            build_cache=build_cache,
         )
         for i, page in enumerate(pages):
             if token and token.is_cancelled:

--- a/bengal/rendering/pipeline/cache_checker.py
+++ b/bengal/rendering/pipeline/cache_checker.py
@@ -335,9 +335,21 @@ class CacheChecker:
             meta_description = getattr(page, "_meta_description", None) or ""
             cached_ast = getattr(page, "_ast_cache", None) if persist_tokens else None
 
+        from bengal.content.discovery_facts import collect_parsed_discovery_facts
+
+        discovery_facts = collect_parsed_discovery_facts(page)
+        detected_features = discovery_facts["detected_features"]
+        target_anchors = discovery_facts["target_anchors"]
+
         if parsed_page is not None and hasattr(cache, "store_parsed_page"):
             cache.store_parsed_page(
-                page.source_path, parsed_page, page.metadata, template, parser_version
+                page.source_path,
+                parsed_page,
+                page.metadata,
+                template,
+                parser_version,
+                detected_features=detected_features,
+                target_anchors=target_anchors,
             )
         else:
             cache.store_parsed_content(
@@ -352,6 +364,8 @@ class CacheChecker:
                 ast=cached_ast,
                 excerpt=excerpt,
                 meta_description=meta_description,
+                detected_features=detected_features,
+                target_anchors=target_anchors,
             )
 
     def cache_rendered_output(

--- a/tests/unit/cache/test_build_cache.py
+++ b/tests/unit/cache/test_build_cache.py
@@ -1083,6 +1083,35 @@ class TestInvalidationMethods:
         assert result is True
         assert str(test_file) not in cache.parsed_content
 
+    def test_get_parsed_discovery_facts_returns_cached_features(self, tmp_path):
+        """Warm discovery can reuse per-page CSS features and target anchors."""
+        cache = BuildCache(site_root=tmp_path)
+
+        test_file = tmp_path / "content" / "page.md"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("# Page")
+        cache.update_file(test_file)
+
+        cache.store_parsed_content(
+            test_file,
+            html="<p>Content</p>",
+            toc="",
+            toc_items=[],
+            links=[],
+            metadata={"title": "Page"},
+            template="default.html",
+            parser_version="1.0",
+            detected_features=["mermaid"],
+            target_anchors=["install-guide"],
+        )
+
+        facts = cache.get_parsed_discovery_facts(test_file)
+
+        assert facts == {
+            "detected_features": ["mermaid"],
+            "target_anchors": ["install-guide"],
+        }
+
     def test_get_excerpt_for_path_returns_excerpt_from_cache(self, tmp_path):
         """Test get_excerpt_for_path returns excerpt without full validation."""
         cache = BuildCache(site_root=tmp_path)

--- a/tests/unit/discovery/test_surgical_discovery.py
+++ b/tests/unit/discovery/test_surgical_discovery.py
@@ -54,6 +54,9 @@ def make_mock_build_cache(parsed_pages: dict | None = None) -> MagicMock:
 
         build_cache.get_parsed_page.side_effect = get_parsed_page
 
+    # Unchanged by default — callers override when testing change detection.
+    build_cache.is_changed.return_value = False
+
     return build_cache
 
 
@@ -322,3 +325,19 @@ class TestSurgicalDiscoveryExplicitlyChangedFiles:
             assert result is None
         finally:
             discovery._executor.shutdown(wait=True)
+
+    def test_build_cache_is_changed_bypasses_parsed_cache(
+        self, content_dir: Path, mock_cache: MagicMock
+    ) -> None:
+        """When build_cache reports a content change, skip parsed-cache reconstruction."""
+        file_path = content_dir / "docs" / "getting-started.md"
+        mock_cache.get_metadata.return_value = make_page_core(file_path, "Cached")
+        build_cache = make_mock_build_cache({"getting-started": CACHED_PARSED_DATA})
+        build_cache.is_changed.return_value = True
+
+        discovery = ContentDiscovery(content_dir)
+        discovery._build_cache = build_cache
+
+        result = discovery._create_page_surgical(file_path, mock_cache)
+
+        assert result is None

--- a/tests/unit/orchestration/incremental/test_cleanup.py
+++ b/tests/unit/orchestration/incremental/test_cleanup.py
@@ -139,6 +139,27 @@ class TestCleanupDeletedFiles:
         assert output_path.exists()
         assert count == 0
 
+    def test_no_cleanup_for_relative_cache_key_when_source_exists(
+        self, mock_site, mock_cache, tmp_path
+    ):
+        """Canonical content keys (content/page.md) must resolve against site root."""
+        output_path = mock_site.output_dir / "page" / "index.html"
+        output_path.parent.mkdir(parents=True)
+        output_path.write_text("<html></html>")
+
+        source_path = tmp_path / "content" / "page.md"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("Content")
+
+        mock_cache.output_sources = {
+            "page/index.html": "content/page.md",
+        }
+
+        count = cleanup_deleted_files(mock_site, mock_cache)
+
+        assert output_path.exists()
+        assert count == 0
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/orchestration/render/test_shard_worker.py
+++ b/tests/unit/orchestration/render/test_shard_worker.py
@@ -22,7 +22,6 @@ import pytest
 from bengal.orchestration.build.options import BuildOptions
 from bengal.orchestration.render.isolated.partition import discover_content_files
 from bengal.orchestration.render.isolated.shard_worker import parse_shard, render_shard
-from bengal.snapshots.render_plan import page_view_from_live_page
 
 if TYPE_CHECKING:
     from bengal.core.site import Site
@@ -35,59 +34,132 @@ def _built(site_factory, root: str) -> Site:
     from bengal.cache import directive_cache
     from bengal.utils.cache_registry import clear_all_caches
 
-    # Start from clean process-global caches. The directive-cache is an id(site)-keyed
-    # singleton; a prior in-process test's site (or a recycled id()) can leave entries
-    # that poison this fixture's parse — e.g. child-cards on test-navigation's
-    # docs/_index.md rendering against a stale section, perturbing content_hash and
-    # flaking the parse-parity assertion under xdist ordering. The subprocess harnesses
-    # below already guard against this; the in-process oracle build must too.
     clear_all_caches()
     directive_cache.clear_cache()
+    directive_cache.reset_for_testing()
+    directive_cache.configure_cache(enabled=False)
 
     site = site_factory(root)
-    site.build(BuildOptions(quiet=True, force_sequential=True))
+    site.build(BuildOptions(quiet=True, force_sequential=True, incremental=False))
     return site
+
+
+# Parse-leg parity runs in its own subprocess (mirrors the render-parity harnesses below):
+# a real worker IS a separate process, and a fresh interpreter is the only contamination-
+# free way to assert PageView parity. In-process, sharing the interpreter with other
+# fixtures' builds poisons parse via id(site)-keyed global caches — child-cards on
+# test-navigation's docs/_index.md flaked under xdist when a prior test left directive
+# cache entries that perturbed content_hash.
+_PARSE_PARITY_CHILD = """
+import json, sys
+from pathlib import Path
+
+from bengal.cache import directive_cache
+from bengal.core.site import Site
+from bengal.orchestration.build.options import BuildOptions
+from bengal.orchestration.render.isolated.partition import discover_content_files
+from bengal.orchestration.render.isolated.shard_worker import parse_shard
+from bengal.orchestration.render.tracking import clear_thread_local_pipelines
+from bengal.snapshots.render_plan import page_view_from_live_page
+from bengal.utils.cache_registry import clear_all_caches
+
+root = Path(sys.argv[1])
+
+clear_all_caches()
+directive_cache.clear_cache()
+directive_cache.reset_for_testing()
+directive_cache.configure_cache(enabled=False)
+
+site = Site.from_config(root)
+site.build(BuildOptions(quiet=True, force_sequential=True, incremental=False))
+content_dir = root / "content"
+files = discover_content_files(content_dir, site=site)
+
+clear_all_caches()
+directive_cache.reset_for_testing()
+clear_thread_local_pipelines()
+reparsed = parse_shard(files, site, content_dir=content_dir)
+in_proc = {p.source_path: p for p in site.pages}
+
+mismatches = []
+checked = 0
+for page in reparsed:
+    if page.source_path not in in_proc:
+        mismatches.append({"path": str(page.source_path), "error": "unknown reparsed file"})
+        continue
+    pv_reparsed = page_view_from_live_page(page, site)
+    pv_in_process = page_view_from_live_page(in_proc[page.source_path], site)
+    if pv_reparsed != pv_in_process:
+        mismatches.append(
+            {
+                "path": str(page.source_path),
+                "reparsed_hash": pv_reparsed.content_hash,
+                "in_process_hash": pv_in_process.content_hash,
+            }
+        )
+    checked += 1
+
+print(
+    "PARITY "
+    + json.dumps(
+        {
+            "n_files": len(files),
+            "n_reparsed": len(reparsed),
+            "checked": checked,
+            "mismatches": mismatches,
+        }
+    )
+)
+"""
 
 
 # Byte-parity vs the in-process path is gated in CI after #431 (deterministic aggregate
 # outputs) and #529 (stable sitemap/agent.json ordering). render_isolation stays OFF by
 # default until the backend is promoted default-on.
-@pytest.mark.parallel_unsafe
+@pytest.mark.serial
 @pytest.mark.parametrize("root", ROOTS)
-def test_parse_shard_matches_in_process_parse(site_factory, root):
+def test_parse_shard_matches_in_process_parse(root, tmp_path):
     """A worker re-parsing a file shard in isolation produces pages whose PageView is
     identical to the in-process parse of the same files — proving the parse leg is
     self-contained and reproduces the build's discovery+parse exactly."""
-    from bengal.cache import directive_cache
-    from bengal.utils.cache_registry import clear_all_caches
+    import json
+    import os
+    import shutil
+    import subprocess
+    import sys
+    from pathlib import Path
 
-    clear_all_caches()
-    directive_cache.reset_for_testing()
-    directive_cache.configure_cache(enabled=False)
-    try:
-        site = _built(site_factory, root)
-        content_dir = site.root_path / "content"
+    src = Path(__file__).parents[3] / "roots" / root
+    if not src.exists():  # pragma: no cover - fixture must exist
+        pytest.skip(f"missing test root {src}")
 
-        files = discover_content_files(content_dir, site=site)
+    site_root = tmp_path / "site"
+    shutil.copytree(src, site_root)
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = "0"
 
-        clear_all_caches()
-        directive_cache.reset_for_testing()
+    proc = subprocess.run(
+        [sys.executable, "-c", _PARSE_PARITY_CHILD, str(site_root)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    report = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("PARITY "):
+            report = json.loads(line[len("PARITY ") :])
+    assert report is not None, (
+        f"parse parity child produced no report; rc={proc.returncode}\n"
+        f"stderr tail:\n{proc.stderr[-4000:]}"
+    )
 
-        reparsed = parse_shard(files, site, content_dir=content_dir)
-
-        in_proc = {p.source_path: p for p in site.pages}
-
-        assert reparsed, f"{root} produced no parsed pages"
-        checked = 0
-        for page in reparsed:
-            assert page.source_path in in_proc, f"reparsed an unknown file: {page.source_path}"
-            pv_reparsed = page_view_from_live_page(page, site)
-            pv_in_process = page_view_from_live_page(in_proc[page.source_path], site)
-            assert pv_reparsed == pv_in_process, f"reparsed page diverged for {page.source_path}"
-            checked += 1
-        assert checked == len(files)
-    finally:
-        directive_cache.configure_cache(enabled=True)
+    assert report["n_reparsed"] > 0, f"{root} produced no parsed pages"
+    assert report["checked"] == report["n_files"], (
+        f"{root}: cover incomplete ({report['checked']} of {report['n_files']} files)"
+    )
+    assert not report["mismatches"], f"{root} parse parity diverged: {report['mismatches']}"
 
 
 @pytest.mark.parametrize("root", ROOTS)

--- a/tests/unit/orchestration/test_feature_detector.py
+++ b/tests/unit/orchestration/test_feature_detector.py
@@ -209,14 +209,17 @@ graph TD
 
     def test_detect_features_from_plain_text_cache_when_raw_empty(self) -> None:
         """Cache-hit pages with empty raw content should use plain_text cache."""
+        from types import SimpleNamespace
+
         from bengal.orchestration.feature_detector import FeatureDetector
 
         detector = FeatureDetector()
 
-        page = MagicMock()
-        page._raw_content = ""
-        page._plain_text_cache = "Page with ```mermaid\ngraph TD\n``` diagram"
-        page.metadata = {}
+        page = SimpleNamespace(
+            _raw_content="",
+            _plain_text_cache="Page with ```mermaid\ngraph TD\n``` diagram",
+            metadata={},
+        )
 
         features = detector.detect_features_in_page(page)
 

--- a/tests/unit/orchestration/test_feature_detector.py
+++ b/tests/unit/orchestration/test_feature_detector.py
@@ -207,6 +207,21 @@ graph TD
 
         assert "interactive" in features
 
+    def test_detect_features_from_plain_text_cache_when_raw_empty(self) -> None:
+        """Cache-hit pages with empty raw content should use plain_text cache."""
+        from bengal.orchestration.feature_detector import FeatureDetector
+
+        detector = FeatureDetector()
+
+        page = MagicMock()
+        page._raw_content = ""
+        page._plain_text_cache = "Page with ```mermaid\ngraph TD\n``` diagram"
+        page.metadata = {}
+
+        features = detector.detect_features_in_page(page)
+
+        assert "mermaid" in features
+
 
 class TestDetectSiteFeatures:
     """Tests for detect_site_features function."""


### PR DESCRIPTION
## Summary

- Wire `build_cache` through the render pipeline (`BuildContext`, `pipeline_runner`, `sequential`) so warm rebuilds can hit parsed/rendered caches instead of always re-parsing.
- Persist per-page `detected_features` and `target_anchors` in the parsed content cache; restore them when reconstructing pages from cache so CSS feature detection and xref indexing stay correct with empty `raw_content`.
- Add `bengal.content.discovery_facts` as the layer-safe shared extractor; delegate `FeatureDetector` to it.
- Partial progress on saga #332 (epic #330 / v0.6.0); closes completed umbrella issues #532 and #381 on GitHub.

## Proof

- [x] Focused tests: `tests/unit/orchestration/test_feature_detector.py`, `tests/unit/cache/test_build_cache.py` (`test_get_parsed_discovery_facts_returns_cached_features`, `test_detect_features_from_plain_text_cache_when_raw_empty`)
- [ ] `poe proof-pr` or scoped equivalent:
- [x] Docs/examples/changelog updated or no-impact noted: no-impact — internal warm-build/cache plumbing; no user-facing API or config change

## Performance Evidence

Required when this PR makes a performance claim, changes a hot path, or changes
free-threaded/concurrent behavior.

- Benchmark matrix row: not applicable (enables future warm-build wins; no committed baseline update in this PR)
- Command: not applicable
- Python build: not applicable
- Machine/OS: not applicable
- Baseline commit or saved result: not applicable
- Current commit or saved result: not applicable
- Artifact path: not applicable
- Interpretation: not applicable — plumbing for #332; proportionality test + baseline flip deferred to follow-up

## Steward Notes

- Remaining #332 work: incremental xref/output-path passes, proportionality integration test, warm-build baseline update.
- GitHub issues #532 (Pridelands epic) and #381 (FT worker caps) were closed as fully shipped prior to this PR.

Made with [Cursor](https://cursor.com)